### PR TITLE
fix: BYPASS_AUTH for contract tests in CI (#9)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,7 @@ jobs:
           SQLITE_PATH: file:./dev.db
           PORT: 3001
           GEOCODING_ENABLED: false
+          BYPASS_AUTH: true
       - name: Wait for backend to be ready
         run: |
           for i in $(seq 1 30); do

--- a/src/backend/middleware/auth.ts
+++ b/src/backend/middleware/auth.ts
@@ -67,6 +67,17 @@ export async function requireAuth(
   res: Response,
   next: NextFunction,
 ): Promise<void> {
+  // CI escape hatch: skip JWT verification in contract tests.
+  // Only active when BYPASS_AUTH is explicitly set to 'true'.
+  if (process.env.BYPASS_AUTH === 'true') {
+    (req as any).user = {
+      id: 'test-user-00000000-0000-0000-0000-000000000000',
+      clerkId: 'test_clerk_id',
+      email: 'test@example.com',
+    };
+    return next();
+  }
+
   const authHeader = req.headers.authorization;
   const token = authHeader?.startsWith('Bearer ') ? authHeader.slice(7) : undefined;
 


### PR DESCRIPTION
Closes #9

Adds BYPASS_AUTH env var escape hatch to requireAuth middleware. When set to 'true', skips JWT verification and attaches a hardcoded test user. Only enabled in the CI contract tests job — no other job sets this variable.

BRD reference: N/A — infrastructure