### PR TITLE
fix: UI visual delta — 17 mockup discrepancies (#14)

### DIFF
--- a/src/frontend/App.tsx
+++ b/src/frontend/App.tsx
@@ -27,16 +27,17 @@ export function App() {
   return (
     <div className="flex flex-col h-screen overflow-hidden">
       {/* Navigation bar */}
-      <nav className="flex items-center gap-1 px-5 py-2 border-b border-gray-200 bg-white flex-shrink-0 z-[100]">
-        <span className="font-bold text-base text-gray-900 mr-3">
-          ✈️ Travel Tracker
+      <nav className="flex items-center gap-1 px-5 py-2 border-b border-gray-200 bg-white flex-shrink-0 z-[100] shadow-sm">
+        <span className="font-bold text-base mr-3 flex items-center">
+          <span className="inline-flex items-center justify-center w-6 h-6 bg-teal-600 rounded text-white text-xs font-bold mr-2">T</span>
+          <span className="text-teal-600 font-bold">Travel Tracker</span>
         </span>
         <NavLink
           to="/map"
           className={({ isActive }) =>
             `no-underline px-3.5 py-2 rounded-md text-sm transition-colors ${
               isActive
-                ? 'font-semibold text-blue-600 bg-blue-50'
+                ? 'font-semibold text-teal-700 bg-teal-50'
                 : 'font-normal text-gray-700 hover:bg-gray-100'
             }`
           }
@@ -48,7 +49,7 @@ export function App() {
           className={({ isActive }) =>
             `no-underline px-3.5 py-2 rounded-md text-sm transition-colors ${
               isActive
-                ? 'font-semibold text-blue-600 bg-blue-50'
+                ? 'font-semibold text-teal-700 bg-teal-50'
                 : 'font-normal text-gray-700 hover:bg-gray-100'
             }`
           }
@@ -60,7 +61,7 @@ export function App() {
           className={({ isActive }) =>
             `no-underline px-3.5 py-2 rounded-md text-sm transition-colors ${
               isActive
-                ? 'font-semibold text-blue-600 bg-blue-50'
+                ? 'font-semibold text-teal-700 bg-teal-50'
                 : 'font-normal text-gray-700 hover:bg-gray-100'
             }`
           }
@@ -106,8 +107,14 @@ export function App() {
           {/* TR-11: Nested trips routes — TripsLayout owns the two-panel shell */}
           <Route path="/trips" element={<TripsLayout />}>
             <Route index element={
-              <div className="flex items-center justify-center h-full text-gray-400 text-sm">
-                Select a trip from the list
+              <div className="flex flex-col items-center justify-center h-full text-gray-400 p-12 text-center">
+                <div className="w-14 h-14 rounded-full bg-gray-200 flex items-center justify-center mb-4">
+                  <span className="text-2xl text-gray-300">🗺</span>
+                </div>
+                <p className="text-base font-semibold text-gray-500 mb-1.5">Select a trip</p>
+                <p className="text-sm text-gray-400 max-w-[260px] leading-relaxed">
+                  Choose a trip from the list to view its details, places, and itinerary.
+                </p>
               </div>
             } />
             <Route path=":id" element={<TripDetailPage />} />

--- a/src/frontend/components/TripDetail/AddPlaceFlow.tsx
+++ b/src/frontend/components/TripDetail/AddPlaceFlow.tsx
@@ -107,7 +107,7 @@ export function AddPlaceFlow({ tripId, onClose }: AddPlaceFlowProps) {
 
   const mutationError = addPlace.error ?? createCity.error;
 
-  const inputClass = 'w-full px-2.5 py-2 border border-gray-300 rounded-md text-sm bg-white focus:outline-none focus:ring-2 focus:ring-blue-500 box-border';
+  const inputClass = 'w-full px-2.5 py-2 border border-gray-300 rounded-md text-sm bg-white focus:outline-none focus:ring-2 focus:ring-teal-500 box-border';
   const labelClass = 'block text-xs font-semibold text-gray-700 mb-1';
 
   if (showCarryForward && addedPlaceId !== null && addedCityId !== null) {
@@ -159,7 +159,7 @@ export function AddPlaceFlow({ tripId, onClose }: AddPlaceFlowProps) {
                   </div>
                 ))}
                 <div
-                  className="px-3 py-2.5 cursor-pointer text-sm text-blue-600 font-semibold hover:bg-blue-50 border-b border-gray-100 last:border-b-0"
+                  className="px-3 py-2.5 cursor-pointer text-sm text-teal-600 font-semibold hover:bg-teal-50 border-b border-gray-100 last:border-b-0"
                   onClick={() => { setShowNewCityForm(true); setNewCityName(query); }}
                 >
                   + Add new: "{query}"
@@ -229,7 +229,7 @@ export function AddPlaceFlow({ tripId, onClose }: AddPlaceFlowProps) {
               <button
                 type="submit"
                 disabled={createCity.isPending || addPlace.isPending}
-                className="px-4.5 py-2 bg-blue-600 text-white border-none rounded-md text-sm font-semibold hover:bg-blue-700 disabled:opacity-60 cursor-pointer"
+                className="px-4.5 py-2 bg-teal-600 text-white border-none rounded-md text-sm font-semibold hover:bg-teal-700 disabled:opacity-60 cursor-pointer"
               >
                 {createCity.isPending || addPlace.isPending ? 'Adding…' : mutationError ? 'Retry' : 'Add City & Place'}
               </button>

--- a/src/frontend/components/TripDetail/ItemForm.tsx
+++ b/src/frontend/components/TripDetail/ItemForm.tsx
@@ -57,7 +57,7 @@ function Field({ label, value, onChange, type = 'text', placeholder }: {
     <div className="mb-3.5">
       <label className="block text-xs font-semibold text-gray-700 mb-1">{label}</label>
       <input
-        className="w-full px-2.5 py-1.5 border border-gray-300 rounded-md text-sm bg-white focus:outline-none focus:ring-2 focus:ring-blue-500"
+        className="w-full px-2.5 py-1.5 border border-gray-300 rounded-md text-sm bg-white focus:outline-none focus:ring-2 focus:ring-teal-500"
         type={type}
         value={value}
         placeholder={placeholder}
@@ -212,7 +212,7 @@ export function ItemForm({ tripId, tripPlaceId, existingItem, onClose }: ItemFor
               <div className="mb-3.5">
                 <label className="block text-xs font-semibold text-gray-700 mb-1">Status</label>
                 <select
-                  className="w-full px-2.5 py-1.5 border border-gray-300 rounded-md text-sm bg-white focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  className="w-full px-2.5 py-1.5 border border-gray-300 rounded-md text-sm bg-white focus:outline-none focus:ring-2 focus:ring-teal-500"
                   value={status}
                   onChange={(e) => setStatus(e.target.value as ItemStatus)}
                 >
@@ -237,7 +237,7 @@ export function ItemForm({ tripId, tripPlaceId, existingItem, onClose }: ItemFor
                     <label className="block text-xs font-semibold text-gray-700 mb-1">Check-in Date</label>
                     <input
                       type="date"
-                      className="w-full px-2.5 py-1.5 border border-gray-300 rounded-md text-sm bg-white focus:outline-none focus:ring-2 focus:ring-blue-500"
+                      className="w-full px-2.5 py-1.5 border border-gray-300 rounded-md text-sm bg-white focus:outline-none focus:ring-2 focus:ring-teal-500"
                       value={checkInDate}
                       onChange={(e) => setCheckInDate(e.target.value)}
                     />
@@ -246,7 +246,7 @@ export function ItemForm({ tripId, tripPlaceId, existingItem, onClose }: ItemFor
                     <label className="block text-xs font-semibold text-gray-700 mb-1">Check-out Date</label>
                     <input
                       type="date"
-                      className="w-full px-2.5 py-1.5 border border-gray-300 rounded-md text-sm bg-white focus:outline-none focus:ring-2 focus:ring-blue-500"
+                      className="w-full px-2.5 py-1.5 border border-gray-300 rounded-md text-sm bg-white focus:outline-none focus:ring-2 focus:ring-teal-500"
                       value={checkOutDate}
                       min={checkInDate}
                       onChange={(e) => setCheckOutDate(e.target.value)}
@@ -297,7 +297,7 @@ export function ItemForm({ tripId, tripPlaceId, existingItem, onClose }: ItemFor
                   <div className="mb-3.5">
                     <label className="block text-xs font-semibold text-gray-700 mb-1">Post-visit Notes</label>
                     <textarea
-                      className="w-full px-2.5 py-1.5 border border-gray-300 rounded-md text-sm bg-white focus:outline-none focus:ring-2 focus:ring-blue-500 resize-y h-20"
+                      className="w-full px-2.5 py-1.5 border border-gray-300 rounded-md text-sm bg-white focus:outline-none focus:ring-2 focus:ring-teal-500 resize-y h-20"
                       value={postVisitNotes}
                       onChange={(e) => setPostVisitNotes(e.target.value)}
                     />
@@ -309,7 +309,7 @@ export function ItemForm({ tripId, tripPlaceId, existingItem, onClose }: ItemFor
               <div className="mb-3.5">
                 <label className="block text-xs font-semibold text-gray-700 mb-1">Notes</label>
                 <textarea
-                  className="w-full px-2.5 py-1.5 border border-gray-300 rounded-md text-sm bg-white focus:outline-none focus:ring-2 focus:ring-blue-500 resize-y h-[70px]"
+                  className="w-full px-2.5 py-1.5 border border-gray-300 rounded-md text-sm bg-white focus:outline-none focus:ring-2 focus:ring-teal-500 resize-y h-[70px]"
                   value={notes}
                   onChange={(e) => setNotes(e.target.value)}
                 />
@@ -328,7 +328,7 @@ export function ItemForm({ tripId, tripPlaceId, existingItem, onClose }: ItemFor
                 <button
                   type="submit"
                   disabled={isSubmitting}
-                  className="px-4.5 py-2 bg-blue-600 text-white border-none rounded-md text-sm font-semibold hover:bg-blue-700 disabled:opacity-60 disabled:cursor-not-allowed cursor-pointer"
+                  className="px-4.5 py-2 bg-teal-600 text-white border-none rounded-md text-sm font-semibold hover:bg-teal-700 disabled:opacity-60 disabled:cursor-not-allowed cursor-pointer"
                 >
                   {isSubmitting ? 'Saving…' : isEditing ? 'Save' : 'Add Item'}
                 </button>

--- a/src/frontend/components/TripDetail/PlaceSection.tsx
+++ b/src/frontend/components/TripDetail/PlaceSection.tsx
@@ -76,17 +76,16 @@ export function PlaceSection({ place, tripId, isLocked, tripStartDate, tripEndDa
   const dateRange = derivePlaceDateRange(place.items, tripStartDate, tripEndDate);
 
   return (
-    <div className="border border-gray-200 rounded-lg overflow-hidden mb-4">
+    <div className="border border-gray-200 rounded-lg overflow-hidden mb-4 shadow-sm">
       {/* Section header */}
-      <div className="bg-gray-50 px-4 py-3 flex justify-between items-center border-b border-gray-200">
+      <div className="bg-gray-100 px-4 py-3 flex justify-between items-center border-b border-gray-200">
         <div>
           {/* D-04: City name + country code (full country name not yet in API — see completion report) */}
           <span className="font-semibold text-sm text-gray-900">{place.city.name}</span>
-          <span className="ml-1.5 text-xs text-gray-500">{place.city.country_code}</span>
 
-          {/* D-03: Per-place date range */}
+          {/* D-03/DELTA-09: Country code · date range on single subtitle line */}
           <p className="mt-0.5 text-xs text-gray-500">
-            {formatDate(dateRange.start)} – {formatDate(dateRange.end)}
+            {place.city.country_code} · {formatDate(dateRange.start)} – {formatDate(dateRange.end)}
           </p>
 
           {/* Activity tags */}
@@ -95,7 +94,7 @@ export function PlaceSection({ place, tripId, isLocked, tripStartDate, tripEndDa
               {place.activities.map((a) => (
                 <span
                   key={a.id}
-                  className="inline-block px-2 py-0.5 rounded text-xs bg-purple-100 text-purple-700"
+                  className="inline-block px-2 py-0.5 rounded text-xs bg-violet-100 text-violet-800"
                 >
                   {a.name}
                 </span>
@@ -108,7 +107,7 @@ export function PlaceSection({ place, tripId, isLocked, tripStartDate, tripEndDa
           <button
             type="button"
             onClick={() => setShowAddItem(true)}
-            className="px-3.5 py-1.5 bg-blue-600 text-white text-xs font-medium rounded-md hover:bg-blue-700 cursor-pointer"
+            className="px-3.5 py-1.5 bg-teal-600 text-white text-xs font-medium rounded-md hover:bg-teal-700 cursor-pointer"
           >
             + Add Item
           </button>

--- a/src/frontend/components/TripDetail/TripDetail.tsx
+++ b/src/frontend/components/TripDetail/TripDetail.tsx
@@ -28,10 +28,10 @@ interface TripDetailProps {
 }
 
 /** The linear next-step for the persistent status bar (F-04/TR-12). */
-const NEXT_STATUS: Partial<Record<TripStatus, { to: TripStatus; label: string }>> = {
-  planning: { to: 'active', label: 'Mark as Active' },
-  active: { to: 'review_pending', label: 'Move to Review' },
-  review_pending: { to: 'locked', label: 'Lock Trip' },
+const NEXT_STATUS: Partial<Record<TripStatus, { to: TripStatus; label: string; hint: string }>> = {
+  planning: { to: 'active', label: 'Mark as Active', hint: 'Next: active → review → lock' },
+  active: { to: 'review_pending', label: 'Move to Review', hint: 'Next: post-trip review → lock' },
+  review_pending: { to: 'locked', label: 'Lock Trip', hint: 'Next: lock trip' },
 };
 
 /** Status labels for display in the bar. */
@@ -94,68 +94,49 @@ export function TripDetail({ trip }: TripDetailProps) {
 
   return (
     <div className="flex flex-col h-full">
-      {/* Scrollable content area */}
-      <div className="flex-1 overflow-y-auto p-6">
-        {/* Header */}
-        <div className="flex justify-between items-start gap-3 mb-4">
+      {/* Header zone */}
+      <div className="flex-shrink-0 p-6 pb-3">
+        {/* DELTA-04: Title left, actions [StatusBadge | Edit | Photos] right */}
+        <div className="flex justify-between items-start gap-3 mb-2">
           <div className="min-w-0">
-            {/* Title row */}
-            <div className="flex items-center gap-3 flex-wrap">
-              <h1 className="text-2xl font-bold text-gray-900 m-0">{trip.name}</h1>
-              <StatusBadge status={trip.status} />
+            <h1 className="text-2xl font-bold text-gray-900 m-0">{trip.name}</h1>
+
+            {/* DELTA-05: Single inline meta row — date | companions | categories/activities */}
+            <div className="flex items-center flex-wrap gap-2 mt-1">
+              <span className="text-xs text-slate-500">
+                {formatDate(trip.start_date)} – {formatDate(trip.end_date)}
+              </span>
+
+              {trip.companions.length > 0 && (
+                <>
+                  <span className="text-slate-300 text-xs">|</span>
+                  <span className="text-xs text-slate-500">
+                    {trip.companions.map((c) => c.name).join(', ')}
+                  </span>
+                </>
+              )}
+
+              {(trip.categories.length > 0 || trip.activities.length > 0) && (
+                <>
+                  <span className="text-slate-300 text-xs">|</span>
+                  {trip.categories.map((c) => (
+                    <span key={c.id} className="bg-violet-100 text-violet-800 px-2 py-0.5 rounded-full text-xs font-medium">
+                      {c.name}
+                    </span>
+                  ))}
+                  {trip.activities.map((a) => (
+                    <span key={a.id} className="bg-violet-100 text-violet-800 px-2 py-0.5 rounded-full text-xs font-medium">
+                      {a.name}
+                    </span>
+                  ))}
+                </>
+              )}
             </div>
-
-            {/* Date range */}
-            <p className="mt-1 text-sm text-gray-500">
-              {formatDate(trip.start_date)} – {formatDate(trip.end_date)}
-            </p>
-
-            {/* D-01: Companions */}
-            {trip.companions.length > 0 && (
-              <div className="mt-2 flex items-center gap-2 flex-wrap">
-                <span className="text-xs text-gray-400">With</span>
-                {trip.companions.map((c) => (
-                  <span
-                    key={c.id}
-                    className="inline-flex items-center justify-center w-7 h-7 rounded-full bg-blue-100 text-blue-700 text-xs font-semibold"
-                    title={c.name}
-                  >
-                    {c.name.slice(0, 2).toUpperCase()}
-                  </span>
-                ))}
-                <span className="text-sm text-gray-600">
-                  {trip.companions.map((c) => c.name).join(', ')}
-                </span>
-              </div>
-            )}
-
-            {/* D-02: Category + Activity badges */}
-            {(trip.categories.length > 0 || trip.activities.length > 0) && (
-              <div className="mt-2 flex flex-wrap gap-1.5">
-                {trip.categories.map((c) => (
-                  <span key={c.id} className="px-2 py-0.5 rounded-full text-xs bg-gray-100 text-gray-600 font-medium">
-                    {c.name}
-                  </span>
-                ))}
-                {trip.activities.map((a) => (
-                  <span key={a.id} className="px-2 py-0.5 rounded-full text-xs bg-purple-100 text-purple-700 font-medium">
-                    {a.name}
-                  </span>
-                ))}
-              </div>
-            )}
           </div>
 
-          {/* Edit + Photos buttons */}
+          {/* DELTA-04: Right actions: StatusBadge → Edit → Photos */}
           <div className="flex items-center gap-2 flex-shrink-0">
-            {/* PH-03/F-08: Photos button placeholder */}
-            <button
-              type="button"
-              onClick={handlePhotos}
-              className="px-3 py-1.5 border border-gray-300 rounded-md bg-white text-sm text-gray-600 hover:bg-gray-50 cursor-pointer"
-            >
-              📷 Photos
-            </button>
+            <StatusBadge status={trip.status} />
             {!isLocked && (
               <button
                 type="button"
@@ -165,9 +146,61 @@ export function TripDetail({ trip }: TripDetailProps) {
                 Edit
               </button>
             )}
+            {/* PH-03/F-08: Photos button placeholder */}
+            <button
+              type="button"
+              onClick={handlePhotos}
+              className="px-3 py-1.5 border border-gray-300 rounded-md bg-white text-sm text-gray-600 hover:bg-gray-50 cursor-pointer"
+            >
+              📷 Photos
+            </button>
           </div>
         </div>
+      </div>
 
+      {/* F-04/TR-12 DELTA-06: Status bar — between header and scrollable content */}
+      <div className="flex-shrink-0 flex items-center justify-between px-6 py-3 bg-gray-100 border-b border-gray-200">
+        <span className="text-sm text-gray-600">
+          Status: <span className="font-semibold text-gray-800">{STATUS_LABELS[trip.status]}</span>
+        </span>
+        <div className="flex items-center gap-2">
+          {nextStep && (
+            <>
+              <button
+                type="button"
+                onClick={() => { void handleNextStep(); }}
+                disabled={isPending}
+                className={`px-4 py-1.5 rounded-md text-sm font-semibold transition-colors ${
+                  nextStep.to === 'locked'
+                    ? 'bg-yellow-100 border border-amber-400 text-amber-800 hover:bg-yellow-200'
+                    : 'bg-emerald-600 text-white hover:bg-emerald-700'
+                } disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer`}
+              >
+                {isPending ? 'Updating…' : nextStep.label}
+              </button>
+              <span className="text-xs text-gray-500 ml-2">{nextStep.hint}</span>
+            </>
+          )}
+          {isLocked && (
+            <button
+              type="button"
+              onClick={handleUnlockBar}
+              disabled={isPending}
+              className="px-4 py-1.5 rounded-md text-sm border border-gray-300 bg-white text-gray-600 hover:bg-gray-50 disabled:opacity-50 cursor-pointer"
+            >
+              Unlock
+            </button>
+          )}
+          {trip.status === 'locked' && !nextStep && (
+            <span className="px-4 py-1.5 rounded-md text-sm bg-gray-100 text-gray-500">
+              Locked
+            </span>
+          )}
+        </div>
+      </div>
+
+      {/* Scrollable content area */}
+      <div className="flex-1 overflow-y-auto p-6">
         {/* "Coming soon" toast for Photos */}
         {photosToast && (
           <div className="mb-4 px-4 py-2 bg-gray-100 border border-gray-200 rounded-md text-sm text-gray-600">
@@ -208,44 +241,6 @@ export function TripDetail({ trip }: TripDetailProps) {
             + Add Place (City)
           </button>
         )}
-      </div>
-
-      {/* F-04/TR-12: Persistent status transition bar — sticky to bottom of right panel */}
-      <div className="flex-shrink-0 flex items-center justify-between px-6 py-3 border-t border-gray-200 bg-white">
-        <span className="text-sm text-gray-600">
-          Status: <span className="font-semibold text-gray-800">{STATUS_LABELS[trip.status]}</span>
-        </span>
-        <div className="flex items-center gap-2">
-          {nextStep && (
-            <button
-              type="button"
-              onClick={() => { void handleNextStep(); }}
-              disabled={isPending}
-              className={`px-4 py-1.5 rounded-md text-sm font-semibold transition-colors ${
-                nextStep.to === 'locked'
-                  ? 'bg-yellow-100 border border-amber-400 text-amber-800 hover:bg-yellow-200'
-                  : 'bg-blue-600 text-white hover:bg-blue-700'
-              } disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer`}
-            >
-              {isPending ? 'Updating…' : nextStep.label}
-            </button>
-          )}
-          {isLocked && (
-            <button
-              type="button"
-              onClick={handleUnlockBar}
-              disabled={isPending}
-              className="px-4 py-1.5 rounded-md text-sm border border-gray-300 bg-white text-gray-600 hover:bg-gray-50 disabled:opacity-50 cursor-pointer"
-            >
-              Unlock
-            </button>
-          )}
-          {trip.status === 'locked' && !nextStep && (
-            <span className="px-4 py-1.5 rounded-md text-sm bg-gray-100 text-gray-500">
-              Locked
-            </span>
-          )}
-        </div>
       </div>
 
       {/* Modals */}

--- a/src/frontend/components/TripDetail/TripForm.tsx
+++ b/src/frontend/components/TripDetail/TripForm.tsx
@@ -89,7 +89,7 @@ export function TripForm({ existingTrip, onClose }: TripFormProps) {
 
   const chipClass = (isSelected: boolean) =>
     isSelected
-      ? 'px-2.5 py-1 rounded-full text-xs cursor-pointer border-2 border-blue-600 bg-blue-100 text-blue-800 font-medium'
+      ? 'px-2.5 py-1 rounded-full text-xs cursor-pointer border-2 border-teal-600 bg-teal-100 text-teal-800 font-medium'
       : 'px-2.5 py-1 rounded-full text-xs cursor-pointer border border-gray-300 bg-white text-gray-700 hover:border-gray-400';
 
   return (
@@ -109,7 +109,7 @@ export function TripForm({ existingTrip, onClose }: TripFormProps) {
           <div className="mb-4">
             <label className="block text-xs font-semibold text-gray-700 mb-1.5">Name *</label>
             <input
-              className="w-full px-2.5 py-2 border border-gray-300 rounded-md text-sm bg-white focus:outline-none focus:ring-2 focus:ring-blue-500"
+              className="w-full px-2.5 py-2 border border-gray-300 rounded-md text-sm bg-white focus:outline-none focus:ring-2 focus:ring-teal-500"
               value={name}
               onChange={(e) => setName(e.target.value)}
               required
@@ -121,7 +121,7 @@ export function TripForm({ existingTrip, onClose }: TripFormProps) {
               <label className="block text-xs font-semibold text-gray-700 mb-1.5">Start Date *</label>
               <input
                 type="date"
-                className="w-full px-2.5 py-2 border border-gray-300 rounded-md text-sm bg-white focus:outline-none focus:ring-2 focus:ring-blue-500"
+                className="w-full px-2.5 py-2 border border-gray-300 rounded-md text-sm bg-white focus:outline-none focus:ring-2 focus:ring-teal-500"
                 value={startDate}
                 onChange={(e) => setStartDate(e.target.value)}
                 required
@@ -131,7 +131,7 @@ export function TripForm({ existingTrip, onClose }: TripFormProps) {
               <label className="block text-xs font-semibold text-gray-700 mb-1.5">End Date *</label>
               <input
                 type="date"
-                className="w-full px-2.5 py-2 border border-gray-300 rounded-md text-sm bg-white focus:outline-none focus:ring-2 focus:ring-blue-500"
+                className="w-full px-2.5 py-2 border border-gray-300 rounded-md text-sm bg-white focus:outline-none focus:ring-2 focus:ring-teal-500"
                 value={endDate}
                 min={startDate}
                 onChange={(e) => setEndDate(e.target.value)}
@@ -143,7 +143,7 @@ export function TripForm({ existingTrip, onClose }: TripFormProps) {
           <div className="mb-4">
             <label className="block text-xs font-semibold text-gray-700 mb-1.5">Photo Album URL (optional)</label>
             <input
-              className="w-full px-2.5 py-2 border border-gray-300 rounded-md text-sm bg-white focus:outline-none focus:ring-2 focus:ring-blue-500"
+              className="w-full px-2.5 py-2 border border-gray-300 rounded-md text-sm bg-white focus:outline-none focus:ring-2 focus:ring-teal-500"
               value={photoRef}
               onChange={(e) => setPhotoRef(e.target.value)}
               placeholder="https://..."
@@ -221,7 +221,7 @@ export function TripForm({ existingTrip, onClose }: TripFormProps) {
             <button
               type="submit"
               disabled={isSubmitting}
-              className="px-4.5 py-2.5 bg-blue-600 text-white border-none rounded-md text-sm font-semibold hover:bg-blue-700 disabled:opacity-60 disabled:cursor-not-allowed cursor-pointer"
+              className="px-4.5 py-2.5 bg-teal-600 text-white border-none rounded-md text-sm font-semibold hover:bg-teal-700 disabled:opacity-60 disabled:cursor-not-allowed cursor-pointer"
             >
               {isSubmitting ? 'Saving…' : isEditing ? 'Save Changes' : 'Create Trip'}
             </button>

--- a/src/frontend/components/TripList/TripCard.tsx
+++ b/src/frontend/components/TripList/TripCard.tsx
@@ -10,7 +10,6 @@
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import { StatusBadge } from '../shared/StatusBadge';
-import { sanitiseUrl } from '../../utils/urlSanitiser';
 import { formatDate } from '../../utils/formatDate';
 import type { TripSummary } from '../../types/api';
 
@@ -36,7 +35,6 @@ const MAX_PLACE_BADGES = 4;
  */
 export function TripCard({ trip, onEdit, isSelected = false }: TripCardProps) {
   const navigate = useNavigate();
-  const safeUrl = sanitiseUrl(trip.photo_album_ref);
 
   const places = trip.places ?? [];
   const visiblePlaces = places.slice(0, MAX_PLACE_BADGES);
@@ -44,7 +42,7 @@ export function TripCard({ trip, onEdit, isSelected = false }: TripCardProps) {
 
   const cardClass = [
     'bg-white border rounded-lg p-3 cursor-pointer transition-shadow hover:shadow-md',
-    isSelected ? 'border-blue-500 ring-1 ring-blue-500' : 'border-gray-200',
+    isSelected ? 'border-teal-500 ring-1 ring-teal-500' : 'border-gray-200',
   ].join(' ');
 
   return (
@@ -68,16 +66,6 @@ export function TripCard({ trip, onEdit, isSelected = false }: TripCardProps) {
         </div>
         <div className="flex items-center gap-1.5 flex-shrink-0">
           <StatusBadge status={trip.status} />
-          <button
-            type="button"
-            onClick={(e) => {
-              e.stopPropagation();
-              onEdit(trip);
-            }}
-            className="px-2.5 py-0.5 border border-gray-300 rounded text-xs bg-white hover:bg-gray-50 text-gray-600"
-          >
-            Edit
-          </button>
         </div>
       </div>
 
@@ -100,37 +88,17 @@ export function TripCard({ trip, onEdit, isSelected = false }: TripCardProps) {
         </div>
       )}
 
-      {/* Companions */}
-      {trip.companions.length > 0 && (
-        <div className="mt-1.5 text-xs text-gray-500">
-          With: {trip.companions.map((c) => c.name).join(', ')}
-        </div>
-      )}
-
       {/* Categories */}
       {trip.categories.length > 0 && (
         <div className="mt-1.5 flex flex-wrap gap-1">
           {trip.categories.map((cat) => (
-            <span key={cat.id} className="inline-block px-1.5 py-0.5 rounded text-xs bg-gray-100 text-gray-600">
+            <span key={cat.id} className="inline-block px-1.5 py-0.5 rounded text-xs bg-violet-100 text-violet-800">
               {cat.name}
             </span>
           ))}
         </div>
       )}
 
-      {/* Photo album link — SEC-12 */}
-      {safeUrl && (
-        <div className="mt-1.5 text-xs">
-          <a href={safeUrl} target="_blank" rel="noopener noreferrer" onClick={(e) => e.stopPropagation()}>
-            📷 Photo album
-          </a>
-        </div>
-      )}
-      {trip.photo_album_ref && !safeUrl && (
-        <div className="mt-1.5 text-xs text-gray-500">
-          Photo ref: {trip.photo_album_ref}
-        </div>
-      )}
     </div>
   );
 }

--- a/src/frontend/components/TripList/TripsLayout.tsx
+++ b/src/frontend/components/TripList/TripsLayout.tsx
@@ -95,20 +95,20 @@ export function TripsLayout() {
   return (
     <div className="flex h-full overflow-hidden">
       {/* Left panel — fixed 360px, scrollable */}
-      <div className="w-[360px] flex-shrink-0 flex flex-col h-full border-r border-gray-200 bg-white overflow-hidden">
+      <div className="w-[320px] flex-shrink-0 flex flex-col h-full border-r border-gray-200 bg-white overflow-hidden">
         {/* Panel header */}
         <div className="flex items-center justify-between px-4 pt-4 pb-2 flex-shrink-0">
           {/* D-05: trip count badge */}
           <h2 className="text-base font-bold text-gray-900">
-            Trips
-            <span className="ml-2 inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-600">
+            My Trips
+            <span className="ml-2 inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-gray-200 text-gray-500">
               {tripCount}
             </span>
           </h2>
           <button
             type="button"
             onClick={() => setShowForm(true)}
-            className="px-3 py-1.5 bg-blue-600 text-white text-sm font-semibold rounded-md hover:bg-blue-700 transition-colors"
+            className="px-3 py-1.5 bg-teal-600 text-white text-sm font-semibold rounded-md hover:bg-teal-700 transition-colors"
           >
             + New
           </button>
@@ -122,7 +122,7 @@ export function TripsLayout() {
             value={searchText}
             onChange={(e) => setSearchText(e.target.value)}
             aria-label="Search trips by name"
-            className="w-full px-3 py-1.5 border border-gray-300 rounded-md text-sm bg-white focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+            className="w-full px-3 py-1.5 border border-gray-300 rounded-md text-sm bg-white focus:outline-none focus:ring-2 focus:ring-teal-500 focus:border-transparent"
           />
         </div>
 
@@ -142,7 +142,7 @@ export function TripsLayout() {
                 }
                 className={
                   isActive
-                    ? 'px-2.5 py-1 rounded-full text-xs font-medium bg-blue-600 text-white border border-blue-600'
+                    ? 'px-2.5 py-1 rounded-full text-xs font-medium bg-teal-600 text-white border border-teal-600'
                     : 'px-2.5 py-1 rounded-full text-xs font-medium bg-white text-gray-600 border border-gray-200 hover:border-gray-300'
                 }
               >
@@ -158,7 +158,7 @@ export function TripsLayout() {
             value={sortBy}
             onChange={(e) => setSortBy(e.target.value as SortOption)}
             aria-label="Sort trips"
-            className="w-full px-3 py-1.5 border border-gray-300 rounded-md text-sm bg-white text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+            className="w-full px-3 py-1.5 border border-gray-300 rounded-md text-sm bg-white text-gray-700 focus:outline-none focus:ring-2 focus:ring-teal-500 focus:border-transparent"
           >
             <option value="date_desc">Newest first</option>
             <option value="date_asc">Oldest first</option>
@@ -170,13 +170,13 @@ export function TripsLayout() {
         {/* Map filter badge */}
         {mapFilterLabel && (
           <div className="px-4 pb-2 flex-shrink-0">
-            <span className="inline-flex items-center gap-1.5 px-2 py-1 bg-blue-50 border border-blue-200 rounded-md text-xs text-blue-700">
+            <span className="inline-flex items-center gap-1.5 px-2 py-1 bg-teal-50 border border-teal-200 rounded-md text-xs text-teal-700">
               Map filter: {mapFilterLabel}
               <button
                 type="button"
                 onClick={clearMapFilter}
                 aria-label="Clear map filter"
-                className="text-blue-700 hover:text-blue-900 text-base leading-none"
+                className="text-teal-700 hover:text-teal-900 text-base leading-none"
               >
                 ×
               </button>

--- a/src/frontend/components/shared/LoadingSpinner.tsx
+++ b/src/frontend/components/shared/LoadingSpinner.tsx
@@ -21,7 +21,7 @@ export function LoadingSpinner({ message = 'Loading…' }: LoadingSpinnerProps) 
   return (
     <div className="flex items-center gap-2.5 p-4 text-gray-500 text-sm" role="status" aria-label={message}>
       <div
-        className="w-5 h-5 rounded-full border-2 border-gray-200 border-t-blue-500 flex-shrink-0"
+        className="w-5 h-5 rounded-full border-2 border-gray-200 border-t-teal-500 flex-shrink-0"
         style={{ animation: 'spin 0.7s linear infinite' }}
       />
       <span>{message}</span>

--- a/src/frontend/components/shared/StatusBadge.tsx
+++ b/src/frontend/components/shared/StatusBadge.tsx
@@ -20,7 +20,7 @@ const LABELS: Record<TripStatus | ItemStatus, string> = {
   // Trip statuses
   planning: 'Planning',
   active: 'Active',
-  review_pending: 'Review Pending',
+  review_pending: 'Review',
   locked: 'Locked',
   // Item statuses
   consider: 'Consider',
@@ -32,9 +32,9 @@ const LABELS: Record<TripStatus | ItemStatus, string> = {
 
 /** Maps status values to Tailwind class combinations. */
 const COLOR_CLASSES: Record<TripStatus | ItemStatus, string> = {
-  planning: 'bg-blue-100 text-blue-800',
-  active: 'bg-green-100 text-green-800',
-  review_pending: 'bg-orange-100 text-orange-800',
+  planning: 'bg-teal-100 text-teal-900',
+  active: 'bg-amber-100 text-amber-800',
+  review_pending: 'bg-amber-100 text-amber-600',
   locked: 'bg-gray-100 text-gray-700',
   consider: 'bg-indigo-100 text-indigo-800',
   confirmed: 'bg-green-100 text-green-800',


### PR DESCRIPTION
Closes #14

BRD §5.1 TR-11

## Summary

- Implements all 17 DELTA items from the UX Option B mockup comparison (DELTA-07 tab strip deferred per COO brief scope note)
- Zero `blue-` Tailwind tokens remaining in frontend source files
- All 55 frontend tests pass, TypeScript type check clean

## Changes by delta

| Delta | Area | Change |
|-------|------|--------|
| DELTA-01 | Color theme | All blue tokens → teal equivalents across 8 files |
| DELTA-02 | StatusBadge: active | green → amber-100/amber-800 |
| DELTA-03 | StatusBadge: review_pending | label → "Review"; orange → amber-100/amber-600 |
| DELTA-04 | TripDetail header | StatusBadge moved to right actions; order: Status → Edit → Photos |
| DELTA-05 | TripDetail meta row | Collapsed to single inline row with pipe separators; removed avatar circles and "With" label |
| DELTA-06 | Status bar | Repositioned above scrollable content; bg → gray-100; CTA → emerald-600; "Next:" hint text added |
| DELTA-08 | PlaceSection | shadow-sm on outer card; header bg → gray-100 |
| DELTA-09 | PlaceSection subtitle | Country code and date range combined on one line with · separator |
| DELTA-10 | Left panel heading | "Trips" → "My Trips" |
| DELTA-11 | Left panel width | 360px → 320px |
| DELTA-12 | Trip count badge | bg-gray-100/gray-600 → bg-gray-200/gray-500 |
| DELTA-13 | Category chips | gray → violet-100/violet-800 (TripCard, TripDetail, PlaceSection) |
| DELTA-14 | TripCard companions | Removed companions display from card |
| DELTA-15 | TripCard edit button | Removed inline Edit button; onEdit prop retained |
| DELTA-16 | TripCard photo album | Removed photo album link/ref from card |
| DELTA-17 | Nav bar | Teal square brand icon, teal brand text, shadow-sm, teal active nav links |
| DELTA-18 | Empty state | Replaced plain text with structured empty state (icon, title, description) |

## Test plan

- [x] `npm run test:frontend` — 55 tests pass (4 suites)
- [x] `npm run type:check` — clean
- [ ] Manual UAT: verify visual match against Option B mockup

🤖 Generated with [Claude Code](https://claude.com/claude-code)