### PR TITLE
feat: NR-03 — add user_id to trips, items, trip_places (#6)

### DIFF
--- a/src/backend/db/schema.ts
+++ b/src/backend/db/schema.ts
@@ -249,6 +249,7 @@ export const trips = sqliteTable(
     // Status progression: planning → active → review_pending → locked
     status: text('status').notNull().default('planning'),
     photoAlbumRef: text('photo_album_ref'), // URL or folder path — no file stored (PH-01)
+    userId: text('user_id').references(() => users.id), // NULL = no owner yet (ADL-16)
     createdAt: text('created_at')
       .notNull()
       .default(sql`(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))`),
@@ -260,6 +261,7 @@ export const trips = sqliteTable(
     index('idx_trips_status').on(t.status),
     index('idx_trips_start_date').on(t.startDate),
     index('idx_trips_end_date').on(t.endDate),
+    index('trips_user_id_idx').on(t.userId),
     check(
       'chk_trips_status',
       sql`${t.status} IN ('planning', 'active', 'review_pending', 'locked')`,
@@ -350,6 +352,7 @@ export const tripPlaces = sqliteTable(
     cityId: integer('city_id')
       .notNull()
       .references(() => cities.id),
+    userId: text('user_id').references(() => users.id), // NULL = no owner yet (ADL-16)
     createdAt: text('created_at')
       .notNull()
       .default(sql`(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))`),
@@ -363,6 +366,7 @@ export const tripPlaces = sqliteTable(
     index('idx_trip_places_trip').on(t.tripId),
     // Critical for cross-trip queries joining on city_id (IT-07, IT-09)
     index('idx_trip_places_city').on(t.cityId),
+    index('trip_places_user_id_idx').on(t.userId),
   ],
 );
 
@@ -426,6 +430,7 @@ export const items = sqliteTable(
     carriedFromItemId: integer('carried_from_item_id').references(
       (): AnySQLiteColumn => items.id,
     ),
+    userId: text('user_id').references(() => users.id), // NULL = no owner yet (ADL-16)
     createdAt: text('created_at')
       .notNull()
       .default(sql`(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))`),
@@ -442,6 +447,7 @@ export const items = sqliteTable(
     index('idx_items_carried')
       .on(t.carriedFromItemId)
       .where(sql`${t.carriedFromItemId} IS NOT NULL`),
+    index('items_user_id_idx').on(t.userId),
     check(
       'chk_items_item_type',
       sql`${t.itemType} IN ('restaurant', 'hotel', 'flight', 'car_rental', 'experience', 'note')`,

--- a/src/backend/migrations/0003_aromatic_typhoid_mary.sql
+++ b/src/backend/migrations/0003_aromatic_typhoid_mary.sql
@@ -1,0 +1,6 @@
+ALTER TABLE `items` ADD `user_id` text REFERENCES users(id);--> statement-breakpoint
+CREATE INDEX `items_user_id_idx` ON `items` (`user_id`);--> statement-breakpoint
+ALTER TABLE `trip_places` ADD `user_id` text REFERENCES users(id);--> statement-breakpoint
+CREATE INDEX `trip_places_user_id_idx` ON `trip_places` (`user_id`);--> statement-breakpoint
+ALTER TABLE `trips` ADD `user_id` text REFERENCES users(id);--> statement-breakpoint
+CREATE INDEX `trips_user_id_idx` ON `trips` (`user_id`);

--- a/src/backend/migrations/meta/0003_snapshot.json
+++ b/src/backend/migrations/meta/0003_snapshot.json
@@ -1,0 +1,1691 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "47de557f-5a4e-445f-a4f9-06affaefb59e",
+  "prevId": "8bd2c7a0-e55a-4add-8a96-8436b5b695c2",
+  "tables": {
+    "activities": {
+      "name": "activities",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "activities_name_unique": {
+          "name": "activities_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "chk_activities_is_active": {
+          "name": "chk_activities_is_active",
+          "value": "\"activities\".\"is_active\" IN (0, 1)"
+        }
+      }
+    },
+    "cities": {
+      "name": "cities",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "country_code": {
+          "name": "country_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "region_id": {
+          "name": "region_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "geocode_status": {
+          "name": "geocode_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "geocode_attempted_at": {
+          "name": "geocode_attempted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "idx_cities_country": {
+          "name": "idx_cities_country",
+          "columns": [
+            "country_code"
+          ],
+          "isUnique": false
+        },
+        "idx_cities_region": {
+          "name": "idx_cities_region",
+          "columns": [
+            "region_id"
+          ],
+          "isUnique": false
+        },
+        "idx_cities_geocode": {
+          "name": "idx_cities_geocode",
+          "columns": [
+            "geocode_status"
+          ],
+          "isUnique": false,
+          "where": "\"cities\".\"geocode_status\" = 'pending'"
+        }
+      },
+      "foreignKeys": {
+        "cities_country_code_countries_country_code_fk": {
+          "name": "cities_country_code_countries_country_code_fk",
+          "tableFrom": "cities",
+          "tableTo": "countries",
+          "columnsFrom": [
+            "country_code"
+          ],
+          "columnsTo": [
+            "country_code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "cities_region_id_regions_id_fk": {
+          "name": "cities_region_id_regions_id_fk",
+          "tableFrom": "cities",
+          "tableTo": "regions",
+          "columnsFrom": [
+            "region_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "chk_cities_geocode_status": {
+          "name": "chk_cities_geocode_status",
+          "value": "\"cities\".\"geocode_status\" IN ('pending', 'resolved')"
+        }
+      }
+    },
+    "companions": {
+      "name": "companions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "companions_name_unique": {
+          "name": "companions_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "chk_companions_is_active": {
+          "name": "chk_companions_is_active",
+          "value": "\"companions\".\"is_active\" IN (0, 1)"
+        }
+      }
+    },
+    "countries": {
+      "name": "countries",
+      "columns": {
+        "country_code": {
+          "name": "country_code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "region_tier_enabled": {
+          "name": "region_tier_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "region_tier_label": {
+          "name": "region_tier_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "chk_countries_region_tier_enabled": {
+          "name": "chk_countries_region_tier_enabled",
+          "value": "\"countries\".\"region_tier_enabled\" IN (0, 1)"
+        }
+      }
+    },
+    "item_car_rentals": {
+      "name": "item_car_rentals",
+      "columns": {
+        "item_id": {
+          "name": "item_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pickup_location": {
+          "name": "pickup_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dropoff_location": {
+          "name": "dropoff_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pickup_datetime": {
+          "name": "pickup_datetime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dropoff_datetime": {
+          "name": "dropoff_datetime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "booking_reference": {
+          "name": "booking_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vehicle_class": {
+          "name": "vehicle_class",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "item_car_rentals_item_id_items_id_fk": {
+          "name": "item_car_rentals_item_id_items_id_fk",
+          "tableFrom": "item_car_rentals",
+          "tableTo": "items",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "item_experiences": {
+      "name": "item_experiences",
+      "columns": {
+        "item_id": {
+          "name": "item_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "post_visit_notes": {
+          "name": "post_visit_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_item_experiences_rating": {
+          "name": "idx_item_experiences_rating",
+          "columns": [
+            "rating"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "item_experiences_item_id_items_id_fk": {
+          "name": "item_experiences_item_id_items_id_fk",
+          "tableFrom": "item_experiences",
+          "tableTo": "items",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "chk_item_experiences_rating": {
+          "name": "chk_item_experiences_rating",
+          "value": "\"item_experiences\".\"rating\" IS NULL OR (\"item_experiences\".\"rating\" BETWEEN 1 AND 5)"
+        }
+      }
+    },
+    "item_flights": {
+      "name": "item_flights",
+      "columns": {
+        "item_id": {
+          "name": "item_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "airline": {
+          "name": "airline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "flight_number": {
+          "name": "flight_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "departure_airport": {
+          "name": "departure_airport",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "arrival_airport": {
+          "name": "arrival_airport",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "departure_datetime": {
+          "name": "departure_datetime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "arrival_datetime": {
+          "name": "arrival_datetime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "booking_reference": {
+          "name": "booking_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "seat": {
+          "name": "seat",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "item_flights_item_id_items_id_fk": {
+          "name": "item_flights_item_id_items_id_fk",
+          "tableFrom": "item_flights",
+          "tableTo": "items",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "item_hotels": {
+      "name": "item_hotels",
+      "columns": {
+        "item_id": {
+          "name": "item_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "property_name": {
+          "name": "property_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "check_in_date": {
+          "name": "check_in_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "check_out_date": {
+          "name": "check_out_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "booking_reference": {
+          "name": "booking_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "confirmation_number": {
+          "name": "confirmation_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "post_visit_notes": {
+          "name": "post_visit_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_item_hotels_rating": {
+          "name": "idx_item_hotels_rating",
+          "columns": [
+            "rating"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "item_hotels_item_id_items_id_fk": {
+          "name": "item_hotels_item_id_items_id_fk",
+          "tableFrom": "item_hotels",
+          "tableTo": "items",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "chk_item_hotels_rating": {
+          "name": "chk_item_hotels_rating",
+          "value": "\"item_hotels\".\"rating\" IS NULL OR (\"item_hotels\".\"rating\" BETWEEN 1 AND 5)"
+        }
+      }
+    },
+    "item_restaurants": {
+      "name": "item_restaurants",
+      "columns": {
+        "item_id": {
+          "name": "item_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "neighbourhood_area": {
+          "name": "neighbourhood_area",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cuisine_type": {
+          "name": "cuisine_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "post_visit_notes": {
+          "name": "post_visit_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_item_restaurants_rating": {
+          "name": "idx_item_restaurants_rating",
+          "columns": [
+            "rating"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "item_restaurants_item_id_items_id_fk": {
+          "name": "item_restaurants_item_id_items_id_fk",
+          "tableFrom": "item_restaurants",
+          "tableTo": "items",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "chk_item_restaurants_rating": {
+          "name": "chk_item_restaurants_rating",
+          "value": "\"item_restaurants\".\"rating\" IS NULL OR (\"item_restaurants\".\"rating\" BETWEEN 1 AND 5)"
+        }
+      }
+    },
+    "items": {
+      "name": "items",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "trip_id": {
+          "name": "trip_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "trip_place_id": {
+          "name": "trip_place_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "item_type": {
+          "name": "item_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'consider'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_carried_forward": {
+          "name": "is_carried_forward",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "carried_from_item_id": {
+          "name": "carried_from_item_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "idx_items_trip": {
+          "name": "idx_items_trip",
+          "columns": [
+            "trip_id"
+          ],
+          "isUnique": false
+        },
+        "idx_items_trip_place": {
+          "name": "idx_items_trip_place",
+          "columns": [
+            "trip_place_id"
+          ],
+          "isUnique": false
+        },
+        "idx_items_type": {
+          "name": "idx_items_type",
+          "columns": [
+            "item_type"
+          ],
+          "isUnique": false
+        },
+        "idx_items_status": {
+          "name": "idx_items_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "idx_items_carried": {
+          "name": "idx_items_carried",
+          "columns": [
+            "carried_from_item_id"
+          ],
+          "isUnique": false,
+          "where": "\"items\".\"carried_from_item_id\" IS NOT NULL"
+        },
+        "items_user_id_idx": {
+          "name": "items_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "items_trip_id_trips_id_fk": {
+          "name": "items_trip_id_trips_id_fk",
+          "tableFrom": "items",
+          "tableTo": "trips",
+          "columnsFrom": [
+            "trip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "items_trip_place_id_trip_places_id_fk": {
+          "name": "items_trip_place_id_trip_places_id_fk",
+          "tableFrom": "items",
+          "tableTo": "trip_places",
+          "columnsFrom": [
+            "trip_place_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "items_carried_from_item_id_items_id_fk": {
+          "name": "items_carried_from_item_id_items_id_fk",
+          "tableFrom": "items",
+          "tableTo": "items",
+          "columnsFrom": [
+            "carried_from_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "items_user_id_users_id_fk": {
+          "name": "items_user_id_users_id_fk",
+          "tableFrom": "items",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "chk_items_item_type": {
+          "name": "chk_items_item_type",
+          "value": "\"items\".\"item_type\" IN ('restaurant', 'hotel', 'flight', 'car_rental', 'experience', 'note')"
+        },
+        "chk_items_status": {
+          "name": "chk_items_status",
+          "value": "\"items\".\"status\" IN ('consider', 'confirmed', 'completed', 'cancelled', 'next_time')"
+        },
+        "chk_items_is_carried_forward": {
+          "name": "chk_items_is_carried_forward",
+          "value": "\"items\".\"is_carried_forward\" IN (0, 1)"
+        }
+      }
+    },
+    "map_shading_config": {
+      "name": "map_shading_config",
+      "columns": {
+        "state_key": {
+          "name": "state_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "color_hex": {
+          "name": "color_hex",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "chk_map_shading_state_key": {
+          "name": "chk_map_shading_state_key",
+          "value": "\"map_shading_config\".\"state_key\" IN ('active', 'planned', 'visited_once', 'visited_once_planning', 'visited_multiple', 'visited_multiple_planning')"
+        }
+      }
+    },
+    "regions": {
+      "name": "regions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "country_code": {
+          "name": "country_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "iso_3166_2": {
+          "name": "iso_3166_2",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "idx_regions_country": {
+          "name": "idx_regions_country",
+          "columns": [
+            "country_code"
+          ],
+          "isUnique": false
+        },
+        "uniq_regions_iso_3166_2": {
+          "name": "uniq_regions_iso_3166_2",
+          "columns": [
+            "iso_3166_2"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "regions_country_code_countries_country_code_fk": {
+          "name": "regions_country_code_countries_country_code_fk",
+          "tableFrom": "regions",
+          "tableTo": "countries",
+          "columnsFrom": [
+            "country_code"
+          ],
+          "columnsTo": [
+            "country_code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "trip_activities_map": {
+      "name": "trip_activities_map",
+      "columns": {
+        "trip_id": {
+          "name": "trip_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "activity_id": {
+          "name": "activity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "trip_activities_map_trip_id_trips_id_fk": {
+          "name": "trip_activities_map_trip_id_trips_id_fk",
+          "tableFrom": "trip_activities_map",
+          "tableTo": "trips",
+          "columnsFrom": [
+            "trip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "trip_activities_map_activity_id_activities_id_fk": {
+          "name": "trip_activities_map_activity_id_activities_id_fk",
+          "tableFrom": "trip_activities_map",
+          "tableTo": "activities",
+          "columnsFrom": [
+            "activity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "trip_activities_map_trip_id_activity_id_pk": {
+          "columns": [
+            "trip_id",
+            "activity_id"
+          ],
+          "name": "trip_activities_map_trip_id_activity_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "trip_categories": {
+      "name": "trip_categories",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "trip_categories_name_unique": {
+          "name": "trip_categories_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "chk_trip_categories_is_active": {
+          "name": "chk_trip_categories_is_active",
+          "value": "\"trip_categories\".\"is_active\" IN (0, 1)"
+        }
+      }
+    },
+    "trip_categories_map": {
+      "name": "trip_categories_map",
+      "columns": {
+        "trip_id": {
+          "name": "trip_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_tcm_category": {
+          "name": "idx_tcm_category",
+          "columns": [
+            "category_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "trip_categories_map_trip_id_trips_id_fk": {
+          "name": "trip_categories_map_trip_id_trips_id_fk",
+          "tableFrom": "trip_categories_map",
+          "tableTo": "trips",
+          "columnsFrom": [
+            "trip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "trip_categories_map_category_id_trip_categories_id_fk": {
+          "name": "trip_categories_map_category_id_trip_categories_id_fk",
+          "tableFrom": "trip_categories_map",
+          "tableTo": "trip_categories",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "trip_categories_map_trip_id_category_id_pk": {
+          "columns": [
+            "trip_id",
+            "category_id"
+          ],
+          "name": "trip_categories_map_trip_id_category_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "trip_companions_map": {
+      "name": "trip_companions_map",
+      "columns": {
+        "trip_id": {
+          "name": "trip_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "companion_id": {
+          "name": "companion_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_tcpm_companion": {
+          "name": "idx_tcpm_companion",
+          "columns": [
+            "companion_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "trip_companions_map_trip_id_trips_id_fk": {
+          "name": "trip_companions_map_trip_id_trips_id_fk",
+          "tableFrom": "trip_companions_map",
+          "tableTo": "trips",
+          "columnsFrom": [
+            "trip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "trip_companions_map_companion_id_companions_id_fk": {
+          "name": "trip_companions_map_companion_id_companions_id_fk",
+          "tableFrom": "trip_companions_map",
+          "tableTo": "companions",
+          "columnsFrom": [
+            "companion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "trip_companions_map_trip_id_companion_id_pk": {
+          "columns": [
+            "trip_id",
+            "companion_id"
+          ],
+          "name": "trip_companions_map_trip_id_companion_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "trip_place_activities_map": {
+      "name": "trip_place_activities_map",
+      "columns": {
+        "trip_place_id": {
+          "name": "trip_place_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "activity_id": {
+          "name": "activity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "trip_place_activities_map_trip_place_id_trip_places_id_fk": {
+          "name": "trip_place_activities_map_trip_place_id_trip_places_id_fk",
+          "tableFrom": "trip_place_activities_map",
+          "tableTo": "trip_places",
+          "columnsFrom": [
+            "trip_place_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "trip_place_activities_map_activity_id_activities_id_fk": {
+          "name": "trip_place_activities_map_activity_id_activities_id_fk",
+          "tableFrom": "trip_place_activities_map",
+          "tableTo": "activities",
+          "columnsFrom": [
+            "activity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "trip_place_activities_map_trip_place_id_activity_id_pk": {
+          "columns": [
+            "trip_place_id",
+            "activity_id"
+          ],
+          "name": "trip_place_activities_map_trip_place_id_activity_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "trip_places": {
+      "name": "trip_places",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "trip_id": {
+          "name": "trip_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "city_id": {
+          "name": "city_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "uniq_trip_places_trip_city": {
+          "name": "uniq_trip_places_trip_city",
+          "columns": [
+            "trip_id",
+            "city_id"
+          ],
+          "isUnique": true
+        },
+        "idx_trip_places_trip": {
+          "name": "idx_trip_places_trip",
+          "columns": [
+            "trip_id"
+          ],
+          "isUnique": false
+        },
+        "idx_trip_places_city": {
+          "name": "idx_trip_places_city",
+          "columns": [
+            "city_id"
+          ],
+          "isUnique": false
+        },
+        "trip_places_user_id_idx": {
+          "name": "trip_places_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "trip_places_trip_id_trips_id_fk": {
+          "name": "trip_places_trip_id_trips_id_fk",
+          "tableFrom": "trip_places",
+          "tableTo": "trips",
+          "columnsFrom": [
+            "trip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "trip_places_city_id_cities_id_fk": {
+          "name": "trip_places_city_id_cities_id_fk",
+          "tableFrom": "trip_places",
+          "tableTo": "cities",
+          "columnsFrom": [
+            "city_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "trip_places_user_id_users_id_fk": {
+          "name": "trip_places_user_id_users_id_fk",
+          "tableFrom": "trip_places",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "trips": {
+      "name": "trips",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'planning'"
+        },
+        "photo_album_ref": {
+          "name": "photo_album_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "idx_trips_status": {
+          "name": "idx_trips_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "idx_trips_start_date": {
+          "name": "idx_trips_start_date",
+          "columns": [
+            "start_date"
+          ],
+          "isUnique": false
+        },
+        "idx_trips_end_date": {
+          "name": "idx_trips_end_date",
+          "columns": [
+            "end_date"
+          ],
+          "isUnique": false
+        },
+        "trips_user_id_idx": {
+          "name": "trips_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "trips_user_id_users_id_fk": {
+          "name": "trips_user_id_users_id_fk",
+          "tableFrom": "trips",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "chk_trips_status": {
+          "name": "chk_trips_status",
+          "value": "\"trips\".\"status\" IN ('planning', 'active', 'review_pending', 'locked')"
+        }
+      }
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "clerk_id": {
+          "name": "clerk_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_clerk_id_unique": {
+          "name": "users_clerk_id_unique",
+          "columns": [
+            "clerk_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/src/backend/migrations/meta/_journal.json
+++ b/src/backend/migrations/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1773988784172,
       "tag": "0002_aspiring_killraven",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "6",
+      "when": 1773993747053,
+      "tag": "0003_aromatic_typhoid_mary",
+      "breakpoints": true
     }
   ]
 }

--- a/src/backend/routes/__tests__/cities.carry-forward.test.ts
+++ b/src/backend/routes/__tests__/cities.carry-forward.test.ts
@@ -61,6 +61,13 @@ async function createTestDb() {
       FOREIGN KEY (country_code) REFERENCES countries(country_code),
       FOREIGN KEY (region_id) REFERENCES regions(id)
     )`,
+    `CREATE TABLE IF NOT EXISTS users (
+      id TEXT PRIMARY KEY NOT NULL,
+      clerk_id TEXT NOT NULL UNIQUE,
+      email TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    )`,
     `CREATE TABLE IF NOT EXISTS trips (
       id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
       name TEXT NOT NULL,
@@ -68,8 +75,10 @@ async function createTestDb() {
       end_date TEXT NOT NULL,
       status TEXT DEFAULT 'planning' NOT NULL,
       photo_album_ref TEXT,
+      user_id TEXT,
       created_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')) NOT NULL,
-      updated_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')) NOT NULL
+      updated_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')) NOT NULL,
+      FOREIGN KEY (user_id) REFERENCES users(id)
     )`,
     `CREATE TABLE IF NOT EXISTS trip_categories (
       id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
@@ -117,10 +126,12 @@ async function createTestDb() {
       id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
       trip_id INTEGER NOT NULL,
       city_id INTEGER NOT NULL,
+      user_id TEXT,
       created_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')) NOT NULL,
       updated_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')) NOT NULL,
       FOREIGN KEY (trip_id) REFERENCES trips(id) ON DELETE CASCADE,
-      FOREIGN KEY (city_id) REFERENCES cities(id)
+      FOREIGN KEY (city_id) REFERENCES cities(id),
+      FOREIGN KEY (user_id) REFERENCES users(id)
     )`,
     `CREATE TABLE IF NOT EXISTS trip_place_activities_map (
       trip_place_id INTEGER NOT NULL,
@@ -138,10 +149,12 @@ async function createTestDb() {
       notes TEXT,
       is_carried_forward INTEGER DEFAULT 0 NOT NULL,
       carried_from_item_id INTEGER,
+      user_id TEXT,
       created_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')) NOT NULL,
       updated_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')) NOT NULL,
       FOREIGN KEY (trip_id) REFERENCES trips(id) ON DELETE CASCADE,
-      FOREIGN KEY (trip_place_id) REFERENCES trip_places(id)
+      FOREIGN KEY (trip_place_id) REFERENCES trip_places(id),
+      FOREIGN KEY (user_id) REFERENCES users(id)
     )`,
     `CREATE TABLE IF NOT EXISTS item_flights (
       item_id INTEGER PRIMARY KEY NOT NULL,

--- a/src/backend/routes/__tests__/trips.delete.test.ts
+++ b/src/backend/routes/__tests__/trips.delete.test.ts
@@ -73,6 +73,13 @@ async function createTestDb() {
       FOREIGN KEY (country_code) REFERENCES countries(country_code),
       FOREIGN KEY (region_id) REFERENCES regions(id)
     )`,
+    `CREATE TABLE IF NOT EXISTS users (
+      id TEXT PRIMARY KEY NOT NULL,
+      clerk_id TEXT NOT NULL UNIQUE,
+      email TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    )`,
     `CREATE TABLE IF NOT EXISTS trips (
       id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
       name TEXT NOT NULL,
@@ -80,8 +87,10 @@ async function createTestDb() {
       end_date TEXT NOT NULL,
       status TEXT DEFAULT 'planning' NOT NULL,
       photo_album_ref TEXT,
+      user_id TEXT,
       created_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')) NOT NULL,
-      updated_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')) NOT NULL
+      updated_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')) NOT NULL,
+      FOREIGN KEY (user_id) REFERENCES users(id)
     )`,
     `CREATE TABLE IF NOT EXISTS trip_categories (
       id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
@@ -129,10 +138,12 @@ async function createTestDb() {
       id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
       trip_id INTEGER NOT NULL,
       city_id INTEGER NOT NULL,
+      user_id TEXT,
       created_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')) NOT NULL,
       updated_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')) NOT NULL,
       FOREIGN KEY (trip_id) REFERENCES trips(id) ON DELETE CASCADE,
-      FOREIGN KEY (city_id) REFERENCES cities(id)
+      FOREIGN KEY (city_id) REFERENCES cities(id),
+      FOREIGN KEY (user_id) REFERENCES users(id)
     )`,
     `CREATE TABLE IF NOT EXISTS trip_place_activities_map (
       trip_place_id INTEGER NOT NULL,
@@ -150,10 +161,12 @@ async function createTestDb() {
       notes TEXT,
       is_carried_forward INTEGER DEFAULT 0 NOT NULL,
       carried_from_item_id INTEGER,
+      user_id TEXT,
       created_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')) NOT NULL,
       updated_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')) NOT NULL,
       FOREIGN KEY (trip_id) REFERENCES trips(id) ON DELETE CASCADE,
-      FOREIGN KEY (trip_place_id) REFERENCES trip_places(id)
+      FOREIGN KEY (trip_place_id) REFERENCES trip_places(id),
+      FOREIGN KEY (user_id) REFERENCES users(id)
     )`,
     `CREATE TABLE IF NOT EXISTS item_flights (
       item_id INTEGER PRIMARY KEY NOT NULL,


### PR DESCRIPTION
Part 1 of ADL-18. Adds nullable user_id FK to ownership tables.

## Changes

- `trips.user_id TEXT` — FK → `users.id`, nullable, index `trips_user_id_idx`
- `items.user_id TEXT` — FK → `users.id`, nullable, index `items_user_id_idx`
- `trip_places.user_id TEXT` — FK → `users.id`, nullable, index `trip_places_user_id_idx`
- Migration: `0003_aromatic_typhoid_mary.sql`
- Test DDL updated in `trips.delete.test.ts` and `cities.carry-forward.test.ts` to include `users` table and `user_id` columns

All columns are nullable — existing rows have `user_id = NULL` until a user signs in. The repository layer (ADL-18, separate Backend dispatch) will enforce `WHERE user_id = ?`.

Refs #6
BRD N/A — ADL-16