### PR TITLE
feat: FEAT-BD — multi-select delete UI (#7)

### DIFF
--- a/src/frontend/components/TripList/TripCard.tsx
+++ b/src/frontend/components/TripList/TripCard.tsx
@@ -6,6 +6,9 @@
  * Actions: click to navigate to TripDetail (relative URL for nested route),
  *          Edit button to open edit form.
  * SEC-12: photo_album_ref is handled by sanitiseUrl before rendering.
+ *
+ * FEAT-BD: In selection mode, shows a checkbox. Locked trips cannot be
+ *          selected (checkbox disabled, card visually muted).
  */
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
@@ -20,6 +23,12 @@ interface TripCardProps {
   onEdit: (trip: TripSummary) => void;
   /** Whether this card is the currently selected trip in the two-panel layout. */
   isSelected?: boolean;
+  /** Whether the list is in multi-select delete mode. */
+  selectionMode?: boolean;
+  /** Whether this card is checked in selection mode. */
+  isChecked?: boolean;
+  /** Called when the checkbox state changes. */
+  onCheckChange?: (id: number, checked: boolean) => void;
 }
 
 /** Maximum number of place badges to show before truncating (D-06). */
@@ -32,33 +41,77 @@ const MAX_PLACE_BADGES = 4;
  * @param trip - The trip data to render.
  * @param onEdit - Callback when the Edit button is clicked.
  * @param isSelected - Highlights the card when it is the active trip.
+ * @param selectionMode - When true, shows a checkbox instead of navigation.
+ * @param isChecked - Whether the checkbox is checked.
+ * @param onCheckChange - Callback when checkbox changes.
  */
-export function TripCard({ trip, onEdit, isSelected = false }: TripCardProps) {
+export function TripCard({
+  trip,
+  onEdit,
+  isSelected = false,
+  selectionMode = false,
+  isChecked = false,
+  onCheckChange,
+}: TripCardProps) {
   const navigate = useNavigate();
 
   const places = trip.places ?? [];
   const visiblePlaces = places.slice(0, MAX_PLACE_BADGES);
   const extraCount = places.length - MAX_PLACE_BADGES;
+  const isLocked = trip.status === 'locked';
 
+  // In selection mode, locked trips are visually muted and non-selectable
   const cardClass = [
-    'bg-white border rounded-lg p-3 cursor-pointer transition-shadow hover:shadow-md',
-    isSelected ? 'border-teal-500 ring-1 ring-teal-500' : 'border-gray-200',
-  ].join(' ');
+    'bg-white border rounded-lg p-3 transition-shadow',
+    selectionMode
+      ? isLocked
+        ? 'opacity-50 cursor-default'
+        : 'cursor-pointer hover:shadow-md'
+      : 'cursor-pointer hover:shadow-md',
+    isSelected && !selectionMode ? 'border-teal-500 ring-1 ring-teal-500' : 'border-gray-200',
+    selectionMode && isChecked && !isLocked ? 'border-teal-400 ring-1 ring-teal-400' : '',
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  const handleClick = () => {
+    if (selectionMode) {
+      if (!isLocked && onCheckChange) {
+        onCheckChange(trip.id, !isChecked);
+      }
+      return;
+    }
+    navigate(String(trip.id));
+  };
 
   return (
     <div
       className={cardClass}
-      onClick={() => navigate(String(trip.id))}
+      onClick={handleClick}
       onMouseEnter={(e) => {
-        if (!isSelected) (e.currentTarget as HTMLDivElement).style.boxShadow = '0 4px 12px rgba(0,0,0,0.08)';
+        if (!isSelected && !selectionMode) (e.currentTarget as HTMLDivElement).style.boxShadow = '0 4px 12px rgba(0,0,0,0.08)';
       }}
       onMouseLeave={(e) => {
-        if (!isSelected) (e.currentTarget as HTMLDivElement).style.boxShadow = '';
+        if (!isSelected && !selectionMode) (e.currentTarget as HTMLDivElement).style.boxShadow = '';
       }}
     >
-      {/* Header row: name + status + edit */}
+      {/* Header row: checkbox (selection mode) or name + status + edit */}
       <div className="flex justify-between items-start gap-2">
-        <div className="min-w-0">
+        {selectionMode && (
+          <div className="flex-shrink-0 pt-0.5" onClick={(e) => e.stopPropagation()}>
+            <input
+              type="checkbox"
+              checked={isChecked}
+              disabled={isLocked}
+              onChange={(e) => {
+                if (onCheckChange) onCheckChange(trip.id, e.target.checked);
+              }}
+              aria-label={`Select trip ${trip.name}`}
+              className="h-4 w-4 rounded border-gray-300 text-teal-600 focus:ring-teal-500 disabled:opacity-40"
+            />
+          </div>
+        )}
+        <div className="min-w-0 flex-1">
           <h3 className="text-sm font-semibold text-gray-900 truncate">{trip.name}</h3>
           <p className="text-xs text-gray-500 mt-0.5">
             {formatDate(trip.start_date)} – {formatDate(trip.end_date)}
@@ -98,7 +151,6 @@ export function TripCard({ trip, onEdit, isSelected = false }: TripCardProps) {
           ))}
         </div>
       )}
-
     </div>
   );
 }

--- a/src/frontend/components/TripList/TripsLayout.tsx
+++ b/src/frontend/components/TripList/TripsLayout.tsx
@@ -8,10 +8,15 @@
  *
  * URL-encoded trip selection: navigating to /trips/:id updates the Outlet;
  * back-button and bookmarks work out of the box.
+ *
+ * FEAT-BD: Multi-select delete mode. A "Select" toggle enters selection mode;
+ *          a bulk action bar shows selected count, "Select all", and red "Delete".
+ *          Locked trips cannot be selected. Confirmation via window.confirm before
+ *          sequential DELETE /api/trips/:id calls.
  */
-import React, { useMemo, useState } from 'react';
+import React, { useMemo, useState, useCallback } from 'react';
 import { Outlet, useNavigate, useSearchParams, useParams } from 'react-router-dom';
-import { useTrips, type TripFilters, type TripFormData } from '../../hooks/useTrips';
+import { useTrips, type TripFilters, type TripFormData, useDeleteTrip } from '../../hooks/useTrips';
 import { useActiveCategories, useActiveActivities } from '../../hooks/useAdmin';
 import { TripCard } from './TripCard';
 import { TripForm } from '../TripDetail/TripForm';
@@ -42,6 +47,11 @@ export function TripsLayout() {
   const [searchText, setSearchText] = useState('');
   const [sortBy, setSortBy] = useState<SortOption>('date_desc');
 
+  // FEAT-BD: Multi-select delete state
+  const [selectionMode, setSelectionMode] = useState(false);
+  const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set());
+  const [isDeleting, setIsDeleting] = useState(false);
+
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
   const { id: selectedId } = useParams<{ id?: string }>();
@@ -52,6 +62,7 @@ export function TripsLayout() {
   const cityFilter = searchParams.get('city') ? Number(searchParams.get('city')) : null;
 
   const { data: trips, isLoading, error } = useTrips(filters);
+  const deleteTrip = useDeleteTrip();
 
   const handleEdit = (trip: TripSummary) => {
     setEditingTrip(trip);
@@ -92,6 +103,70 @@ export function TripsLayout() {
 
   const tripCount = displayedTrips.length;
 
+  // FEAT-BD: Selectable trips are those that are not locked
+  const selectableTrips = useMemo(
+    () => displayedTrips.filter((t) => t.status !== 'locked'),
+    [displayedTrips],
+  );
+
+  // FEAT-BD: Enter / exit selection mode
+  const enterSelectionMode = () => {
+    setSelectionMode(true);
+    setSelectedIds(new Set());
+  };
+
+  const exitSelectionMode = () => {
+    setSelectionMode(false);
+    setSelectedIds(new Set());
+  };
+
+  // FEAT-BD: Checkbox toggle handler
+  const handleCheckChange = useCallback((id: number, checked: boolean) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (checked) {
+        next.add(id);
+      } else {
+        next.delete(id);
+      }
+      return next;
+    });
+  }, []);
+
+  // FEAT-BD: Select all (only selectable / non-locked trips)
+  const handleSelectAll = () => {
+    setSelectedIds(new Set(selectableTrips.map((t) => t.id)));
+  };
+
+  // FEAT-BD: Bulk delete
+  const handleBulkDelete = async () => {
+    const count = selectedIds.size;
+    if (count === 0) return;
+
+    const confirmed = window.confirm(
+      `Delete ${count} trip${count === 1 ? '' : 's'}? This cannot be undone.`,
+    );
+    if (!confirmed) return;
+
+    setIsDeleting(true);
+    try {
+      for (const id of selectedIds) {
+        await deleteTrip.mutateAsync(id);
+      }
+      // If the currently viewed trip was deleted, navigate away
+      if (selectedId && selectedIds.has(Number(selectedId))) {
+        navigate('/trips', { replace: true });
+      }
+      exitSelectionMode();
+    } catch (err) {
+      // Partial success is possible — exit selection mode and let list refresh show current state
+      exitSelectionMode();
+      alert(`Some trips could not be deleted: ${err instanceof Error ? err.message : String(err)}`);
+    } finally {
+      setIsDeleting(false);
+    }
+  };
+
   return (
     <div className="flex h-full overflow-hidden">
       {/* Left panel — fixed 360px, scrollable */}
@@ -105,14 +180,61 @@ export function TripsLayout() {
               {tripCount}
             </span>
           </h2>
-          <button
-            type="button"
-            onClick={() => setShowForm(true)}
-            className="px-3 py-1.5 bg-teal-600 text-white text-sm font-semibold rounded-md hover:bg-teal-700 transition-colors"
-          >
-            + New
-          </button>
+          <div className="flex items-center gap-2">
+            {selectionMode ? (
+              <button
+                type="button"
+                onClick={exitSelectionMode}
+                className="px-3 py-1.5 bg-gray-100 text-gray-700 text-sm font-semibold rounded-md hover:bg-gray-200 transition-colors"
+              >
+                Cancel
+              </button>
+            ) : (
+              <>
+                <button
+                  type="button"
+                  onClick={enterSelectionMode}
+                  className="px-3 py-1.5 bg-gray-100 text-gray-700 text-sm font-semibold rounded-md hover:bg-gray-200 transition-colors"
+                >
+                  Select
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setShowForm(true)}
+                  className="px-3 py-1.5 bg-teal-600 text-white text-sm font-semibold rounded-md hover:bg-teal-700 transition-colors"
+                >
+                  + New
+                </button>
+              </>
+            )}
+          </div>
         </div>
+
+        {/* FEAT-BD: Bulk action bar — visible in selection mode */}
+        {selectionMode && (
+          <div className="px-4 pb-2 flex-shrink-0">
+            <div className="flex items-center justify-between bg-gray-50 border border-gray-200 rounded-md px-3 py-2 gap-2">
+              <span className="text-xs text-gray-600 font-medium">
+                {selectedIds.size} selected
+              </span>
+              <button
+                type="button"
+                onClick={handleSelectAll}
+                className="text-xs text-teal-600 hover:text-teal-800 font-medium"
+              >
+                Select all
+              </button>
+              <button
+                type="button"
+                onClick={() => { void handleBulkDelete(); }}
+                disabled={selectedIds.size === 0 || isDeleting}
+                className="px-2.5 py-1 bg-red-600 text-white text-xs font-semibold rounded hover:bg-red-700 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+              >
+                {isDeleting ? 'Deleting…' : 'Delete'}
+              </button>
+            </div>
+          </div>
+        )}
 
         {/* F-06: Search field */}
         <div className="px-4 pb-2 flex-shrink-0">
@@ -203,6 +325,9 @@ export function TripsLayout() {
               trip={trip}
               onEdit={handleEdit}
               isSelected={selectedId === String(trip.id)}
+              selectionMode={selectionMode}
+              isChecked={selectedIds.has(trip.id)}
+              onCheckChange={handleCheckChange}
             />
           ))}
         </div>

--- a/src/frontend/hooks/useTrips.ts
+++ b/src/frontend/hooks/useTrips.ts
@@ -6,7 +6,7 @@
  * directly — always use a hook.
  */
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { apiGet, apiPost, apiPatch } from '../utils/apiClient';
+import { apiGet, apiPost, apiPatch, apiDelete } from '../utils/apiClient';
 import type { TripSummary, TripDetail, TripStatus } from '../types/api';
 
 /** Filters accepted by GET /api/trips */
@@ -150,6 +150,24 @@ export function useUnlockTrip() {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: (id: number) => apiPatch<TripSummary>(`/api/trips/${id}/unlock`, {}),
+    onSuccess: (_result, id) => {
+      void qc.invalidateQueries({ queryKey: ['trips'] });
+      void qc.invalidateQueries({ queryKey: ['trips', id] });
+      void qc.invalidateQueries({ queryKey: ['map', 'shading'] });
+    },
+  });
+}
+
+/**
+ * Deletes a trip via DELETE /api/trips/:id.
+ * On success, invalidates trips list and map shading queries.
+ *
+ * @returns useMutation result. Call mutateAsync(id) to delete.
+ */
+export function useDeleteTrip() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (id: number) => apiDelete(`/api/trips/${id}`),
     onSuccess: (_result, id) => {
       void qc.invalidateQueries({ queryKey: ['trips'] });
       void qc.invalidateQueries({ queryKey: ['trips', id] });


### PR DESCRIPTION
Closes #7

BRD §5.1 — bulk delete trips from list.

## Summary
- Adds a "Select" toggle button to the trips left-panel header that enters multi-select mode; a "Cancel" button returns to normal mode
- Each TripCard gains a checkbox in selection mode; locked trips show a disabled, muted checkbox
- A bulk action bar appears above the list showing selected count, "Select all" link, and a red "Delete" button (disabled when 0 selected)
- On Delete: `window.confirm` confirmation, then sequential `DELETE /api/trips/:id` calls; list refetches and selection mode exits on completion

## Changes
- `hooks/useTrips.ts` — new `useDeleteTrip` hook using the existing `apiDelete` util
- `TripCard.tsx` — new props: `selectionMode`, `isChecked`, `onCheckChange`; locked trips are opacity-50 and non-selectable
- `TripsLayout.tsx` — owns all selection state; no backend files modified

## Test plan
- [ ] `npm run type:check` — passes
- [ ] `npm run test:frontend` — all 55 tests pass
- [ ] In-browser: click "Select", check a non-locked trip, click "Delete", confirm → trip removed from list
- [ ] Locked trips: checkbox is disabled in selection mode
- [ ] "Select all" selects all non-locked trips in the current filtered view
- [ ] Cancelling confirmation leaves selection unchanged
- [ ] If the currently viewed trip is deleted, view navigates away to /trips

🤖 Generated with [Claude Code](https://claude.com/claude-code)