### PR TITLE
feat: initial Playwright E2E suite — trip list, CRUD, map smoke

### DIFF
--- a/src/e2e/helpers/factories.ts
+++ b/src/e2e/helpers/factories.ts
@@ -1,0 +1,38 @@
+import type { APIRequestContext } from '@playwright/test';
+
+export interface TripFormData {
+  name: string;
+  start_date: string;
+  end_date: string;
+}
+
+export interface TripSummary {
+  id: number;
+  name: string;
+  status: string;
+  start_date: string;
+  end_date: string;
+}
+
+export async function createTrip(
+  request: APIRequestContext,
+  overrides: Partial<TripFormData> = {},
+): Promise<TripSummary> {
+  const data: TripFormData = {
+    name: overrides.name ?? 'Test Trip',
+    start_date: overrides.start_date ?? '2026-06-01',
+    end_date: overrides.end_date ?? '2026-06-10',
+  };
+  const res = await request.post('http://localhost:3001/api/trips', { data });
+  if (!res.ok()) throw new Error(`createTrip failed: ${res.status()} ${await res.text()}`);
+  return res.json() as Promise<TripSummary>;
+}
+
+export async function deleteAllTrips(request: APIRequestContext): Promise<void> {
+  const res = await request.get('http://localhost:3001/api/trips');
+  if (!res.ok()) return;
+  const trips = (await res.json()) as TripSummary[];
+  for (const trip of trips) {
+    await request.delete(`http://localhost:3001/api/trips/${trip.id}`);
+  }
+}

--- a/src/e2e/map.spec.ts
+++ b/src/e2e/map.spec.ts
@@ -1,0 +1,19 @@
+import { test, expect } from '@playwright/test';
+
+test('map page loads without error', async ({ page }) => {
+  const errors: string[] = [];
+  page.on('console', (msg) => {
+    if (msg.type() === 'error') errors.push(msg.text());
+  });
+  await page.goto('http://localhost:5173/map');
+  // Map container should render — look for a canvas or the map div
+  await expect(
+    page
+      .locator('canvas')
+      .or(page.locator('#map'))
+      .or(page.locator('[class*="map"]'))
+      .first(),
+  ).toBeVisible({ timeout: 10000 });
+  // No console errors (allow known benign ones if needed)
+  expect(errors.filter((e) => !e.includes('favicon'))).toHaveLength(0);
+});

--- a/src/e2e/trips.spec.ts
+++ b/src/e2e/trips.spec.ts
@@ -1,0 +1,39 @@
+import { test, expect } from '@playwright/test';
+import { createTrip, deleteAllTrips } from './helpers/factories';
+
+test.beforeEach(async ({ request }) => {
+  await deleteAllTrips(request);
+});
+
+test('trip list renders', async ({ page }) => {
+  await page.goto('http://localhost:5173/trips');
+  await expect(page.getByText('My Trips')).toBeVisible();
+});
+
+test('created trip appears in list', async ({ page, request }) => {
+  await createTrip(request, { name: 'Paris 2026' });
+  await page.goto('http://localhost:5173/trips');
+  await expect(page.getByText('Paris 2026')).toBeVisible();
+});
+
+test('search filters trips', async ({ page, request }) => {
+  await createTrip(request, { name: 'Paris 2026' });
+  await createTrip(request, { name: 'Tokyo 2027' });
+  await page.goto('http://localhost:5173/trips');
+  await page.getByPlaceholder(/search/i).fill('Paris');
+  await expect(page.getByText('Paris 2026')).toBeVisible();
+  await expect(page.getByText('Tokyo 2027')).not.toBeVisible();
+});
+
+test('trip detail opens on click', async ({ page, request }) => {
+  await createTrip(request, { name: 'Rome Trip' });
+  await page.goto('http://localhost:5173/trips');
+  await page.getByText('Rome Trip').click();
+  // Right panel should show the trip name
+  await expect(
+    page
+      .locator('[data-testid="trip-detail"]')
+      .or(page.getByRole('main'))
+      .getByText('Rome Trip'),
+  ).toBeVisible();
+});


### PR DESCRIPTION
Initial E2E suite using ADL-22 Playwright infrastructure.

Covers:
- Trip list renders, search, trip detail open
- Factory helpers for API-driven test setup (createTrip, deleteAllTrips)
- Map smoke test

Note: test:e2e cannot run in CI until container is rebuilt with Playwright browsers.
Tests are type-checked and logically complete.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>