### PR TITLE
fix(deps): migrate @clerk/clerk-react → @clerk/react (#44)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "hasInstallScript": true,
       "dependencies": {
-        "@clerk/clerk-react": "^5.61.3",
+        "@clerk/react": "^5.54.0",
         "@libsql/client": "^0.14.0",
         "@tanstack/react-query": "^5.90.21",
         "cors": "^2.8.6",
@@ -464,28 +464,27 @@
         "specificity": "bin/cli.js"
       }
     },
-    "node_modules/@clerk/clerk-react": {
-      "version": "5.61.3",
-      "resolved": "https://registry.npmjs.org/@clerk/clerk-react/-/clerk-react-5.61.3.tgz",
-      "integrity": "sha512-W21aNEeHtqh3xJLuW5g2ydben/1D5pSnxsl/kCnv0IY1zma7lO+aIJ7Br2bR4FKKkiu695mPnjtY+fvkQmCXBg==",
-      "deprecated": "This package is no longer supported. Please use @clerk/react instead. See the upgrade guide for more info: https://clerk.com/docs/guides/development/upgrading/upgrade-guides/core-3",
+    "node_modules/@clerk/react": {
+      "version": "5.54.0",
+      "resolved": "https://registry.npmjs.org/@clerk/react/-/react-5.54.0.tgz",
+      "integrity": "sha512-Le6F2a3jF0dlFU1w7MI53bvrvOTWp+8Tp85OkVIjws0bym3UvvXZFhbcI9Kk6rF4Xwd/qpZe9dJP70WlaB4TOQ==",
       "license": "MIT",
       "dependencies": {
-        "@clerk/shared": "^3.47.2",
+        "@clerk/shared": "^3.33.0",
         "tslib": "2.8.1"
       },
       "engines": {
-        "node": ">=18.17.0"
+        "node": ">=20.9.0"
       },
       "peerDependencies": {
-        "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0",
-        "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0"
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-0",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-0"
       }
     },
     "node_modules/@clerk/shared": {
-      "version": "3.47.2",
-      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-3.47.2.tgz",
-      "integrity": "sha512-dwUT27DKq3Gr9vn9lAfc/LSe79P1rKIib8/mTWA7ZEzY7XX2Yq5UnDMCMznYrI8oVLdJrCT4ypFXRgnH306Oew==",
+      "version": "3.47.3",
+      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-3.47.3.tgz",
+      "integrity": "sha512-jG0wMIZuuc8zaKieg9Os8ocTphG+llluRukUUdyVnu4+ZI1syVf+dkpDP3ZK69yLavTX3D0KAmkmQqTPzQV/Nw==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "test:e2e:clean": "rm -f ./e2e.db"
   },
   "dependencies": {
-    "@clerk/clerk-react": "^5.61.3",
+    "@clerk/react": "^5.54.0",
     "@libsql/client": "^0.14.0",
     "@tanstack/react-query": "^5.90.21",
     "cors": "^2.8.6",

--- a/src/frontend/App.tsx
+++ b/src/frontend/App.tsx
@@ -11,7 +11,7 @@
  */
 import React from 'react';
 import { Routes, Route, NavLink, Navigate } from 'react-router-dom';
-import { UserButton } from '@clerk/clerk-react';
+import { UserButton } from '@clerk/react';
 import { MapPage } from './pages/MapPage';
 import { TripDetailPage } from './pages/TripDetailPage';
 import { AdminPage } from './pages/AdminPage';

--- a/src/frontend/main.tsx
+++ b/src/frontend/main.tsx
@@ -12,7 +12,7 @@ import React from 'react';
 import { createRoot } from 'react-dom/client';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { BrowserRouter } from 'react-router-dom';
-import { ClerkProvider, SignedIn, SignedOut, RedirectToSignIn, useAuth } from '@clerk/clerk-react';
+import { ClerkProvider, SignedIn, SignedOut, RedirectToSignIn, useAuth } from '@clerk/react';
 import { App } from './App';
 import { setTokenGetter } from './utils/apiClient';
 import './index.css';


### PR DESCRIPTION
## Summary

- Removes the deprecated `@clerk/clerk-react` package and replaces it with `@clerk/react`
- Updates import paths in `src/frontend/main.tsx` and `src/frontend/App.tsx`
- Eliminates the deprecation warning shown on container rebuild

Closes #44

## Version note

`@clerk/react` v6 (the `latest` tag) **does not export** `SignedIn`, `SignedOut`, or `RedirectToSignIn`. These components were moved or renamed in v6. To preserve the existing component usage without any behavioural change, this PR installs `@clerk/react@^5.54.0` — the v5 release of the renamed package — which is API-identical to `@clerk/clerk-react@^5`.

If a future PR upgrades to `@clerk/react` v6, the gating components in `main.tsx` will need to be updated to the v6 equivalents (e.g. `ClerkLoaded`/`ClerkLoading`).

## Test plan

- [x] `npm run type:check` — passes
- [x] `npm run test:frontend` — 55 tests pass
- [x] `npm run test:backend` — 186 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)