### PR TITLE
fix(backend): resolve remaining 43 TypeScript errors

### DIFF
--- a/src/backend/middleware/__tests__/auth.test.ts
+++ b/src/backend/middleware/__tests__/auth.test.ts
@@ -117,7 +117,8 @@ describe('requireAuth middleware', () => {
   it('attaches req.user and calls next() on a valid token', async () => {
     vi.mocked(jwtVerify).mockResolvedValueOnce({
       payload: { sub: 'user_clerk123', email: 'test@example.com' },
-    } as Awaited<ReturnType<typeof jwtVerify>>);
+      protectedHeader: { alg: 'RS256' },
+    } as unknown as Awaited<ReturnType<typeof jwtVerify>>);
 
     vi.mocked(userRepository.findOrCreateByClerkId).mockResolvedValueOnce({
       id: 'internal-uuid-456',
@@ -149,7 +150,8 @@ describe('requireAuth middleware', () => {
   it('returns 401 when userRepository throws', async () => {
     vi.mocked(jwtVerify).mockResolvedValueOnce({
       payload: { sub: 'user_clerk123', email: 'test@example.com' },
-    } as Awaited<ReturnType<typeof jwtVerify>>);
+      protectedHeader: { alg: 'RS256' },
+    } as unknown as Awaited<ReturnType<typeof jwtVerify>>);
 
     vi.mocked(userRepository.findOrCreateByClerkId).mockRejectedValueOnce(
       new Error('DB error'),

--- a/src/backend/routes/admin.ts
+++ b/src/backend/routes/admin.ts
@@ -95,7 +95,7 @@ function createAdminListRouter(table: AdminTable, resourceName: string): Router 
     '/:id',
     validateBody(UpdateAdminItemSchema),
     asyncHandler(async (req, res) => {
-      const id = parseInt(req.params.id, 10);
+      const id = parseInt(String(req.params.id), 10);
       if (isNaN(id)) throw new NotFoundError(resourceName);
 
       const db = getDb();
@@ -121,7 +121,7 @@ function createAdminListRouter(table: AdminTable, resourceName: string): Router 
   router.delete(
     '/:id',
     asyncHandler(async (req, res) => {
-      const id = parseInt(req.params.id, 10);
+      const id = parseInt(String(req.params.id), 10);
       if (isNaN(id)) throw new NotFoundError(resourceName);
 
       const db = getDb();
@@ -175,7 +175,7 @@ adminRouter.patch(
   '/countries/:countryCode',
   validateBody(UpdateCountrySchema),
   asyncHandler(async (req, res) => {
-    const countryCode = req.params.countryCode.toUpperCase();
+    const countryCode = String(req.params.countryCode).toUpperCase();
     const db = getDb();
 
     const existing = await db
@@ -217,7 +217,7 @@ adminRouter.patch(
 adminRouter.get(
   '/countries/:countryCode/regions',
   asyncHandler(async (req, res) => {
-    const countryCode = req.params.countryCode.toUpperCase();
+    const countryCode = String(req.params.countryCode).toUpperCase();
     const db = getDb();
 
     const rows = await db
@@ -243,7 +243,7 @@ adminRouter.post(
   '/countries/:countryCode/regions',
   validateBody(CreateRegionSchema),
   asyncHandler(async (req, res) => {
-    const countryCode = req.params.countryCode.toUpperCase();
+    const countryCode = String(req.params.countryCode).toUpperCase();
     const db = getDb();
 
     const countryRow = await db
@@ -257,11 +257,11 @@ adminRouter.post(
       throw new ValidationError('Country does not have region tier enabled');
     }
 
-    const { name } = req.body;
+    const { name, iso3166_2 } = req.body;
     const now = new Date().toISOString();
     const inserted = await db
       .insert(regions)
-      .values({ countryCode, name, createdAt: now, updatedAt: now })
+      .values({ countryCode, name, iso3166_2, createdAt: now, updatedAt: now })
       .returning();
 
     const r = inserted[0];
@@ -280,8 +280,8 @@ adminRouter.patch(
   '/countries/:countryCode/regions/:regionId',
   validateBody(UpdateRegionSchema),
   asyncHandler(async (req, res) => {
-    const countryCode = req.params.countryCode.toUpperCase();
-    const regionId = parseInt(req.params.regionId, 10);
+    const countryCode = String(req.params.countryCode).toUpperCase();
+    const regionId = parseInt(String(req.params.regionId), 10);
     if (isNaN(regionId)) throw new NotFoundError('Region');
 
     const db = getDb();

--- a/src/backend/routes/cities.ts
+++ b/src/backend/routes/cities.ts
@@ -146,7 +146,7 @@ citiesRouter.patch(
   '/:id',
   validateBody(PatchCitySchema),
   asyncHandler(async (req, res) => {
-    const cityId = parseInt(req.params.id, 10);
+    const cityId = parseInt(String(req.params.id), 10);
     if (isNaN(cityId)) throw new NotFoundError('City');
 
     const db = getDb();
@@ -199,7 +199,7 @@ citiesRouter.patch(
 citiesRouter.get(
   '/:id/carry-forward',
   asyncHandler(async (req, res) => {
-    const cityId = parseInt(req.params.id, 10);
+    const cityId = parseInt(String(req.params.id), 10);
     if (isNaN(cityId)) throw new NotFoundError('City');
 
     const db = getDb();
@@ -254,7 +254,7 @@ citiesRouter.get(
   '/:id/items',
   validateQuery(CityItemsQuerySchema),
   asyncHandler(async (req, res) => {
-    const cityId = parseInt(req.params.id, 10);
+    const cityId = parseInt(String(req.params.id), 10);
     if (isNaN(cityId)) throw new NotFoundError('City');
 
     const userId = req.user!.id;

--- a/src/backend/routes/items.ts
+++ b/src/backend/routes/items.ts
@@ -32,7 +32,7 @@ itemsRouter.get(
   validateQuery(ListItemsQuerySchema),
   asyncHandler(async (req, res) => {
     const userId = req.user!.id;
-    const tripId = parseInt(req.params.tripId, 10);
+    const tripId = parseInt(String(req.params.tripId), 10);
     if (isNaN(tripId)) throw new NotFoundError('Trip');
 
     const { place_id, type, status } = req.query as {
@@ -54,7 +54,7 @@ itemsRouter.post(
   validateBody(CreateItemSchema),
   asyncHandler(async (req, res) => {
     const userId = req.user!.id;
-    const tripId = parseInt(req.params.tripId, 10);
+    const tripId = parseInt(String(req.params.tripId), 10);
     if (isNaN(tripId)) throw new NotFoundError('Trip');
 
     await assertNotLocked(tripId);
@@ -95,8 +95,8 @@ itemsRouter.patch(
   validateBody(UpdateItemSchema),
   asyncHandler(async (req, res) => {
     const userId = req.user!.id;
-    const tripId = parseInt(req.params.tripId, 10);
-    const itemId = parseInt(req.params.itemId, 10);
+    const tripId = parseInt(String(req.params.tripId), 10);
+    const itemId = parseInt(String(req.params.itemId), 10);
     if (isNaN(tripId) || isNaN(itemId)) throw new NotFoundError('Item');
 
     await assertNotLocked(tripId);
@@ -129,8 +129,8 @@ itemsRouter.delete(
   '/:itemId',
   asyncHandler(async (req, res) => {
     const userId = req.user!.id;
-    const tripId = parseInt(req.params.tripId, 10);
-    const itemId = parseInt(req.params.itemId, 10);
+    const tripId = parseInt(String(req.params.tripId), 10);
+    const itemId = parseInt(String(req.params.itemId), 10);
     if (isNaN(tripId) || isNaN(itemId)) throw new NotFoundError('Item');
 
     await assertNotLocked(tripId);

--- a/src/backend/routes/map.ts
+++ b/src/backend/routes/map.ts
@@ -62,7 +62,7 @@ mapRouter.patch(
   '/shading/config/:stateKey',
   validateBody(UpdateShadingConfigSchema),
   asyncHandler(async (req, res) => {
-    const { stateKey } = req.params;
+    const stateKey = String(req.params.stateKey);
     const db = getDb();
 
     const existing = await db
@@ -104,7 +104,7 @@ mapRouter.patch(
 mapRouter.get(
   '/shading/countries/:countryCode',
   asyncHandler(async (req, res) => {
-    const countryCode = req.params.countryCode.toUpperCase();
+    const countryCode = String(req.params.countryCode).toUpperCase();
     const db = getDb();
 
     const countryRow = await db
@@ -145,7 +145,7 @@ mapRouter.get(
 mapRouter.get(
   '/shading/regions/:countryCode',
   asyncHandler(async (req, res) => {
-    const countryCode = req.params.countryCode.toUpperCase();
+    const countryCode = String(req.params.countryCode).toUpperCase();
     const db = getDb();
 
     const countryRow = await db

--- a/src/backend/routes/places.ts
+++ b/src/backend/routes/places.ts
@@ -37,7 +37,7 @@ placesRouter.get(
   '/',
   asyncHandler(async (req, res) => {
     const userId = req.user!.id;
-    const tripId = parseInt(req.params.tripId, 10);
+    const tripId = parseInt(String(req.params.tripId), 10);
     if (isNaN(tripId)) throw new NotFoundError('Trip');
 
     const result = await placeRepository.findByTrip(userId, tripId);
@@ -62,7 +62,7 @@ placesRouter.post(
   validateBody(CreatePlaceSchema),
   asyncHandler(async (req, res) => {
     const userId = req.user!.id;
-    const tripId = parseInt(req.params.tripId, 10);
+    const tripId = parseInt(String(req.params.tripId), 10);
     if (isNaN(tripId)) throw new NotFoundError('Trip');
 
     const { city_id } = req.body;
@@ -101,8 +101,8 @@ placesRouter.delete(
   '/:placeId',
   asyncHandler(async (req, res) => {
     const userId = req.user!.id;
-    const tripId = parseInt(req.params.tripId, 10);
-    const placeId = parseInt(req.params.placeId, 10);
+    const tripId = parseInt(String(req.params.tripId), 10);
+    const placeId = parseInt(String(req.params.placeId), 10);
     if (isNaN(tripId) || isNaN(placeId)) throw new NotFoundError('Place');
 
     const deleted = await placeRepository.delete(userId, tripId, placeId);
@@ -120,8 +120,8 @@ placesRouter.post(
   validateBody(CarryForwardBodySchema),
   asyncHandler(async (req, res) => {
     const userId = req.user!.id;
-    const tripId = parseInt(req.params.tripId, 10);
-    const placeId = parseInt(req.params.placeId, 10);
+    const tripId = parseInt(String(req.params.tripId), 10);
+    const placeId = parseInt(String(req.params.placeId), 10);
     if (isNaN(tripId) || isNaN(placeId)) throw new NotFoundError('Place');
 
     const db = getDb();
@@ -176,8 +176,8 @@ placesRouter.post(
   validateBody(AddPlaceActivitySchema),
   asyncHandler(async (req, res) => {
     const userId = req.user!.id;
-    const tripId = parseInt(req.params.tripId, 10);
-    const placeId = parseInt(req.params.placeId, 10);
+    const tripId = parseInt(String(req.params.tripId), 10);
+    const placeId = parseInt(String(req.params.placeId), 10);
     if (isNaN(tripId) || isNaN(placeId)) throw new NotFoundError('Place');
 
     const { activity_id } = req.body;
@@ -213,8 +213,8 @@ placesRouter.delete(
   '/:placeId/activities/:activityId',
   asyncHandler(async (req, res) => {
     const userId = req.user!.id;
-    const placeId = parseInt(req.params.placeId, 10);
-    const activityId = parseInt(req.params.activityId, 10);
+    const placeId = parseInt(String(req.params.placeId), 10);
+    const activityId = parseInt(String(req.params.activityId), 10);
     if (isNaN(placeId) || isNaN(activityId)) throw new NotFoundError('Activity');
 
     // SEC-03: verify the place belongs to the requesting user before deleting

--- a/src/backend/routes/trip-countries.ts
+++ b/src/backend/routes/trip-countries.ts
@@ -26,7 +26,7 @@ router.post(
   validateBody(AddCountriesSchema),
   asyncHandler(async (req, res) => {
     const userId = req.user!.id;
-    const tripId = parseInt(req.params.tripId, 10);
+    const tripId = parseInt(String(req.params.tripId), 10);
     const { country_codes } = req.body;
     const trip = await tripRepository.findByIdOrThrow(userId, tripId);
     if (trip.status === 'locked') throw new LockError();
@@ -40,8 +40,8 @@ router.delete(
   '/:code',
   asyncHandler(async (req, res) => {
     const userId = req.user!.id;
-    const tripId = parseInt(req.params.tripId, 10);
-    const { code } = req.params;
+    const tripId = parseInt(String(req.params.tripId), 10);
+    const code = String(req.params.code);
     const trip = await tripRepository.findByIdOrThrow(userId, tripId);
     if (trip.status === 'locked') throw new LockError();
     const removed = await tripRepository.removeCountry(tripId, code);

--- a/src/backend/routes/trips.ts
+++ b/src/backend/routes/trips.ts
@@ -156,7 +156,7 @@ tripsRouter.get(
   '/:id',
   asyncHandler(async (req, res) => {
     const userId = req.user!.id;
-    const tripId = parseInt(req.params.id, 10);
+    const tripId = parseInt(String(req.params.id), 10);
     if (isNaN(tripId)) throw new NotFoundError('Trip');
 
     const trip = await tripRepository.findByIdOrThrow(userId, tripId);
@@ -241,7 +241,7 @@ tripsRouter.patch(
   validateBody(UpdateTripSchema),
   asyncHandler(async (req, res) => {
     const userId = req.user!.id;
-    const tripId = parseInt(req.params.id, 10);
+    const tripId = parseInt(String(req.params.id), 10);
     if (isNaN(tripId)) throw new NotFoundError('Trip');
 
     const trip = await tripRepository.findByIdOrThrow(userId, tripId);
@@ -282,7 +282,7 @@ tripsRouter.patch(
   validateBody(UpdateTripStatusSchema),
   asyncHandler(async (req, res) => {
     const userId = req.user!.id;
-    const tripId = parseInt(req.params.id, 10);
+    const tripId = parseInt(String(req.params.id), 10);
     if (isNaN(tripId)) throw new NotFoundError('Trip');
 
     const trip = await tripRepository.findByIdOrThrow(userId, tripId);
@@ -303,7 +303,7 @@ tripsRouter.patch(
   '/:id/lock',
   asyncHandler(async (req, res) => {
     const userId = req.user!.id;
-    const tripId = parseInt(req.params.id, 10);
+    const tripId = parseInt(String(req.params.id), 10);
     if (isNaN(tripId)) throw new NotFoundError('Trip');
 
     const trip = await tripRepository.findByIdOrThrow(userId, tripId);
@@ -326,7 +326,7 @@ tripsRouter.patch(
   '/:id/unlock',
   asyncHandler(async (req, res) => {
     const userId = req.user!.id;
-    const tripId = parseInt(req.params.id, 10);
+    const tripId = parseInt(String(req.params.id), 10);
     if (isNaN(tripId)) throw new NotFoundError('Trip');
 
     const trip = await tripRepository.findByIdOrThrow(userId, tripId);

--- a/src/backend/validation/admin.schemas.ts
+++ b/src/backend/validation/admin.schemas.ts
@@ -25,7 +25,12 @@ export const UpdateCountrySchema = z
   .strict();
 
 /** Schema for POST /api/admin/countries/:countryCode/regions */
-export const CreateRegionSchema = z.object({ name: zName }).strict();
+export const CreateRegionSchema = z
+  .object({
+    name: zName,
+    iso3166_2: z.string().trim().min(1),
+  })
+  .strict();
 
 /** Schema for PATCH /api/admin/countries/:countryCode/regions/:regionId */
 export const UpdateRegionSchema = z.object({ name: zName }).strict();

--- a/src/backend/validation/trips.schemas.ts
+++ b/src/backend/validation/trips.schemas.ts
@@ -9,7 +9,11 @@ import { zName, zIsoDate, zTripStatus, zOptionalString } from './common.js';
 /** Shared date range refinement — end_date must be >= start_date */
 const withDateRefinement = <T extends z.ZodTypeAny>(schema: T) =>
   (schema as unknown as z.ZodObject<{ start_date: z.ZodTypeAny; end_date: z.ZodTypeAny }>).refine(
-    (data) => data.end_date >= data.start_date,
+    (data: { start_date: unknown; end_date: unknown }) => {
+      const start = data.start_date as string;
+      const end = data.end_date as string;
+      return end >= start;
+    },
     { message: 'end_date must be on or after start_date', path: ['end_date'] },
   );
 


### PR DESCRIPTION
## Summary

- **`req.params` coercion (TS2345/TS2339):** `ParamsDictionary` is typed as `string | string[]`. Wrapped all `req.params.*` accesses in `String()` at the handler boundary in `admin.ts`, `cities.ts`, `items.ts`, `map.ts`, `places.ts`, `trip-countries.ts`, and `trips.ts`.
- **Auth test mocks (TS2352):** Added `protectedHeader: { alg: 'RS256' }` to the two `jwtVerify` mock objects and switched to an `unknown`-first double-cast to satisfy `JWTVerifyResult & ResolvedKey`.
- **Validation schema (TS18046):** Added an explicit typed parameter `(data: { start_date: unknown; end_date: unknown })` in `trips.schemas.ts`'s `withDateRefinement` callback to narrow `unknown`.
- **Admin regions insert (TS2769):** The `regions` table has `iso3166_2` as `notNull`, but the `POST /regions` handler and `CreateRegionSchema` omitted it. Added `iso3166_2` to both the Zod schema and the `db.insert().values()` call.

## Test plan

- [x] `npm run type:check:backend` — exits 0 (zero errors)
- [x] `npm run test:backend` — 186/186 tests pass
- [ ] CI passes on GitHub Actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)