### PR TITLE
fix(tsconfig): convert root to project references container

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,20 +1,7 @@
 {
-  "compilerOptions": {
-    "target": "ES2022",
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
-    "lib": ["ES2022"],
-    "outDir": "./dist",
-    "rootDir": "./src",
-    "strict": true,
-    "esModuleInterop": true,
-    "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true,
-    "resolveJsonModule": true,
-    "declaration": true,
-    "declarationMap": true,
-    "sourceMap": true
-  },
-  "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "files": [],
+  "references": [
+    { "path": "./tsconfig.frontend.json" },
+    { "path": "./tsconfig.backend.json" }
+  ]
 }


### PR DESCRIPTION
## Summary

- Root `tsconfig.json` was sweeping in `src/**/*` without JSX settings, causing IDE errors on `.tsx` files
- Replaced with a project references container (`files: []`) pointing to `tsconfig.frontend.json` and `tsconfig.backend.json`
- IDE now routes each file to the correct config automatically
- `type:check:all` unaffected — scripts call sub-configs directly

## Test plan
- [x] `npm run type:check:all` — PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)