### PR TITLE
chore(Gate 1.5-A): add BYPASS_AUTH prod guard

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,6 +31,11 @@ ALLOWED_ORIGINS=http://localhost:5173,http://localhost:3001
 # Node environment
 NODE_ENV=development
 
+# ⚠️  SECURITY — DO NOT SET IN PRODUCTION
+# Disables JWT authentication entirely. Only for contract tests and CI.
+# The server will throw a fatal error if this is set in NODE_ENV=production.
+# BYPASS_AUTH=true
+
 # Frontend API base URL (used by Vite build)
 VITE_API_BASE_URL=http://localhost:3001
 

--- a/src/backend/server.ts
+++ b/src/backend/server.ts
@@ -156,6 +156,19 @@ app.use(errorHandler);
 async function startup(): Promise<void> {
   console.info('[STARTUP] Travel Tracker API starting...');
 
+  // 0. Guard: BYPASS_AUTH must never be set outside test/CI environments.
+  if (process.env.BYPASS_AUTH === 'true') {
+    if (process.env.NODE_ENV === 'production') {
+      throw new Error(
+        'BYPASS_AUTH=true is not allowed in production. Remove it from your environment and restart.',
+      );
+    }
+    console.warn(
+      '[SECURITY WARNING] BYPASS_AUTH=true — JWT authentication is DISABLED. ' +
+        'This must only be used in test/CI environments. Never set this in production.',
+    );
+  }
+
   // 1. Verify DB connection
   const db = getDb();
   console.info('[STARTUP] Database connection: OK');


### PR DESCRIPTION
Adds a fatal error guard in server startup: if `BYPASS_AUTH=true` is set in `NODE_ENV=production`, the server throws and refuses to start. In any other environment a loud `console.warn` fires to remind developers this is a test-only escape hatch.

Also adds `BYPASS_AUTH` to `.env.example` with a security warning comment.

## Changes
- `src/backend/server.ts` — guard added at top of `startup()`, before any seeding
- `.env.example` — `BYPASS_AUTH` documented as commented-out with warning

## Test plan
- [ ] All existing backend tests pass (186/186)
- [ ] Type check clean
- [ ] Biome clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)