### PR TITLE
fix(BUG-18,19,20): P3 code quality tidy-up

### DIFF
--- a/src/backend/middleware/auth.ts
+++ b/src/backend/middleware/auth.ts
@@ -101,9 +101,3 @@ export async function requireAuth(req: Request, res: Response, next: NextFunctio
     res.status(401).json({ error: 'Unauthorized' });
   }
 }
-
-/**
- * @deprecated Phase 1 passthrough alias — kept for backward compatibility during
- * transition. server.ts has been updated to use requireAuth directly.
- */
-export const authenticate = requireAuth;

--- a/src/frontend/components/TripDetail/TripDetail.tsx
+++ b/src/frontend/components/TripDetail/TripDetail.tsx
@@ -11,7 +11,7 @@
  *
  * Locked trips show a read-only banner and hide all write controls.
  */
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
 import { useLockTrip, useUnlockTrip, useUpdateTripStatus } from '../../hooks/useTrips';
 import type { TripDetail as TripDetailType, TripStatus } from '../../types/api';
 import { formatDate } from '../../utils/formatDate';
@@ -61,6 +61,9 @@ export function TripDetail({ trip }: TripDetailProps) {
   const isLocked = trip.status === 'locked';
   const statusError = updateStatus.error ?? lockTrip.error ?? unlockTrip.error;
   const isPending = updateStatus.isPending || lockTrip.isPending || unlockTrip.isPending;
+
+  // BUG-18: memoised so AddPlaceFlow's useEffect dep on onClose is stable
+  const handleAddPlaceClose = useCallback(() => setShowAddPlace(false), []);
 
   const nextStep = NEXT_STATUS[trip.status];
 
@@ -251,7 +254,7 @@ export function TripDetail({ trip }: TripDetailProps) {
 
       {/* Modals */}
       {showEdit && <TripForm existingTrip={trip} onClose={() => setShowEdit(false)} />}
-      {showAddPlace && <AddPlaceFlow tripId={trip.id} onClose={() => setShowAddPlace(false)} />}
+      {showAddPlace && <AddPlaceFlow tripId={trip.id} onClose={handleAddPlaceClose} />}
 
       <ConfirmDialog
         isOpen={confirmLock}

--- a/src/frontend/components/TripList/TripsLayout.tsx
+++ b/src/frontend/components/TripList/TripsLayout.tsx
@@ -49,6 +49,7 @@ export function TripsLayout() {
   const [selectionMode, setSelectionMode] = useState(false);
   const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set());
   const [isDeleting, setIsDeleting] = useState(false);
+  const [deleteError, setDeleteError] = useState<Error | null>(null);
   const [pendingDelete, setPendingDelete] = useState<{
     ids: Set<number>;
     timer: ReturnType<typeof setTimeout>;
@@ -170,9 +171,7 @@ export function TripsLayout() {
             navigate('/trips', { replace: true });
           }
         } catch (err) {
-          alert(
-            `Some trips could not be deleted: ${err instanceof Error ? err.message : String(err)}`,
-          );
+          setDeleteError(err instanceof Error ? err : new Error(String(err)));
         } finally {
           setIsDeleting(false);
           setPendingDelete(null);
@@ -350,6 +349,7 @@ export function TripsLayout() {
         <div className="flex-1 overflow-y-auto px-4 pb-4 flex flex-col gap-2">
           {isLoading && <LoadingSpinner message="Loading trips…" />}
           {error && <ErrorMessage error={error} />}
+          {deleteError && <ErrorMessage error={deleteError} />}
 
           {!isLoading && !error && displayedTrips.length === 0 && (
             <p className="text-gray-500 text-center py-10 text-sm">


### PR DESCRIPTION
Closes #56
Closes #57
Closes #58

## Summary

- **BUG-19**: Remove deprecated `authenticate` export alias from `auth.ts` — confirmed no production code imports it (only test mock objects reference it by name, which is unaffected by removing the export)
- **BUG-20**: Replace browser `alert()` in bulk-delete error handler with `setDeleteError` state rendered via `<ErrorMessage>`, matching the UI error pattern used elsewhere in the component
- **BUG-18**: Wrap `onClose` passed to `<AddPlaceFlow>` in `useCallback` so the `useEffect` dependency in AddPlaceFlow is stable and does not re-run on every parent render

## Test plan
- [ ] `npm run check` passes (Biome lint + format)
- [ ] `npm run type:check:all` passes
- [ ] `npm run test:backend` passes (186 tests)
- [ ] `npm run test:frontend` passes (61 tests)
- [ ] CI green