### PR TITLE
feat(MAP-01): region-aware map click filtering (#52)

### DIFF
--- a/src/backend/repositories/trips.ts
+++ b/src/backend/repositories/trips.ts
@@ -14,6 +14,7 @@ import {
   companions,
   countries,
   getDb,
+  regions,
   tripActivitiesMap,
   tripCategories,
   tripCategoriesMap,
@@ -294,6 +295,7 @@ export const tripRepository = {
         cityCountryCode: cities.countryCode,
         cityCountryName: countries.name,
         cityRegionId: cities.regionId,
+        cityRegionIso: regions.iso3166_2,
         cityLatitude: cities.latitude,
         cityLongitude: cities.longitude,
         cityGeocodeStatus: cities.geocodeStatus,
@@ -301,6 +303,7 @@ export const tripRepository = {
       .from(tripPlaces)
       .leftJoin(cities, eq(cities.id, tripPlaces.cityId))
       .leftJoin(countries, eq(countries.countryCode, cities.countryCode))
+      .leftJoin(regions, eq(regions.id, cities.regionId))
       .where(eq(tripPlaces.tripId, tripId));
   },
 

--- a/src/backend/routes/trips.ts
+++ b/src/backend/routes/trips.ts
@@ -81,6 +81,7 @@ async function buildTripResponse(trip: {
       name: p.cityName,
       country_code: p.cityCountryCode,
       region_id: p.cityRegionId,
+      region_iso: p.cityRegionIso ?? null,
       latitude: p.cityLatitude,
       longitude: p.cityLongitude,
       geocode_status: p.cityGeocodeStatus,

--- a/src/frontend/components/PostTripReview/__tests__/ReviewPanel.test.tsx
+++ b/src/frontend/components/PostTripReview/__tests__/ReviewPanel.test.tsx
@@ -114,6 +114,7 @@ function makePlace(items: Item[], overrides: Partial<TripPlace> = {}): TripPlace
       country_code: 'JP',
       country_name: 'Japan',
       region_id: null,
+      region_iso: null,
       latitude: null,
       longitude: null,
       geocode_status: 'pending' as const,

--- a/src/frontend/components/TripList/TripList.tsx
+++ b/src/frontend/components/TripList/TripList.tsx
@@ -22,14 +22,16 @@ export function filterAndSortTrips(
   searchText: string,
   sortBy: SortOption,
   countryFilter: string | null,
-  _regionFilter: string | null,
+  regionFilter: string | null,
   cityFilter: number | null,
 ): TripSummary[] {
   let result = trips;
 
-  // Map filter: city takes priority, then country (_regionFilter not yet implemented)
+  // Map filter priority: city > region > country
   if (cityFilter !== null) {
     result = result.filter((t) => t.places.some((p) => p.city_id === cityFilter));
+  } else if (regionFilter !== null) {
+    result = result.filter((t) => t.places.some((p) => p.city.region_iso === regionFilter));
   } else if (countryFilter !== null) {
     result = result.filter((t) => t.places.some((p) => p.city.country_code === countryFilter));
   }

--- a/src/frontend/components/TripList/__tests__/filterAndSortTrips.test.ts
+++ b/src/frontend/components/TripList/__tests__/filterAndSortTrips.test.ts
@@ -12,7 +12,12 @@ function makeTrip(
   id: number,
   name: string,
   start_date: string,
-  places: Array<{ city_id: number; country_code: string; city_name?: string }> = [],
+  places: Array<{
+    city_id: number;
+    country_code: string;
+    city_name?: string;
+    region_iso?: string | null;
+  }> = [],
 ): TripSummary {
   return {
     id,
@@ -36,6 +41,7 @@ function makeTrip(
         country_code: p.country_code,
         country_name: null,
         region_id: null,
+        region_iso: p.region_iso ?? null,
         latitude: null,
         longitude: null,
         geocode_status: 'resolved',
@@ -187,5 +193,60 @@ describe('filterAndSortTrips — city-name search (TR-13)', () => {
     const result = filterAndSortTrips(tripsWithCityNames, 'Spring', 'date_desc', null, null, null);
     expect(result).toHaveLength(1);
     expect(result[0].id).toBe(10);
+  });
+});
+
+describe('filterAndSortTrips — region filter (MAP-01)', () => {
+  const tripsWithRegions: TripSummary[] = [
+    makeTrip(20, 'California Dreaming', '2024-05-01', [
+      { city_id: 200, country_code: 'US', region_iso: 'US-CA' },
+    ]),
+    makeTrip(21, 'New York State of Mind', '2024-06-01', [
+      { city_id: 201, country_code: 'US', region_iso: 'US-NY' },
+    ]),
+    makeTrip(22, 'Texas Trip', '2024-07-01', [
+      { city_id: 202, country_code: 'US', region_iso: 'US-TX' },
+    ]),
+    makeTrip(23, 'No Region City', '2024-08-01', [
+      { city_id: 203, country_code: 'FR', region_iso: null },
+    ]),
+  ];
+
+  it('returns trips with matching region_iso', () => {
+    const result = filterAndSortTrips(tripsWithRegions, '', 'date_desc', null, 'US-CA', null);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe(20);
+  });
+
+  it('does not return trips without matching region_iso', () => {
+    const result = filterAndSortTrips(tripsWithRegions, '', 'date_desc', null, 'US-CA', null);
+    const ids = result.map((t) => t.id);
+    expect(ids).not.toContain(21);
+    expect(ids).not.toContain(22);
+    expect(ids).not.toContain(23);
+  });
+
+  it('region filter takes priority over country filter when both present', () => {
+    // All trips are US but only US-NY should match when region filter is set
+    const result = filterAndSortTrips(tripsWithRegions, '', 'date_desc', 'US', 'US-NY', null);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe(21);
+  });
+
+  it('city filter takes priority over region filter when both present', () => {
+    // city 202 is US-TX but city filter should win
+    const result = filterAndSortTrips(tripsWithRegions, '', 'date_desc', null, 'US-CA', 202);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe(22);
+  });
+
+  it('returns empty array when region filter matches no trips', () => {
+    const result = filterAndSortTrips(tripsWithRegions, '', 'date_desc', null, 'US-WA', null);
+    expect(result).toHaveLength(0);
+  });
+
+  it('does not match trips where city region_iso is null', () => {
+    const result = filterAndSortTrips(tripsWithRegions, '', 'date_desc', null, 'US-CA', null);
+    expect(result.map((t) => t.id)).not.toContain(23);
   });
 });

--- a/src/frontend/types/api.ts
+++ b/src/frontend/types/api.ts
@@ -100,6 +100,7 @@ export interface City {
   /** Full country name — present in trip detail responses (DP-04). Null for list/map endpoints. */
   country_name: string | null;
   region_id: number | null;
+  region_iso: string | null;
   latitude: number | null;
   longitude: number | null;
   geocode_status: GeocodeStatus;


### PR DESCRIPTION
Closes #52
BRD: MAP-01 / ADL-26

## Summary

- Backend (`trips.ts` repository): adds LEFT JOIN to the `regions` table in `getPlaces()`, exposing `cityRegionIso` in the result set
- Backend (`routes/trips.ts`): serialises `region_iso` into the `buildTripResponse` summary city object (`null` when the city has no region)
- Frontend (`api.ts`): adds `region_iso: string | null` to the `City` interface
- Frontend (`TripList.tsx`): implements the `regionFilter` parameter (drops the `_` stub prefix) with filter priority `city > region > country` per ADL-26 Decision 3
- Tests (`filterAndSortTrips.test.ts`): extends `makeTrip` helper with `region_iso` and adds 6 new region-filter test cases
- Tests (`ReviewPanel.test.tsx`): adds `region_iso: null` to satisfy the updated `City` type

## Verification

- `npm run check` — pass
- `npm run type:check:all` — pass
- `npm run test:backend` — 342/342 pass
- `npm run test:frontend` — 78/78 pass (72 existing + 6 new)