### PR TITLE
feat(UX-04): auto-populate region in AddPlaceFlow from Nominatim

### DIFF
--- a/src/backend/routes/admin.ts
+++ b/src/backend/routes/admin.ts
@@ -229,6 +229,7 @@ adminRouter.get(
         id: r.id,
         country_code: r.countryCode,
         name: r.name,
+        iso_3166_2: r.iso3166_2,
         created_at: r.createdAt,
         updated_at: r.updatedAt,
       })),

--- a/src/frontend/components/TripDetail/AddPlaceFlow.tsx
+++ b/src/frontend/components/TripDetail/AddPlaceFlow.tsx
@@ -43,6 +43,7 @@ export function AddPlaceFlow({ tripId, onClose }: AddPlaceFlowProps) {
   const [newCityName, setNewCityName] = useState('');
   const [newCityCountryCode, setNewCityCountryCode] = useState('');
   const [newCityRegionId, setNewCityRegionId] = useState<number | null>(null);
+  const [autoRegionIso, setAutoRegionIso] = useState<string | null>(null);
   const [countryLookupPending, setCountryLookupPending] = useState(false);
   const [addedPlaceId, setAddedPlaceId] = useState<number | null>(null);
   const [addedCityId, setAddedCityId] = useState<number | null>(null);
@@ -152,18 +153,27 @@ export function AddPlaceFlow({ tripId, onClose }: AddPlaceFlowProps) {
     }
   };
 
+  // UX-04: auto-select region once both ISO code and regions list are available
+  useEffect(() => {
+    if (!autoRegionIso || !countryRegions.length) return;
+    const match = countryRegions.find((r) => r.iso_3166_2 === autoRegionIso);
+    if (match) setNewCityRegionId(match.id);
+  }, [autoRegionIso, countryRegions]);
+
   /** Opens the new-city form and fires a background Nominatim lookup to
-   *  auto-populate the country field (GE-15). */
+   *  auto-populate the country and region fields (GE-15, UX-04). */
   const handleOpenNewCityForm = (cityName: string) => {
     setShowNewCityForm(true);
     setNewCityName(cityName);
     setNewCityCountryCode('');
     setNewCityRegionId(null);
+    setAutoRegionIso(null);
     if (cityName.trim().length >= 2) {
       setCountryLookupPending(true);
       lookupCityCountry(cityName.trim())
-        .then((code) => {
-          if (code) setNewCityCountryCode(code);
+        .then(({ countryCode, regionIso }) => {
+          if (countryCode) setNewCityCountryCode(countryCode);
+          if (regionIso) setAutoRegionIso(regionIso);
           setCountryLookupPending(false);
         })
         .catch(() => setCountryLookupPending(false));
@@ -337,6 +347,7 @@ export function AddPlaceFlow({ tripId, onClose }: AddPlaceFlowProps) {
                 onChange={(e) => {
                   setNewCityCountryCode(e.target.value);
                   setNewCityRegionId(null);
+                  setAutoRegionIso(null);
                 }}
                 required
               >

--- a/src/frontend/hooks/useCities.ts
+++ b/src/frontend/hooks/useCities.ts
@@ -18,21 +18,24 @@ const NOMINATIM_USER_AGENT = 'TravelTracker/1.0 (personal-use-app)';
 interface NominatimResult {
   address?: {
     country_code?: string;
+    'ISO3166-2-lvl4'?: string;
   };
 }
 
 /**
  * Looks up a city name via Nominatim and returns the ISO 3166-1 alpha-2
- * country code (upper-cased) if found, or null otherwise.
+ * country code (upper-cased) and ISO 3166-2 subdivision code if found.
  *
- * Used by AddPlaceFlow to auto-populate the country field (GE-15).
+ * Used by AddPlaceFlow to auto-populate the country and region fields (GE-15, UX-04).
  * Fire-and-forget style — errors are silently swallowed so the user
- * can still select the country manually if lookup fails.
+ * can still select the country/region manually if lookup fails.
  *
  * @param cityName - The city name to look up.
- * @returns Upper-cased country code (e.g. "FR") or null.
+ * @returns Object with upper-cased country code (e.g. "FR") and region ISO (e.g. "US-CA"), both nullable.
  */
-export async function lookupCityCountry(cityName: string): Promise<string | null> {
+export async function lookupCityCountry(
+  cityName: string,
+): Promise<{ countryCode: string | null; regionIso: string | null }> {
   try {
     const params = new URLSearchParams({
       q: cityName,
@@ -43,12 +46,15 @@ export async function lookupCityCountry(cityName: string): Promise<string | null
     const resp = await fetch(`${NOMINATIM_BASE}?${params}`, {
       headers: { 'User-Agent': NOMINATIM_USER_AGENT },
     });
-    if (!resp.ok) return null;
+    if (!resp.ok) return { countryCode: null, regionIso: null };
     const data = (await resp.json()) as NominatimResult[];
-    const code = data[0]?.address?.country_code;
-    return code ? code.toUpperCase() : null;
+    const item = data[0];
+    return {
+      countryCode: item?.address?.country_code?.toUpperCase() ?? null,
+      regionIso: item?.address?.['ISO3166-2-lvl4'] ?? null,
+    };
   } catch {
-    return null;
+    return { countryCode: null, regionIso: null };
   }
 }
 

--- a/src/frontend/types/api.ts
+++ b/src/frontend/types/api.ts
@@ -69,6 +69,7 @@ export interface Region {
   id: number;
   country_code: string;
   name: string;
+  iso_3166_2: string;
   created_at: string;
   updated_at: string;
 }


### PR DESCRIPTION
Extends Nominatim lookup to also return ISO3166-2 code and auto-select region dropdown when creating a new city.

No BRD ref — PO direction 2026-03-23.

## Changes
- `src/backend/routes/admin.ts` — `GET /api/admin/countries/:countryCode/regions` now includes `iso_3166_2` in each region row
- `src/frontend/types/api.ts` — `Region` interface gains `iso_3166_2: string`
- `src/frontend/hooks/useCities.ts` — `lookupCityCountry` now returns `{ countryCode, regionIso }` instead of a bare string; `NominatimResult` captures `ISO3166-2-lvl4`
- `src/frontend/components/TripDetail/AddPlaceFlow.tsx` — stores `autoRegionIso` from lookup; `useEffect` auto-selects matching region once regions list loads; resets on country change and form open

## Graceful degradation
- No `ISO3166-2-lvl4` from Nominatim → `regionIso` is null, user picks manually
- ISO code present but no matching DB region → no auto-select, user picks manually
- Region dropdown remains visible and editable — auto-populate is a convenience only