### PR TITLE
fix: log 4xx as warn, 5xx as error in error handler

### DIFF
--- a/src/backend/middleware/error-handler.ts
+++ b/src/backend/middleware/error-handler.ts
@@ -27,8 +27,13 @@ export function errorHandler(
 ): void {
   const statusCode = err.statusCode ?? 500;
 
-  // Log full error server-side (SEC-08: never log req/res body)
-  console.error('[ERROR]', req.method, req.path, statusCode, err.message, err.stack);
+  // Log full error server-side (SEC-08: never log req/res body).
+  // 4xx = expected client/application errors → warn. 5xx = unexpected → error.
+  if (statusCode < 500) {
+    console.warn('[WARN]', req.method, req.path, statusCode, err.message);
+  } else {
+    console.error('[ERROR]', req.method, req.path, statusCode, err.message, err.stack);
+  }
 
   // Return sanitised error to client — never expose stack traces
   if (statusCode < 500) {


### PR DESCRIPTION
## Problem

`console.error('[ERROR]', ...)` was used for ALL errors including expected 4xx responses like `NotFoundError`. This generated misleading `[ERROR]` log lines for normal application flows — e.g. the geocode retry queue's 404-based stale-entry cleanup, which is working as designed.

## Fix

Split logging by status code: 4xx → `console.warn('[WARN]')`, 5xx → `console.error('[ERROR]')` with stack trace.

Stack traces are still included for 5xx (unexpected server errors). 4xx logs are concise — message only, no stack trace needed since these are known application errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)