### PR TITLE
fix(MAP-01): lower region zoom threshold + improve contrast

### DIFF
--- a/src/frontend/components/Map/MapView.tsx
+++ b/src/frontend/components/Map/MapView.tsx
@@ -24,7 +24,7 @@ const MAPTILER_KEY = import.meta.env.VITE_MAPTILER_KEY as string;
 const MAP_STYLE = `https://api.maptiler.com/maps/streets-v2/style.json?key=${MAPTILER_KEY}`;
 
 /** Minimum zoom level at which region shading is loaded. */
-const REGION_ZOOM_THRESHOLD = 4;
+const REGION_ZOOM_THRESHOLD = 3;
 
 interface MapViewProps {
   /** All loaded trips — city pins are derived from their places. */

--- a/src/frontend/components/Map/RegionLayer.tsx
+++ b/src/frontend/components/Map/RegionLayer.tsx
@@ -1,7 +1,7 @@
 /**
  * RegionLayer — MapLibre fill layer for region-level shading.
  *
- * Loaded lazily when map zoom >= 4. Uses the 40 MB regions GeoJSON served
+ * Loaded lazily when map zoom >= 3. Uses the 40 MB regions GeoJSON served
  * at /geo/regions.json. Feature matching uses the iso_3166_2 property
  * (e.g. 'US-CA' for California).
  *
@@ -31,7 +31,12 @@ const regionFillLayer: FillLayerSpecification = {
       ['feature-state', 'colorHex'],
       'transparent',
     ],
-    'fill-opacity': 0.6,
+    // Higher opacity than the country layer (0.7) so visited regions visibly
+    // stand out even when using the same colour — stacking creates contrast.
+    'fill-opacity': 0.9,
+    // Always draw region boundaries when this layer is active, giving a clear
+    // state/province grid regardless of visit status.
+    'fill-outline-color': '#64748B',
   },
 };
 


### PR DESCRIPTION
## Changes

**Zoom threshold:** `REGION_ZOOM_THRESHOLD` 4 → 3. Regions now appear when a country fills the viewport, not after a deeper zoom.

**Contrast:** Region `fill-opacity` was 0.6 — lower than the country layer at 0.7, making visited regions nearly invisible when using the same colour. Raised to 0.9. Since the region layer renders on top, visited regions now appear visibly darker/more saturated via opacity stacking, even with identical colour values.

**Outlines:** Added `fill-outline-color: '#64748B'` so state/province boundary lines are always drawn when the layer is active — makes the region grid visible regardless of visit status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)