### PR TITLE
chore: update README and CLAUDE.md to current state

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,9 +144,20 @@ what this step misses — if startup reads are consistently clean, the verificat
 is working. Repeated gaps signal that more work should move to dedicated sessions.
 
 ## Key files
-- `src/backend/server.ts` — Express app entry point
-- `src/backend/db/schema.ts` — Drizzle schema
+- `src/backend/server.ts` — Express app entry point, startup sequence, middleware
+- `src/backend/db/schema.ts` — Drizzle schema (single source of truth for all tables)
+- `src/backend/db/index.ts` — DB connection + table exports
+- `src/backend/routes/` — Express routers (trips, places, cities, map, admin)
+- `src/backend/repositories/` — User-scoped DB queries (ADL-18)
+- `src/backend/services/shading.service.ts` — Map shading state computation
+- `src/backend/migrations/` — Drizzle migration SQL files (0000–0005)
 - `src/frontend/main.tsx` — React entry point
-- `drizzle.config.ts` — DB config
-- `.github/workflows/` — CI/CD pipelines
+- `src/frontend/components/Map/` — MapLibre map, country + region shading layers
+- `src/frontend/components/TripDetail/AddPlaceFlow.tsx` — Add place modal (city search, create, carry-forward)
+- `src/frontend/hooks/` — TanStack Query hooks for all API resources
+- `src/frontend/services/geocodeRetryQueue.ts` — NR-06 offline geocoding retry
+- `_project/tracker.json` — Feature/bug tracker (COO-maintained)
+- `_project/travel-tracker-BRD.md` — Business requirements document (v2.6)
+- `drizzle.config.ts` — Drizzle + DB config
+- `.github/workflows/` — CI (type check, tests) + security (audit, Gitleaks, Semgrep)
 - `patches/drizzle-kit+0.31.9.patch` — drizzle-kit SQLite bug fixes (patch-package)

--- a/README.md
+++ b/README.md
@@ -1,36 +1,63 @@
 # Travel Tracker
 
-A personal travel tracking desktop app. Log trips, places, and items (restaurants, hotels, flights, experiences, and more), and view your travel history on an interactive world map with country and region shading.
+A personal travel tracking app. Log trips, places, and items (restaurants, hotels, flights, experiences, and more), and view your travel history on an interactive world map with country and region shading.
+
+---
+
+## Tech stack
+
+| Layer | Technology |
+|-------|-----------|
+| Frontend | React 18, Vite, Tailwind CSS, TanStack Query v5 |
+| Map | MapLibre GL JS via react-map-gl |
+| Backend | Node.js, Express, TypeScript |
+| ORM | Drizzle ORM |
+| Database | SQLite via @libsql/client (PostgreSQL-ready — config change only) |
+| Auth | Clerk (BYPASS_AUTH=true available for local dev) |
+| Geocoding | OpenStreetMap Nominatim (queued and retried when offline) |
+| Map data | Natural Earth GeoJSON (bundled — no internet required for boundaries) |
+| Linting | Biome |
 
 ---
 
 ## Setup
 
-**Prerequisites:** Node.js 18+, npm
+**Prerequisites:** Node.js 22+, npm
 
 ```bash
 npm ci
 ```
 
-> **Important:** Always run `npm ci` inside the environment where you will run the app. If you cloned the repo on macOS and are running in a Linux devcontainer (or vice versa), run `npm ci` again inside the container so native binaries (esbuild, libsql) match the platform.
+> **Platform note:** If you cloned on macOS and are running inside a Linux devcontainer (or vice versa), run `npm ci` again inside the container so native binaries (esbuild, libsql) match the platform.
 
-### Database initialisation (first run)
+### Environment variables
+
+Copy `.env.example` to `.env.local` and fill in the values:
 
 ```bash
-npm run db:push    # Apply schema to a fresh SQLite file
-npm run db:seed    # Populate default data (countries, shading config, etc.)
+cp .env.example .env.local
 ```
 
-The database file path is set via `.env.local`:
+| Variable | Required | Notes |
+|----------|----------|-------|
+| `SQLITE_PATH` | Yes | e.g. `file:./dev.db` |
+| `VITE_MAPTILER_KEY` | Yes | Free key at [maptiler.com](https://www.maptiler.com/) |
+| `BYPASS_AUTH` | Dev only | Set to `true` to skip Clerk auth locally |
+| `CLERK_PUBLISHABLE_KEY` | Production | Clerk dashboard |
+| `CLERK_SECRET_KEY` | Production | Clerk dashboard |
 
-```
-DB_TYPE=sqlite
-SQLITE_PATH=./data/travel-tracker.db
+### Database (first run)
+
+Apply migrations and start the backend — seeding runs automatically on first startup:
+
+```bash
+npm run db:migrate   # apply all pending migrations
+npm run dev:api      # backend starts and seeds countries, regions, and defaults
 ```
 
 ---
 
-## Running the app (beta — localhost in browser)
+## Running
 
 Open two terminals:
 
@@ -42,46 +69,37 @@ npm run dev:api    # → http://localhost:3001
 npm run dev        # → http://localhost:5173
 ```
 
-Open `http://localhost:5173` in your browser.
-
----
-
-## Data storage — important constraints
-
-Travel Tracker stores all data in a **local SQLite file** (`.db`). This has two implications you should be aware of before use:
-
-### OneDrive / cloud sync
-
-The database file **can** be placed inside an OneDrive-synced folder for personal backup and to access your data across your own devices. However:
-
-- **Only one device should have the app running at a time.** SQLite does not support concurrent write access from multiple machines. If two devices write simultaneously via a synced folder, the database will corrupt.
-- OneDrive sync is for **backup and single-user roaming** only — not real-time multi-device sync.
-- Before opening the app on a second device, ensure OneDrive has fully synced the latest database file from the first device, and that the first device is not actively running the app.
-
-### Multi-user access
-
-Multi-user access (trip companions, shared trips) is out of scope for this version. The app is designed for a single owner. A future hosted version will support multi-user access with proper concurrency controls.
+Open `http://localhost:5173`.
 
 ---
 
 ## Testing
 
 ```bash
-npm run test:backend        # Backend unit tests
-npm run test:frontend       # Frontend unit tests
-npm run test:contract       # Contract tests (requires backend running on :3001)
-npm run type:check          # TypeScript type check (frontend)
+npm run check              # Biome lint + format
+npm run type:check:all     # TypeScript (frontend + backend)
+npm run test:backend       # Backend unit tests (Vitest)
+npm run test:frontend      # Frontend unit tests (Vitest)
+npm run test:contract      # Contract tests (requires backend running on :3001)
 ```
 
 ---
 
-## Tech stack
+## Schema changes
 
-| Layer | Technology |
-|-------|-----------|
-| Frontend | React 18, Vite, TanStack Query v5, MapLibre GL JS |
-| Backend | Node.js, Express, TypeScript |
-| ORM | Drizzle ORM |
-| Database | SQLite via @libsql/client (PostgreSQL-ready — config change only) |
-| Map data | Natural Earth GeoJSON (bundled — no internet required for boundaries) |
-| Geocoding | OpenStreetMap Nominatim (online; queued and retried offline) |
+**Never use `db:push`.** Always use the migration workflow:
+
+```bash
+npm run db:generate   # generate a new migration SQL file from schema changes
+npm run db:migrate    # apply pending migrations
+```
+
+`db:push` is disabled. See `patches/drizzle-kit+0.31.9.patch` for context.
+
+---
+
+## Data storage
+
+All data is stored in a local SQLite file. The path is set by `SQLITE_PATH` in `.env.local`.
+
+**OneDrive / cloud sync:** The database file can live inside a synced folder for personal backup, but only one device should run the app at a time. SQLite does not support concurrent writes from multiple machines via a synced folder.


### PR DESCRIPTION
## README
- Removes `db:push` (forbidden) and `db:seed` (non-existent)
- Correct first-run flow: `db:migrate` then start backend (auto-seeds)
- All env vars documented (SQLITE_PATH, VITE_MAPTILER_KEY, BYPASS_AUTH, Clerk)
- Updated tech stack: Tailwind CSS, Clerk, Biome
- Correct test commands including `npm run check`

## CLAUDE.md
- Expanded key files section with routes, repositories, services, map components, hooks, tracker, BRD

🤖 Generated with [Claude Code](https://claude.com/claude-code)