### PR TITLE
chore: run type:check:all in CI (#77)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
           node-version: "22"
           cache: "npm"
       - run: npm ci
-      - run: npm run type:check
+      - run: npm run type:check:all
 
   test-backend:
     name: Backend Tests


### PR DESCRIPTION
## Summary

- CI typecheck job was running `npm run type:check` (frontend tsconfig only) — backend TypeScript was never verified in CI
- Fixed to `npm run type:check:all`, consistent with the pre-push checklist in CLAUDE.md

## Test plan

- [x] `npm run check` — clean
- [x] `npm run type:check:all` — clean (confirms the fix works and backend is currently clean)
- [x] `npm run test:backend` — 355 passed
- [x] `npm run test:frontend` — 78 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)