### PR TITLE
chore(hc01): allow Clerk JWKS domain in devcontainer firewall

### DIFF
--- a/.devcontainer/init-firewall.sh
+++ b/.devcontainer/init-firewall.sh
@@ -72,7 +72,8 @@ for domain in \
     "statsig.com" \
     "marketplace.visualstudio.com" \
     "vscode.blob.core.windows.net" \
-    "update.code.visualstudio.com"; do
+    "update.code.visualstudio.com" \
+    "just-raptor-89.clerk.accounts.dev"; do
     echo "Resolving $domain..."
     ips=$(dig +noall +answer A "$domain" | awk '$4 == "A" {print $5}')
     if [ -z "$ips" ]; then


### PR DESCRIPTION
## Summary

- Adds `just-raptor-89.clerk.accounts.dev` to the allowed domains loop in `.devcontainer/init-firewall.sh` so the backend can reach the Clerk JWKS endpoint for JWT verification in local dev
- Removes `BYPASS_AUTH=true` from `.env.local` so real Clerk JWT validation is active in the devcontainer
- `BYPASS_AUTH` remains documented (commented out) in `.env.example` for CI/agent use

Addresses: NR-14 / HC-01 / OP-06

> **Note:** HC-01 does NOT close on this change alone — closure requires PO end-to-end UAT as documented in `jobs/architect/tech/OP-06-hardening-checklist.md`.

## Test plan
- [ ] Verify `.devcontainer/init-firewall.sh` includes `just-raptor-89.clerk.accounts.dev` in the allowed domains loop
- [ ] Verify `.env.local` no longer contains `BYPASS_AUTH=true`
- [ ] Verify `.env.example` still has `BYPASS_AUTH` documented (commented out)
- [ ] PO UAT: rebuild devcontainer, confirm Clerk JWKS endpoint is reachable and JWT auth works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)