### PR TITLE
chore(hc07b): null userId audit and backfill script

### DIFF
--- a/jobs/COO/inbox/20260323_2400-BACKEND-hc07b-complete.md
+++ b/jobs/COO/inbox/20260323_2400-BACKEND-hc07b-complete.md
@@ -1,0 +1,62 @@
+# HC-07b — Null userId Audit and Backfill — Completion Report
+
+**Date:** 2026-03-23
+**Agent:** Backend
+**Task:** HC-07b — Null userId audit and backfill (OP-06 / NR-14)
+
+---
+
+## Audit Results (Before Backfill)
+
+| Table | null_count |
+|---|---|
+| trips | 0 |
+| trip_places | 0 |
+| items | 0 |
+
+All counts were zero — the dev database has no null-owned records.
+
+## Backfill Status
+
+**Backfill was not needed.** All three tables already have no null user_id rows.
+The single user record in dev.db uses a test user (`clerk_id = test_clerk_id`,
+internal UUID `test-user-00000000-0000-0000-0000-000000000000`).
+
+## OWNER_CLERK_ID Status
+
+`OWNER_CLERK_ID` is **not set** in `.env.local`. The file contains Clerk API keys
+(`CLERK_SECRET_KEY`, `VITE_CLERK_PUBLISHABLE_KEY`) but no explicit `OWNER_CLERK_ID`
+variable. Since all null counts are already zero, this did not block the task.
+
+For future environments where null records exist, `OWNER_CLERK_ID` must be set
+in `.env.local` before running the backfill. The SQL script at
+`jobs/architect/tech/HC-07b-backfill.sql` documents the steps.
+
+## Post-Backfill Verification
+
+Not applicable — no backfill was run. The audit query returned all zeros.
+
+## Deliverable
+
+SQL script written at: `jobs/architect/tech/HC-07b-backfill.sql`
+
+The script includes:
+- Step 1: Audit query (count nulls in all three tables)
+- Step 2: Owner UUID lookup by clerk_id
+- Step 3: Backfill UPDATE statements for trips, trip_places, items
+- Step 4: Post-backfill verification query
+
+## PR Information
+
+- Branch: `chore/hc07b-null-userid-backfill`
+- PR: TBD (see below)
+- CI status: Pending push
+
+## Pre-push Check Results
+
+| Check | Result |
+|---|---|
+| `npm run check` (Biome) | PASS |
+| `npm run type:check:all` | PASS |
+| `npm run test:backend` (355 tests) | PASS |
+| `npm run test:frontend` (78 tests) | PASS |

--- a/jobs/architect/tech/HC-07b-backfill.sql
+++ b/jobs/architect/tech/HC-07b-backfill.sql
@@ -1,0 +1,84 @@
+-- HC-07b — Null userId Audit and Backfill
+-- OP-06 Security Hardening Checklist, NR-14 pre-condition
+-- Author: Backend agent
+-- Date: 2026-03-23
+--
+-- Context:
+--   The trips, trip_places, and items tables have nullable user_id columns.
+--   This is a pre-auth migration artifact (ADL-16: NULL = no owner yet).
+--   Before HC-03 (map shading scoped to a user) can be enabled, any
+--   null-owned records must be backfilled to the owner's UUID. Otherwise,
+--   the owner's pre-auth trips will disappear from their map when shading
+--   is scoped.
+--
+-- Usage:
+--   Replace <OWNER_CLERK_ID> with the value of OWNER_CLERK_ID from .env.local.
+--   Run against the target database (dev.db for development, or the hosted
+--   LibSQL/SQLite database for production).
+--
+--   Example (sqlite3 CLI):
+--     sqlite3 dev.db < HC-07b-backfill.sql
+--
+--   Or pipe with substitution:
+--     CLERK_ID="user_abc123"
+--     sqlite3 dev.db "$(sed "s/<OWNER_CLERK_ID>/$CLERK_ID/g" HC-07b-backfill.sql)"
+
+-- ============================================================
+-- STEP 1 — AUDIT: Count null user_id rows before backfill
+-- ============================================================
+-- All three counts should be 0 if the system was always auth-gated.
+-- Any non-zero count indicates pre-auth records that need backfilling.
+
+SELECT 'trips' AS tbl, COUNT(*) AS null_count FROM trips WHERE user_id IS NULL
+UNION ALL
+SELECT 'trip_places', COUNT(*) FROM trip_places WHERE user_id IS NULL
+UNION ALL
+SELECT 'items', COUNT(*) FROM items WHERE user_id IS NULL;
+
+-- ============================================================
+-- STEP 2 — IDENTIFY OWNER: Look up internal UUID from Clerk ID
+-- ============================================================
+-- The OWNER_CLERK_ID is the `sub` claim value from the owner's Clerk JWT.
+-- It is stored in .env.local as OWNER_CLERK_ID.
+-- The internal users.id (UUID v4) is the authoritative application principal.
+-- All ownership columns reference users.id, never the Clerk ID directly.
+
+SELECT id AS owner_uuid
+FROM users
+WHERE clerk_id = '<OWNER_CLERK_ID>';
+
+-- ============================================================
+-- STEP 3 — BACKFILL: Assign null-owned rows to the owner
+-- ============================================================
+-- Only run these statements if Step 1 returned non-zero counts.
+-- These use a correlated subquery so the OWNER_CLERK_ID substitution
+-- remains the only change needed across all three statements.
+
+UPDATE trips
+SET user_id = (SELECT id FROM users WHERE clerk_id = '<OWNER_CLERK_ID>')
+WHERE user_id IS NULL;
+
+UPDATE trip_places
+SET user_id = (SELECT id FROM users WHERE clerk_id = '<OWNER_CLERK_ID>')
+WHERE user_id IS NULL;
+
+UPDATE items
+SET user_id = (SELECT id FROM users WHERE clerk_id = '<OWNER_CLERK_ID>')
+WHERE user_id IS NULL;
+
+-- ============================================================
+-- STEP 4 — VERIFY: All counts must be 0 after backfill
+-- ============================================================
+-- Re-run the same audit query. If any count is non-zero, the backfill
+-- did not complete successfully — investigate before proceeding.
+
+SELECT 'trips' AS tbl, COUNT(*) AS null_count FROM trips WHERE user_id IS NULL
+UNION ALL
+SELECT 'trip_places', COUNT(*) FROM trip_places WHERE user_id IS NULL
+UNION ALL
+SELECT 'items', COUNT(*) FROM items WHERE user_id IS NULL;
+
+-- Expected result:
+-- trips       | 0
+-- trip_places | 0
+-- items       | 0


### PR DESCRIPTION
## Summary

- Runs HC-07b audit of `trips`, `trip_places`, and `items` tables for null `user_id` records
- All counts were zero in dev.db — no backfill was needed
- Provides documented SQL script for environments where pre-auth records exist
- Documents OWNER_CLERK_ID status (not set in `.env.local`; not needed since counts are 0)

## References

- NR-14 — security gate pre-condition
- HC-07b — OP-06 hardening checklist item
- OP-06 — security hardening checklist

## Audit Results

| Table | null_count (before) | null_count (after) |
|---|---|---|
| trips | 0 | 0 |
| trip_places | 0 | 0 |
| items | 0 | 0 |

No backfill was required. All null counts were already zero.

## Files

- `jobs/architect/tech/HC-07b-backfill.sql` — documented SQL script with audit, backfill, and verification steps
- `jobs/COO/inbox/20260323_2400-BACKEND-hc07b-complete.md` — completion report

## Pre-push Checks

- `npm run check` (Biome): PASS
- `npm run type:check:all`: PASS
- `npm run test:backend` (355 tests): PASS
- `npm run test:frontend` (78 tests): PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)