### PR TITLE
feat(op08): custom Semgrep security rules for OP-06 enforcement

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -63,6 +63,7 @@ jobs:
             --config p/react \
             --config p/nodejs \
             --config p/owasp-top-ten \
+            --config .semgrep/security.yml \
             --error \
             --quiet
         # To suppress a false positive, add a comment above the line:

--- a/.semgrep/security.yml
+++ b/.semgrep/security.yml
@@ -1,0 +1,52 @@
+# Travel Tracker — Custom Semgrep Rules
+# ADL-29: Security enforcement for OP-06 compliance
+#
+# These rules enforce the access control model established by ADL-27 and OP-06.
+# Run automatically in CI alongside generic rulesets (security.yml).
+#
+# Maintenance: Update when new route files are added or auth middleware pattern changes.
+# See ADL-29 and jobs/architect/tech/OP-06-hardening-checklist.md for rationale.
+#
+# Suppression format:
+#   // nosemgrep: travel-tracker.<rule-id> -- reason: <justification>
+
+rules:
+  - id: express-route-no-auth
+    patterns:
+      - pattern: |
+          $ROUTER.$METHOD($PATH, ...)
+      - pattern-not-inside: |
+          import { requireAuth } from ...
+      - pattern-not-inside: |
+          import { requireOwner } from ...
+    message: >
+      Express route handler in src/backend/routes/ with no reference to requireAuth or
+      requireOwner. All routes under /api/ must be protected. If this route is legitimately
+      public, add a nosemgrep suppression with justification.
+    languages: [typescript]
+    severity: ERROR
+    paths:
+      include:
+        - src/backend/routes/*.ts
+      exclude:
+        - src/backend/routes/__tests__/**
+        - src/backend/routes/items-helper.ts
+
+  # Rule 2 — drizzle-unscoped-user-table (WARNING)
+  # TODO: Rule 2 — see ADL-29
+  #
+  # Drizzle's fluent query API chains (.select().from().innerJoin().where()) produce
+  # deeply nested AST nodes that Semgrep's generic pattern matching cannot reliably
+  # distinguish from properly-scoped variants without excessive false positives.
+  # Specifically, `pattern-not: $DB.select(...).from($TABLE).$CHAIN.where(...userId...)`
+  # does not traverse through multi-level method chains in the TypeScript AST,
+  # resulting in every chained query being flagged regardless of whether userId
+  # scoping is present somewhere in the chain.
+  #
+  # The shading.service.ts queries (trips, tripPlaces) are intentionally unscoped —
+  # they aggregate across all users to compute map shading states, applied via JOIN
+  # condition rather than WHERE clause. A reliable rule would need to either:
+  #   (a) Use taint tracking (semgrep Pro), or
+  #   (b) Be narrowed to only flag direct .where()-less terminations with no chain at all
+  #
+  # Raise a GitHub issue to revisit once semgrep Pro or a refined pattern is available.

--- a/jobs/COO/inbox/20260324_0530-BACKEND-op08-semgrep-complete.md
+++ b/jobs/COO/inbox/20260324_0530-BACKEND-op08-semgrep-complete.md
@@ -1,0 +1,56 @@
+# OP-08 Complete — Custom Semgrep Security Rules
+
+**Branch:** `feat/op08-semgrep-security-rules`
+**PR:** https://github.com/ryanv11/travel-tracker/pull/94
+**CI:** All jobs green (Security Checks + CI both pass)
+
+---
+
+## Deliverables
+
+### `.semgrep/security.yml` (new file)
+Custom Semgrep ruleset with file header per brief spec (ADL-29).
+
+**Rule 1: `express-route-no-auth` (ERROR) — ACTIVE**
+Flags route files in `src/backend/routes/*.ts` that import neither `requireAuth` nor `requireOwner`. Scope limited to `src/backend/routes/*.ts`, excluding `__tests__/` and `items-helper.ts`.
+
+**Rule 2: `drizzle-unscoped-user-table` (WARNING) — COMMENTED OUT**
+Drizzle's fluent query API produces deeply nested AST nodes that Semgrep's generic TypeScript pattern matching cannot reliably traverse. The `pattern-not` for chained `.where(...userId...)` does not match through multi-level method chains. Attempting to activate this rule would flag every chained query in `shading.service.ts` regardless of the JOIN-based userId scoping. Commented out with `# TODO: Rule 2 — see ADL-29` and a detailed rationale note in the YAML. A GitHub issue should be raised to revisit with Semgrep Pro taint tracking.
+
+### `.github/workflows/security.yml` (updated)
+Added `--config .semgrep/security.yml` to the Semgrep SAST step alongside the existing rulesets.
+
+---
+
+## Suppressions added
+
+**`items-helper.ts`** — excluded via `paths.exclude` in the rule (not a route file; shared query helper with no route handler patterns).
+
+**`trips.ts`** — 8 suppressions (all route handlers including `.use()` for nested routers):
+`tripsRouter.use`, `tripsRouter.get` (×2), `tripsRouter.post`, `tripsRouter.patch` (×4), `tripsRouter.delete`
+
+**`places.ts`** — 7 suppressions:
+`placesRouter.get`, `placesRouter.post` (×3), `placesRouter.patch`, `placesRouter.delete` (×2)
+
+**`items.ts`** — 4 suppressions:
+`itemsRouter.get`, `itemsRouter.post`, `itemsRouter.patch`, `itemsRouter.delete`
+
+**`trip-countries.ts`** — 2 suppressions:
+`router.post`, `router.delete`
+
+**Suppression justification (all 4 files):** `requireAuth` is applied globally via `app.use('/api/', requireAuth)` in `server.ts`. These route files intentionally omit per-file auth imports; auth is guaranteed at the app layer.
+
+**Suppression format used:** `// nosemgrep: travel-tracker.express-route-no-auth -- reason: <justification>` placed on the line immediately preceding each route handler call (Biome-compatible position; Semgrep honours leading-line nosemgrep comments).
+
+---
+
+## Pre-push checks
+
+- `npm run check` (Biome) — pass
+- `npm run type:check:all` — pass
+- `npm run test:backend` — 376 tests pass
+- `npm run test:frontend` — 78 tests pass
+
+## CI status
+
+Both `Security Checks` and `CI` jobs green on the PR and latest push.

--- a/src/backend/routes/items.ts
+++ b/src/backend/routes/items.ts
@@ -27,7 +27,8 @@ export default itemsRouter;
 // ----------------------------------------------------------------
 // GET /api/trips/:tripId/items
 // ----------------------------------------------------------------
-itemsRouter.get( // nosemgrep: travel-tracker.express-route-no-auth -- reason: requireAuth applied globally via app.use('/api/', requireAuth) in server.ts
+// nosemgrep: travel-tracker.express-route-no-auth -- reason: requireAuth applied globally via app.use('/api/', requireAuth) in server.ts
+itemsRouter.get(
   '/',
   validateQuery(ListItemsQuerySchema),
   asyncHandler(async (req, res) => {
@@ -53,7 +54,8 @@ itemsRouter.get( // nosemgrep: travel-tracker.express-route-no-auth -- reason: r
 // ----------------------------------------------------------------
 // POST /api/trips/:tripId/items
 // ----------------------------------------------------------------
-itemsRouter.post( // nosemgrep: travel-tracker.express-route-no-auth -- reason: requireAuth applied globally via app.use('/api/', requireAuth) in server.ts
+// nosemgrep: travel-tracker.express-route-no-auth -- reason: requireAuth applied globally via app.use('/api/', requireAuth) in server.ts
+itemsRouter.post(
   '/',
   validateBody(CreateItemSchema),
   asyncHandler(async (req, res) => {
@@ -94,7 +96,8 @@ itemsRouter.post( // nosemgrep: travel-tracker.express-route-no-auth -- reason: 
 // ----------------------------------------------------------------
 // PATCH /api/trips/:tripId/items/:itemId
 // ----------------------------------------------------------------
-itemsRouter.patch( // nosemgrep: travel-tracker.express-route-no-auth -- reason: requireAuth applied globally via app.use('/api/', requireAuth) in server.ts
+// nosemgrep: travel-tracker.express-route-no-auth -- reason: requireAuth applied globally via app.use('/api/', requireAuth) in server.ts
+itemsRouter.patch(
   '/:itemId',
   validateBody(UpdateItemSchema),
   asyncHandler(async (req, res) => {
@@ -129,7 +132,8 @@ itemsRouter.patch( // nosemgrep: travel-tracker.express-route-no-auth -- reason:
 // ----------------------------------------------------------------
 // DELETE /api/trips/:tripId/items/:itemId
 // ----------------------------------------------------------------
-itemsRouter.delete( // nosemgrep: travel-tracker.express-route-no-auth -- reason: requireAuth applied globally via app.use('/api/', requireAuth) in server.ts
+// nosemgrep: travel-tracker.express-route-no-auth -- reason: requireAuth applied globally via app.use('/api/', requireAuth) in server.ts
+itemsRouter.delete(
   '/:itemId',
   asyncHandler(async (req, res) => {
     const userId = req.user!.id;

--- a/src/backend/routes/items.ts
+++ b/src/backend/routes/items.ts
@@ -27,7 +27,7 @@ export default itemsRouter;
 // ----------------------------------------------------------------
 // GET /api/trips/:tripId/items
 // ----------------------------------------------------------------
-itemsRouter.get(
+itemsRouter.get( // nosemgrep: travel-tracker.express-route-no-auth -- reason: requireAuth applied globally via app.use('/api/', requireAuth) in server.ts
   '/',
   validateQuery(ListItemsQuerySchema),
   asyncHandler(async (req, res) => {
@@ -53,7 +53,7 @@ itemsRouter.get(
 // ----------------------------------------------------------------
 // POST /api/trips/:tripId/items
 // ----------------------------------------------------------------
-itemsRouter.post(
+itemsRouter.post( // nosemgrep: travel-tracker.express-route-no-auth -- reason: requireAuth applied globally via app.use('/api/', requireAuth) in server.ts
   '/',
   validateBody(CreateItemSchema),
   asyncHandler(async (req, res) => {
@@ -94,7 +94,7 @@ itemsRouter.post(
 // ----------------------------------------------------------------
 // PATCH /api/trips/:tripId/items/:itemId
 // ----------------------------------------------------------------
-itemsRouter.patch(
+itemsRouter.patch( // nosemgrep: travel-tracker.express-route-no-auth -- reason: requireAuth applied globally via app.use('/api/', requireAuth) in server.ts
   '/:itemId',
   validateBody(UpdateItemSchema),
   asyncHandler(async (req, res) => {
@@ -129,7 +129,7 @@ itemsRouter.patch(
 // ----------------------------------------------------------------
 // DELETE /api/trips/:tripId/items/:itemId
 // ----------------------------------------------------------------
-itemsRouter.delete(
+itemsRouter.delete( // nosemgrep: travel-tracker.express-route-no-auth -- reason: requireAuth applied globally via app.use('/api/', requireAuth) in server.ts
   '/:itemId',
   asyncHandler(async (req, res) => {
     const userId = req.user!.id;

--- a/src/backend/routes/places.ts
+++ b/src/backend/routes/places.ts
@@ -30,7 +30,7 @@ export default placesRouter;
 // ----------------------------------------------------------------
 // GET /api/trips/:tripId/places
 // ----------------------------------------------------------------
-placesRouter.get(
+placesRouter.get( // nosemgrep: travel-tracker.express-route-no-auth -- reason: requireAuth applied globally via app.use('/api/', requireAuth) in server.ts
   '/',
   asyncHandler(async (req, res) => {
     const userId = req.user!.id;
@@ -56,7 +56,7 @@ placesRouter.get(
 // ----------------------------------------------------------------
 // POST /api/trips/:tripId/places
 // ----------------------------------------------------------------
-placesRouter.post(
+placesRouter.post( // nosemgrep: travel-tracker.express-route-no-auth -- reason: requireAuth applied globally via app.use('/api/', requireAuth) in server.ts
   '/',
   validateBody(CreatePlaceSchema),
   asyncHandler(async (req, res) => {
@@ -98,7 +98,7 @@ placesRouter.post(
 // ----------------------------------------------------------------
 // DELETE /api/trips/:tripId/places/:placeId
 // ----------------------------------------------------------------
-placesRouter.delete(
+placesRouter.delete( // nosemgrep: travel-tracker.express-route-no-auth -- reason: requireAuth applied globally via app.use('/api/', requireAuth) in server.ts
   '/:placeId',
   asyncHandler(async (req, res) => {
     const userId = req.user!.id;
@@ -116,7 +116,7 @@ placesRouter.delete(
 // ----------------------------------------------------------------
 // PATCH /api/trips/:tripId/places/:placeId
 // ----------------------------------------------------------------
-placesRouter.patch(
+placesRouter.patch( // nosemgrep: travel-tracker.express-route-no-auth -- reason: requireAuth applied globally via app.use('/api/', requireAuth) in server.ts
   '/:placeId',
   validateBody(UpdatePlaceDatesSchema),
   asyncHandler(async (req, res) => {
@@ -151,7 +151,7 @@ placesRouter.patch(
 // ----------------------------------------------------------------
 // POST /api/trips/:tripId/places/:placeId/carry-forward  (C1 — IT-07 execution)
 // ----------------------------------------------------------------
-placesRouter.post(
+placesRouter.post( // nosemgrep: travel-tracker.express-route-no-auth -- reason: requireAuth applied globally via app.use('/api/', requireAuth) in server.ts
   '/:placeId/carry-forward',
   validateBody(CarryForwardBodySchema),
   asyncHandler(async (req, res) => {
@@ -207,7 +207,7 @@ placesRouter.post(
 // ----------------------------------------------------------------
 // POST /api/trips/:tripId/places/:placeId/activities
 // ----------------------------------------------------------------
-placesRouter.post(
+placesRouter.post( // nosemgrep: travel-tracker.express-route-no-auth -- reason: requireAuth applied globally via app.use('/api/', requireAuth) in server.ts
   '/:placeId/activities',
   validateBody(AddPlaceActivitySchema),
   asyncHandler(async (req, res) => {
@@ -247,7 +247,7 @@ placesRouter.post(
 // ----------------------------------------------------------------
 // DELETE /api/trips/:tripId/places/:placeId/activities/:activityId
 // ----------------------------------------------------------------
-placesRouter.delete(
+placesRouter.delete( // nosemgrep: travel-tracker.express-route-no-auth -- reason: requireAuth applied globally via app.use('/api/', requireAuth) in server.ts
   '/:placeId/activities/:activityId',
   asyncHandler(async (req, res) => {
     const userId = req.user!.id;

--- a/src/backend/routes/places.ts
+++ b/src/backend/routes/places.ts
@@ -30,7 +30,8 @@ export default placesRouter;
 // ----------------------------------------------------------------
 // GET /api/trips/:tripId/places
 // ----------------------------------------------------------------
-placesRouter.get( // nosemgrep: travel-tracker.express-route-no-auth -- reason: requireAuth applied globally via app.use('/api/', requireAuth) in server.ts
+// nosemgrep: travel-tracker.express-route-no-auth -- reason: requireAuth applied globally via app.use('/api/', requireAuth) in server.ts
+placesRouter.get(
   '/',
   asyncHandler(async (req, res) => {
     const userId = req.user!.id;
@@ -56,7 +57,8 @@ placesRouter.get( // nosemgrep: travel-tracker.express-route-no-auth -- reason: 
 // ----------------------------------------------------------------
 // POST /api/trips/:tripId/places
 // ----------------------------------------------------------------
-placesRouter.post( // nosemgrep: travel-tracker.express-route-no-auth -- reason: requireAuth applied globally via app.use('/api/', requireAuth) in server.ts
+// nosemgrep: travel-tracker.express-route-no-auth -- reason: requireAuth applied globally via app.use('/api/', requireAuth) in server.ts
+placesRouter.post(
   '/',
   validateBody(CreatePlaceSchema),
   asyncHandler(async (req, res) => {
@@ -98,7 +100,8 @@ placesRouter.post( // nosemgrep: travel-tracker.express-route-no-auth -- reason:
 // ----------------------------------------------------------------
 // DELETE /api/trips/:tripId/places/:placeId
 // ----------------------------------------------------------------
-placesRouter.delete( // nosemgrep: travel-tracker.express-route-no-auth -- reason: requireAuth applied globally via app.use('/api/', requireAuth) in server.ts
+// nosemgrep: travel-tracker.express-route-no-auth -- reason: requireAuth applied globally via app.use('/api/', requireAuth) in server.ts
+placesRouter.delete(
   '/:placeId',
   asyncHandler(async (req, res) => {
     const userId = req.user!.id;
@@ -116,7 +119,8 @@ placesRouter.delete( // nosemgrep: travel-tracker.express-route-no-auth -- reaso
 // ----------------------------------------------------------------
 // PATCH /api/trips/:tripId/places/:placeId
 // ----------------------------------------------------------------
-placesRouter.patch( // nosemgrep: travel-tracker.express-route-no-auth -- reason: requireAuth applied globally via app.use('/api/', requireAuth) in server.ts
+// nosemgrep: travel-tracker.express-route-no-auth -- reason: requireAuth applied globally via app.use('/api/', requireAuth) in server.ts
+placesRouter.patch(
   '/:placeId',
   validateBody(UpdatePlaceDatesSchema),
   asyncHandler(async (req, res) => {
@@ -151,7 +155,8 @@ placesRouter.patch( // nosemgrep: travel-tracker.express-route-no-auth -- reason
 // ----------------------------------------------------------------
 // POST /api/trips/:tripId/places/:placeId/carry-forward  (C1 — IT-07 execution)
 // ----------------------------------------------------------------
-placesRouter.post( // nosemgrep: travel-tracker.express-route-no-auth -- reason: requireAuth applied globally via app.use('/api/', requireAuth) in server.ts
+// nosemgrep: travel-tracker.express-route-no-auth -- reason: requireAuth applied globally via app.use('/api/', requireAuth) in server.ts
+placesRouter.post(
   '/:placeId/carry-forward',
   validateBody(CarryForwardBodySchema),
   asyncHandler(async (req, res) => {
@@ -207,7 +212,8 @@ placesRouter.post( // nosemgrep: travel-tracker.express-route-no-auth -- reason:
 // ----------------------------------------------------------------
 // POST /api/trips/:tripId/places/:placeId/activities
 // ----------------------------------------------------------------
-placesRouter.post( // nosemgrep: travel-tracker.express-route-no-auth -- reason: requireAuth applied globally via app.use('/api/', requireAuth) in server.ts
+// nosemgrep: travel-tracker.express-route-no-auth -- reason: requireAuth applied globally via app.use('/api/', requireAuth) in server.ts
+placesRouter.post(
   '/:placeId/activities',
   validateBody(AddPlaceActivitySchema),
   asyncHandler(async (req, res) => {
@@ -247,7 +253,8 @@ placesRouter.post( // nosemgrep: travel-tracker.express-route-no-auth -- reason:
 // ----------------------------------------------------------------
 // DELETE /api/trips/:tripId/places/:placeId/activities/:activityId
 // ----------------------------------------------------------------
-placesRouter.delete( // nosemgrep: travel-tracker.express-route-no-auth -- reason: requireAuth applied globally via app.use('/api/', requireAuth) in server.ts
+// nosemgrep: travel-tracker.express-route-no-auth -- reason: requireAuth applied globally via app.use('/api/', requireAuth) in server.ts
+placesRouter.delete(
   '/:placeId/activities/:activityId',
   asyncHandler(async (req, res) => {
     const userId = req.user!.id;

--- a/src/backend/routes/trip-countries.ts
+++ b/src/backend/routes/trip-countries.ts
@@ -21,7 +21,8 @@ const AddCountriesSchema = z.object({
   country_codes: z.array(z.string().length(2)).min(1),
 });
 
-router.post( // nosemgrep: travel-tracker.express-route-no-auth -- reason: requireAuth applied globally via app.use('/api/', requireAuth) in server.ts
+// nosemgrep: travel-tracker.express-route-no-auth -- reason: requireAuth applied globally via app.use('/api/', requireAuth) in server.ts
+router.post(
   '/',
   validateBody(AddCountriesSchema),
   asyncHandler(async (req, res) => {
@@ -36,7 +37,8 @@ router.post( // nosemgrep: travel-tracker.express-route-no-auth -- reason: requi
   }),
 );
 
-router.delete( // nosemgrep: travel-tracker.express-route-no-auth -- reason: requireAuth applied globally via app.use('/api/', requireAuth) in server.ts
+// nosemgrep: travel-tracker.express-route-no-auth -- reason: requireAuth applied globally via app.use('/api/', requireAuth) in server.ts
+router.delete(
   '/:code',
   asyncHandler(async (req, res) => {
     const userId = req.user!.id;

--- a/src/backend/routes/trip-countries.ts
+++ b/src/backend/routes/trip-countries.ts
@@ -21,7 +21,7 @@ const AddCountriesSchema = z.object({
   country_codes: z.array(z.string().length(2)).min(1),
 });
 
-router.post(
+router.post( // nosemgrep: travel-tracker.express-route-no-auth -- reason: requireAuth applied globally via app.use('/api/', requireAuth) in server.ts
   '/',
   validateBody(AddCountriesSchema),
   asyncHandler(async (req, res) => {
@@ -36,7 +36,7 @@ router.post(
   }),
 );
 
-router.delete(
+router.delete( // nosemgrep: travel-tracker.express-route-no-auth -- reason: requireAuth applied globally via app.use('/api/', requireAuth) in server.ts
   '/:code',
   asyncHandler(async (req, res) => {
     const userId = req.user!.id;

--- a/src/backend/routes/trips.ts
+++ b/src/backend/routes/trips.ts
@@ -33,9 +33,9 @@ import tripCountriesRouter from './trip-countries.js';
 export const tripsRouter = Router();
 
 // Mount nested routers with mergeParams: true (defined in those files)
-tripsRouter.use('/:tripId/places', placesRouter);
-tripsRouter.use('/:tripId/items', itemsRouter);
-tripsRouter.use('/:tripId/countries', tripCountriesRouter);
+tripsRouter.use('/:tripId/places', placesRouter); // nosemgrep: travel-tracker.express-route-no-auth -- reason: requireAuth applied globally via app.use('/api/', requireAuth) in server.ts
+tripsRouter.use('/:tripId/items', itemsRouter); // nosemgrep: travel-tracker.express-route-no-auth -- reason: requireAuth applied globally via app.use('/api/', requireAuth) in server.ts
+tripsRouter.use('/:tripId/countries', tripCountriesRouter); // nosemgrep: travel-tracker.express-route-no-auth -- reason: requireAuth applied globally via app.use('/api/', requireAuth) in server.ts
 
 // ----------------------------------------------------------------
 // Helpers
@@ -106,7 +106,7 @@ async function buildTripResponse(trip: {
 // ----------------------------------------------------------------
 // GET /api/trips
 // ----------------------------------------------------------------
-tripsRouter.get(
+tripsRouter.get( // nosemgrep: travel-tracker.express-route-no-auth -- reason: requireAuth applied globally via app.use('/api/', requireAuth) in server.ts
   '/',
   validateQuery(ListTripsQuerySchema),
   asyncHandler(async (req, res) => {
@@ -133,7 +133,7 @@ tripsRouter.get(
 // ----------------------------------------------------------------
 // POST /api/trips
 // ----------------------------------------------------------------
-tripsRouter.post(
+tripsRouter.post( // nosemgrep: travel-tracker.express-route-no-auth -- reason: requireAuth applied globally via app.use('/api/', requireAuth) in server.ts
   '/',
   validateBody(CreateTripSchema),
   asyncHandler(async (req, res) => {
@@ -174,7 +174,7 @@ tripsRouter.post(
 // ----------------------------------------------------------------
 // GET /api/trips/:id
 // ----------------------------------------------------------------
-tripsRouter.get(
+tripsRouter.get( // nosemgrep: travel-tracker.express-route-no-auth -- reason: requireAuth applied globally via app.use('/api/', requireAuth) in server.ts
   '/:id',
   asyncHandler(async (req, res) => {
     const userId = req.user!.id;
@@ -256,7 +256,7 @@ tripsRouter.get(
 // ----------------------------------------------------------------
 // PATCH /api/trips/:id
 // ----------------------------------------------------------------
-tripsRouter.patch(
+tripsRouter.patch( // nosemgrep: travel-tracker.express-route-no-auth -- reason: requireAuth applied globally via app.use('/api/', requireAuth) in server.ts
   '/:id',
   validateBody(UpdateTripSchema),
   asyncHandler(async (req, res) => {
@@ -305,7 +305,7 @@ tripsRouter.patch(
 // ----------------------------------------------------------------
 // PATCH /api/trips/:id/status
 // ----------------------------------------------------------------
-tripsRouter.patch(
+tripsRouter.patch( // nosemgrep: travel-tracker.express-route-no-auth -- reason: requireAuth applied globally via app.use('/api/', requireAuth) in server.ts
   '/:id/status',
   validateBody(UpdateTripStatusSchema),
   asyncHandler(async (req, res) => {
@@ -327,7 +327,7 @@ tripsRouter.patch(
 // ----------------------------------------------------------------
 // PATCH /api/trips/:id/lock  (convenience alias)
 // ----------------------------------------------------------------
-tripsRouter.patch(
+tripsRouter.patch( // nosemgrep: travel-tracker.express-route-no-auth -- reason: requireAuth applied globally via app.use('/api/', requireAuth) in server.ts
   '/:id/lock',
   asyncHandler(async (req, res) => {
     const userId = req.user!.id;
@@ -350,7 +350,7 @@ tripsRouter.patch(
 // ----------------------------------------------------------------
 // PATCH /api/trips/:id/unlock  (convenience alias → review_pending)
 // ----------------------------------------------------------------
-tripsRouter.patch(
+tripsRouter.patch( // nosemgrep: travel-tracker.express-route-no-auth -- reason: requireAuth applied globally via app.use('/api/', requireAuth) in server.ts
   '/:id/unlock',
   asyncHandler(async (req, res) => {
     const userId = req.user!.id;
@@ -392,7 +392,7 @@ tripsRouter.patch(
  * @returns 400 if id is not a positive integer.
  * @returns 404 if trip does not exist.
  */
-tripsRouter.delete(
+tripsRouter.delete( // nosemgrep: travel-tracker.express-route-no-auth -- reason: requireAuth applied globally via app.use('/api/', requireAuth) in server.ts
   '/:id',
   asyncHandler(async (req, res) => {
     // Validate path param — id must be a positive integer

--- a/src/backend/routes/trips.ts
+++ b/src/backend/routes/trips.ts
@@ -106,7 +106,8 @@ async function buildTripResponse(trip: {
 // ----------------------------------------------------------------
 // GET /api/trips
 // ----------------------------------------------------------------
-tripsRouter.get( // nosemgrep: travel-tracker.express-route-no-auth -- reason: requireAuth applied globally via app.use('/api/', requireAuth) in server.ts
+// nosemgrep: travel-tracker.express-route-no-auth -- reason: requireAuth applied globally via app.use('/api/', requireAuth) in server.ts
+tripsRouter.get(
   '/',
   validateQuery(ListTripsQuerySchema),
   asyncHandler(async (req, res) => {
@@ -133,7 +134,8 @@ tripsRouter.get( // nosemgrep: travel-tracker.express-route-no-auth -- reason: r
 // ----------------------------------------------------------------
 // POST /api/trips
 // ----------------------------------------------------------------
-tripsRouter.post( // nosemgrep: travel-tracker.express-route-no-auth -- reason: requireAuth applied globally via app.use('/api/', requireAuth) in server.ts
+// nosemgrep: travel-tracker.express-route-no-auth -- reason: requireAuth applied globally via app.use('/api/', requireAuth) in server.ts
+tripsRouter.post(
   '/',
   validateBody(CreateTripSchema),
   asyncHandler(async (req, res) => {
@@ -174,7 +176,8 @@ tripsRouter.post( // nosemgrep: travel-tracker.express-route-no-auth -- reason: 
 // ----------------------------------------------------------------
 // GET /api/trips/:id
 // ----------------------------------------------------------------
-tripsRouter.get( // nosemgrep: travel-tracker.express-route-no-auth -- reason: requireAuth applied globally via app.use('/api/', requireAuth) in server.ts
+// nosemgrep: travel-tracker.express-route-no-auth -- reason: requireAuth applied globally via app.use('/api/', requireAuth) in server.ts
+tripsRouter.get(
   '/:id',
   asyncHandler(async (req, res) => {
     const userId = req.user!.id;
@@ -256,7 +259,8 @@ tripsRouter.get( // nosemgrep: travel-tracker.express-route-no-auth -- reason: r
 // ----------------------------------------------------------------
 // PATCH /api/trips/:id
 // ----------------------------------------------------------------
-tripsRouter.patch( // nosemgrep: travel-tracker.express-route-no-auth -- reason: requireAuth applied globally via app.use('/api/', requireAuth) in server.ts
+// nosemgrep: travel-tracker.express-route-no-auth -- reason: requireAuth applied globally via app.use('/api/', requireAuth) in server.ts
+tripsRouter.patch(
   '/:id',
   validateBody(UpdateTripSchema),
   asyncHandler(async (req, res) => {
@@ -305,7 +309,8 @@ tripsRouter.patch( // nosemgrep: travel-tracker.express-route-no-auth -- reason:
 // ----------------------------------------------------------------
 // PATCH /api/trips/:id/status
 // ----------------------------------------------------------------
-tripsRouter.patch( // nosemgrep: travel-tracker.express-route-no-auth -- reason: requireAuth applied globally via app.use('/api/', requireAuth) in server.ts
+// nosemgrep: travel-tracker.express-route-no-auth -- reason: requireAuth applied globally via app.use('/api/', requireAuth) in server.ts
+tripsRouter.patch(
   '/:id/status',
   validateBody(UpdateTripStatusSchema),
   asyncHandler(async (req, res) => {
@@ -327,7 +332,8 @@ tripsRouter.patch( // nosemgrep: travel-tracker.express-route-no-auth -- reason:
 // ----------------------------------------------------------------
 // PATCH /api/trips/:id/lock  (convenience alias)
 // ----------------------------------------------------------------
-tripsRouter.patch( // nosemgrep: travel-tracker.express-route-no-auth -- reason: requireAuth applied globally via app.use('/api/', requireAuth) in server.ts
+// nosemgrep: travel-tracker.express-route-no-auth -- reason: requireAuth applied globally via app.use('/api/', requireAuth) in server.ts
+tripsRouter.patch(
   '/:id/lock',
   asyncHandler(async (req, res) => {
     const userId = req.user!.id;
@@ -350,7 +356,8 @@ tripsRouter.patch( // nosemgrep: travel-tracker.express-route-no-auth -- reason:
 // ----------------------------------------------------------------
 // PATCH /api/trips/:id/unlock  (convenience alias → review_pending)
 // ----------------------------------------------------------------
-tripsRouter.patch( // nosemgrep: travel-tracker.express-route-no-auth -- reason: requireAuth applied globally via app.use('/api/', requireAuth) in server.ts
+// nosemgrep: travel-tracker.express-route-no-auth -- reason: requireAuth applied globally via app.use('/api/', requireAuth) in server.ts
+tripsRouter.patch(
   '/:id/unlock',
   asyncHandler(async (req, res) => {
     const userId = req.user!.id;
@@ -392,7 +399,8 @@ tripsRouter.patch( // nosemgrep: travel-tracker.express-route-no-auth -- reason:
  * @returns 400 if id is not a positive integer.
  * @returns 404 if trip does not exist.
  */
-tripsRouter.delete( // nosemgrep: travel-tracker.express-route-no-auth -- reason: requireAuth applied globally via app.use('/api/', requireAuth) in server.ts
+// nosemgrep: travel-tracker.express-route-no-auth -- reason: requireAuth applied globally via app.use('/api/', requireAuth) in server.ts
+tripsRouter.delete(
   '/:id',
   asyncHandler(async (req, res) => {
     // Validate path param — id must be a positive integer


### PR DESCRIPTION
OP-08 — ADL-29

## Summary
- Adds `.semgrep/security.yml` with Rule 1: `express-route-no-auth` (ERROR severity) — flags route files in `src/backend/routes/` that import neither `requireAuth` nor `requireOwner`
- Rule 2 (`drizzle-unscoped-user-table`) is commented out with a `# TODO: Rule 2 — see ADL-29` note due to Drizzle fluent chain AST matching limitations causing excessive false positives
- Updates `.github/workflows/security.yml` to include `--config .semgrep/security.yml` in the Semgrep SAST step

## Suppressions added
- `items-helper.ts` excluded via `paths.exclude` (helper file, not a route, auth applied at parent level)
- `trips.ts`, `places.ts`, `items.ts`, `trip-countries.ts` — all route handlers have `// nosemgrep: travel-tracker.express-route-no-auth` comments; these files are protected by the global `app.use('/api/', requireAuth)` in `server.ts` and intentionally omit per-file auth imports

## Test plan
- [x] `npm run type:check:all` — clean
- [x] `npm run test:backend` — 376 tests pass
- [x] `npm run test:frontend` — 78 tests pass
- [ ] CI Semgrep SAST job — pending (rule runs in semgrep/semgrep container)

🤖 Generated with [Claude Code](https://claude.com/claude-code)