### PR TITLE
fix(BUG-24): restore main CI — fixture userId + SHA-pinned action refs (#97)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,8 @@ jobs:
     name: Biome (lint + format)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "22"
           cache: "npm"
@@ -23,8 +23,8 @@ jobs:
     name: Type Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "22"
           cache: "npm"
@@ -35,8 +35,8 @@ jobs:
     name: Backend Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "22"
           cache: "npm"
@@ -47,8 +47,8 @@ jobs:
     name: Frontend Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "22"
           cache: "npm"
@@ -59,8 +59,8 @@ jobs:
     name: Contract Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "22"
           cache: "npm"

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "22"
           cache: "npm"
@@ -36,13 +36,13 @@ jobs:
       security-events: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0 # Full history required for Gitleaks
 
       # SEC-13a: Scan for accidentally committed secrets
       - name: Gitleaks secret scan
-        uses: gitleaks/gitleaks-action@v2
+        uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -53,7 +53,7 @@ jobs:
       image: semgrep/semgrep
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       # SEC-13c: SAST covering TypeScript, React, Node.js, OWASP Top 10
       - name: Semgrep SAST

--- a/_project/tracker.json
+++ b/_project/tracker.json
@@ -1032,6 +1032,28 @@
       "notes": "requireOwner added to citiesRouter.patch('/:id'). PR #92 CI green, pending merge. GitHub issue #91."
     },
     {
+      "id": "BUG-24",
+      "type": "bug",
+      "title": "Main CI red — test fixtures missing userId (Type Check) + unpinned action tags (Semgrep)",
+      "status": "done",
+      "owner": "coo",
+      "priority": "P1",
+      "brdRefs": [],
+      "phase": 1,
+      "notes": "Type Check: 9 errors — shading.user-scope.test.ts (8) and items.rating-sort-filter.test.ts (1) inserted trip_places without userId after HC-07c NOT NULL (#86); squash-merge race. Semgrep: new registry rule github-actions-mutable-action-tag flagged 15 mutable uses: refs — all pinned to full commit SHAs. Fixed 2026-07-07. GitHub issue #97."
+    },
+    {
+      "id": "DEP-01",
+      "type": "task",
+      "title": "npm audit — 26 vulnerabilities (3 critical, 10 high) accrued since 2026-03 dependency freeze",
+      "status": "open",
+      "owner": "backend",
+      "priority": "P1",
+      "brdRefs": [],
+      "phase": 1,
+      "notes": "Dependency Vulnerability Scan job red since 2026-07-07 on a docs-only diff — advisories published post-freeze. Needs deliberate update pass (not audit fix --force): dev vs runtime split, majors assessed individually, full test suite + app verification, security-backlog.md npm-audit section updated in same PR per Document lifecycle rule. GitHub issue #98."
+    },
+    {
       "id": "OP-08",
       "type": "requirement",
       "title": "Security enforcement mechanisms for new work — regression suite + Semgrep rules",

--- a/src/backend/routes/__tests__/items.rating-sort-filter.test.ts
+++ b/src/backend/routes/__tests__/items.rating-sort-filter.test.ts
@@ -323,7 +323,10 @@ async function seedTripPlace(
   tripId: number,
   cityId: number,
 ) {
-  const [place] = await db.insert(schema.tripPlaces).values({ tripId, cityId }).returning();
+  const [place] = await db
+    .insert(schema.tripPlaces)
+    .values({ tripId, cityId, userId: TEST_USER_ID })
+    .returning();
   return place;
 }
 

--- a/src/backend/services/__tests__/shading.user-scope.test.ts
+++ b/src/backend/services/__tests__/shading.user-scope.test.ts
@@ -293,7 +293,9 @@ describe('HC-03 — shading queries scoped to userId', () => {
         })
         .returning();
 
-      await db.insert(schema.tripPlaces).values({ tripId: trip.id, cityId: city[0].id });
+      await db
+        .insert(schema.tripPlaces)
+        .values({ tripId: trip.id, cityId: city[0].id, userId: OWNER_USER_ID });
 
       const results = await getAllCountryShading(OWNER_USER_ID);
       const jp = results.find((r) => r.countryCode === 'JP');
@@ -320,7 +322,9 @@ describe('HC-03 — shading queries scoped to userId', () => {
         })
         .returning();
 
-      await db.insert(schema.tripPlaces).values({ tripId: trip.id, cityId: city[0].id });
+      await db
+        .insert(schema.tripPlaces)
+        .values({ tripId: trip.id, cityId: city[0].id, userId: OWNER_USER_ID });
 
       const results = await getAllCountryShading(OTHER_USER_ID);
       const jp = results.find((r) => r.countryCode === 'JP');
@@ -378,7 +382,9 @@ describe('HC-03 — shading queries scoped to userId', () => {
           userId: OWNER_USER_ID,
         })
         .returning();
-      await db.insert(schema.tripPlaces).values({ tripId: ownerTrip.id, cityId: jpCity.id });
+      await db
+        .insert(schema.tripPlaces)
+        .values({ tripId: ownerTrip.id, cityId: jpCity.id, userId: OWNER_USER_ID });
 
       // Other user visited DE
       const [otherTrip] = await db
@@ -391,7 +397,9 @@ describe('HC-03 — shading queries scoped to userId', () => {
           userId: OTHER_USER_ID,
         })
         .returning();
-      await db.insert(schema.tripPlaces).values({ tripId: otherTrip.id, cityId: deCity.id });
+      await db
+        .insert(schema.tripPlaces)
+        .values({ tripId: otherTrip.id, cityId: deCity.id, userId: OTHER_USER_ID });
 
       // Owner sees JP visited, DE never visited
       const ownerResults = await getAllCountryShading(OWNER_USER_ID);
@@ -427,7 +435,9 @@ describe('HC-03 — shading queries scoped to userId', () => {
           userId: OWNER_USER_ID,
         })
         .returning();
-      await db.insert(schema.tripPlaces).values({ tripId: trip.id, cityId: city.id });
+      await db
+        .insert(schema.tripPlaces)
+        .values({ tripId: trip.id, cityId: city.id, userId: OWNER_USER_ID });
 
       const result = await getCountryShading('FR', OWNER_USER_ID);
       expect(result).not.toBeNull();
@@ -451,7 +461,9 @@ describe('HC-03 — shading queries scoped to userId', () => {
           userId: OWNER_USER_ID,
         })
         .returning();
-      await db.insert(schema.tripPlaces).values({ tripId: trip.id, cityId: city.id });
+      await db
+        .insert(schema.tripPlaces)
+        .values({ tripId: trip.id, cityId: city.id, userId: OWNER_USER_ID });
 
       const result = await getCountryShading('FR', OTHER_USER_ID);
       expect(result).not.toBeNull();
@@ -487,7 +499,9 @@ describe('HC-03 — shading queries scoped to userId', () => {
           userId: OWNER_USER_ID,
         })
         .returning();
-      await db.insert(schema.tripPlaces).values({ tripId: trip.id, cityId: city.id });
+      await db
+        .insert(schema.tripPlaces)
+        .values({ tripId: trip.id, cityId: city.id, userId: OWNER_USER_ID });
 
       const results = await getRegionShading('AU', OWNER_USER_ID);
       const nsw = results.find((r) => r.iso3166_2 === 'AU-NSW');
@@ -518,7 +532,9 @@ describe('HC-03 — shading queries scoped to userId', () => {
           userId: OWNER_USER_ID,
         })
         .returning();
-      await db.insert(schema.tripPlaces).values({ tripId: trip.id, cityId: city.id });
+      await db
+        .insert(schema.tripPlaces)
+        .values({ tripId: trip.id, cityId: city.id, userId: OWNER_USER_ID });
 
       const results = await getRegionShading('AU', OTHER_USER_ID);
       const nsw = results.find((r) => r.iso3166_2 === 'AU-NSW');


### PR DESCRIPTION
Closes #97

Restores a green CI baseline on main (red since the 03-24 merge window for Type Check; since 2026-07-07 for Semgrep):

1. **Type Check (9 errors → 0):** `trip_places` fixture inserts in `shading.user-scope.test.ts` and `items.rating-sort-filter.test.ts` now include `userId` — they predated the HC-07c NOT NULL change (#86) and raced past each other via squash merges.
2. **Semgrep (15 blocking findings → 0):** all `uses:` refs in ci.yml/security.yml pinned to full 40-char commit SHAs (new registry rule `github-actions-mutable-action-tag`).

Also adds tracker entries BUG-24 (this, done) and DEP-01 (open — the npm-audit vulnerabilities, #98, which keep the Dependency Vulnerability Scan job red until the cleanup-phase dependency pass).

Pre-push: Biome ✓, type:check:all ✓, backend 462 ✓, frontend 78 ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)