### PR TITLE
chore: record depwire Q3 resolution (audit §5) — rejected, leftovers deleted

### DIFF
--- a/audits/session-a-doc-integrity.md
+++ b/audits/session-a-doc-integrity.md
@@ -168,6 +168,7 @@ tech-blueprint, ER-schema, project-plan.txt, dependency-graph.txt, security-spec
 1. **OP-06 checklist statuses:** HC-01…HC-07c, ADL-27, and OP-08 all merged (PRs #80–#94) but the checklist still shows 6× FAIL / 2× PARTIAL. May I (in a writing session) flip the verified items to PASS with commit citations — or do you want an independent re-verification first? *(Also: the agent-memory note "gate BLOCKED, 4 FAIL/2 PARTIAL" is stale and updated per this audit.)*
 2. **Local real-auth:** the firewall now allows Clerk JWKS (HC-01), but CLAUDE.md/CODEBASE.md still say it's unreachable and GitHub issue #23 is still open. Is real-JWT local dev confirmed working, so the docs can be fixed and #23 closed? Is `BYPASS_AUTH=true` still the intended local default?
 3. **Depwire:** it was removed by commit 3823044, but an untracked `.mcp.json` re-registers it and `.depwire/` output (dated 2026-03-20) sits in the working tree. Deliberate re-adoption (needs an ADL per the Architect-involvement guardrail) or leftover to delete?
+   > RESOLVED (2026-07-07) by Ryan: leftover, not re-adoption — "we tried depwire and it wasn't worth incorporating; we took some ideas from it, but that's about it." `.depwire/` and `.mcp.json` deleted from the working tree; commit 3823044's removal stands. Remaining follow-up: strip the depwire steps from the codebase-health.md methodology (doc 26, doc-fix queue).
 4. **`claude-code/` clone:** why is a git-ignored clone of the upstream claude-code repo in the workspace, and should CODEBASE.md keep describing it as project content slated for extraction?
 5. **BRD v2.7 sign-off:** every changelog entry lists you as approving author except v2.7 (SE-01–07), which lists only "COO". Do you retroactively approve §5.11 as written?
 6. **Product direction conflict:** BRD §3/NF-01 still promise a solo, offline-capable local Mac app, while §5.11 + the shipped code mandate Clerk-authenticated multi-user operation (internet-dependent). Which is the real target, and should NF-01/§3 be rewritten?
@@ -555,6 +556,8 @@ Notes: the UAT log itself is in good shape — findings carry checkboxes, bug ID
 | Sev | Class | Doc location | Evidence | Disposition |
 |-----|-------|--------------|----------|-------------|
 | MED | STALE + CONTRADICTORY (with a committed decision) | Entire `.depwire/` directory + untracked `.mcp.json` registering the depwire MCP server | Commit 3823044 (2026-03-21) removed Depwire deliberately ("remove Depwire"), the day *after* these files were generated. The untracked working-tree state resurrects the tool with no recorded decision. Any agent (or the MCP server itself) consuming these files gets a March-era codebase view presented as current. | Confirm with Ryan: delete, or regenerate + record re-adoption decision (also affects codebase-health.md methodology, doc 26) |
+
+> RESOLVED (2026-07-07): Ryan confirmed leftover (see Q3 in §5) — `.depwire/` and `.mcp.json` deleted; the 3823044 removal decision stands.
 
 
 

--- a/jobs/COO/park-docs/20260707_1600-COO-park.txt
+++ b/jobs/COO/park-docs/20260707_1600-COO-park.txt
@@ -62,9 +62,11 @@ drift concentrates exactly where no closing rule exists — fixed as OP-09.
    reference, BRD header v2.5→v2.7 + OQ closures, map-shading spec user
    scoping, ADL-28 entry in main log.
 
-6. Untracked working-tree items pending Ryan (audit Q3/Q4): .mcp.json +
-   .depwire/ (depwire was removed by 3823044 but resurrected untracked);
-   .planning/drift-ledger.jsonl has uncommitted pre-session edits.
+6. Untracked working-tree items: RESOLVED for depwire — Ryan confirmed
+   (2026-07-07) it was tried and rejected ("took some ideas from it, that's
+   about it"); .depwire/ + .mcp.json deleted, 3823044 removal stands (audit
+   Q3 stamped). Q4 (claude-code/ clone) still open.
+   .planning/drift-ledger.jsonl still has uncommitted pre-session edits.
 
 ## Carried forward from 2026-03-24 park (still open)
 - PO UAT: HC-01 end-to-end sequence (formally closes NR-14) — rebuild


### PR DESCRIPTION
Records Ryan's answer to doc-integrity audit Q3: depwire was trialled and rejected ("took some ideas from it, that's about it"). The untracked `.depwire/` output (14 files, stamped 2026-03-20) and `.mcp.json` MCP registration were leftovers contradicting removal commit 3823044 — deleted from the working tree this session.

- Stamps audit §5 Q3 and §32 with the resolution (OP-09 open-question closure)
- Updates park-doc outstanding item 6 (depwire resolved; Q4 + drift-ledger remain)
- Docs-only; no tracker entry (resolves a question inside audit #100's report, no new requirement)

Known-red exception: npm audit job red on main is tracked as DEP-01/#98.

🤖 Generated with [Claude Code](https://claude.com/claude-code)