### PR TITLE
fix(BUG-25): verify trip ownership on POST items (#108)

### DIFF
--- a/src/backend/repositories/items.ts
+++ b/src/backend/repositories/items.ts
@@ -16,9 +16,10 @@ import {
   itemHotels,
   itemRestaurants,
   items,
+  trips,
 } from '../db/index.js';
 import type { Item } from '../db/schema.js';
-import { NotFoundError } from '../errors.js';
+import { LockError, NotFoundError } from '../errors.js';
 import { fetchItemsWithExtensions } from '../routes/items-helper.js';
 import { ensureExperienceExtension } from '../services/items.service.js';
 
@@ -89,6 +90,23 @@ export const itemRepository = {
    * Creates a new item on a trip owned by userId. Returns the created item
    * with extension fields merged in.
    */
+  /**
+   * Verifies the trip exists, is owned by userId, and is not locked.
+   * Mirrors placeRepository.assertWritable — child inserts (items) carry no
+   * userId scoping of their own, so the owning trip must be checked before create.
+   */
+  async assertWritable(userId: string, tripId: number): Promise<void> {
+    const db = getDb();
+    const rows = await db
+      .select({ status: trips.status, userId: trips.userId })
+      .from(trips)
+      .where(eq(trips.id, tripId))
+      .limit(1);
+    if (!rows.length) throw new NotFoundError('Trip');
+    if (rows[0].userId !== userId) throw new NotFoundError('Trip');
+    if (rows[0].status === 'locked') throw new LockError();
+  },
+
   async create(
     userId: string,
     tripId: number,

--- a/src/backend/routes/__tests__/security.access-matrix.test.ts
+++ b/src/backend/routes/__tests__/security.access-matrix.test.ts
@@ -737,4 +737,18 @@ describe('Part C — Cross-user data isolation', () => {
     expect(res.status).toBe(403);
     expect(res.body).toMatchObject({ error: 'Forbidden' });
   });
+
+  // Cross-user WRITE isolation on nested resources — a create must not attach
+  // child rows to another user's trip (regression for the items-POST ownership hole).
+  it('POST /api/trips/:tripAId/items → 404 (USER_B cannot add items to USER_A trip)', async () => {
+    const res = await supertest(app)
+      .post(`/api/trips/${tripAId}/items`)
+      .send({ item_type: 'flight', status: 'confirmed', airline: 'BA', flight_number: 'BA001' });
+    expect(res.status).toBe(404);
+  });
+
+  it('POST /api/trips/:tripAId/places → 404 (USER_B cannot add places to USER_A trip)', async () => {
+    const res = await supertest(app).post(`/api/trips/${tripAId}/places`).send({ city_id: 1 });
+    expect(res.status).toBe(404);
+  });
 });

--- a/src/backend/routes/items.ts
+++ b/src/backend/routes/items.ts
@@ -69,7 +69,9 @@ itemsRouter.post(
     const tripId = parseInt(String(req.params.tripId), 10);
     if (Number.isNaN(tripId)) throw new NotFoundError('Trip');
 
-    await assertNotLocked(tripId);
+    // Verify trip ownership before inserting (items carry no independent userId
+    // scoping on create — cross-user writes must 404 here, not fall through).
+    await itemRepository.assertWritable(userId, tripId);
 
     const body = req.body;
 


### PR DESCRIPTION
Closes #108
BRD §5.11 SE-05 · OP-06 access matrix

## What
`POST /api/trips/:tripId/items` verified lock status but not trip ownership, so any authenticated user could add items to another user's unlocked trip (sequential trip ids). Sibling `POST places` was already safe.

## Change
- `itemRepository.assertWritable(userId, tripId)` — existence + ownership + lock, mirroring `placeRepository.assertWritable`.
- POST items route calls it before insert; cross-user attempts now **404** (opaque, per SE-05).
- Access-matrix Part C extended with cross-user **write** cases (items + places) — the coverage gap that let this survive.

## Verification
- `npm run type:check:all` ✓
- `npm run test:backend` ✓ (464 pass; new Part C cases fail against the pre-fix code)
- `npm run check` (biome) ✓
- `npm run test:frontend` ✓ (unaffected)

## Source
`audits/session-b-code-safety.md` Area 3 HIGH / Q1.

## COO follow-up
Tracker entry BUG-25 still needs to be added (issue #108 in its `notes`) — `scripts/tracker.js` is broken (BUG-23) and the file is hand-edited JSONC, so leaving the tracker write to the COO merge step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)