### PR TITLE
chore: audit-b doc fixes — ungated queue (Session A dispositions)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,10 +15,6 @@ SQLITE_PATH=
 # PostgreSQL: connection string (Phase 2 only — leave blank for SQLite)
 DATABASE_URL=
 
-# MapTiler API key for map tile rendering (requires internet)
-# Get a free key at: https://www.maptiler.com/
-MAPTILER_KEY=
-
 # Express server port (default: 3001)
 PORT=3001
 
@@ -32,9 +28,17 @@ ALLOWED_ORIGINS=http://localhost:5173,http://localhost:3001
 NODE_ENV=development
 
 # ⚠️  SECURITY — DO NOT SET IN PRODUCTION
-# Disables JWT authentication entirely. Only for contract tests and CI.
+# Disables JWT authentication entirely (backend). Only for contract tests and CI.
 # The server will throw a fatal error if this is set in NODE_ENV=production.
+# Must be kept in sync with VITE_BYPASS_AUTH below, or requests are tokenless and 401.
 # BYPASS_AUTH=true
+
+# Geocoding toggle — set false in CI to avoid hitting Nominatim (ADL-10). Default: enabled.
+GEOCODING_ENABLED=true
+
+# Clerk JWKS endpoint — where jose fetches the public keys to verify JWT signatures.
+# Format: <CLERK_ISSUER>/.well-known/jwks.json. Required unless BYPASS_AUTH=true.
+CLERK_JWKS_URI=https://just-raptor-89.clerk.accounts.dev/.well-known/jwks.json
 
 # Clerk JWT issuer — the Clerk instance URL. Used by jwtVerify to validate the `iss` claim.
 # This is not secret; it is the public Clerk Frontend API hostname.
@@ -49,6 +53,14 @@ OWNER_CLERK_ID=
 # Frontend API base URL (used by Vite build)
 VITE_API_BASE_URL=http://localhost:3001
 
-# MapTiler API key (VITE_ prefix exposes it to the frontend bundle)
-# Same key as MAPTILER_KEY above — both are required.
+# Clerk publishable key (frontend). main.tsx throws at startup if this is unset and
+# VITE_BYPASS_AUTH is not 'true'. Find it in the Clerk dashboard under API Keys.
+VITE_CLERK_PUBLISHABLE_KEY=
+
+# Frontend auth bypass — must match backend BYPASS_AUTH. When 'true', the frontend
+# skips ClerkProvider and sends no Authorization header (local/CI only).
+# VITE_BYPASS_AUTH=true
+
+# MapTiler API key (VITE_ prefix exposes it to the frontend bundle).
+# This is the only MapTiler key the code reads.
 VITE_MAPTILER_KEY=your_maptiler_key_here

--- a/CODEBASE.md
+++ b/CODEBASE.md
@@ -69,9 +69,10 @@ a data model rebuild.
 /workspace
 ├── src/                        App source code (frontend + backend)
 ├── geo/                        Static GeoJSON data (countries, regions)
-├── data/                       Seed data and DB output directory
+├── data/                       Seed data (countries.json, regions.json). The SQLite
+│                               file is written to the repo root, not here.
 ├── tests/                      Contract tests
-├── scripts/                    Utility scripts (GitHub issue lifecycle etc.)
+├── scripts/                    tracker.js — tracker.json dashboard CLI
 ├── patches/                    patch-package patches (drizzle-kit bug fixes)
 ├── .github/workflows/          CI/CD pipelines
 │
@@ -119,7 +120,7 @@ src/
 │       ├── TripList/           Left panel — trip list, search, filters, sort
 │       │   ├── TripsLayout.tsx Two-panel shell (list + <Outlet />)
 │       │   ├── TripCard.tsx    Individual trip card
-│       │   └── TripList.ts     Filter/sort logic (pure function)
+│       │   └── TripList.tsx    Trip list rendering + filter/sort logic
 │       ├── TripDetail/         Right panel — trip detail view and edit form
 │       │   ├── TripDetail.tsx  Main detail view
 │       │   ├── TripForm.tsx    Create/edit trip modal
@@ -140,7 +141,8 @@ src/
 │
 └── backend/
     ├── server.ts               Express app — middleware, route mounting, startup
-    ├── server-test-app.ts      Lightweight Express app for contract tests (no auth)
+    ├── server-test-app.ts      Lightweight Express app for backend route unit tests
+    │                           (mirrors server.ts's pipeline; contract tests use the real server)
     ├── errors.ts               Typed error classes
     ├── db/
     │   ├── schema.ts           Drizzle schema — single source of truth for DB shape
@@ -221,7 +223,11 @@ when adding a role, not just this one.
 | **Docs** | `jobs/docs/` | User-facing and maintenance documentation |
 | **Integrations** | `jobs/integrations/` | Phase 2 notification engine and external integrations (pending, post-MVP) |
 
-### Job directory structure (same for every agent)
+### Job directory structure (typical agent)
+
+The structure below is the full layout used by the working software agents. Not every agent
+has every subdirectory — the PO role (`jobs/PO/`), being human-driven, holds only its UAT
+logs (`uat-log.md`, `uat-archive.md`) and no inbox/outbox/tech tree.
 
 ```
 jobs/<agent>/
@@ -298,13 +304,14 @@ Two GitHub Actions workflows run on every push and PR:
 
 | Workflow | Jobs |
 |---|---|
-| `ci.yml` | Type Check · Backend Tests · Frontend Tests · Contract Tests |
+| `ci.yml` | Biome (lint + format) · Type Check · Backend Tests · Frontend Tests · Contract Tests |
 | `security.yml` | Dependency Scan (npm audit) · Secret Scan (Gitleaks) · SAST (Semgrep) |
 
 E2E tests (Playwright) are **not in CI** — run on demand with `npm run test:e2e`.
 
-All jobs must be green before a PR is merged. Contract tests require a live backend;
-in CI they run against a test Express app (`server-test-app.ts`).
+All jobs must be green before a PR is merged. Contract tests require a live backend; in CI
+they run against the **real** server (`npm run start` with `BYPASS_AUTH=true`), not
+`server-test-app.ts` — that lightweight app is used only by the backend route unit tests.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -42,9 +42,16 @@ cp .env.example .env.local
 |----------|----------|-------|
 | `SQLITE_PATH` | Yes | e.g. `file:./dev.db` |
 | `VITE_MAPTILER_KEY` | Yes | Free key at [maptiler.com](https://www.maptiler.com/) |
-| `BYPASS_AUTH` | Dev only | Set to `true` to skip Clerk auth locally |
-| `CLERK_PUBLISHABLE_KEY` | Production | Clerk dashboard |
-| `CLERK_SECRET_KEY` | Production | Clerk dashboard |
+| `BYPASS_AUTH` | Dev only | Backend: `true` skips JWT auth locally. Server throws a fatal error if set with `NODE_ENV=production`. |
+| `VITE_BYPASS_AUTH` | Dev only | Frontend counterpart — must match `BYPASS_AUTH`, or the app throws at startup. |
+| `VITE_CLERK_PUBLISHABLE_KEY` | Unless bypassing | Clerk publishable key. Frontend throws at startup if unset and not bypassing. |
+| `CLERK_JWKS_URI` | Unless bypassing | Clerk JWKS endpoint, e.g. `https://<instance>.clerk.accounts.dev/.well-known/jwks.json`. |
+| `CLERK_ISSUER` | Unless bypassing | Clerk instance URL; validated as the JWT `iss` claim. |
+| `OWNER_CLERK_ID` | For admin | Clerk user ID granted owner/admin access (ADL-27). Unset = safe lockout (no admin), not escalation. |
+
+Auth uses Clerk-issued JWTs verified via JWKS (jose) — there is no Clerk *secret* key in this
+architecture. See `.env.example` for the complete annotated list (`HOST`, `ALLOWED_ORIGINS`,
+`VITE_API_BASE_URL`, `GEOCODING_ENABLED`, etc. all have working defaults).
 
 ### Database (first run)
 

--- a/_project/security-backlog.md
+++ b/_project/security-backlog.md
@@ -17,7 +17,7 @@ COO sign-off required at Phase 2 gate review.
 
 | ID | Finding | Action Required | Status |
 |----|---------|----------------|--------|
-| H1 | No authentication — all endpoints open | Implement real auth in src/backend/middleware/auth.ts | DONE (Clerk JWT, issues #1–4, 2026-03-20) |
+| H1 | No authentication — all endpoints open | Implement real auth in src/backend/middleware/auth.ts | DONE (Clerk JWT, NR-14 issues #1, #2, #4 — #3 is the unrelated Tailwind migration; merged 2026-03-21) |
 | H2 | No HTTPS — plaintext transport | TLS at reverse proxy (nginx/Caddy) before binding change | OPEN |
 | M3 | trust proxy not configured for reverse proxy | app.set('trust proxy', 1) when deploying behind proxy | OPEN |
 

--- a/_project/security-spec.md
+++ b/_project/security-spec.md
@@ -66,6 +66,8 @@ over-engineering (security theatre that slows delivery and adds no real protecti
 - SQLite file is unencrypted on disk. Personal travel data is exposed to anyone with filesystem access.
   Accepted: this is a personal single-user app; OS-level encryption (FileVault) mitigates.
 - No auth on localhost API. Accepted: localhost only; no other user on the machine.
+  > SUPERSEDED (2026-07-15): this acceptance was reversed by NR-14 — the API now requires Clerk
+  > JWT auth (`requireAuth`) in Phase 1. The STRIDE "Phase 1 — no auth" cells above are historical.
 
 **Phase 2 — all HIGH STRIDE items must be resolved before launch.** See Phase 2 gate below.
 
@@ -250,6 +252,12 @@ server-side only and never returned to the client.
 
 ## SEC-09: Authentication Stub — Phase 1
 
+> SUPERSEDED (2026-07-15) by NR-14 / ADL-20 / ADL-27 — retained for history.
+> Real authentication shipped in Phase 1, not Phase 2: `server.ts` applies `requireAuth`
+> to all `/api/*` routes, and `middleware/auth.ts` performs full Clerk JWT verification via
+> jose/JWKS. Owner-only routes additionally use `requireOwner` (ADL-27). The "empty passthrough
+> stub" described below no longer exists. Current auth truth: OP-06 hardening checklist + ADL-20.
+
 **Owner: BACKEND**
 **Required by: Phase 2 — stub only in Phase 1**
 
@@ -389,6 +397,12 @@ Semgrep runs in seconds on a codebase this size. There is no reason not to have 
 Implement before any hosted deployment. These are not optional.
 
 ### Authentication
+
+> SUPERSEDED (2026-07-15) by ADL-20 / NR-14 — retained for history.
+> The design below (OAuth2/OIDC or session cookies; self-managed JWTs with 15-min tokens and
+> refresh rotation) was NOT the design implemented. Phase 1 shipped Clerk-issued JWTs verified
+> via JWKS (jose); token lifecycle is managed by Clerk's SDK. The authoritative auth design is
+> ADL-20; the current control status is the OP-06 hardening checklist.
 
 - Replace `authenticate()` stub with real auth.
 - Use **OAuth 2.0 / OpenID Connect** (preferred) or secure session cookies.
@@ -542,6 +556,12 @@ Additional packages to add to `package.json`:
 ## What This Spec Does NOT Require in Phase 1
 
 These are explicitly deferred — not forgotten:
+
+> PARTIALLY SUPERSEDED (2026-07-15) by NR-14 / ADL-27 — retained for history.
+> The **Authentication** row (and by extension the "no auth" rationale in the IDOR and
+> Password-hashing rows) is no longer accurate: Clerk JWT auth and owner-based access control
+> shipped in Phase 1. The remaining rows (HTTPS, DAST, encrypted-at-rest, pentest, RBAC/ABAC,
+> audit logging) are still deferred as stated.
 
 | Item | Deferred to | Reason |
 |------|-------------|--------|

--- a/_project/travel-tracker-BRD.md
+++ b/_project/travel-tracker-BRD.md
@@ -1,6 +1,6 @@
 # Business Requirements Document
 ## Travel Tracker Application
-**Version:** 2.5
+**Version:** 2.7
 **Date:** March 2026
 **Author:** Claude (BSA) / Ryan V (Product Owner)
 **Status:** Approved

--- a/audits/session-a-doc-integrity.md
+++ b/audits/session-a-doc-integrity.md
@@ -110,6 +110,25 @@
 
 **Systemic pattern worth fixing once, not per-doc:** documents here declare authority ("binding", "authoritative", "single source of truth", "implement from this document") and then freeze. Five docs claim authority over security alone. The consolidation map (§4) proposes one canonical home per topic.
 
+---
+
+> **DOC-FIX EXECUTION STATUS (updated 2026-07-15, PR #110)**
+> The **ungated** (decision-free) items from the doc-fix brief have been executed on branch
+> `chore/audit-b-doc-fixes` (PR #110):
+> - **DONE:** README + `.env.example` env-var reconciliation (doc 3); CODEBASE.md contract-test /
+>   Biome-CI / scripts / data / job-dir / TripList.tsx rows (doc 2); security-spec.md supersession
+>   stamps (doc 7); API reference auth section + missing endpoints, v1.3→1.4 (doc 27);
+>   frontend-component-reference snapshot banner + path/transition/zoom fixes (doc 28);
+>   map-shading-spec user-scoping correction (doc 20); codebase-health.md depwire removal (doc 26);
+>   security-backlog.md H1 citation (§3 SUSPECT); ER-schema banner + `schema.ts:15` (doc 19);
+>   BRD header 2.5→2.7 (doc 6); `drizzle.config.ts` db:push comment.
+> - **STILL PENDING (gated on Ryan's answers, see `audits/questions-for-ryan.md`):** OP-06 status
+>   flips + hardening-gate (Q4/doc 25/9); CLAUDE.md/CODEBASE.md firewall-Clerk claims + issue #23
+>   (Q5); test-policy 423-vs-403 (Q6/doc 10); BRD §3/NF-01 + OQ closures (Q1/Q15/doc 6); project
+>   objective home (Q19/doc 11); screenshots dir (Q16); DOCX (Q18); shadcn (Q14); `claude-code/`
+>   framing (Q17/doc 2).
+> Individual disposition rows below are NOT restamped per-line; this block is the execution index.
+
 ## 2. Drift findings (Audit 1)
 
 *Per-document tables below (severity/classification/evidence/disposition in each doc's section).*

--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -3,8 +3,11 @@
  *
  * Used by drizzle-kit for schema migration generation and application:
  *   npm run db:generate  → generate migration files from schema changes
- *   npm run db:push      → apply schema directly to the database (dev shortcut)
+ *   npm run db:migrate   → apply pending migrations
  *   npm run db:studio    → open Drizzle Studio to inspect the database
+ *
+ * db:push is FORBIDDEN (ADL-15) and removed from package.json — it bypasses the
+ * patched migration path and can desync the migrations journal. Use generate + migrate.
  *
  * The dialect and credentials are driven by environment variables so this
  * same config file works for both SQLite (Phase 1) and PostgreSQL (Phase 2).
@@ -14,8 +17,8 @@
  * SQLITE_PATH must be a libSQL URL: file:./dev.db or file:/absolute/path.
  */
 
-import { defineConfig } from 'drizzle-kit';
 import { config } from 'dotenv';
+import { defineConfig } from 'drizzle-kit';
 
 // Load .env.local explicitly — dotenv/config only reads .env by default
 config({ path: '.env.local' });

--- a/jobs/architect/tech/20260307-ER-schema.md
+++ b/jobs/architect/tech/20260307-ER-schema.md
@@ -4,6 +4,12 @@
 **Author:** Architect
 **Status:** Approved for DATABASE implementation
 
+> HISTORICAL — snapshot of the original 19-table design as of 2026-03-07, not maintained.
+> The auth/ownership layer added since (users, trip_countries, is_owner, place date ranges,
+> user_id FKs) is NOT reflected here. The authoritative current schema is
+> `src/backend/db/schema.ts`; the evolution is recorded in the architecture-decisions-log
+> (ADL-16/19/20/23/24/27).
+
 ---
 
 ## Design Decisions (Summary)

--- a/jobs/architect/tech/20260307-map-shading-spec.md
+++ b/jobs/architect/tech/20260307-map-shading-spec.md
@@ -2,7 +2,18 @@
 **Version:** 1.2
 **Date:** 2026-03-21
 **Author:** Architect
-**Status:** Approved — implement in BACKEND
+**Status:** Approved — implemented in BACKEND (with the user-scoping correction below).
+
+> ⚠️ USER-SCOPING CORRECTION (2026-07-15, HC-03) — read before re-implementing from this spec.
+> The example SQL throughout this document (`WHERE tp.city_id = :city_id`, the country/region
+> aggregates in §3–§5) is written **without `user_id` scoping**. That predates HC-03: as
+> shipped, **every serving shading query must additionally filter to the requesting user**
+> (`JOIN trips t … AND t.user_id = :user_id`). OP-06 found that the unscoped form leaks other
+> users' travel into a user's map. Do not copy the SQL below verbatim — add the user_id join.
+>
+> Per-user *shading configuration* (colours/labels per user) is decided but NOT yet implemented
+> (ADL-28): `map_shading_config` remains a single global table. Treat per-user config as future
+> work, not current behaviour.
 
 **Amendment (v1.2 — 2026-03-21):** Country shading extended to include
 `trip_countries` direct associations (ADL-23). §4 replaced in full. §3 and §5

--- a/jobs/architect/tech/codebase-health.md
+++ b/jobs/architect/tech/codebase-health.md
@@ -6,7 +6,15 @@
 
 ## How to Run This Assessment
 
-This is the project's own health scoring methodology, calibrated for the Travel Tracker stack. It replaces depwire's health score, which is inaccurate for this codebase (see CLAUDE.md for depwire limitations).
+This is the project's own health scoring methodology, calibrated for the Travel Tracker stack.
+
+> DEPWIRE REMOVED (2026-07-15, per Q3 resolution 2026-07-07) — the `depwire` tool was evaluated
+> and rejected; the removal commit (3823044) stands and CLAUDE.md carries no depwire content
+> (the old cross-reference was dead). **Every `depwire …` command referenced below is defunct.**
+> Substitute manual methods: for coupling/dependents use `grep -rn "from '.*<module>'" src` and
+> read the import blocks; for God-file symbol counts read the file; for circular dependencies use
+> `npx madge --circular src` if a tool is wanted. The scoring dimensions and thresholds still hold —
+> only the depwire data source is gone.
 
 ### Scoring dimensions and weights
 
@@ -38,7 +46,7 @@ This is the project's own health scoring methodology, calibrated for the Travel 
 
 **God Files:** `depwire list_files --directory src` symbol counts. Flag any route file >30 symbols or service file >60 symbols. Verify by reading — tree-sitter inflates counts with local variable declarations.
 
-**Orphans & Dead Code:** Read `src/backend/middleware/auth.ts` (is it still a stub?), check for any TODO (Phase 2) blocks that were never actioned. Do not use depwire dead-code output.
+**Orphans & Dead Code:** Genuine unreachable application code only. (Historical note: `auth.ts` was a Phase-1 stub when this methodology was written; it is now full Clerk JWT verification, so the "is it still a stub?" prompt is obsolete.) Check for any TODO (Phase 2) blocks that were never actioned.
 
 **Dependency Depth:** Trace the longest import chain manually from a page/server entry point. Count hops.
 
@@ -88,7 +96,7 @@ Zero. Confirmed. Clean.
 Three large files: `schema.ts` (57 symbols — appropriate, it is the schema), `shading.service.ts` (50 symbols — appropriate, multi-path shading computation), `trips.ts` (47 raw symbols — inflated by inline helper functions that belong in repositories). None are doing unrelated things; size is domain-justified except in `trips.ts`.
 
 **Orphans & Dead Code — 85/B**
-No genuine dead application code. `auth.ts` is a live SEC-09 stub with exactly 2 dependents (server.ts, server-test-app.ts) — seam is clean for Clerk replacement per ADL-20. No unreachable routes or unused exports identified.
+No genuine dead application code. (As of this assessment `auth.ts` was a live SEC-09 stub with 2 dependents — server.ts, server-test-app.ts — and the seam was clean for Clerk replacement per ADL-20; the replacement has since shipped and auth.ts now performs real JWT verification.) No unreachable routes or unused exports identified.
 
 **Dependency Depth — 85/B**
 Backend: server → routes → services → db = 4 levels. Frontend: pages → components → hooks → apiClient = 4 levels. Validation adds one layer where needed. Max depth 7 is end-to-end across the full stack, not within either side alone.

--- a/jobs/backend/tech/20260307-api-reference.md
+++ b/jobs/backend/tech/20260307-api-reference.md
@@ -1,7 +1,8 @@
 # Travel Tracker — Backend API Reference
 
-**Version:** 1.3
-**Date:** 2026-03-19 (updated: FEAT-BD — DELETE /api/trips/:id endpoint)
+**Version:** 1.4
+**Date:** 2026-07-15 (updated: auth conventions (NR-14); trip-countries, place-date PATCH,
+item rating sort/filter — audit doc-fix pass)
 **Base URL:** `http://localhost:3001`
 **Author:** BACKEND
 
@@ -14,7 +15,8 @@ This document is the authoritative contract between BACKEND and FRONTEND. FRONTE
 1. [Conventions](#conventions)
 2. [Trips](#trips)
 3. [Places (nested under Trips)](#places)
-4. [Items (nested under Trips)](#items)
+4. [Trip Countries (nested under Trips)](#trip-countries)
+5. [Items (nested under Trips)](#items)
 5. [Cities](#cities)
 6. [Map Shading](#map-shading)
 7. [Admin](#admin)
@@ -29,7 +31,22 @@ This document is the authoritative contract between BACKEND and FRONTEND. FRONTE
 All API endpoints are prefixed with `/api`. The server runs on `http://localhost:3001` by default.
 
 ### Authentication
-Phase 1: No authentication required. All endpoints are open. Phase 2 will add token-based auth — the `Authorization` header is reserved.
+Since NR-14 (ADL-20), **all `/api/*` routes require a Clerk-issued JWT**. Send it as a bearer token:
+
+```
+Authorization: Bearer <clerk_jwt>
+```
+
+- Missing/invalid/expired token → **401 Unauthorized** (`{ "error": "Unauthorized" }`).
+- The token is verified server-side against Clerk's JWKS (jose); the `iss` claim must match `CLERK_ISSUER`.
+- Exempt (no token): `GET /health` and the `/geo/*` static assets — these sit outside `/api/`.
+- **Owner-only routes** additionally require the caller to be the app owner (ADL-27); a non-owner
+  gets **403 Forbidden** (`{ "error": "Forbidden" }`). These are: all `/api/admin/*` routes,
+  `POST /api/cities`, and the shading-config writes under `/api/map/shading/config`.
+- Cross-user access to another user's resource returns **404** (opaque, per SE-05), not 403.
+- **Local/CI bypass:** with `BYPASS_AUTH=true` (backend) the server injects a fixed test user and
+  skips verification. Contract tests run this way. Never set it in production (the server refuses
+  to boot with it under `NODE_ENV=production`).
 
 ### Date Format
 All dates are ISO 8601 strings:
@@ -46,7 +63,8 @@ Fields with no data are returned as `null` (not omitted).
 | `201 Created` | Successful POST |
 | `204 No Content` | Successful DELETE — no body |
 | `400 Bad Request` | Validation failure or invalid input |
-| `403 Forbidden` | Trip is locked; write rejected |
+| `401 Unauthorized` | Missing, invalid, or expired auth token |
+| `403 Forbidden` | Trip is locked (write rejected), or owner-only route accessed by a non-owner |
 | `404 Not Found` | Resource does not exist |
 | `409 Conflict` | Uniqueness violation |
 | `500 Internal Server Error` | Unexpected server error |
@@ -519,6 +537,37 @@ Remove a place from a trip. This also deletes all items and activity tags associ
 
 ---
 
+### PATCH /api/trips/:tripId/places/:placeId
+
+Update a place's date range (UX-02). Both fields are optional and nullable.
+
+> Note: this is a full-replace PATCH — a field omitted from the body is set to `null`, not left
+> unchanged (unlike the other PATCH endpoints in this API). Send both fields to preserve both.
+> *(Whether this replace-semantics is intended is Session B Q6, pending PO confirmation.)*
+
+**Path Parameters:**
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `tripId` | integer | Trip ID |
+| `placeId` | integer | Place ID |
+
+**Request Body:**
+```json
+{ "arrived_on": "2026-06-01", "departed_on": "2026-06-05" }
+```
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `arrived_on` | string \| null | No | ISO date (YYYY-MM-DD) the traveller arrived |
+| `departed_on` | string \| null | No | ISO date (YYYY-MM-DD) the traveller departed |
+
+**Response: `200 OK`** — the updated place object.
+
+**Errors:**
+- `403` — trip is locked
+- `404` — place not found on trip
+
+---
+
 ### POST /api/trips/:tripId/places/:placeId/activities
 
 Tag an activity to a trip place.
@@ -604,6 +653,53 @@ For each source item, a new item is created with:
 - `400` — `source_item_ids` is empty, contains non-integer values, or one or more IDs do not exist
 - `403` — target trip is locked
 - `404` — trip or place not found (or place does not belong to trip)
+
+---
+
+## Trip Countries
+
+Countries associated with a trip (ADL-23). This denormalised set drives map shading independently
+of the trip's places. Nested under a trip; both writes reject a locked trip.
+
+### POST /api/trips/:tripId/countries
+
+Add one or more ISO 3166-1 alpha-2 country codes to a trip. Idempotent per code.
+
+**Request Body:**
+```json
+{ "country_codes": ["AU", "NZ"] }
+```
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `country_codes` | string[] | Yes | One or more 2-letter country codes (min 1) |
+
+**Response: `200 OK`**
+```json
+{ "countries": ["AU", "NZ"] }
+```
+
+**Errors:**
+- `400` — validation failure (empty array, or a code not exactly 2 characters)
+- `403` — trip is locked
+- `404` — trip not found (or not owned by the caller)
+
+---
+
+### DELETE /api/trips/:tripId/countries/:code
+
+Remove a single country association from a trip.
+
+**Path Parameters:**
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `tripId` | integer | Trip ID |
+| `code` | string | ISO 3166-1 alpha-2 country code |
+
+**Response: `204 No Content`**
+
+**Errors:**
+- `403` — trip is locked
+- `404` — trip not found, or the country is not associated with the trip
 
 ---
 
@@ -1001,6 +1097,8 @@ Get all completed items at this city across all trips. Useful for building a "be
 |-----------|------|----------|-------------|
 | `type` | string | No | Filter by `item_type` (e.g. `"restaurant"`) |
 | `min_rating` | integer | No | Only include items with rating ≥ this value (1–5) |
+| `sort_by` | string | No | `rating` — sort by effective rating (IT-08) |
+| `sort_order` | string | No | `asc` or `desc` (default `desc`); applies when `sort_by` is set |
 
 **Response: `200 OK`**
 ```json

--- a/jobs/frontend/tech/20260308-frontend-component-reference.md
+++ b/jobs/frontend/tech/20260308-frontend-component-reference.md
@@ -1,6 +1,14 @@
 # Frontend Component Reference
 Date: 2026-03-08
 
+> PARTIAL SNAPSHOT (banner added 2026-07-15) — the component/hook tree below is a Phase-1
+> snapshot and predates the two-panel layout (TR-11), the Tailwind migration, Clerk auth
+> (`main.tsx` now wraps the app in `ClerkProvider`), and UX-02. It omits components added since
+> (e.g. `TripsLayout.tsx`, `PlaceDateForm.tsx`, `useGeocodeRetryQueue.ts`). For **authoritative
+> API paths and methods, use `jobs/backend/tech/20260307-api-reference.md`** — do not treat the
+> hook→endpoint mappings here as current. The specific method/path/transition errors called out
+> by the 2026-07 audit have been corrected inline below; the tree itself has not been rebuilt.
+
 ## Architecture Overview
 
 ```
@@ -35,7 +43,7 @@ src/frontend/
     ├── Map/
     │   ├── MapView.tsx         ← Full-page MapLibre map, integrates all map layers
     │   ├── CountryLayer.tsx    ← GeoJSON country fills + feature-state shading
-    │   ├── RegionLayer.tsx     ← GeoJSON region fills (lazy, zoom >= 4)
+    │   ├── RegionLayer.tsx     ← GeoJSON region fills (lazy, zoom >= 3)
     │   └── CityMarkers.tsx     ← GeoJSON symbol layer for city pins
     ├── TripList/
     │   ├── TripList.tsx        ← Filter bar + card grid + TripForm modal trigger
@@ -70,8 +78,8 @@ src/frontend/
 | useCreateTrip() | Mutation | invalidates ['trips'] | POST /api/trips |
 | useUpdateTrip() | Mutation | invalidates ['trips', id] | PATCH /api/trips/:id |
 | useUpdateTripStatus() | Mutation | invalidates ['trips', id] | PATCH /api/trips/:id (status only) |
-| useLockTrip() | Mutation | invalidates ['trips', id] | POST /api/trips/:id/lock |
-| useUnlockTrip() | Mutation | invalidates ['trips', id] | POST /api/trips/:id/unlock |
+| useLockTrip() | Mutation | invalidates ['trips', id] | PATCH /api/trips/:id/lock |
+| useUnlockTrip() | Mutation | invalidates ['trips', id] | PATCH /api/trips/:id/unlock |
 | useAddPlace() | Mutation | invalidates ['trips', tripId] | POST /api/trips/:id/places |
 | useRemovePlace() | Mutation | invalidates ['trips', tripId] | DELETE /api/trips/:id/places/:placeId |
 | useCarryForward() | Mutation | invalidates ['trips', tripId] | POST /api/trips/:id/places/:placeId/carry-forward |
@@ -83,8 +91,8 @@ src/frontend/
 | useCreateCity() | Mutation | — | POST /api/cities |
 | useMapShading() | Query (5min stale) | ['map', 'shading'] | GET /api/map/shading |
 | useRegionShading(countryCode?) | Query | ['map', 'regions', countryCode] | GET /api/map/shading/regions/:code |
-| useShadingConfig() | Query | ['map', 'shading-config'] | GET /api/admin/shading-config |
-| useUpdateShadingColor() | Mutation | invalidates ['map'] | PATCH /api/admin/shading-config/:key |
+| useShadingConfig() | Query | ['map', 'shading-config'] | GET /api/map/shading/config |
+| useUpdateShadingColor() | Mutation | invalidates ['map'] | PATCH /api/map/shading/config/:stateKey |
 | useCategories() | Query | ['admin', 'categories'] | GET /api/admin/categories |
 | useActivities() | Query | ['admin', 'activities'] | GET /api/admin/activities |
 | useCompanions() | Query | ['admin', 'companions'] | GET /api/admin/companions |
@@ -110,5 +118,6 @@ src/frontend/
 planning → active
 active → review_pending
 review_pending → locked
-locked → active  (unlock)
+review_pending → planning
+locked → review_pending  (unlock — returns to review_pending, NOT active)
 ```

--- a/src/backend/db/schema.ts
+++ b/src/backend/db/schema.ts
@@ -12,7 +12,10 @@
  * column names and relationships are identical; only the table builder
  * and column type imports change.
  *
- * @see jobs/architect/tech/20260307-ER-schema.md (v1.1 — authoritative)
+ * @see jobs/architect/tech/20260307-ER-schema.md (v1.1 — original design, historical).
+ *      Schema evolution since v1.1 (users, trip_countries, is_owner, place dates,
+ *      user_id FKs) is recorded in the architecture-decisions-log (ADL-16/19/20/23/24/27).
+ *      This file — not the ER doc — is the authoritative current schema.
  */
 
 import { sql } from 'drizzle-orm';


### PR DESCRIPTION
Executes the **decision-free** items from the Session B doc-fix brief
(`jobs/COO/outbox/20260708_0645-COO-brief-audit-session-b-doc-fixes.md`). Gated items that
depend on Ryan's open questions were deliberately left untouched (tracked in
`audits/questions-for-ryan.md`).

## Batch 1 (commit aa933ba)
- `drizzle.config.ts`: drop `db:push` "dev shortcut"; state it's forbidden (ADL-15)
- `schema.ts:15` + `ER-schema.md`: repoint the "authoritative" comment; historical banner on the ER doc
- BRD header version 2.5 → 2.7 (matches changelog)

## Batch 2 (this commit)
- **README + `.env.example`**: removed dead `CLERK_PUBLISHABLE_KEY`/`CLERK_SECRET_KEY` (neither exists in code — JWKS-based, no secret key); added the real auth vars + `GEOCODING_ENABLED`; dropped unused non-VITE `MAPTILER_KEY`. Fresh setup per README no longer throws.
- **CODEBASE.md**: 5 CI jobs incl. Biome; contract tests run the real server (`npm run start`, `BYPASS_AUTH=true`), not `server-test-app.ts`; corrected `scripts/`, `data/`, job-dir (PO differs), `TripList.tsx`.
- **security-spec.md**: supersession stamps on SEC-09, the Phase-2 auth prescription, the STRIDE "no auth" acceptance, and the deferred-items table.
- **api-reference.md v1.3 → 1.4**: real auth conventions section + 401/403; `PATCH …/places/:placeId` (dates); trip-countries `POST`/`DELETE`; item `sort_by`/`sort_order` params.
- **frontend-component-reference.md**: snapshot banner + authoritative-paths pointer; lock/unlock are PATCH not POST; shading-config path `/api/map/shading/config`; `locked → review_pending`; zoom ≥ 3.
- **map-shading-spec.md**: HC-03 user-scoping correction (don't copy the unscoped SQL); ADL-28 per-user config decided-not-implemented.
- **codebase-health.md**: depwire-removed banner (Q3); `auth.ts` no-longer-a-stub.
- **security-backlog.md**: corrected H1 citation — #3 is the Tailwind migration, not auth; merged 2026-03-21 (verified via `gh`).

## Deliberately NOT touched (Q-gated)
CLAUDE.md/CODEBASE.md firewall-Clerk claims (Q5), `claude-code/` framing (Q17), OP-06 status flips (Q4), test-policy 423/403 (Q6), BRD OQ-02/§3 (Q1/Q15), project-plan objective home (Q19), screenshots dir (Q16), DOCX (Q18), shadcn (Q14).

## Verification
- `npm run check` (biome) ✓ · `npm run type:check:all` ✓ · `npm run test:backend` ✓ (462) · `npm run test:frontend` ✓ (78)
- Env vars cross-checked against `grep process.env / import.meta.env` in `src/`.

Source: `audits/session-a-doc-integrity.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)