### PR TITLE
fix(HC-02): azp validation + NR-14 gate close-out (Q5 real-auth UAT)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,8 @@ PORT=3001
 HOST=127.0.0.1
 
 # Comma-separated allowed CORS origins (SEC-02). Default covers Vite dev + API itself.
+# Also used as the JWT azp (authorized party) allowlist (HC-02) — Clerk session tokens
+# carry the issuing browser origin in `azp` (they have no `aud` claim).
 ALLOWED_ORIGINS=http://localhost:5173,http://localhost:3001
 
 # Node environment

--- a/_project/hardening-gate.md
+++ b/_project/hardening-gate.md
@@ -14,6 +14,14 @@
 > (audit Q5):** the live auth/IDOR spot-checks (1.5-B, 1.5-C) and JWT audience validation.
 > Gate 2.0 (hosted deployment) and Gate 3.0 (companion access) items remain open by design.
 
+> **GATE 1.5 CLOSED (2026-07-16, audit Q5 — PR #115).** The real-auth PO UAT ran and
+> passed (owner + second non-owner account — see the 2026-07-16 session in
+> `jobs/PO/uat-log.md`), closing the 1.5-B/1.5-C live spot-checks. Audience validation
+> landed as `azp`-against-`ALLOWED_ORIGINS` (Clerk session tokens carry no `aud` claim —
+> corrected premise, PR #115). **OP-06 §7 now reads 13/13 PASS; NR-14 is formally
+> closed.** UAT finding BUG-26 (#116, admin nav visible to non-owners) is tracked
+> separately and does not affect the gate.
+
 ---
 
 ## Purpose
@@ -285,10 +293,12 @@ The following items in `security-backlog.md` need updating to reflect current st
 ### Gate 1.5 — Auth Hardening
 - [x] 1.5-A: BYPASS_AUTH guard — production startup guard in `server.ts` (HC-08 PASS);
   `BYPASS_AUTH=false` documented in `.env.example`
-- [~] 1.5-B: Auth enforcement — code-verified (`requireAuth` mounted; 401 on missing/invalid
-  token unit-tested, HC-09/HC-10 PASS). **Live spot-check pending real-auth PO UAT (Q5).**
-- [~] 1.5-C: IDOR — cross-user → 404 code-verified (HC-10 PASS) + access-matrix regression
-  suite (PR #93). **Two-user live spot-check pending real-auth PO UAT (Q5).**
+- [x] 1.5-B: Auth enforcement — code-verified (`requireAuth` mounted; 401 on missing/invalid
+  token unit-tested, HC-09/HC-10 PASS). Live spot-check passed in the Q5 real-auth PO UAT
+  (2026-07-16, PR #115).
+- [x] 1.5-C: IDOR — cross-user → 404 code-verified (HC-10 PASS) + access-matrix regression
+  suite (PR #93). Two-user live spot-check passed in the Q5 real-auth PO UAT (2026-07-16,
+  PR #115): non-owner account saw only its own (empty) data; admin writes 403'd.
 - [x] 1.5-D: Admin data model — per-user, deferred to Gate 3.0 (decision recorded 2026-03-21)
 
 ### Gate 2.0 — Hosted Deployment

--- a/_project/tracker.json
+++ b/_project/tracker.json
@@ -569,12 +569,12 @@
       "id": "NR-14",
       "type": "requirement",
       "title": "Pre-shared-access hardening gate — formal go/no-go before non-owner access",
-      "status": "in-progress",
+      "status": "done",
       "owner": "coo",
       "priority": "P1",
       "brdRefs": ["NF-07", "SE-01", "SE-02", "SE-03", "SE-04", "SE-05", "SE-06", "SE-07"],
       "phase": 1,
-      "notes": "Phase 1.5 gate. Architect deliverables received 2026-03-23: OP-06 checklist (13 items HC-01–HC-13), ADL-27 (is_owner column + requireOwner middleware), ADL-27 corrections. DONE: HC-01 firewall (#80), HC-02 JWT issuer (#88), HC-03 shading scope (#84), HC-04 admin routes (#82), HC-05 shading config (#82), HC-06 city creation (#82), HC-07b null audit (#81), HC-07c NOT NULL migration (#86), ADL-27 schema+middleware (#82). PRs #84/#86/#88 pending merge. NR-14 closes after merge + PO HC-01 UAT sign-off (6-step sequence in park doc)."
+      "notes": "Phase 1.5 gate. Architect deliverables received 2026-03-23: OP-06 checklist (13 items HC-01–HC-13), ADL-27 (is_owner column + requireOwner middleware), ADL-27 corrections. DONE: HC-01 firewall (#80), HC-02 JWT issuer (#88), HC-03 shading scope (#84), HC-04 admin routes (#82), HC-05 shading config (#82), HC-06 city creation (#82), HC-07b null audit (#81), HC-07c NOT NULL migration (#86), ADL-27 schema+middleware (#82). PRs #84/#86/#88 pending merge. NR-14 closes after merge + PO HC-01 UAT sign-off (6-step sequence in park doc). CLOSED 2026-07-16: Q5 real-auth PO UAT passed (owner + second non-owner account: Clerk sign-in through firewall, data separation, admin 403 for non-owner); HC-02 audience half landed as azp validation in PR #115 (live token decode showed Clerk session tokens carry azp, not aud). OP-06 gate 13/13 PASS. One non-blocking UAT finding: BUG-26 (#116, admin nav visible to non-owner, frontend polish)."
     },
     {
       "id": "NR-15",
@@ -1041,6 +1041,17 @@
       "brdRefs": [],
       "phase": 1,
       "notes": "Regex at tracker.js:27 strips comment syntax inside JSON string literals; the BUG-A note added 2026-03-23 contains 'trips.ts:280' preceded by a double-slash, truncating the string — every tracker.js run since fails to parse. Fix: string-aware comment stripping. Found 2026-07-07 during OP-09 work. GitHub issue #96."
+    },
+    {
+      "id": "BUG-26",
+      "type": "bug",
+      "title": "Admin panel nav entry visible to non-owner users",
+      "status": "open",
+      "owner": "frontend",
+      "priority": "P3",
+      "brdRefs": ["SE-02"],
+      "phase": 1,
+      "notes": "Found during Q5 real-auth UAT (2026-07-16), HC-01 step 5 second-account check. Non-owner sees the admin button in the banner, page loads, every section renders 'not authorised' (backend requireOwner correctly 403s — not a security hole, presentation gating only). Frontend should hide the nav entry for non-owners. PO verdict: 'suboptimal pass'. GitHub issue #116. Does not block NR-14."
     },
     {
       "id": "BUG-25",

--- a/jobs/PO/uat-log.md
+++ b/jobs/PO/uat-log.md
@@ -51,7 +51,38 @@ Screenshots: save to `jobs/PO/screenshots/[date]-[short-description].png`
 
 ## Open Sessions
 
-<!-- None — all sessions closed -->
+### UAT Session — 2026-07-16
+
+**Scope:** Q5 real-auth end-to-end (OP-06 HC-01 verification, 6-step sequence)
+**Build:** main @ 0c56fc2 + fix/hc02-azp-validation (azp validation live via tsx watch)
+**Verdict:** PASS — closes HC-01. One non-blocking UX finding (BUG-26).
+
+#### Findings
+
+- [ ] Admin panel nav button visible to non-owner users
+      Steps: 1. Sign in as a fresh non-owner Clerk account (ryanvilliers00+test@gmail.com)
+             2. Observe banner — admin button present
+             3. Click it — admin page loads, every section renders "not authorised"
+      Expected: Admin nav entry hidden entirely for non-owners
+      Actual: Button visible; page loads; backend requireOwner correctly 403s all sections
+      Screenshot: none
+      Fixed myself: no
+      Bug: BUG-26 / GitHub #116 (P3, frontend presentation gating — not a security hole;
+      backend enforcement verified correct in this same session)
+
+#### Notes / Observations
+
+1. Owner account: Clerk sign-in completed in-browser through the devcontainer firewall
+   (#80); JWKS 200 from inside the container; no BYPASS_AUTH in `.env.local`; app fully
+   functional under real auth ("it all works" — PO).
+2. Live JWT decoded during session: `sub` = PO's real Clerk user; **no `aud` claim** —
+   Clerk session tokens carry `azp` instead. Drove the HC-02 azp implementation (PR #115).
+3. `OWNER_CLERK_ID` in `.env.local` had literal `<>` brackets (placeholder paste error)
+   — would have broken owner resolution; fixed during session by COO.
+4. Non-owner account saw only its own (empty) data — data separation confirmed
+   (1.5-C live spot-check satisfied alongside 1.5-B).
+5. PO verdict on step 5: "not a complete fail, just a suboptimal pass" — hence PASS with
+   BUG-26 logged.
 
 ### UAT Session — 2026-03-20
 

--- a/jobs/architect/tech/OP-06-hardening-checklist.md
+++ b/jobs/architect/tech/OP-06-hardening-checklist.md
@@ -392,14 +392,23 @@ Required UAT steps (all must pass):
 **Requirement:** `jwtVerify` must validate `iss` and `aud` to prevent token reuse across
 Clerk instances or apps.
 
-**Current state: PARTIAL — issuer done (PR #88 `a12ca3c`), audience deferred.** `auth.ts`
-now calls `jwtVerify(token, jwks, { issuer })` with `issuer` sourced from a required
+**Current state: PASS (issuer PR #88 `a12ca3c`; azp PR #115, 2026-07-16).** `auth.ts`
+calls `jwtVerify(token, jwks, { issuer })` with `issuer` sourced from a required
 `CLERK_ISSUER` env var (startup-guarded like `CLERK_JWKS_URI`); a mismatched `iss` is
-rejected with 401 and is covered by a unit test. **`audience` is still not validated** —
-it was deferred because the real `aud` value can only be confirmed by decoding a live
-Clerk JWT, which requires real auth to be running (HC-01 / audit Q5). Adding
-`audience: process.env.CLERK_AUDIENCE` to the `jwtVerify` options is the remaining work,
-and it should land together with the HC-01 real-auth verification.
+rejected with 401 and is covered by a unit test. The audience half closed with a
+**corrected premise**: a live Clerk session token decoded during the Q5 real-auth UAT
+(2026-07-16) confirmed Clerk session tokens carry **no `aud` claim** — the audience
+equivalent is `azp` (authorized party), set to the browser origin the token was issued
+to (`http://localhost:5173`). PR #115 adds `azp` validation: after `jwtVerify`, a token
+whose `azp` is missing or not in the `ALLOWED_ORIGINS` allowlist is rejected with 401
+(this mirrors Clerk's own `verifyToken` `authorizedParties` semantics, strict on missing
+`azp`). Unit tests cover both rejection paths. No `CLERK_AUDIENCE` env var exists or is
+needed.
+
+> SUPERSEDED (2026-07-16) by PR #115 — retained for history. The `CLERK_AUDIENCE`
+> prescription below assumed Clerk session tokens carry an `aud` claim; a live token
+> decode showed they do not (the audience equivalent is `azp`, validated against
+> `ALLOWED_ORIGINS` instead — see Current state above).
 
 **Remediation:**
 1. Add `CLERK_ISSUER` and `CLERK_AUDIENCE` to `.env.local` and document in `.env.local.example`.
@@ -426,10 +435,12 @@ and it should land together with the HC-01 real-auth verification.
   env vars are not read during BYPASS_AUTH sessions. Contract tests that use `BYPASS_AUTH`
   do not need these vars set and are unaffected by this validation addition.
 
-**Verification:**
-- Contract test: Supply a JWT signed by a different Clerk instance (or forge `iss`); confirm 401.
-- Contract test: Supply a JWT with a mismatched `aud`; confirm 401.
-- Code review: Confirm `jwtVerify` options include issuer and audience.
+**Verification (updated 2026-07-16, PR #115 — `aud` → `azp` per the corrected premise):**
+- Unit test: token verified but `azp` not in allowlist → 401 (`auth.test.ts`).
+- Unit test: token verified but `azp` missing → 401 (`auth.test.ts`).
+- Unit test: wrong `iss` → 401 (`auth.test.ts`, since #88).
+- Code review: Confirm `jwtVerify` options include issuer, and `azp` is checked against
+  `ALLOWED_ORIGINS` after verification.
 - Code review: Confirm BYPASS_AUTH short-circuit runs before `jwtVerify` is called.
 
 ---
@@ -768,7 +779,7 @@ NR-14 PASSES when all of the following are GREEN:
 | Item | Requirement | Current |
 |---|---|---|
 | HC-01 | Clerk JWKS reachable in local dev | FAIL — firewall landed (#80); **pending real-auth PO UAT (Q5)** |
-| HC-02 | JWT issuer + audience validated | PARTIAL — issuer done (#88); **audience deferred (needs live `aud`, Q5)** |
+| HC-02 | JWT issuer + audience validated | PASS — issuer (#88); azp-as-audience (#115, no `aud` in Clerk tokens) |
 | HC-03 | Map shading user-scoped | PASS (#84) |
 | HC-04 | Admin writes owner-only | PASS (#82) |
 | HC-05 | Companion + shading config not leaked | PASS (#82) |

--- a/jobs/architect/tech/OP-06-hardening-checklist.md
+++ b/jobs/architect/tech/OP-06-hardening-checklist.md
@@ -19,6 +19,13 @@ the NR-14 implementation backlog.
 > can only be confirmed from a live Clerk JWT). **NR-14 therefore remains BLOCKED** on
 > these two real-auth items — see §7. Per-item citations are inline below.
 
+> **GATE CLOSED (2026-07-16, audit Q5 — PR #115).** The Q5 real-auth PO UAT ran and
+> passed (owner + second non-owner account), closing HC-01. HC-02's audience half closed
+> with a corrected premise: Clerk session tokens carry no `aud` claim — `azp` is
+> validated against `ALLOWED_ORIGINS` instead. **All 13 items PASS; NR-14 is formally
+> closed** — see §7. One non-blocking UAT finding: BUG-26 / #116 (admin nav visible to
+> non-owners; backend 403 enforcement verified correct).
+
 ---
 
 ## 1. Trust Boundaries
@@ -347,13 +354,24 @@ primary remediation target for NR-14.
 **Requirement:** Real JWT auth must work in local dev. `BYPASS_AUTH=true` must not be
 required in `.env.local` for the PO's manual testing session.
 
-**Current state: FAIL — config landed, closure pending UAT (audit Q5).** The firewall
-allow-list change merged in PR #80 (`d6c9236`) adds `just-raptor-89.clerk.accounts.dev`
-to `init-firewall.sh`. Per the verification note below, that change is necessary but not
-sufficient: HC-01 closes only when real-auth is verified end-to-end by the PO under UAT.
-That UAT has **not** run — `BYPASS_AUTH=true` is still present in `.env.local`. This is
-the open item tracked as audit Q5 ("is real local auth working now — work through
-together"); it and HC-02's audience gap are the only two things blocking NR-14.
+**Current state: PASS (2026-07-16 — Q5 real-auth PO UAT, recorded in the PO UAT log;
+PR #115).** The firewall allow-list change merged in PR #80 (`d6c9236`) adds
+`just-raptor-89.clerk.accounts.dev` to `init-firewall.sh`; JWKS fetch confirmed 200 from
+inside the container. The required end-to-end UAT ran 2026-07-16 with `BYPASS_AUTH`
+absent from `.env.local`:
+- Steps 1–2: Clerk sign-in screen appeared and completed in-browser; no JWKS errors.
+- Step 3: API requests authenticated as the PO's real Clerk user (verified JWT `sub`
+  matched `OWNER_CLERK_ID`); trip data scoped to that user (fresh real account, empty
+  list — correct, pre-UAT data lives under the BYPASS_AUTH test user by design, #23).
+- Step 4: owner role resolved from a real token; admin functionality available to the
+  owner. (Prerequisite fix: `OWNER_CLERK_ID` in `.env.local` had literal `<>` brackets
+  from a placeholder paste — corrected during the UAT session.)
+- Step 5: second non-owner Clerk account signed in; saw only its own (empty) data; all
+  admin sections refused ("not authorised", backend 403 via `requireOwner`). One
+  non-blocking finding: the admin nav button is visible to non-owners (frontend
+  presentation gating only) — logged as **BUG-26 / issue #116**, does not block HC-01.
+- Step 6: no BYPASS_AUTH warnings in the server log.
+PO verdict: PASS ("suboptimal pass" on step 5 UX, tracked separately).
 
 **Remediation:**
 1. Add `just-raptor-89.clerk.accounts.dev` to the allowed-domains loop in
@@ -778,7 +796,7 @@ NR-14 PASSES when all of the following are GREEN:
 
 | Item | Requirement | Current |
 |---|---|---|
-| HC-01 | Clerk JWKS reachable in local dev | FAIL — firewall landed (#80); **pending real-auth PO UAT (Q5)** |
+| HC-01 | Clerk JWKS reachable in local dev | PASS — firewall (#80); real-auth PO UAT passed 2026-07-16 (Q5, PR #115) |
 | HC-02 | JWT issuer + audience validated | PASS — issuer (#88); azp-as-audience (#115, no `aud` in Clerk tokens) |
 | HC-03 | Map shading user-scoped | PASS (#84) |
 | HC-04 | Admin writes owner-only | PASS (#82) |
@@ -792,10 +810,10 @@ NR-14 PASSES when all of the following are GREEN:
 | HC-12 | Geo files are public data only | PASS |
 | HC-13 | Explicitly-shared role non-operative (no implicit fallback) | PASS |
 
-**NR-14 status: BLOCKED** — 11 PASS, 1 FAIL (HC-01), 1 PARTIAL (HC-02). Both remaining
-items are gated solely on real-auth end-to-end verification (audit Q5); no code work
-remains for them beyond the audience-validation addition, which itself needs a live
-Clerk `aud` value to configure.
+**NR-14 status: PASS (2026-07-16)** — 13/13 PASS. The gate is formally closed: HC-01
+closed on the Q5 real-auth PO UAT; HC-02 closed with azp-as-audience validation (PR
+#115). One non-blocking UAT finding tracked separately (BUG-26 / #116 — admin nav
+visible to non-owners; backend enforcement verified correct).
 
 ---
 
@@ -855,3 +873,4 @@ to any NR-09–13 brief.
 |---|---|
 | 2026-03-23 | Initial issue — current state assessment included |
 | 2026-07-15 | Audit Q4: flipped HC-03/04/05/06/07 FAIL/PARTIAL → PASS with commit citations (PRs #80–#94, verified against current tree); §2/§4/§5 stamped superseded-in-part. HC-01 (FAIL) and HC-02 audience (PARTIAL) held open — both gated on real-auth PO UAT (audit Q5). NR-14 remains BLOCKED on those two. |
+| 2026-07-16 | Audit Q5 (PR #115): HC-01 → PASS on real-auth PO UAT (owner + non-owner accounts); HC-02 → PASS with corrected premise (Clerk tokens carry `azp` not `aud`; azp validated against ALLOWED_ORIGINS). **NR-14 gate closed, 13/13 PASS.** UAT finding BUG-26 (#116) logged, non-blocking. |

--- a/src/backend/middleware/__tests__/auth.test.ts
+++ b/src/backend/middleware/__tests__/auth.test.ts
@@ -7,6 +7,7 @@
  *   3. Invalid/malformed token → 401
  *   4. Valid token → calls userRepository, attaches req.user, calls next()
  *   5. Wrong JWT issuer → 401 (HC-02)
+ *   6. Missing or non-allowlisted azp claim → 401 (HC-02)
  *
  * jose's jwtVerify and userRepository are mocked so no network calls
  * or database access occur in these tests.
@@ -119,7 +120,7 @@ describe('requireAuth middleware', () => {
 
   it('attaches req.user and calls next() on a valid token', async () => {
     vi.mocked(jwtVerify).mockResolvedValueOnce({
-      payload: { sub: 'user_clerk123', email: 'test@example.com' },
+      payload: { sub: 'user_clerk123', email: 'test@example.com', azp: 'http://localhost:5173' },
       protectedHeader: { alg: 'RS256' },
     } as unknown as Awaited<ReturnType<typeof jwtVerify>>);
 
@@ -154,7 +155,7 @@ describe('requireAuth middleware', () => {
 
   it('returns 401 when userRepository throws', async () => {
     vi.mocked(jwtVerify).mockResolvedValueOnce({
-      payload: { sub: 'user_clerk123', email: 'test@example.com' },
+      payload: { sub: 'user_clerk123', email: 'test@example.com', azp: 'http://localhost:5173' },
       protectedHeader: { alg: 'RS256' },
     } as unknown as Awaited<ReturnType<typeof jwtVerify>>);
 
@@ -185,6 +186,41 @@ describe('requireAuth middleware', () => {
 
     await requireAuth(req, res, next as unknown as NextFunction);
 
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(401);
+  });
+
+  // HC-02: azp (authorized party) validation — Clerk session tokens carry azp, not aud.
+  it('returns 401 when azp is not in the origin allowlist', async () => {
+    vi.mocked(jwtVerify).mockResolvedValueOnce({
+      payload: { sub: 'user_clerk123', azp: 'https://evil.example.com' },
+      protectedHeader: { alg: 'RS256' },
+    } as unknown as Awaited<ReturnType<typeof jwtVerify>>);
+
+    const req = makeReq('Bearer other.apps.token');
+    const { res } = makeRes();
+    const next = vi.fn();
+
+    await requireAuth(req, res, next as unknown as NextFunction);
+
+    expect(userRepository.findOrCreateByClerkId).not.toHaveBeenCalled();
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(401);
+  });
+
+  it('returns 401 when azp is missing from the payload', async () => {
+    vi.mocked(jwtVerify).mockResolvedValueOnce({
+      payload: { sub: 'user_clerk123' },
+      protectedHeader: { alg: 'RS256' },
+    } as unknown as Awaited<ReturnType<typeof jwtVerify>>);
+
+    const req = makeReq('Bearer token.without.azp');
+    const { res } = makeRes();
+    const next = vi.fn();
+
+    await requireAuth(req, res, next as unknown as NextFunction);
+
+    expect(userRepository.findOrCreateByClerkId).not.toHaveBeenCalled();
     expect(next).not.toHaveBeenCalled();
     expect(res.status).toHaveBeenCalledWith(401);
   });

--- a/src/backend/middleware/auth.ts
+++ b/src/backend/middleware/auth.ts
@@ -9,10 +9,11 @@
  *
  * Flow:
  *   1. Extract Bearer token from Authorization header
- *   2. Verify JWT signature against Clerk's JWKS endpoint (lazy-initialized)
- *   3. Resolve internal user via userRepository.findOrCreateByClerkId()
- *   4. Attach req.user = { id, clerkId, email } and call next()
- *   5. On any failure: respond 401 Unauthorized
+ *   2. Verify JWT signature + issuer against Clerk's JWKS endpoint (lazy-initialized)
+ *   3. Verify azp claim against the origin allowlist (HC-02 — Clerk's audience equivalent)
+ *   4. Resolve internal user via userRepository.findOrCreateByClerkId()
+ *   5. Attach req.user = { id, clerkId, email } and call next()
+ *   6. On any failure: respond 401 Unauthorized
  */
 
 import type { NextFunction, Request, Response } from 'express';
@@ -67,6 +68,23 @@ function getIssuer(): string {
   return issuer;
 }
 
+/**
+ * HC-02: Clerk session tokens carry no `aud` claim — the audience-equivalent is `azp`
+ * (authorized party), set to the browser origin the token was issued to (verified against
+ * a live token, 2026-07-16). The set of origins a session token may legitimately be
+ * issued to is exactly the CORS allowlist, so ALLOWED_ORIGINS is reused here (same
+ * parse + default as server.ts).
+ *
+ * Tokens with a missing azp are rejected too — every Clerk browser session token has one.
+ * Revisit if a native (iOS) client is added; its tokens may carry a different azp shape.
+ */
+function getAuthorizedParties(): string[] {
+  return (process.env.ALLOWED_ORIGINS ?? 'http://localhost:5173,http://localhost:3001')
+    .split(',')
+    .map((o) => o.trim())
+    .filter(Boolean);
+}
+
 // ----------------------------------------------------------------
 // Middleware
 // ----------------------------------------------------------------
@@ -105,6 +123,14 @@ export async function requireAuth(req: Request, res: Response, next: NextFunctio
     const jwks = getJWKS();
     const issuer = getIssuer();
     const { payload } = await jwtVerify(token, jwks, { issuer });
+
+    // HC-02: azp must be one of our known origins (Clerk's audience equivalent).
+    const azp = payload.azp;
+    if (typeof azp !== 'string' || !getAuthorizedParties().includes(azp)) {
+      res.status(401).json({ error: 'Unauthorized' });
+      return;
+    }
+
     const clerkId = payload.sub!;
     const email = (payload.email as string | undefined) ?? '';
 


### PR DESCRIPTION
Closes #23
BRD NR-14 / OP-06 §6 HC-01, HC-02

## Summary
Audit Q5 execution — real local auth verified end-to-end by the PO, plus the final code item blocking NR-14:

**Code (HC-02 audience half):** Decoding a live Clerk session token during the UAT confirmed Clerk session tokens carry **no `aud` claim** — the audience equivalent is `azp` (authorized party), the browser origin the token was issued to. `requireAuth` now 401s any verified token whose `azp` is missing or not in the `ALLOWED_ORIGINS` allowlist. Unit tests added for both rejection paths.

**Docs (same-PR lifecycle updates, commits to follow):** OP-06 HC-01/HC-02 flips with citations, UAT session record, hardening-gate NR-14 status.

## UAT evidence (HC-01)
- Clerk sign-in completes in-browser through the devcontainer firewall (#80); JWKS fetch confirmed 200 from inside the container
- Verified JWT `sub` = PO's real Clerk user; `iss` = instance URL; token verified by jose (not bypass)
- `BYPASS_AUTH` absent from `.env.local` — real-auth path active
- OWNER_CLERK_ID paste error (literal `<>` brackets) found and fixed in `.env.local` — owner resolution now works with a real token

🤖 Generated with [Claude Code](https://claude.com/claude-code)