### PR TITLE
fix(BUG-26): hide admin panel from non-owner users (#116)

### DIFF
--- a/src/backend/routes/__tests__/security.access-matrix.test.ts
+++ b/src/backend/routes/__tests__/security.access-matrix.test.ts
@@ -10,6 +10,8 @@
  * Exempt from Part A: /health (liveness probe), /geo/* (public static — OP-06 §1.2)
  * Not in Part B: /api/map/shading/countries/:code and /api/map/shading/regions/:code
  *   are requireAuth only (not owner-restricted) — intentional per OP-06 §2 access matrix.
+ *   GET /api/me is also requireAuth only (BUG-26) — every authenticated user may ask
+ *   who they are; see Part D for its shape/isOwner coverage.
  */
 
 import { createClient } from '@libsql/client';
@@ -497,6 +499,11 @@ describe('Part A — Unauthenticated rejection: all API routes return 401', () =
     const res = await supertest(app).post('/api/admin/countries/US/regions').send({});
     expect(res.status).toBe(401);
   });
+
+  it('GET /api/me → 401', async () => {
+    const res = await supertest(app).get('/api/me');
+    expect(res.status).toBe(401);
+  });
 });
 
 // ================================================================
@@ -750,5 +757,53 @@ describe('Part C — Cross-user data isolation', () => {
   it('POST /api/trips/:tripAId/places → 404 (USER_B cannot add places to USER_A trip)', async () => {
     const res = await supertest(app).post(`/api/trips/${tripAId}/places`).send({ city_id: 1 });
     expect(res.status).toBe(404);
+  });
+});
+
+// ================================================================
+// Part D — GET /api/me identity endpoint (BUG-26 / SE-02)
+//
+// requireAuth only (NOT requireOwner — every authenticated user may
+// ask who they are). Returns exactly { id, email, isOwner } echoed
+// from the middleware-resolved req.user. No DB queries of its own.
+// ================================================================
+
+describe('Part D — GET /api/me returns the caller identity with isOwner flag', () => {
+  it('owner: 200 with { id, email, isOwner: 1 }', async () => {
+    mockAuthEnabled = true;
+    mockIsOwner = 1;
+    mockUserId = USER_A_ID;
+
+    const res = await supertest(app).get('/api/me');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      id: USER_A_ID,
+      email: 'usera@example.com',
+      isOwner: 1,
+    });
+  });
+
+  it('non-owner: 200 with { id, email, isOwner: 0 } — NOT 403', async () => {
+    mockAuthEnabled = true;
+    mockIsOwner = 0;
+    mockUserId = USER_B_ID;
+
+    const res = await supertest(app).get('/api/me');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      id: USER_B_ID,
+      email: 'userb@example.com',
+      isOwner: 0,
+    });
+  });
+
+  it('response contains no fields beyond id, email, isOwner (no clerkId leak)', async () => {
+    mockAuthEnabled = true;
+    mockIsOwner = 1;
+    mockUserId = USER_A_ID;
+
+    const res = await supertest(app).get('/api/me');
+    expect(res.status).toBe(200);
+    expect(Object.keys(res.body).sort()).toEqual(['email', 'id', 'isOwner']);
   });
 });

--- a/src/backend/routes/me.ts
+++ b/src/backend/routes/me.ts
@@ -1,0 +1,26 @@
+/**
+ * Travel Tracker — Me Router (BUG-26 / SE-02)
+ *
+ * GET /api/me — returns the authenticated user's identity, including the
+ * isOwner flag, so the frontend can gate owner-only UI (Admin panel).
+ *
+ * Auth: requireAuth only (globally mounted on /api/ in server.ts).
+ * Deliberately NOT requireOwner — every authenticated user may ask who they
+ * are; the response is the caller's own identity, nothing else.
+ *
+ * No repository/DB queries here — req.user is already fully resolved by the
+ * auth middleware (userRepository.findOrCreateByClerkId).
+ */
+
+import { Router } from 'express';
+
+export const meRouter = Router();
+
+// ----------------------------------------------------------------
+// GET /api/me — identity of the authenticated caller
+// ----------------------------------------------------------------
+meRouter.get('/', (req, res) => {
+  // req.user is guaranteed by the global requireAuth middleware.
+  const { id, email, isOwner } = req.user!;
+  res.json({ id, email, isOwner });
+});

--- a/src/backend/server-test-app.ts
+++ b/src/backend/server-test-app.ts
@@ -28,6 +28,7 @@ import { errorHandler } from './middleware/error-handler.js';
 import { adminRouter } from './routes/admin.js';
 import { citiesRouter } from './routes/cities.js';
 import { mapRouter } from './routes/map.js';
+import { meRouter } from './routes/me.js';
 import { tripsRouter } from './routes/trips.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -108,6 +109,7 @@ app.use('/api/trips', tripsRouter);
 app.use('/api/cities', citiesRouter);
 app.use('/api/map', mapRouter);
 app.use('/api/admin', adminRouter);
+app.use('/api/me', meRouter); // BUG-26: identity endpoint for frontend owner gating
 
 // Health check
 app.get('/health', (_req, res) => res.json({ status: 'ok' }));

--- a/src/backend/server.ts
+++ b/src/backend/server.ts
@@ -38,6 +38,7 @@ import { userRepository } from './repositories/users.js';
 import { adminRouter } from './routes/admin.js';
 import { citiesRouter } from './routes/cities.js';
 import { mapRouter } from './routes/map.js';
+import { meRouter } from './routes/me.js';
 import { tripsRouter } from './routes/trips.js';
 import { processQueue } from './services/geocoding.service.js';
 import { seedAdminData, seedCountries, seedRegions } from './services/startup.service.js';
@@ -143,6 +144,7 @@ app.use('/api/trips', tripsRouter); // includes nested /:tripId/places and /:tri
 app.use('/api/cities', citiesRouter);
 app.use('/api/map', mapRouter);
 app.use('/api/admin', adminRouter);
+app.use('/api/me', meRouter); // BUG-26: identity endpoint for frontend owner gating
 
 // Health check (useful for development)
 app.get('/health', (_req, res) => res.json({ status: 'ok' }));

--- a/src/frontend/App.tsx
+++ b/src/frontend/App.tsx
@@ -11,18 +11,56 @@
  */
 
 import { UserButton } from '@clerk/react';
+import type { ReactNode } from 'react';
 import { Navigate, NavLink, Route, Routes } from 'react-router-dom';
 import { TripsLayout } from './components/TripList/TripsLayout';
 import { useGeocodeRetryQueue } from './hooks/useGeocodeRetryQueue';
+import { useMe } from './hooks/useMe';
 import { AdminPage } from './pages/AdminPage';
 import { MapPage } from './pages/MapPage';
 import { TripDetailPage } from './pages/TripDetailPage';
+
+/**
+ * BUG-26 / SE-02: Owner gate for the /admin route.
+ *
+ * Renders nothing while identity is loading (no flash of admin content),
+ * then either the guarded children (owner) or a small not-authorised
+ * message (non-owner). A message was chosen over a silent redirect so a
+ * hard refresh on /admin never bounces the owner to / mid-load, and a
+ * non-owner gets an explicit explanation instead of a mystery redirect.
+ * Backend enforcement (requireOwner → 403) is unaffected — this is
+ * presentation-layer gating only.
+ */
+function RequireOwner({ children }: { children: ReactNode }) {
+  const { data: me, isPending } = useMe();
+
+  if (isPending) return null;
+
+  if (!me?.isOwner) {
+    return (
+      <div className="flex flex-col items-center justify-center h-full text-gray-400 p-12 text-center">
+        <p className="text-base font-semibold text-gray-500 mb-1.5">Not authorised</p>
+        <p className="text-sm text-gray-400 max-w-[280px] leading-relaxed">
+          The admin panel is only available to the site owner.
+        </p>
+        <NavLink to="/map" className="mt-4 text-sm text-teal-600 underline">
+          Back to the map
+        </NavLink>
+      </div>
+    );
+  }
+
+  return <>{children}</>;
+}
 
 /**
  * Root application component with navigation and route definitions.
  */
 export function App() {
   const { pendingCount, retryAll, dismiss } = useGeocodeRetryQueue();
+  // BUG-26: owner-aware nav — me is undefined while loading, so the Admin
+  // link stays hidden until isOwner is confirmed (no flash for non-owners).
+  const { data: me } = useMe();
 
   return (
     <div className="flex flex-col h-screen overflow-hidden">
@@ -58,18 +96,21 @@ export function App() {
         >
           Trips
         </NavLink>
-        <NavLink
-          to="/admin"
-          className={({ isActive }) =>
-            `no-underline px-3.5 py-2 rounded-md text-sm transition-colors ${
-              isActive
-                ? 'font-semibold text-teal-700 bg-teal-50'
-                : 'font-normal text-gray-700 hover:bg-gray-100'
-            }`
-          }
-        >
-          Admin
-        </NavLink>
+        {/* BUG-26: Admin link is owner-only (hidden while identity loads) */}
+        {!!me?.isOwner && (
+          <NavLink
+            to="/admin"
+            className={({ isActive }) =>
+              `no-underline px-3.5 py-2 rounded-md text-sm transition-colors ${
+                isActive
+                  ? 'font-semibold text-teal-700 bg-teal-50'
+                  : 'font-normal text-gray-700 hover:bg-gray-100'
+              }`
+            }
+          >
+            Admin
+          </NavLink>
+        )}
 
         {/* NR-06: offline geocoding indicator */}
         {pendingCount > 0 && (
@@ -127,7 +168,15 @@ export function App() {
             <Route path=":id" element={<TripDetailPage />} />
           </Route>
 
-          <Route path="/admin" element={<AdminPage />} />
+          {/* BUG-26: /admin is owner-gated — direct nav as non-owner never renders the panel */}
+          <Route
+            path="/admin"
+            element={
+              <RequireOwner>
+                <AdminPage />
+              </RequireOwner>
+            }
+          />
           {/* Fallback */}
           <Route path="*" element={<Navigate to="/map" replace />} />
         </Routes>

--- a/src/frontend/__tests__/App.test.tsx
+++ b/src/frontend/__tests__/App.test.tsx
@@ -1,0 +1,134 @@
+/**
+ * Component tests for App owner-gating (BUG-26 / SE-02).
+ *
+ * Mocks:
+ *   - useMe() from hooks/useMe — controls identity loading/owner state
+ *   - useGeocodeRetryQueue() — inert (no pending geocodes)
+ *   - @clerk/react UserButton — rendered as a stub
+ *   - Page components (MapPage, AdminPage, TripDetailPage, TripsLayout) —
+ *     lightweight stubs so App renders without MapLibre/query wiring
+ *
+ * Covers:
+ *   - Admin nav link shown for owner
+ *   - Admin nav link hidden for non-owner
+ *   - Admin nav link hidden while identity is loading (no flash)
+ *   - Direct /admin navigation as non-owner renders not-authorised, not the panel
+ *   - Direct /admin navigation as owner renders the admin panel
+ *   - Direct /admin navigation while loading renders neither (blank, no flash)
+ *
+ * Source: src/frontend/App.tsx
+ */
+
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { App } from '../App';
+import type { Me } from '../types/api';
+
+// ----------------------------------------------------------------
+// Mocks
+// ----------------------------------------------------------------
+
+const mockUseMe = vi.fn<() => { data: Me | undefined; isPending: boolean }>();
+
+vi.mock('../hooks/useMe', () => ({
+  useMe: () => mockUseMe(),
+}));
+
+vi.mock('../hooks/useGeocodeRetryQueue', () => ({
+  useGeocodeRetryQueue: () => ({ pendingCount: 0, retryAll: vi.fn(), dismiss: vi.fn() }),
+}));
+
+vi.mock('@clerk/react', () => ({
+  UserButton: () => <div data-testid="user-button" />,
+}));
+
+vi.mock('../pages/MapPage', () => ({
+  MapPage: () => <div data-testid="map-page">Map page</div>,
+}));
+
+vi.mock('../pages/AdminPage', () => ({
+  AdminPage: () => <div data-testid="admin-page">Admin panel content</div>,
+}));
+
+vi.mock('../pages/TripDetailPage', () => ({
+  TripDetailPage: () => <div data-testid="trip-detail-page" />,
+}));
+
+vi.mock('../components/TripList/TripsLayout', () => ({
+  TripsLayout: () => <div data-testid="trips-layout" />,
+}));
+
+// ----------------------------------------------------------------
+// Fixtures / helpers
+// ----------------------------------------------------------------
+
+const OWNER: Me = { id: 'user-a', email: 'owner@example.com', isOwner: 1 };
+const NON_OWNER: Me = { id: 'user-b', email: 'guest@example.com', isOwner: 0 };
+
+function renderApp(initialPath = '/map') {
+  return render(
+    <MemoryRouter initialEntries={[initialPath]}>
+      <App />
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// ----------------------------------------------------------------
+// Admin nav link visibility
+// ----------------------------------------------------------------
+
+describe('Admin nav link (BUG-26)', () => {
+  it('is shown for the owner', () => {
+    mockUseMe.mockReturnValue({ data: OWNER, isPending: false });
+    renderApp();
+    expect(screen.getByRole('link', { name: 'Admin' })).toBeInTheDocument();
+  });
+
+  it('is hidden for a non-owner', () => {
+    mockUseMe.mockReturnValue({ data: NON_OWNER, isPending: false });
+    renderApp();
+    expect(screen.queryByRole('link', { name: 'Admin' })).not.toBeInTheDocument();
+    // Sanity: the rest of the nav is intact
+    expect(screen.getByRole('link', { name: 'Map' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Trips' })).toBeInTheDocument();
+  });
+
+  it('is hidden while identity is loading (no flash)', () => {
+    mockUseMe.mockReturnValue({ data: undefined, isPending: true });
+    renderApp();
+    expect(screen.queryByRole('link', { name: 'Admin' })).not.toBeInTheDocument();
+  });
+});
+
+// ----------------------------------------------------------------
+// /admin route guard
+// ----------------------------------------------------------------
+
+describe('/admin route guard (BUG-26)', () => {
+  it('renders the admin panel for the owner', () => {
+    mockUseMe.mockReturnValue({ data: OWNER, isPending: false });
+    renderApp('/admin');
+    expect(screen.getByTestId('admin-page')).toBeInTheDocument();
+    expect(screen.queryByText('Not authorised')).not.toBeInTheDocument();
+  });
+
+  it('renders not-authorised (never the panel) for a non-owner on direct navigation', () => {
+    mockUseMe.mockReturnValue({ data: NON_OWNER, isPending: false });
+    renderApp('/admin');
+    expect(screen.queryByTestId('admin-page')).not.toBeInTheDocument();
+    expect(screen.getByText('Not authorised')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Back to the map' })).toBeInTheDocument();
+  });
+
+  it('renders neither panel nor message while identity is loading (no flash)', () => {
+    mockUseMe.mockReturnValue({ data: undefined, isPending: true });
+    renderApp('/admin');
+    expect(screen.queryByTestId('admin-page')).not.toBeInTheDocument();
+    expect(screen.queryByText('Not authorised')).not.toBeInTheDocument();
+  });
+});

--- a/src/frontend/hooks/useMe.ts
+++ b/src/frontend/hooks/useMe.ts
@@ -1,0 +1,26 @@
+/**
+ * React Query hook for the identity endpoint (GET /api/me).
+ *
+ * BUG-26 / SE-02: exposes the authenticated user's { id, email, isOwner }
+ * so the UI can gate owner-only surfaces (Admin nav link, /admin route).
+ *
+ * The backend enforces admin access with requireOwner regardless — this hook
+ * is presentation-layer gating only. While the query is loading, callers must
+ * treat the user as non-owner (default hidden — no flash of the admin link).
+ */
+import { useQuery } from '@tanstack/react-query';
+import type { Me } from '../types/api';
+import { apiGet } from '../utils/apiClient';
+
+/**
+ * Fetches the authenticated user's identity.
+ * @returns React Query result containing Me ({ id, email, isOwner }).
+ */
+export function useMe() {
+  return useQuery({
+    queryKey: ['me'],
+    queryFn: () => apiGet<Me>('/api/me'),
+    // Identity is stable for a session — avoid refetch churn on window focus.
+    staleTime: 5 * 60 * 1000,
+  });
+}

--- a/src/frontend/types/api.ts
+++ b/src/frontend/types/api.ts
@@ -275,3 +275,15 @@ export interface CityItem {
   experience_rating: number | null;
   experience_post_visit_notes: string | null;
 }
+
+// ============================================================
+// ME (GET /api/me) — BUG-26 / SE-02
+// ============================================================
+
+/** Identity of the authenticated caller, used for owner-only UI gating. */
+export interface Me {
+  id: string;
+  email: string;
+  /** ADL-27 owner flag: 1 = owner, 0 = non-owner. */
+  isOwner: number;
+}

--- a/tests/contract/me.contract.test.ts
+++ b/tests/contract/me.contract.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Contract tests — /api/me (BUG-26 / SE-02)
+ *
+ * Verifies the identity endpoint honours its contract against a running backend.
+ * Requires a running backend: npm run dev:api
+ *
+ * Environment assumption (same as the other contract suites — see ci.yml):
+ * the server runs with BYPASS_AUTH=true and OWNER_CLERK_ID=test_clerk_id, so the
+ * bypass test user (clerkId 'test_clerk_id') resolves as owner and /api/me
+ * returns isOwner: 1. Unauthenticated 401 coverage lives in the backend unit
+ * suite (security.access-matrix.test.ts Part A) — under BYPASS_AUTH every
+ * request is authenticated, so it cannot be exercised here.
+ *
+ * Coverage:
+ *   GET /api/me — 200, exact shape { id, email, isOwner }
+ */
+
+import { beforeAll, describe, expect, it } from 'vitest';
+import { api, requireServer } from './_setup.js';
+
+// ─── Server check ─────────────────────────────────────────────────────────────
+
+beforeAll(async () => {
+  await requireServer();
+});
+
+// ─── GET /api/me ──────────────────────────────────────────────────────────────
+
+describe('GET /api/me', () => {
+  it('200 — returns the authenticated caller identity', async () => {
+    const res = await api.get('/api/me').expect(200);
+
+    expect(res.body).toMatchObject({
+      id: 'test-user-00000000-0000-0000-0000-000000000000',
+      email: 'test@example.com',
+      isOwner: 1, // OWNER_CLERK_ID=test_clerk_id in the test environment
+    });
+  });
+
+  it('200 — response contains exactly id, email, isOwner (no clerkId leak)', async () => {
+    const res = await api.get('/api/me').expect(200);
+    expect(Object.keys(res.body).sort()).toEqual(['email', 'id', 'isOwner']);
+  });
+});


### PR DESCRIPTION
Closes #116
BRD §5.11 SE-02 | Tracker BUG-26 | Brief: `jobs/COO/outbox/20260716_0443-COO-brief-bug26-admin-nav-nonowner.md`

## What

Non-owner accounts saw the Admin button and could open `/admin` (every section then 403'd — backend enforcement was already correct). This adds presentation-layer owner gating:

**Backend**
- New `GET /api/me` (`src/backend/routes/me.ts`), mounted in `server.ts` and `server-test-app.ts` behind the globally-mounted `requireAuth`. Returns `{ id, email, isOwner }` echoed straight from the middleware-resolved `req.user` — no DB queries, no new tables/columns.

**Frontend**
- New `useMe` hook (`src/frontend/hooks/useMe.ts`, TanStack Query v5, `queryKey ['me']`, 5-min staleTime) + `Me` type in `types/api.ts`
- Admin nav link renders only when `me.isOwner` is truthy — while identity is loading the link is hidden (default hidden, no flash)
- `/admin` route wrapped in a `RequireOwner` guard in `App.tsx`

## Design decision — /admin guard for non-owners

**Rendered a small not-authorised message (with a "Back to the map" link) rather than a silent redirect to `/`.** Rationale: `RequireOwner` renders nothing while `useMe` is pending, so a redirect-on-unknown would bounce the *owner* off `/admin` on a hard refresh before identity resolves; and for a non-owner an explicit message is clearer than a mystery redirect. The admin panel component is never mounted for non-owners.

## Tests

- `security.access-matrix.test.ts` (living matrix): Part A row `GET /api/me → 401`; new Part D — owner gets `isOwner: 1`, non-owner gets `200` + `isOwner: 0` (NOT 403), and the response contains exactly `id`/`email`/`isOwner` (no `clerkId` leak)
- `tests/contract/me.contract.test.ts`: live shape check under the CI bypass env (`BYPASS_AUTH=true`, `OWNER_CLERK_ID=test_clerk_id` → `isOwner: 1`)
- `src/frontend/__tests__/App.test.tsx`: Admin link shown for owner / hidden for non-owner / hidden while loading; `/admin` direct nav renders panel for owner, not-authorised for non-owner, and neither while loading
- Verified live: `/api/me` returns the correct body under bypass, and `401` with no token and with a garbage token in real-auth mode

## Pre-push results

- `npm run check` (biome) — clean
- `npm run type:check:all` — clean
- `npm run test:backend` — 470 passed, 1 skipped
- `npm run test:frontend` — 84 passed
- `npm run test:contract` — 101 passed (against a locally started backend, CI-style env)
- Doc lifecycle: OP-06 §2 access matrix is stamped SUPERSEDED (2026-07-15); the living access matrix (`security.access-matrix.test.ts`) is updated in this PR — no other status/verdict doc asserts a fact this change alters

## Security checklist (per CLAUDE.md — confirmed)

1. **Auth middleware applied** — ✅ Confirmed: `GET /api/me` is covered by the globally-mounted `requireAuth` (`app.use('/api/', requireAuth)` precedes the mount in both `server.ts` and `server-test-app.ts`). Deliberately NOT `requireOwner` — every authenticated user may ask who they are. Verified by access-matrix Part A (401) and Part D (non-owner 200).
2. **userId-scoped repository queries** — ✅ Confirmed none added: the route performs zero repository/DB queries; it only echoes `req.user`, which `requireAuth` already resolved.
3. **`.notNull()` on new user-data FK columns** — ✅ n/a, confirmed: no schema changes, no new tables or columns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)