### PR TITLE
chore(e2e): set OWNER_CLERK_ID in E2E backend env — un-rot the suite

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -63,8 +63,10 @@ export default defineConfig({
       // Backend — Express on port 3001
       // SQLITE_PATH: isolated e2e database (db:migrate runs before playwright starts)
       // BYPASS_AUTH: skips Clerk JWT verification for all API requests
+      // OWNER_CLERK_ID: makes the bypass test user the owner (ADL-27) — owner-gated
+      // routes (admin, cities POST, shading config) 403 without it
       command:
-        'SQLITE_PATH=file:./e2e.db BYPASS_AUTH=true npm run dev:api',
+        'SQLITE_PATH=file:./e2e.db BYPASS_AUTH=true OWNER_CLERK_ID=test_clerk_id npm run dev:api',
       url: 'http://localhost:3001/api/trips',
       reuseExistingServer: false,
       timeout: 30_000,


### PR DESCRIPTION
## Summary
Found while assessing test effectiveness for Ryan: the Playwright E2E suite (not in CI, so never executed since March) had rotted — the webServer env predates the owner model (ADL-27, #82), so the bypass test user ran as **non-owner** and every owner-gated surface 403'd.

**Before:** 24 pass / 12 fail (3.6m) — all 12 failures traced to the missing owner grant (admin CRUD specs, the `createCity` factory, map shading-config console error).
**After (this one-line env fix):** 34 pass / 2 fail (32s).

The remaining 2 failures (`trips.spec.ts` search + detail-click) pass in isolation — shared-`e2e.db` state leakage between spec files, part of the known E2E isolation/`data-testid` debt (tracked in memory/park docs; candidate for a follow-up brief alongside wiring E2E into CI).

Config-only change; unit/contract suites unaffected (pre-push all green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)