### PR TITLE
feat(MAP-02): map legend for shading colours (#121)

### DIFF
--- a/src/frontend/components/Map/MapLegend.tsx
+++ b/src/frontend/components/Map/MapLegend.tsx
@@ -1,0 +1,40 @@
+import { useShadingConfig } from '../../hooks/useMapShading';
+
+/**
+ * Small overlay legend explaining what the map's country/region shading colours mean.
+ *
+ * Fully data-driven from GET /api/map/shading/config (via useShadingConfig, which shares
+ * the React Query cache with the Admin → Map Shading tab) — no hardcoded colours or state
+ * names live here, so an admin colour change is reflected automatically.
+ *
+ * Renders nothing while the config is loading (no skeleton flash) and nothing if the
+ * config is unavailable (e.g. a 403 for non-owners, matching the map's current
+ * owner-gated behaviour — see ADL-28).
+ */
+export function MapLegend() {
+  const { data: config, isLoading } = useShadingConfig();
+
+  if (isLoading || !config || config.length === 0) {
+    return null;
+  }
+
+  return (
+    <div
+      className="absolute bottom-3 left-3 z-10 max-w-[70vw] rounded-md bg-white/95 p-2.5 text-xs shadow-md sm:max-w-xs"
+      aria-label="Map shading legend"
+    >
+      <ul className="flex flex-col gap-1">
+        {config.map((state) => (
+          <li key={state.state_key} className="flex items-center gap-2">
+            <span
+              className="h-3 w-3 flex-shrink-0 rounded-sm border border-gray-300"
+              style={{ backgroundColor: state.color_hex }}
+              aria-hidden="true"
+            />
+            <span className="text-gray-700">{state.display_name}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/frontend/components/Map/MapView.tsx
+++ b/src/frontend/components/Map/MapView.tsx
@@ -18,6 +18,7 @@ import type { TripSummary } from '../../types/api';
 import { LoadingSpinner } from '../shared/LoadingSpinner';
 import { CityMarkers } from './CityMarkers';
 import { CountryLayer } from './CountryLayer';
+import { MapLegend } from './MapLegend';
 import { RegionLayer } from './RegionLayer';
 
 const MAPTILER_KEY = import.meta.env.VITE_MAPTILER_KEY as string;
@@ -158,6 +159,10 @@ export function MapView({ trips, onCountryClick }: MapViewProps) {
         {/* City pins — only for geocoded cities */}
         <CityMarkers trips={trips} />
       </MapGL>
+
+      {/* Shading colour legend — bottom-left, clear of the MapLibre attribution
+          (bottom-right) and the loading overlay (top-left) */}
+      <MapLegend />
     </div>
   );
 }

--- a/src/frontend/components/Map/__tests__/MapLegend.test.tsx
+++ b/src/frontend/components/Map/__tests__/MapLegend.test.tsx
@@ -1,0 +1,86 @@
+/**
+ * Tests for MapLegend (MAP-02).
+ *
+ * Mocks:
+ *   - useShadingConfig() from hooks/useMapShading
+ *
+ * Covers:
+ *   - Renders one entry per shading state from a mocked config response,
+ *     with the display name and the config's colour hex applied.
+ *   - Renders nothing while the config query is loading (no skeleton flash).
+ *   - Renders nothing when the config is empty/unavailable (e.g. non-owner 403).
+ *
+ * Source: src/frontend/components/Map/MapLegend.tsx
+ */
+
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import type { ShadingConfig } from '../../../types/api.js';
+import { MapLegend } from '../MapLegend.js';
+
+const mockUseShadingConfig = vi.fn();
+
+vi.mock('../../../hooks/useMapShading.js', () => ({
+  useShadingConfig: () => mockUseShadingConfig(),
+}));
+
+function makeConfig(overrides: Partial<ShadingConfig> = {}): ShadingConfig {
+  return {
+    state_key: 'visited_once',
+    display_name: 'Visited',
+    color_hex: '#2a9d8f',
+    updated_at: '2024-01-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+describe('MapLegend', () => {
+  it('renders an entry for each shading state in the mocked config', () => {
+    const config = [
+      makeConfig({ state_key: 'visited_once', display_name: 'Visited', color_hex: '#2a9d8f' }),
+      makeConfig({ state_key: 'planned', display_name: 'Wishlist', color_hex: '#e76f51' }),
+    ];
+    mockUseShadingConfig.mockReturnValue({ data: config, isLoading: false });
+
+    render(<MapLegend />);
+
+    expect(screen.getByText('Visited')).toBeInTheDocument();
+    expect(screen.getByText('Wishlist')).toBeInTheDocument();
+  });
+
+  it('applies the config colour as the swatch background', () => {
+    const config = [
+      makeConfig({ state_key: 'visited_once', display_name: 'Visited', color_hex: '#2a9d8f' }),
+    ];
+    mockUseShadingConfig.mockReturnValue({ data: config, isLoading: false });
+
+    render(<MapLegend />);
+
+    const swatch = screen.getByText('Visited').previousSibling as HTMLElement;
+    expect(swatch).toHaveStyle({ backgroundColor: '#2a9d8f' });
+  });
+
+  it('renders nothing while the config is loading', () => {
+    mockUseShadingConfig.mockReturnValue({ data: undefined, isLoading: true });
+
+    const { container } = render(<MapLegend />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders nothing when the config is empty', () => {
+    mockUseShadingConfig.mockReturnValue({ data: [], isLoading: false });
+
+    const { container } = render(<MapLegend />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders nothing when the config is unavailable (e.g. non-owner 403)', () => {
+    mockUseShadingConfig.mockReturnValue({ data: undefined, isLoading: false });
+
+    const { container } = render(<MapLegend />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+});


### PR DESCRIPTION
Closes #121

## Summary
- Adds `MapLegend` (`src/frontend/components/Map/MapLegend.tsx`), a small overlay on `/map` explaining what the shading colours mean — one row per configured state with a colour swatch + display name.
- Placed bottom-left in `MapView.tsx`, clear of the MapLibre attribution (bottom-right) and the existing loading spinner overlay (top-left); does not block map pan/zoom.
- Fully data-driven from the existing `useShadingConfig()` hook (`GET /api/map/shading/config`), reusing its React Query cache — no hardcoded colours or state names in the component.
- Renders nothing while the config query is loading (no skeleton flash) and nothing when the config is unavailable (e.g. a 403 for non-owners), matching the map's current owner-gated behaviour. Backend route gating untouched — ADL-28 per-user shading remains out of scope.

## Test plan
- [x] `npm run check` (biome) — clean
- [x] `npm run type:check:all` — clean
- [x] `npm run test:backend` — 470 passed / 1 skipped
- [x] `npm run test:frontend` — 89 passed, including new `MapLegend.test.tsx` (renders entries from mocked config; renders nothing while loading; renders nothing when config is empty/unavailable)
- [ ] CI green (verifying after push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)