### PR TITLE
feat(UX-06): restyle admin panel to match app design language (#120)

### DIFF
--- a/src/frontend/components/Admin/ActivityTab.tsx
+++ b/src/frontend/components/Admin/ActivityTab.tsx
@@ -12,23 +12,18 @@ import {
 import { ErrorMessage } from '../shared/ErrorMessage';
 import { LoadingSpinner } from '../shared/LoadingSpinner';
 
-const inputStyle: React.CSSProperties = {
-  padding: '7px 10px',
-  border: '1px solid #D1D5DB',
-  borderRadius: '6px',
-  fontSize: '14px',
-  flex: 1,
-  minWidth: 0,
-};
-const btnStyle = (v: 'primary' | 'secondary' | 'danger'): React.CSSProperties => ({
-  padding: '5px 12px',
-  border: 'none',
-  borderRadius: '5px',
-  cursor: 'pointer',
-  fontSize: '13px',
-  background: v === 'primary' ? '#2563EB' : v === 'danger' ? '#DC2626' : '#F3F4F6',
-  color: v === 'secondary' ? '#374151' : '#fff',
-});
+const inputClass =
+  'flex-1 min-w-0 px-2.5 py-1.5 border border-gray-300 rounded-md text-sm bg-white focus:outline-none focus:ring-2 focus:ring-teal-500 focus:border-transparent';
+// Primary matches the app's teal "+ New" affordance (TripsLayout.tsx).
+const primaryBtnClass =
+  'px-3 py-1.5 bg-teal-600 text-white text-xs font-semibold rounded-md hover:bg-teal-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer';
+// Secondary matches the app's neutral outline affordance (ItemCard.tsx Edit button).
+const secondaryBtnClass =
+  'px-3 py-1.5 border border-gray-300 rounded-md text-xs font-medium bg-white text-gray-700 hover:bg-gray-50 transition-colors cursor-pointer';
+// Deactivate: quiet/neutral at rest, red only surfaces on hover (UX-06) — avoids
+// a page full of rows dominated by solid destructive-red at rest.
+const deactivateBtnClass =
+  'px-3 py-1.5 border border-gray-300 rounded-md text-xs font-medium bg-white text-gray-600 hover:bg-red-50 hover:border-red-200 hover:text-red-600 transition-colors cursor-pointer';
 
 export function ActivityTab() {
   const { data: activities = [], isLoading, error } = useActivities();
@@ -61,72 +56,57 @@ export function ActivityTab() {
         onSubmit={(e) => {
           void handleCreate(e);
         }}
-        style={{ display: 'flex', gap: '8px', marginBottom: '20px' }}
+        className="flex gap-2 mb-5"
       >
         <input
-          style={inputStyle}
+          className={inputClass}
           value={newName}
           onChange={(e) => setNewName(e.target.value)}
           placeholder="New activity name…"
         />
-        <button type="submit" style={btnStyle('primary')} disabled={create.isPending}>
+        <button type="submit" className={primaryBtnClass} disabled={create.isPending}>
           Add
         </button>
       </form>
       {create.error && <ErrorMessage error={create.error} />}
-      <div style={{ display: 'flex', flexDirection: 'column', gap: '6px' }}>
+      <div className="flex flex-col gap-1.5">
         {activities.map((act) => (
           <div
             key={act.id}
-            style={{
-              display: 'flex',
-              alignItems: 'center',
-              gap: '8px',
-              padding: '8px 10px',
-              border: '1px solid #E5E7EB',
-              borderRadius: '6px',
-              opacity: act.is_active ? 1 : 0.5,
-              background: act.is_active ? '#fff' : '#F9FAFB',
-            }}
+            className={`flex items-center gap-2 px-2.5 py-2 border rounded-md ${
+              act.is_active ? 'border-gray-200 bg-white' : 'border-gray-200 bg-gray-50 opacity-50'
+            }`}
           >
             {editingId === act.id ? (
               <>
                 <input
-                  style={{ ...inputStyle, flex: 1 }}
+                  className={inputClass}
                   value={editName}
                   onChange={(e) => setEditName(e.target.value)}
                   autoFocus
                 />
                 <button
-                  style={btnStyle('primary')}
+                  className={primaryBtnClass}
                   onClick={() => {
                     void handleEditSave(act.id);
                   }}
                 >
                   Save
                 </button>
-                <button style={btnStyle('secondary')} onClick={() => setEditingId(null)}>
+                <button className={secondaryBtnClass} onClick={() => setEditingId(null)}>
                   Cancel
                 </button>
               </>
             ) : (
               <>
-                <span style={{ flex: 1, fontSize: '14px' }}>{act.name}</span>
+                <span className="flex-1 text-sm">{act.name}</span>
                 {!act.is_active && (
-                  <span
-                    style={{
-                      fontSize: '11px',
-                      color: '#6B7280',
-                      background: '#F3F4F6',
-                      padding: '1px 6px',
-                      borderRadius: '4px',
-                    }}
-                  >
+                  <span className="text-[11px] text-gray-500 bg-gray-100 px-1.5 py-0.5 rounded">
                     Inactive
                   </span>
                 )}
                 <button
-                  style={btnStyle('secondary')}
+                  className={secondaryBtnClass}
                   onClick={() => {
                     setEditingId(act.id);
                     setEditName(act.name);
@@ -136,7 +116,7 @@ export function ActivityTab() {
                 </button>
                 {act.is_active ? (
                   <button
-                    style={btnStyle('danger')}
+                    className={deactivateBtnClass}
                     onClick={() => {
                       void del.mutateAsync(act.id);
                     }}
@@ -145,7 +125,7 @@ export function ActivityTab() {
                   </button>
                 ) : (
                   <button
-                    style={btnStyle('secondary')}
+                    className={secondaryBtnClass}
                     onClick={() => {
                       void update.mutateAsync({ id: act.id, data: { is_active: true } });
                     }}

--- a/src/frontend/components/Admin/AdminPanel.tsx
+++ b/src/frontend/components/Admin/AdminPanel.tsx
@@ -32,39 +32,21 @@ export function AdminPanel() {
   const [activeTab, setActiveTab] = useState<Tab>('categories');
 
   return (
-    <div style={{ maxWidth: '860px', margin: '0 auto', padding: '24px 16px' }}>
-      <h1 style={{ fontSize: '22px', fontWeight: 700, marginBottom: '20px', color: '#111827' }}>
-        Admin
-      </h1>
+    <div className="max-w-[860px] mx-auto px-4 py-6">
+      <h1 className="text-xl font-bold text-gray-900 mb-5">Admin</h1>
 
-      {/* Tab bar */}
-      <div
-        style={{
-          display: 'flex',
-          gap: '4px',
-          borderBottom: '2px solid #E5E7EB',
-          marginBottom: '24px',
-          overflowX: 'auto',
-        }}
-      >
+      {/* Tab bar — mirrors the app nav's rounded pill treatment (App.tsx) */}
+      <div className="flex items-center gap-1 border-b border-gray-200 mb-6 overflow-x-auto">
         {TABS.map((tab) => (
           <button
             key={tab.id}
             type="button"
             onClick={() => setActiveTab(tab.id)}
-            style={{
-              padding: '8px 18px',
-              border: 'none',
-              borderBottom: activeTab === tab.id ? '2px solid #2563EB' : '2px solid transparent',
-              marginBottom: '-2px',
-              background: 'none',
-              fontWeight: activeTab === tab.id ? 600 : 400,
-              color: activeTab === tab.id ? '#2563EB' : '#4B5563',
-              cursor: 'pointer',
-              fontSize: '14px',
-              whiteSpace: 'nowrap',
-              borderRadius: '0',
-            }}
+            className={
+              activeTab === tab.id
+                ? 'px-3.5 py-2 mb-[-1px] rounded-t-md text-sm font-semibold text-teal-700 bg-teal-50 border border-b-0 border-teal-100 whitespace-nowrap transition-colors cursor-pointer'
+                : 'px-3.5 py-2 mb-[-1px] rounded-t-md text-sm font-normal text-gray-600 border border-b-0 border-transparent hover:bg-gray-100 whitespace-nowrap transition-colors cursor-pointer'
+            }
           >
             {tab.label}
           </button>

--- a/src/frontend/components/Admin/CategoryTab.tsx
+++ b/src/frontend/components/Admin/CategoryTab.tsx
@@ -15,23 +15,18 @@ import {
 import { ErrorMessage } from '../shared/ErrorMessage';
 import { LoadingSpinner } from '../shared/LoadingSpinner';
 
-const inputStyle: React.CSSProperties = {
-  padding: '7px 10px',
-  border: '1px solid #D1D5DB',
-  borderRadius: '6px',
-  fontSize: '14px',
-  flex: 1,
-  minWidth: 0,
-};
-const btnStyle = (variant: 'primary' | 'secondary' | 'danger'): React.CSSProperties => ({
-  padding: '5px 12px',
-  border: 'none',
-  borderRadius: '5px',
-  cursor: 'pointer',
-  fontSize: '13px',
-  background: variant === 'primary' ? '#2563EB' : variant === 'danger' ? '#DC2626' : '#F3F4F6',
-  color: variant === 'secondary' ? '#374151' : '#fff',
-});
+const inputClass =
+  'flex-1 min-w-0 px-2.5 py-1.5 border border-gray-300 rounded-md text-sm bg-white focus:outline-none focus:ring-2 focus:ring-teal-500 focus:border-transparent';
+// Primary matches the app's teal "+ New" affordance (TripsLayout.tsx).
+const primaryBtnClass =
+  'px-3 py-1.5 bg-teal-600 text-white text-xs font-semibold rounded-md hover:bg-teal-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer';
+// Secondary matches the app's neutral outline affordance (ItemCard.tsx Edit button).
+const secondaryBtnClass =
+  'px-3 py-1.5 border border-gray-300 rounded-md text-xs font-medium bg-white text-gray-700 hover:bg-gray-50 transition-colors cursor-pointer';
+// Deactivate: quiet/neutral at rest, red only surfaces on hover (UX-06) — avoids
+// a page full of rows dominated by solid destructive-red at rest.
+const deactivateBtnClass =
+  'px-3 py-1.5 border border-gray-300 rounded-md text-xs font-medium bg-white text-gray-600 hover:bg-red-50 hover:border-red-200 hover:text-red-600 transition-colors cursor-pointer';
 
 export function CategoryTab() {
   const { data: categories = [], isLoading, error } = useCategories();
@@ -66,74 +61,59 @@ export function CategoryTab() {
         onSubmit={(e) => {
           void handleCreate(e);
         }}
-        style={{ display: 'flex', gap: '8px', marginBottom: '20px' }}
+        className="flex gap-2 mb-5"
       >
         <input
-          style={inputStyle}
+          className={inputClass}
           value={newName}
           onChange={(e) => setNewName(e.target.value)}
           placeholder="New category name…"
         />
-        <button type="submit" style={btnStyle('primary')} disabled={create.isPending}>
+        <button type="submit" className={primaryBtnClass} disabled={create.isPending}>
           Add
         </button>
       </form>
       {create.error && <ErrorMessage error={create.error} />}
 
       {/* List */}
-      <div style={{ display: 'flex', flexDirection: 'column', gap: '6px' }}>
+      <div className="flex flex-col gap-1.5">
         {categories.map((cat) => (
           <div
             key={cat.id}
-            style={{
-              display: 'flex',
-              alignItems: 'center',
-              gap: '8px',
-              padding: '8px 10px',
-              border: '1px solid #E5E7EB',
-              borderRadius: '6px',
-              opacity: cat.is_active ? 1 : 0.5,
-              background: cat.is_active ? '#fff' : '#F9FAFB',
-            }}
+            className={`flex items-center gap-2 px-2.5 py-2 border rounded-md ${
+              cat.is_active ? 'border-gray-200 bg-white' : 'border-gray-200 bg-gray-50 opacity-50'
+            }`}
           >
             {editingId === cat.id ? (
               <>
                 <input
-                  style={{ ...inputStyle, flex: 1 }}
+                  className={inputClass}
                   value={editName}
                   onChange={(e) => setEditName(e.target.value)}
                   autoFocus
                 />
                 <button
-                  style={btnStyle('primary')}
+                  className={primaryBtnClass}
                   onClick={() => {
                     void handleEditSave(cat.id);
                   }}
                 >
                   Save
                 </button>
-                <button style={btnStyle('secondary')} onClick={() => setEditingId(null)}>
+                <button className={secondaryBtnClass} onClick={() => setEditingId(null)}>
                   Cancel
                 </button>
               </>
             ) : (
               <>
-                <span style={{ flex: 1, fontSize: '14px' }}>{cat.name}</span>
+                <span className="flex-1 text-sm">{cat.name}</span>
                 {!cat.is_active && (
-                  <span
-                    style={{
-                      fontSize: '11px',
-                      color: '#6B7280',
-                      background: '#F3F4F6',
-                      padding: '1px 6px',
-                      borderRadius: '4px',
-                    }}
-                  >
+                  <span className="text-[11px] text-gray-500 bg-gray-100 px-1.5 py-0.5 rounded">
                     Inactive
                   </span>
                 )}
                 <button
-                  style={btnStyle('secondary')}
+                  className={secondaryBtnClass}
                   onClick={() => {
                     setEditingId(cat.id);
                     setEditName(cat.name);
@@ -143,7 +123,7 @@ export function CategoryTab() {
                 </button>
                 {cat.is_active ? (
                   <button
-                    style={btnStyle('danger')}
+                    className={deactivateBtnClass}
                     onClick={() => {
                       void del.mutateAsync(cat.id);
                     }}
@@ -152,7 +132,7 @@ export function CategoryTab() {
                   </button>
                 ) : (
                   <button
-                    style={btnStyle('secondary')}
+                    className={secondaryBtnClass}
                     onClick={() => {
                       void update.mutateAsync({ id: cat.id, data: { is_active: true } });
                     }}

--- a/src/frontend/components/Admin/CompanionTab.tsx
+++ b/src/frontend/components/Admin/CompanionTab.tsx
@@ -12,23 +12,18 @@ import {
 import { ErrorMessage } from '../shared/ErrorMessage';
 import { LoadingSpinner } from '../shared/LoadingSpinner';
 
-const inputStyle: React.CSSProperties = {
-  padding: '7px 10px',
-  border: '1px solid #D1D5DB',
-  borderRadius: '6px',
-  fontSize: '14px',
-  flex: 1,
-  minWidth: 0,
-};
-const btnStyle = (v: 'primary' | 'secondary' | 'danger'): React.CSSProperties => ({
-  padding: '5px 12px',
-  border: 'none',
-  borderRadius: '5px',
-  cursor: 'pointer',
-  fontSize: '13px',
-  background: v === 'primary' ? '#2563EB' : v === 'danger' ? '#DC2626' : '#F3F4F6',
-  color: v === 'secondary' ? '#374151' : '#fff',
-});
+const inputClass =
+  'flex-1 min-w-0 px-2.5 py-1.5 border border-gray-300 rounded-md text-sm bg-white focus:outline-none focus:ring-2 focus:ring-teal-500 focus:border-transparent';
+// Primary matches the app's teal "+ New" affordance (TripsLayout.tsx).
+const primaryBtnClass =
+  'px-3 py-1.5 bg-teal-600 text-white text-xs font-semibold rounded-md hover:bg-teal-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer';
+// Secondary matches the app's neutral outline affordance (ItemCard.tsx Edit button).
+const secondaryBtnClass =
+  'px-3 py-1.5 border border-gray-300 rounded-md text-xs font-medium bg-white text-gray-700 hover:bg-gray-50 transition-colors cursor-pointer';
+// Deactivate: quiet/neutral at rest, red only surfaces on hover (UX-06) — avoids
+// a page full of rows dominated by solid destructive-red at rest.
+const deactivateBtnClass =
+  'px-3 py-1.5 border border-gray-300 rounded-md text-xs font-medium bg-white text-gray-600 hover:bg-red-50 hover:border-red-200 hover:text-red-600 transition-colors cursor-pointer';
 
 export function CompanionTab() {
   const { data: companions = [], isLoading, error } = useCompanions();
@@ -61,72 +56,57 @@ export function CompanionTab() {
         onSubmit={(e) => {
           void handleCreate(e);
         }}
-        style={{ display: 'flex', gap: '8px', marginBottom: '20px' }}
+        className="flex gap-2 mb-5"
       >
         <input
-          style={inputStyle}
+          className={inputClass}
           value={newName}
           onChange={(e) => setNewName(e.target.value)}
           placeholder="New companion name…"
         />
-        <button type="submit" style={btnStyle('primary')} disabled={create.isPending}>
+        <button type="submit" className={primaryBtnClass} disabled={create.isPending}>
           Add
         </button>
       </form>
       {create.error && <ErrorMessage error={create.error} />}
-      <div style={{ display: 'flex', flexDirection: 'column', gap: '6px' }}>
+      <div className="flex flex-col gap-1.5">
         {companions.map((comp) => (
           <div
             key={comp.id}
-            style={{
-              display: 'flex',
-              alignItems: 'center',
-              gap: '8px',
-              padding: '8px 10px',
-              border: '1px solid #E5E7EB',
-              borderRadius: '6px',
-              opacity: comp.is_active ? 1 : 0.5,
-              background: comp.is_active ? '#fff' : '#F9FAFB',
-            }}
+            className={`flex items-center gap-2 px-2.5 py-2 border rounded-md ${
+              comp.is_active ? 'border-gray-200 bg-white' : 'border-gray-200 bg-gray-50 opacity-50'
+            }`}
           >
             {editingId === comp.id ? (
               <>
                 <input
-                  style={{ ...inputStyle, flex: 1 }}
+                  className={inputClass}
                   value={editName}
                   onChange={(e) => setEditName(e.target.value)}
                   autoFocus
                 />
                 <button
-                  style={btnStyle('primary')}
+                  className={primaryBtnClass}
                   onClick={() => {
                     void handleEditSave(comp.id);
                   }}
                 >
                   Save
                 </button>
-                <button style={btnStyle('secondary')} onClick={() => setEditingId(null)}>
+                <button className={secondaryBtnClass} onClick={() => setEditingId(null)}>
                   Cancel
                 </button>
               </>
             ) : (
               <>
-                <span style={{ flex: 1, fontSize: '14px' }}>{comp.name}</span>
+                <span className="flex-1 text-sm">{comp.name}</span>
                 {!comp.is_active && (
-                  <span
-                    style={{
-                      fontSize: '11px',
-                      color: '#6B7280',
-                      background: '#F3F4F6',
-                      padding: '1px 6px',
-                      borderRadius: '4px',
-                    }}
-                  >
+                  <span className="text-[11px] text-gray-500 bg-gray-100 px-1.5 py-0.5 rounded">
                     Inactive
                   </span>
                 )}
                 <button
-                  style={btnStyle('secondary')}
+                  className={secondaryBtnClass}
                   onClick={() => {
                     setEditingId(comp.id);
                     setEditName(comp.name);
@@ -136,7 +116,7 @@ export function CompanionTab() {
                 </button>
                 {comp.is_active ? (
                   <button
-                    style={btnStyle('danger')}
+                    className={deactivateBtnClass}
                     onClick={() => {
                       void del.mutateAsync(comp.id);
                     }}
@@ -145,7 +125,7 @@ export function CompanionTab() {
                   </button>
                 ) : (
                   <button
-                    style={btnStyle('secondary')}
+                    className={secondaryBtnClass}
                     onClick={() => {
                       void update.mutateAsync({ id: comp.id, data: { is_active: true } });
                     }}

--- a/src/frontend/components/Admin/CountryTab.tsx
+++ b/src/frontend/components/Admin/CountryTab.tsx
@@ -33,71 +33,34 @@ export function CountryTab() {
         placeholder="Search countries…"
         value={search}
         onChange={(e) => setSearch(e.target.value)}
-        style={{
-          width: '100%',
-          padding: '8px 10px',
-          border: '1px solid #D1D5DB',
-          borderRadius: '6px',
-          fontSize: '14px',
-          marginBottom: '16px',
-          boxSizing: 'border-box',
-        }}
+        className="w-full box-border px-2.5 py-2 mb-4 border border-gray-300 rounded-md text-sm bg-white focus:outline-none focus:ring-2 focus:ring-teal-500 focus:border-transparent"
       />
 
-      <div
-        style={{
-          display: 'flex',
-          flexDirection: 'column',
-          gap: '4px',
-          maxHeight: '500px',
-          overflowY: 'auto',
-        }}
-      >
+      <div className="flex flex-col gap-1 max-h-[500px] overflow-y-auto">
         {filtered.map((country) => (
           <div
             key={country.country_code}
-            style={{
-              display: 'flex',
-              alignItems: 'center',
-              gap: '10px',
-              padding: '8px 10px',
-              border: '1px solid #E5E7EB',
-              borderRadius: '6px',
-            }}
+            className="flex items-center gap-2.5 px-2.5 py-2 border border-gray-200 rounded-md"
           >
-            <span style={{ width: '32px', fontSize: '12px', color: '#6B7280', flexShrink: 0 }}>
-              {country.country_code}
-            </span>
-            <span style={{ flex: 1, fontSize: '14px' }}>{country.name}</span>
+            <span className="w-8 flex-shrink-0 text-xs text-gray-500">{country.country_code}</span>
+            <span className="flex-1 text-sm">{country.name}</span>
 
-            {/* Region tier label (read-only) */}
+            {/* Region tier label (read-only) — reuses the app's indigo badge vocabulary
+                (StatusBadge.tsx "confirmed") rather than a one-off purple. */}
             {country.region_tier_label && (
               <span
-                style={{
-                  fontSize: '12px',
-                  color: country.region_tier_enabled ? '#5B21B6' : '#9CA3AF',
-                  background: country.region_tier_enabled ? '#EDE9FE' : '#F3F4F6',
-                  padding: '1px 8px',
-                  borderRadius: '4px',
-                  flexShrink: 0,
-                }}
+                className={`flex-shrink-0 text-xs px-2 py-0.5 rounded ${
+                  country.region_tier_enabled
+                    ? 'text-indigo-800 bg-indigo-100'
+                    : 'text-gray-400 bg-gray-100'
+                }`}
               >
                 {country.region_tier_label}
               </span>
             )}
 
             {/* Toggle */}
-            <label
-              style={{
-                display: 'flex',
-                alignItems: 'center',
-                gap: '6px',
-                cursor: 'pointer',
-                flexShrink: 0,
-                fontSize: '13px',
-                color: '#374151',
-              }}
-            >
+            <label className="flex items-center gap-1.5 flex-shrink-0 text-[13px] text-gray-700 cursor-pointer">
               <input
                 type="checkbox"
                 checked={country.region_tier_enabled}
@@ -108,6 +71,7 @@ export function CountryTab() {
                   });
                 }}
                 disabled={updateCountry.isPending}
+                className="accent-teal-600"
               />
               Region tier
             </label>
@@ -116,9 +80,7 @@ export function CountryTab() {
       </div>
 
       {filtered.length === 0 && (
-        <p style={{ color: '#6B7280', textAlign: 'center', padding: '20px 0' }}>
-          No countries match your search.
-        </p>
+        <p className="text-gray-500 text-center py-5">No countries match your search.</p>
       )}
 
       {updateCountry.error && <ErrorMessage error={updateCountry.error} />}

--- a/src/frontend/components/Admin/ShadingTab.tsx
+++ b/src/frontend/components/Admin/ShadingTab.tsx
@@ -38,31 +38,19 @@ function ShadingRow({
   return (
     <div
       key={cfg.state_key}
-      style={{
-        display: 'flex',
-        alignItems: 'center',
-        gap: '12px',
-        padding: '10px 12px',
-        border: '1px solid #E5E7EB',
-        borderRadius: '6px',
-      }}
+      className="flex items-center gap-3 px-3 py-2.5 border border-gray-200 rounded-md"
     >
-      {/* Colour swatch — updates in real time via localColor */}
+      {/* Colour swatch — updates in real time via localColor. Fill colour is data-driven,
+          so it stays an inline style rather than a Tailwind class. */}
       <div
-        style={{
-          width: '28px',
-          height: '28px',
-          borderRadius: '4px',
-          background: localColor,
-          border: '1px solid #D1D5DB',
-          flexShrink: 0,
-        }}
+        className="w-7 h-7 rounded flex-shrink-0 border border-gray-300"
+        style={{ background: localColor }}
       />
 
       {/* Display name */}
-      <span style={{ flex: 1, fontSize: '14px', fontWeight: 500 }}>{cfg.display_name}</span>
+      <span className="flex-1 text-sm font-medium">{cfg.display_name}</span>
       {/* Hex label — updates in real time via localColor */}
-      <span style={{ fontSize: '12px', color: '#6B7280' }}>{localColor}</span>
+      <span className="text-xs text-gray-500">{localColor}</span>
 
       {/* Colour picker — onChange updates local preview only; onBlur fires the mutation */}
       <input
@@ -76,14 +64,7 @@ function ShadingRow({
           // Fire the PATCH mutation once the user settles on a colour and leaves.
           onCommit(cfg.state_key, e.target.value);
         }}
-        style={{
-          width: '40px',
-          height: '32px',
-          padding: '2px',
-          border: '1px solid #D1D5DB',
-          borderRadius: '4px',
-          cursor: 'pointer',
-        }}
+        className="w-10 h-8 p-0.5 border border-gray-300 rounded cursor-pointer"
         aria-label={`Colour for ${cfg.display_name}`}
       />
     </div>
@@ -107,10 +88,10 @@ export function ShadingTab() {
 
   return (
     <div>
-      <p style={{ margin: '0 0 16px', fontSize: '14px', color: '#4B5563' }}>
+      <p className="mb-4 text-sm text-gray-600">
         Choose the colour for each map shading state. Changes update the map immediately.
       </p>
-      <div style={{ display: 'flex', flexDirection: 'column', gap: '10px' }}>
+      <div className="flex flex-col gap-2.5">
         {configs.map((cfg) => (
           <ShadingRow key={cfg.state_key} cfg={cfg} onCommit={handleCommit} />
         ))}


### PR DESCRIPTION
Closes #120

## Summary
- Demoted the per-row "Deactivate" button from solid red-at-rest to a quiet neutral outline treatment; red now only surfaces on hover (matches the pattern already used by `ItemCard`'s Delete button).
- Replaced the blue `#2563EB` Add/Save buttons and blue active-tab underline with the app's teal-600/700 vocabulary (`App.tsx` nav links, `TripsLayout.tsx` "+ New" button).
- Restyled the five admin tabs (Categories, Activities, Companions, Map Shading, Countries) with the teal pill treatment used by the app's top nav, applied uniformly.
- Converted all five tab components + `AdminPanel.tsx` from inline `style={}` objects to Tailwind classes, matching how the rest of the app (`TripsLayout`, `ItemCard`, `TripForm`, etc.) is styled.
- `CountryTab`'s region-tier badge switched from a one-off purple to the app's existing indigo badge vocabulary (`StatusBadge.tsx` "confirmed").

Restyle only — no information-architecture, copy, or behaviour changes. DOM structure and accessible names (button/placeholder text) are unchanged.

## Test plan
- [x] `npm run check` (Biome) — clean
- [x] `npm run type:check:all` — clean
- [x] `npm run test:backend` — 470 passed / 1 skipped
- [x] `npm run test:frontend` — 84 passed
- [x] Manual Playwright smoke test against an alternate-port dev instance (API :3002, Vite :5174, `BYPASS_AUTH=true`) exercising the same create → deactivate → re-activate flow as `src/e2e/admin.spec.ts`, plus a visual pass over all five tabs — no console/page errors, `src/e2e/admin.spec.ts` left unmodified
- [ ] CI (pending)

🤖 Generated with [Claude Code](https://claude.com/claude-code)