### PR TITLE
chore(OP-11): stabilise E2E isolation + wire Playwright into CI (#119)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,34 @@ jobs:
       - run: npm ci
       - run: npm run test:frontend
 
+  test-e2e:
+    name: E2E Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: "22"
+          cache: "npm"
+      - run: npm ci
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+      - name: Run E2E suite
+        run: npm run test:e2e
+        env:
+          DB_TYPE: sqlite
+          # GEOCODING_ENABLED=false — CI firewall doesn't allow Nominatim (ADL-10).
+          # SQLITE_PATH/BYPASS_AUTH/OWNER_CLERK_ID are set inline by playwright.config.ts's
+          # webServer command, so they're not needed here.
+          GEOCODING_ENABLED: false
+      - name: Upload Playwright report
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 14
+
   test-contract:
     name: Contract Tests
     runs-on: ubuntu-latest

--- a/_project/security-spec.md
+++ b/_project/security-spec.md
@@ -234,6 +234,15 @@ const limiter = rateLimit({ windowMs: 60_000, max: 300, standardHeaders: true, l
 app.use('/api/', limiter);
 ```
 
+**OP-11 (2026-07-16, #119):** `max` is conditional on `BYPASS_AUTH === 'true'` in
+`src/backend/server.ts` (300 in every real deployment; raised to 5000 only under
+BYPASS_AUTH, which is already fatal in `NODE_ENV=production` — see the guard in
+`server.ts` startup). This exists because Playwright's E2E suite runs all 36 specs
+against one long-lived backend process, and the limiter's counter is per-process —
+it was hitting 300/60s within the suite's own request volume and producing 429s that
+looked like cross-spec state leakage. Production-facing behavior (300 req/min,
+single-user local use) is unchanged; only the test/CI harness gets headroom.
+
 300 req/min is generous for local single-user use. The structure (not the number) is what matters now.
 Phase 2 tightens this to ~60 general / ~20 for writes. No code change needed — config only.
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -93,8 +93,13 @@ export default defineConfig({
       // VITE_BYPASS_AUTH: skips Clerk auth gate so E2E tests can access the app
       // unauthenticated. Must be set at BUILD time in CI (Vite statically replaces
       // import.meta.env.VITE_* at build time), not just at serve time.
+      // VITE_API_BASE_URL: src/frontend/utils/apiClient.ts prefixes every fetch() with
+      // this — it has no fallback, so an unset value bakes literal "undefined" into
+      // every API URL in the built bundle. Locally this is always set via .env.local
+      // (which Vite auto-loads independently of the backend's own dotenv calls), but
+      // .env.local doesn't exist in CI, so it must be set explicitly here for the build.
       command: process.env.CI
-        ? 'VITE_BYPASS_AUTH=true npm run build && npx vite preview --port 5173 --strictPort'
+        ? 'VITE_BYPASS_AUTH=true VITE_API_BASE_URL=http://localhost:3001 npm run build && npx vite preview --port 5173 --strictPort'
         : 'VITE_BYPASS_AUTH=true npm run dev',
       url: 'http://localhost:5173',
       reuseExistingServer: false,

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -26,8 +26,10 @@ import { defineConfig, devices } from '@playwright/test';
 export default defineConfig({
   testDir: './src/e2e',
 
-  // Each test file gets 30s. Increase for slow CI environments if needed.
-  timeout: 30_000,
+  // Each test file gets 30s (45s in CI — 2 vCPU runners are inherently slower than the
+  // local devcontainer even against the built app; see OP-11 webServer comment below for
+  // the actual fix, this is a modest safety margin on top of it, not a substitute for it).
+  timeout: process.env.CI ? 45_000 : 30_000,
 
   // Tests must be deterministic. Fix flakiness at the source, don't retry it away.
   retries: 0,
@@ -58,6 +60,17 @@ export default defineConfig({
 
   // Playwright starts both servers before tests run and tears them down after.
   // reuseExistingServer: false ensures a clean server on every test:e2e invocation.
+  //
+  // OP-11: in CI, both servers run their production-shaped path (non-watch backend,
+  // built + `vite preview` frontend) instead of the dev servers used locally. GitHub
+  // Actions' ubuntu-latest runners (2 vCPU) turned out too slow for Vite's dev server —
+  // its on-demand per-route transform under cold CPU contention pushed test actions past
+  // Playwright's 30s default timeout (30/36 specs failed, ~8.5min run, first-navigation
+  // tests failing at exactly 30.1s). `vite preview` serves pre-built static assets, so
+  // there's no cold-transform cost — this removes the actual bottleneck rather than just
+  // raising timeouts. Locally (already fast and proven stable) the dev servers are kept
+  // for iteration speed; see vite.config.ts `preview` block for the proxy config
+  // `vite preview` needs (it does not inherit `server.proxy`).
   webServer: [
     {
       // Backend — Express on port 3001
@@ -65,8 +78,10 @@ export default defineConfig({
       // BYPASS_AUTH: skips Clerk JWT verification for all API requests
       // OWNER_CLERK_ID: makes the bypass test user the owner (ADL-27) — owner-gated
       // routes (admin, cities POST, shading config) 403 without it
+      // npm run start (non-watch) — no fs-watcher overhead; matches the contract-tests
+      // CI job's convention. `dev:api`'s watch mode buys nothing for a one-shot test run.
       command:
-        'SQLITE_PATH=file:./e2e.db BYPASS_AUTH=true OWNER_CLERK_ID=test_clerk_id npm run dev:api',
+        'SQLITE_PATH=file:./e2e.db BYPASS_AUTH=true OWNER_CLERK_ID=test_clerk_id npm run start',
       url: 'http://localhost:3001/api/trips',
       reuseExistingServer: false,
       timeout: 30_000,
@@ -74,12 +89,17 @@ export default defineConfig({
       stderr: 'pipe',
     },
     {
-      // Frontend — Vite dev server on port 5173
-      // VITE_BYPASS_AUTH: skips Clerk auth gate so E2E tests can access the app unauthenticated
-      command: 'VITE_BYPASS_AUTH=true npm run dev',
+      // Frontend — port 5173.
+      // VITE_BYPASS_AUTH: skips Clerk auth gate so E2E tests can access the app
+      // unauthenticated. Must be set at BUILD time in CI (Vite statically replaces
+      // import.meta.env.VITE_* at build time), not just at serve time.
+      command: process.env.CI
+        ? 'VITE_BYPASS_AUTH=true npm run build && npx vite preview --port 5173 --strictPort'
+        : 'VITE_BYPASS_AUTH=true npm run dev',
       url: 'http://localhost:5173',
       reuseExistingServer: false,
-      timeout: 30_000,
+      // Build adds real wall time on top of server startup — generous in CI only.
+      timeout: process.env.CI ? 90_000 : 30_000,
       stdout: 'pipe',
       stderr: 'pipe',
     },

--- a/src/backend/server.ts
+++ b/src/backend/server.ts
@@ -105,9 +105,20 @@ app.use(express.json({ limit: '100kb' }));
 app.use(express.urlencoded({ extended: true, limit: '100kb' }));
 
 // 4. Rate limiter on /api/ (SEC-07) — 300 req/min for single-user local use
+//
+// OP-11: Playwright's webServer boots ONE backend process for the entire 36-spec
+// E2E run (workers:1, sequential, ~35-40s wall time). The limiter's counter is
+// per-process, so it accumulates across every spec file's beforeEach (deleteAllTrips
+// = 1 GET + N DELETEs) and test body requests — by the last couple of specs in
+// trips.spec.ts, cumulative requests were landing on/near the 300/60s ceiling and
+// getting 429'd. That looked like cross-spec DB state leakage (a test's own trip
+// wouldn't render) but was actually rate-limit exhaustion of one long-lived process.
+// BYPASS_AUTH=true is already fatal in production (guard above) and only ever set
+// in test/CI, so it's a safe signal to raise headroom here rather than disable the
+// control — SEC-07 stays enforced (and at its real limit) for every non-test process.
 const limiter = rateLimit({
   windowMs: 60_000,
-  max: 300,
+  max: process.env.BYPASS_AUTH === 'true' ? 5000 : 300,
   standardHeaders: true,
   legacyHeaders: false,
 });
@@ -115,9 +126,10 @@ app.use('/api/', limiter);
 
 // C3 / SEC-M1: Secondary rate limit for POST /api/cities — 20 req/min (geocoding cost)
 // Independent of global limiter; configured separately as each city creation triggers geocoding.
+// OP-11: same BYPASS_AUTH headroom rationale as the global limiter above.
 const citiesCreateLimiter = rateLimit({
   windowMs: 60_000,
-  max: 20,
+  max: process.env.BYPASS_AUTH === 'true' ? 500 : 20,
   standardHeaders: true,
   legacyHeaders: false,
 });

--- a/src/e2e/helpers/factories.ts
+++ b/src/e2e/helpers/factories.ts
@@ -32,10 +32,21 @@ export async function createTrip(
 
 export async function deleteAllTrips(request: APIRequestContext): Promise<void> {
   const res = await request.get('http://localhost:3001/api/trips');
-  if (!res.ok()) return;
+  // OP-11: previously returned silently on a non-ok response, which let a single
+  // rate-limited or errored GET leave every prior spec file's trips in place —
+  // the next test would then see stale trips with no indication why. Isolation
+  // failures must be loud, not swallowed.
+  if (!res.ok()) {
+    throw new Error(`deleteAllTrips: GET /api/trips failed: ${res.status()} ${await res.text()}`);
+  }
   const trips = (await res.json()) as TripSummary[];
   for (const trip of trips) {
-    await request.delete(`http://localhost:3001/api/trips/${trip.id}`);
+    const delRes = await request.delete(`http://localhost:3001/api/trips/${trip.id}`);
+    if (!delRes.ok()) {
+      throw new Error(
+        `deleteAllTrips: DELETE /api/trips/${trip.id} failed: ${delRes.status()} ${await delRes.text()}`,
+      );
+    }
   }
 }
 

--- a/src/e2e/trips-filters.spec.ts
+++ b/src/e2e/trips-filters.spec.ts
@@ -42,9 +42,18 @@ test('sort Name A–Z orders trips alphabetically', async ({ page, request }) =>
   await createTrip(request, { name: 'Mango Trip' });
 
   await page.goto('http://localhost:5173/trips');
+  // OP-11: wait for the initial (unsorted) list to actually render before interacting —
+  // the <select> exists in the DOM before the trips fetch resolves, so selectOption()
+  // doesn't wait for data. Without this, page.content() below could snapshot the page
+  // before React Query's fetch (or the post-sort re-render) had committed, making
+  // 'Apple Trip' intermittently absent — a real race, not a CI-speed artifact.
+  await expect(page.getByText('Zebra Trip')).toBeVisible();
 
   // Select by option value — matches <option value="name_asc">Name A–Z</option>
   await page.locator('select').selectOption('name_asc');
+
+  // Wait for the re-sorted render to commit before reading DOM order.
+  await expect(page.getByText('Apple Trip')).toBeVisible();
 
   // Apple should precede Mango, Mango should precede Zebra in DOM order
   const html = await page.content();

--- a/src/e2e/trips.spec.ts
+++ b/src/e2e/trips.spec.ts
@@ -29,8 +29,7 @@ test('trip detail opens on click', async ({ page, request }) => {
   await createTrip(request, { name: 'Rome Trip' });
   await page.goto('http://localhost:5173/trips');
   await page.getByText('Rome Trip').click();
-  // Right panel should show the trip name
-  await expect(
-    page.locator('[data-testid="trip-detail"]').or(page.getByRole('main')).getByText('Rome Trip'),
-  ).toBeVisible();
+  // Right panel should show the trip name — trip-detail is a real testid on
+  // TripDetail's root element (see src/frontend/components/TripDetail/TripDetail.tsx)
+  await expect(page.getByTestId('trip-detail').getByText('Rome Trip')).toBeVisible();
 });

--- a/src/frontend/components/TripDetail/TripDetail.tsx
+++ b/src/frontend/components/TripDetail/TripDetail.tsx
@@ -96,7 +96,7 @@ export function TripDetail({ trip }: TripDetailProps) {
   };
 
   return (
-    <div className="flex flex-col h-full">
+    <div className="flex flex-col h-full" data-testid="trip-detail">
       {/* Header zone */}
       <div className="flex-shrink-0 p-6 pb-3">
         {/* DELTA-04: Title left, actions [StatusBadge | Edit | Photos] right */}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -37,4 +37,22 @@ export default defineConfig({
       },
     },
   },
+
+  // OP-11: `vite preview` (used by the CI E2E job — see playwright.config.ts) does NOT
+  // inherit `server.proxy`; it is a separate config block. Without this, every /api and
+  // /geo request from the built app would 404 under `vite preview`.
+  preview: {
+    port: 5173,
+    host: '0.0.0.0',
+    proxy: {
+      '/api': {
+        target: 'http://localhost:3001',
+        changeOrigin: true,
+      },
+      '/geo': {
+        target: 'http://localhost:3001',
+        changeOrigin: true,
+      },
+    },
+  },
 });


### PR DESCRIPTION
Closes #119

## Root cause

The 2 flaky specs (`trips.spec.ts` "search filters trips" and "trip detail
opens on click") were **not** cross-spec DB row leakage — every spec file's
`beforeEach` already calls `deleteAllTrips`, correctly clearing its own
trips before each test.

The actual cause: SEC-07's global rate limiter (`300 req/min`, `express-rate-limit`,
per-process counter). Playwright's `webServer` config boots **one** backend
process for the entire 36-spec run (workers:1, sequential, ~30s wall time),
so the limiter's request counter accumulates across every prior spec's
`beforeEach` + test-body requests. By the last couple of specs in
`trips.spec.ts`, cumulative requests were landing on/near the 300/60s
ceiling and getting `429`'d:

- `trip detail opens on click` — its own `createTrip` POST got a 429,
  throwing visibly.
- `search filters trips` — `deleteAllTrips`'s GET got 429'd, and the helper
  silently returned on a non-ok response (`if (!res.ok()) return;`), leaving
  stale trips in place with zero error signal — this is what made it look
  like a DB-state leak.

## Fixes

1. **`src/backend/server.ts`** — rate-limit `max` is now conditional on
   `BYPASS_AUTH === 'true'` (300 in every real deployment; raised only under
   `BYPASS_AUTH`, which is already fatal in `NODE_ENV=production` per the
   existing startup guard). SEC-07 stays enforced at its real limit for every
   non-test process; only the long-lived E2E harness gets headroom. Applied
   the same fix to the secondary `/api/cities` limiter for consistency.
2. **`src/e2e/helpers/factories.ts`** — `deleteAllTrips` now throws loudly on
   any non-ok GET/DELETE response instead of swallowing it. Isolation
   failures must be loud, not silently corrupt the next test.
3. **`src/frontend/components/TripDetail/TripDetail.tsx`** — added a real
   `data-testid="trip-detail"` on the component root. `trips.spec.ts` no
   longer needs the `.or(page.getByRole('main'))` fallback it was using as a
   stand-in for a non-existent testid.
4. **`.github/workflows/ci.yml`** — new `E2E Tests` job, following existing
   job conventions (pinned action SHAs, `actions/checkout` +
   `actions/setup-node`): `npm ci` → `npx playwright install --with-deps
   chromium` → `npm run test:e2e` (env: `DB_TYPE=sqlite`,
   `GEOCODING_ENABLED=false` — CI firewall doesn't allow Nominatim, ADL-10).
   Uploads `playwright-report/` via `actions/upload-artifact@v4` (pinned SHA)
   on failure.
5. **`_project/security-spec.md`** — added a same-PR note under SEC-07 so the
   spec's code snippet doesn't read as silently stale next to the
   BYPASS_AUTH-only headroom.

## Verification

- 36/36 specs pass on **4 consecutive full local runs** (retries: 0 per
  `playwright.config.ts`; ~27-34s each) after the fix.
- `npm run check`, `npm run type:check:all`, `npm run test:backend` (470
  passed / 1 skipped), `npm run test:frontend` (84 passed) all green.

## Test plan

- [x] 36/36 E2E specs pass, 3+ consecutive local runs, 0 retries
- [x] Pre-push checklist green (biome, type:check:all, backend, frontend)
- [ ] CI green on this PR, including the new E2E Tests job (`gh pr checks`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)