### PR TITLE
feat(OP-12): generated STATUS.md dashboard + BUG-23 JSONC fix (#127)

### DIFF
--- a/.claude/skills/pre-push/SKILL.md
+++ b/.claude/skills/pre-push/SKILL.md
@@ -10,7 +10,11 @@ npm run check              # Biome lint + format
 npm run type:check:all     # TypeScript (frontend + backend)
 npm run test:backend       # Backend unit tests
 npm run test:frontend      # Frontend unit tests
+npm run status:check       # _project/STATUS.md in sync with tracker.json
 ```
+
+If `status:check` fails, run `npm run status` and commit the regenerated
+`_project/STATUS.md` alongside your change — STATUS.md is generated, never hand-edited.
 
 Contract tests require a live backend — only run `npm run test:contract` if the backend is running locally.
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,8 @@ jobs:
           cache: "npm"
       - run: npm ci
       - run: npm run check
+      - name: STATUS.md freshness
+        run: npm run status:check
 
   typecheck:
     name: Type Check

--- a/_project/STATUS.md
+++ b/_project/STATUS.md
@@ -1,0 +1,85 @@
+# Travel Tracker — Status
+
+> **Generated** from `_project/tracker.json` — do not edit by hand.
+> Regenerate with `npm run status`. Staleness is gated by `npm run status:check` (pre-push).
+
+_Tracker last updated: 2026-07-18 (OP-12 dashboard + stale-status sweep)_
+
+## Phases
+
+| Phase | Title | Status |
+|---|---|---|
+| PHASE-0 | Foundation — Architecture & Blueprint | ✅ Done |
+| PHASE-1 | Data Layer — Database Schema & Migrations | ✅ Done |
+| PHASE-2 | API Layer — Backend REST API | ✅ Done |
+| PHASE-3 | UI Layer — React Frontend SPA | ✅ Done |
+| PHASE-4 | QA & Documentation | 🔄 In progress |
+| PHASE-5 | Integrations — Notification Engine | ⬜ Pending |
+
+## Open work (12)
+
+### P0 — Blockers (1)
+
+| ID | Title | Owner | Status |
+|---|---|---|---|
+| FEAT-IT | Item Logging | frontend | ◐ Partial |
+
+### P2 — Important (8)
+
+| ID | Title | Owner | Status |
+|---|---|---|---|
+| OP-07 | UI/UX expert review of frontend | coo | ⬜ Pending |
+| FUTURE-03 | Companion model — linked/unlinked users with invite flow | coo | ⬜ Pending |
+| BRD-IT0809 | Rating sort and filter in item list views, cross-trip by city (IT-08/09) | frontend | 🔄 In progress |
+| BRD-AD07 | Map shading configuration is per-user (AD-07) | backend | 🔄 In progress |
+| BRD-AD08 | Companions list is per-user (AD-08) | backend | 🔄 In progress |
+| BRD-AD09 | Categories/activities are global seeded defaults; deactivation is owner-only (AD-09) | backend | ◐ Partial |
+| BRD-PH03 | Photo management accessible from trip detail header (PH-03) | frontend | ◐ Partial |
+| BRD-FL04 | Flight number lookup — auto-populate fields from flight number + date (FL-04) | backend | ⬜ Pending |
+
+### P3 — Minor (3)
+
+| ID | Title | Owner | Status |
+|---|---|---|---|
+| FUTURE-01 | Import booking confirmations — flights, hotels, etc. | coo | ⬜ Pending |
+| FUTURE-02 | Companion endorsements — tag who added place/item, allow endorsements | coo | ⬜ Pending |
+| QUAL-02 | Test assertion strength and edge case gaps (QA follow-up) | backend | ⬜ Pending |
+
+## Coverage by type
+
+| Type | Progress | Done | Open | Deferred/Closed |
+|---|---|---|---|---|
+| feature | `██████████████▓▓▓▓░░` 23/33 | 23 | 10 | 1 |
+| requirement | `███████████████████░` 29/30 | 29 | 1 | 5 |
+| bug | `████████████████████` 24/24 | 24 | 0 | 3 |
+| task | `████████████████████` 8/8 | 8 | 0 | 0 |
+| chore | `██████████░░░░░░░░░░` 1/2 | 1 | 1 | 0 |
+
+<details>
+<summary>Deferred (8)</summary>
+
+| ID | Title | Owner |
+|---|---|---|
+| BUG-06 | ShadingTab colour picker uses uncontrolled defaultValue | frontend |
+| NR-09 | Subscription admin boundary — separate from trip-level permissions | architect |
+| NR-10 | Delegated trip management — trip-scoped permissions | architect |
+| NR-11 | Global reference data protection | architect |
+| NR-12 | Archive instead of hard delete for structured lists | architect |
+| NR-13 | Global settings risk control — owner/admin only for destructive changes | architect |
+| UX-05 | Photos — full implementation | frontend |
+| ENV-01 | Geocoding retry queue stuck — Nominatim blocked by devcontainer firewall | coo |
+
+</details>
+
+<details>
+<summary>Closed without change (1)</summary>
+
+| ID | Title | Resolution |
+|---|---|---|
+| BUG-17 | BUG-A untracked — trips.ts comment references unlogged issue | not-a-bug |
+
+</details>
+
+---
+
+_85 done · 8 deferred · 1 closed · 12 open — 106 tracked items_

--- a/_project/tracker.json
+++ b/_project/tracker.json
@@ -2,7 +2,7 @@
   "meta": {
     "project": "Travel Tracker",
     "version": "1.0",
-    "updated": "2026-03-21 (triage)"
+    "updated": "2026-07-18 (OP-12 dashboard + stale-status sweep)"
   },
   "items": [
 
@@ -60,7 +60,7 @@
       "priority": "P0",
       "brdRefs": [],
       "phase": 4,
-      "notes": "186 backend + 55 frontend unit tests passing. Contract tests passing. Playwright E2E suite (36 tests) delivered as POC — parked pending panel scoping refactor. README + CODEBASE.md done. Blocked by OP-06 (hardening checklist) before formal phase close."
+      "notes": "186 backend + 55 frontend unit tests passing. Contract tests passing. Playwright E2E suite (36 tests) now a permanent CI gate (OP-11, PR #124). README + CODEBASE.md done. OP-06 gate CLOSED 2026-07-16 (PR #115) — no longer a blocker. Remaining before formal close: OP-07 (UI/UX expert review) + PO phase UAT."
     },
     {
       "id": "PHASE-5",
@@ -648,12 +648,12 @@
       "id": "OP-06",
       "type": "requirement",
       "title": "Pre-access hardening checklist — tied to NR-14",
-      "status": "in-progress",
+      "status": "done",
       "owner": "coo",
       "priority": "P1",
       "brdRefs": ["SE-01", "SE-02", "SE-03", "SE-04", "SE-05", "SE-06", "SE-07"],
       "phase": 1,
-      "notes": "Architect checklist delivered 2026-03-23 (jobs/architect/tech/OP-06-hardening-checklist.md). ADL-27 delivered + corrected. Implementation underway — see NR-14 notes for item-by-item status. Closes when NR-14 passes."
+      "notes": "Architect checklist delivered 2026-03-23 (jobs/architect/tech/OP-06-hardening-checklist.md). ADL-27 delivered + corrected. Gate formally CLOSED 2026-07-16 — 13/13 PASS after Q5 real-auth UAT (PR #115, issue #23). Tracker status flip missed in the #115 close-out, corrected in the OP-12 PR."
     },
     // ─── SE REQUIREMENTS (Security — BRD §5.11, v2.7) ────────────────────────
     {
@@ -744,6 +744,17 @@
       "brdRefs": [],
       "phase": 4,
       "notes": "PO direction 2026-03-09. Schedule after Phase 1 sign-off. Beta provides working baseline for UX review."
+    },
+    {
+      "id": "OP-12",
+      "type": "requirement",
+      "title": "Generated human-readable status dashboard (STATUS.md) from tracker.json",
+      "status": "done",
+      "owner": "coo",
+      "priority": "P2",
+      "brdRefs": [],
+      "phase": 4,
+      "notes": "PO direction 2026-07-18: tracker.json is hard to read as a human — needs a derived, never-hand-maintained snapshot view. scripts/status.js renders _project/STATUS.md (phases, open work by priority, coverage rollup); npm run status regenerates, npm run status:check gates staleness in /pre-push. Shares the string-aware JSONC loader with tracker.js (BUG-23 fix). Part 1 of the prioritisation-mechanic work; part 2 (roadmap/bundles) and a visual dashboard (Artifact) to be designed with PO."
     },
 
     // ─── PO TESTING FEEDBACK (2026-03-09) ────────────────────────────────────
@@ -1057,12 +1068,12 @@
       "id": "BUG-23",
       "type": "bug",
       "title": "scripts/tracker.js comment stripper truncates strings containing // — tracker CLI unusable",
-      "status": "open",
+      "status": "done",
       "owner": "backend",
       "priority": "P2",
       "brdRefs": [],
       "phase": 1,
-      "notes": "Regex at tracker.js:27 strips comment syntax inside JSON string literals; the BUG-A note added 2026-03-23 contains 'trips.ts:280' preceded by a double-slash, truncating the string — every tracker.js run since fails to parse. Fix: string-aware comment stripping. Found 2026-07-07 during OP-09 work. GitHub issue #96."
+      "notes": "Regex at tracker.js:27 strips comment syntax inside JSON string literals; the BUG-A note added 2026-03-23 contains 'trips.ts:280' preceded by a double-slash, truncating the string — every tracker.js run since fails to parse. Found 2026-07-07 during OP-09 work. GitHub issue #96. Fixed in OP-12 PR: string-aware stripper extracted to scripts/lib/tracker-data.js, shared by tracker.js and status.js."
     },
     {
       "id": "BUG-26",

--- a/_project/tracker.json
+++ b/_project/tracker.json
@@ -754,7 +754,7 @@
       "priority": "P2",
       "brdRefs": [],
       "phase": 4,
-      "notes": "PO direction 2026-07-18: tracker.json is hard to read as a human — needs a derived, never-hand-maintained snapshot view. scripts/status.js renders _project/STATUS.md (phases, open work by priority, coverage rollup); npm run status regenerates, npm run status:check gates staleness in /pre-push. Shares the string-aware JSONC loader with tracker.js (BUG-23 fix). Part 1 of the prioritisation-mechanic work; part 2 (roadmap/bundles) and a visual dashboard (Artifact) to be designed with PO."
+      "notes": "GitHub issue #127. PO direction 2026-07-18: tracker.json is hard to read as a human — needs a derived, never-hand-maintained snapshot view. scripts/status.js renders _project/STATUS.md (phases, open work by priority, coverage rollup); npm run status regenerates, npm run status:check gates staleness in /pre-push. Shares the string-aware JSONC loader with tracker.js (BUG-23 fix). Part 1 of the prioritisation-mechanic work; part 2 (roadmap/bundles) and a visual dashboard (Artifact) to be designed with PO."
     },
 
     // ─── PO TESTING FEEDBACK (2026-03-09) ────────────────────────────────────

--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
     "db:migrate": "drizzle-kit migrate",
     "db:seed": "tsx src/backend/db/seed.ts",
     "db:studio": "drizzle-kit studio",
+    "status": "node scripts/status.js",
+    "status:check": "node scripts/status.js --check",
     "test:backend": "vitest run --config vitest.config.backend.ts",
     "test:backend:watch": "vitest --config vitest.config.backend.ts",
     "test:frontend": "vitest run --config vitest.config.frontend.ts",

--- a/scripts/lib/tracker-data.js
+++ b/scripts/lib/tracker-data.js
@@ -1,0 +1,90 @@
+/**
+ * Shared loader for _project/tracker.json (JSONC — allows // and block comments).
+ *
+ * The comment stripper is string-aware: `//` inside a JSON string literal (URLs,
+ * code-comment references like "// BUG-A") is preserved. The previous regex-based
+ * stripper truncated such strings and broke parsing entirely (BUG-23 / issue #96).
+ */
+
+import { readFileSync } from 'fs';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+export const TRACKER_PATH = resolve(__dirname, '../../_project/tracker.json');
+
+export function stripJsonComments(src) {
+  let out = '';
+  let i = 0;
+  let inString = false;
+  while (i < src.length) {
+    const c = src[i];
+    if (inString) {
+      out += c;
+      if (c === '\\') {
+        out += src[i + 1] ?? '';
+        i += 2;
+        continue;
+      }
+      if (c === '"') inString = false;
+      i++;
+      continue;
+    }
+    if (c === '"') {
+      inString = true;
+      out += c;
+      i++;
+      continue;
+    }
+    if (c === '/' && src[i + 1] === '/') {
+      while (i < src.length && src[i] !== '\n') i++;
+      continue;
+    }
+    if (c === '/' && src[i + 1] === '*') {
+      i += 2;
+      while (i < src.length && !(src[i] === '*' && src[i + 1] === '/')) i++;
+      i += 2;
+      continue;
+    }
+    out += c;
+    i++;
+  }
+  return out;
+}
+
+/**
+ * Status values in tracker.json have drifted over time (in-progress vs in_progress,
+ * open, backlog, …). Normalise to a canonical set for display; the raw value is
+ * kept on the item as `rawStatus`.
+ *
+ * Canonical: done | in_progress | partial | blocked | pending | deferred | closed
+ */
+const STATUS_ALIASES = {
+  'in-progress': 'in_progress',
+  open: 'pending',
+  backlog: 'pending',
+  accepted: 'deferred', // accepted limitation — not being worked
+  'not-a-bug': 'closed', // investigated, closed without change
+};
+
+export function normaliseStatus(status) {
+  return STATUS_ALIASES[status] ?? status;
+}
+
+/** Statuses that count as "no further work expected". */
+export const RESOLVED_STATUSES = new Set(['done', 'deferred', 'closed']);
+
+export function isOpen(item) {
+  return !RESOLVED_STATUSES.has(item.status);
+}
+
+export function loadTracker() {
+  const raw = readFileSync(TRACKER_PATH, 'utf8');
+  const data = JSON.parse(stripJsonComments(raw));
+  for (const item of data.items) {
+    item.rawStatus = item.status;
+    item.status = normaliseStatus(item.status);
+  }
+  return data;
+}

--- a/scripts/status.js
+++ b/scripts/status.js
@@ -1,0 +1,146 @@
+#!/usr/bin/env node
+/**
+ * Travel Tracker — human-readable status snapshot generator.
+ *
+ * Renders _project/tracker.json into _project/STATUS.md (markdown dashboard).
+ *
+ * Usage:
+ *   npm run status          Regenerate _project/STATUS.md
+ *   npm run status:check    Exit 1 if STATUS.md is stale (pre-push gate)
+ */
+
+import { readFileSync, writeFileSync } from 'fs';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { loadTracker, isOpen } from './lib/tracker-data.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const OUT_PATH = resolve(__dirname, '../_project/STATUS.md');
+
+const STATUS_DISPLAY = {
+  done: '✅ Done',
+  in_progress: '🔄 In progress',
+  partial: '◐ Partial',
+  blocked: '⛔ Blocked',
+  pending: '⬜ Pending',
+  deferred: '⏸️ Deferred',
+  closed: '✖️ Closed',
+};
+
+const PRIORITY_SECTIONS = [
+  ['P0', 'P0 — Blockers'],
+  ['P1', 'P1 — Critical'],
+  ['P2', 'P2 — Important'],
+  ['P3', 'P3 — Minor'],
+];
+
+function bar(done, partial, total, width = 20) {
+  if (total === 0) return '░'.repeat(width);
+  const d = Math.round((done / total) * width);
+  const p = Math.min(width - d, Math.round((partial / total) * width));
+  return '█'.repeat(d) + '▓'.repeat(p) + '░'.repeat(Math.max(0, width - d - p));
+}
+
+function esc(s) {
+  return String(s).replace(/\|/g, '\\|');
+}
+
+function render(data) {
+  const { meta, items } = data;
+  const lines = [];
+  const push = (...l) => lines.push(...l);
+
+  const phases = items.filter((i) => i.type === 'phase');
+  const work = items.filter((i) => i.type !== 'phase');
+  const open = work.filter(isOpen);
+  const done = work.filter((i) => i.status === 'done');
+  const deferred = work.filter((i) => i.status === 'deferred');
+  const closed = work.filter((i) => i.status === 'closed');
+
+  push(
+    '# Travel Tracker — Status',
+    '',
+    '> **Generated** from `_project/tracker.json` — do not edit by hand.',
+    '> Regenerate with `npm run status`. Staleness is gated by `npm run status:check` (pre-push).',
+    '',
+    `_Tracker last updated: ${meta.updated}_`,
+    ''
+  );
+
+  // ── Phases ────────────────────────────────────────────────────────────────
+  push('## Phases', '', '| Phase | Title | Status |', '|---|---|---|');
+  for (const p of phases) {
+    push(`| ${p.id} | ${esc(p.title)} | ${STATUS_DISPLAY[p.status] ?? p.status} |`);
+  }
+  push('');
+
+  // ── Open work ─────────────────────────────────────────────────────────────
+  push(`## Open work (${open.length})`, '');
+  for (const [pri, heading] of PRIORITY_SECTIONS) {
+    const group = open.filter((i) => (i.priority ?? 'P3') === pri);
+    if (group.length === 0) continue;
+    push(`### ${heading} (${group.length})`, '');
+    push('| ID | Title | Owner | Status |', '|---|---|---|---|');
+    for (const i of group) {
+      push(
+        `| ${i.id} | ${esc(i.title)} | ${i.owner} | ${STATUS_DISPLAY[i.status] ?? i.status} |`
+      );
+    }
+    push('');
+  }
+  if (open.length === 0) push('_No open items._', '');
+
+  // ── Coverage rollup ───────────────────────────────────────────────────────
+  push('## Coverage by type', '', '| Type | Progress | Done | Open | Deferred/Closed |', '|---|---|---|---|---|');
+  const types = ['feature', 'requirement', 'bug', 'task', 'chore'];
+  for (const t of types) {
+    const group = work.filter((i) => i.type === t);
+    if (group.length === 0) continue;
+    const gDone = group.filter((i) => i.status === 'done').length;
+    const gPartial = group.filter((i) => ['partial', 'in_progress'].includes(i.status)).length;
+    const gResolved = group.filter((i) => ['deferred', 'closed'].includes(i.status)).length;
+    const gOpen = group.filter(isOpen).length;
+    const denom = group.length - gResolved;
+    push(
+      `| ${t} | \`${bar(gDone, gPartial, denom)}\` ${gDone}/${denom} | ${gDone} | ${gOpen} | ${gResolved} |`
+    );
+  }
+  push('');
+
+  // ── Deferred / closed ─────────────────────────────────────────────────────
+  if (deferred.length > 0) {
+    push('<details>', `<summary>Deferred (${deferred.length})</summary>`, '');
+    push('| ID | Title | Owner |', '|---|---|---|');
+    for (const i of deferred) push(`| ${i.id} | ${esc(i.title)} | ${i.owner} |`);
+    push('', '</details>', '');
+  }
+  if (closed.length > 0) {
+    push('<details>', `<summary>Closed without change (${closed.length})</summary>`, '');
+    push('| ID | Title | Resolution |', '|---|---|---|');
+    for (const i of closed) push(`| ${i.id} | ${esc(i.title)} | ${i.rawStatus} |`);
+    push('', '</details>', '');
+  }
+
+  push('---', '', `_${done.length} done · ${deferred.length} deferred · ${closed.length} closed · ${open.length} open — ${work.length} tracked items_`, '');
+  return lines.join('\n');
+}
+
+const data = loadTracker();
+const output = render(data);
+
+if (process.argv.includes('--check')) {
+  let current = '';
+  try {
+    current = readFileSync(OUT_PATH, 'utf8');
+  } catch {
+    /* missing file is stale */
+  }
+  if (current !== output) {
+    console.error('STATUS.md is stale — run `npm run status` and commit the result.');
+    process.exit(1);
+  }
+  console.log('STATUS.md is up to date.');
+} else {
+  writeFileSync(OUT_PATH, output);
+  console.log(`Wrote ${OUT_PATH}`);
+}

--- a/scripts/tracker.js
+++ b/scripts/tracker.js
@@ -11,30 +11,15 @@
  *   node scripts/tracker.js --brd MP           Items referencing BRD reqs starting with MP
  */
 
-import { readFileSync } from 'fs';
-import { resolve, dirname } from 'path';
-import { fileURLToPath } from 'url';
-
-const __dirname = dirname(fileURLToPath(import.meta.url));
+import { loadTracker, isOpen } from './lib/tracker-data.js';
 
 // ─── Load data ───────────────────────────────────────────────────────────────
 
-const dataPath = resolve(__dirname, '../_project/tracker.json');
-let raw;
-try {
-  raw = readFileSync(dataPath, 'utf8');
-  // Strip JS-style comments so we can parse the JSON
-  raw = raw.replace(/\/\/[^\n]*/g, '').replace(/\/\*[\s\S]*?\*\//g, '');
-} catch (e) {
-  console.error('Cannot read _project/tracker.json:', e.message);
-  process.exit(1);
-}
-
 let data;
 try {
-  data = JSON.parse(raw);
+  data = loadTracker();
 } catch (e) {
-  console.error('tracker.json parse error:', e.message);
+  console.error('Cannot load _project/tracker.json:', e.message);
   process.exit(1);
 }
 
@@ -66,9 +51,11 @@ function statusLabel(status) {
   switch (status) {
     case 'done':        return `${BGRN}✅ done       ${R}`;
     case 'in_progress': return `${BCYN}🔄 in progress${R}`;
+    case 'partial':     return `${BCYN}◐  partial    ${R}`;
     case 'blocked':     return `${BRED}⏸  blocked    ${R}`;
     case 'pending':     return `${BYLW}⬜ pending    ${R}`;
     case 'deferred':    return `${DIM}◌  deferred   ${R}`;
+    case 'closed':      return `${DIM}✕  closed     ${R}`;
     default:            return status;
   }
 }
@@ -77,9 +64,11 @@ function statusBadge(status) {
   switch (status) {
     case 'done':        return `${BGRN}DONE${R}`;
     case 'in_progress': return `${BCYN}IN PROGRESS${R}`;
+    case 'partial':     return `${BCYN}PARTIAL${R}`;
     case 'blocked':     return `${BRED}BLOCKED${R}`;
     case 'pending':     return `${BYLW}PENDING${R}`;
     case 'deferred':    return `${DIM}DEFERRED${R}`;
+    case 'closed':      return `${DIM}CLOSED${R}`;
     default:            return status;
   }
 }
@@ -140,10 +129,6 @@ const filterBrd      = getArg('--brd');
 const filterOpen     = hasFlag('--open');
 
 // ─── Views ───────────────────────────────────────────────────────────────────
-
-function isOpen(item) {
-  return item.status !== 'done' && item.status !== 'deferred';
-}
 
 function applyFilters(list) {
   return list.filter(item => {
@@ -281,6 +266,7 @@ function showOpenItems(list) {
     for (const item of group) {
       const statusIcon = {
         in_progress: `${BCYN}●${R}`,
+        partial:     `${BCYN}◐${R}`,
         blocked:     `${BRED}◼${R}`,
         pending:     `${BYLW}○${R}`,
       }[item.status] || '·';


### PR DESCRIPTION
Closes #127
Closes #96

Part 1 of the prioritisation-mechanic work (PO direction 2026-07-18): a human-readable, always-derived snapshot of tracker state.

## What
- **`scripts/lib/tracker-data.js`** — shared JSONC loader with string-aware comment stripping (fixes BUG-23: `//` inside note strings broke the naive regex stripper — tracker CLI had been unusable since 2026-03-23) + status-alias normalisation for drifted vocabulary (`in-progress`, `open`, `backlog`, `accepted`, `not-a-bug`)
- **`scripts/status.js`** — renders `_project/STATUS.md`: phases table, open work grouped by priority, coverage-by-type with progress bars, deferred/closed in collapsibles
- **`npm run status` / `npm run status:check`** — regenerate / staleness gate. Wired into `/pre-push` and CI (biome job). STATUS.md is generated, never hand-edited — it cannot become a stale status doc
- **`scripts/tracker.js`** — now uses the shared loader; learns `partial`/`closed` statuses

## Document-lifecycle fixes (same-PR rule)
- OP-06 tracker entry `in-progress` → `done` — gate formally closed 13/13 PASS in PR #115; the tracker flip was missed in that close-out
- PHASE-4 notes refreshed — E2E is a CI gate since PR #124, OP-06 no longer a blocker
- BUG-23 → done (this PR)

Net effect: open items 16 → 12; the dashboard now reflects true state.

## Verification
- Biome, type:check:all, 470 backend + 89 frontend tests, status:check — all green locally
- `node scripts/tracker.js` runs again (first successful parse since March); detail/filter views smoke-tested

🤖 Generated with [Claude Code](https://claude.com/claude-code)