### PR TITLE
chore(OP-13): hook hardening — db:push guard, hook canary, typecheck.sh tidy (#131)

### DIFF
--- a/.claude/hooks/block-db-push.sh
+++ b/.claude/hooks/block-db-push.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# PreToolUse guard (ADL-15): block every form of drizzle-kit push.
+# The migrate workflow (db:generate + db:migrate) is the only sanctioned schema path —
+# push bypasses the patched drizzle-kit and can corrupt/desync the migrations journal.
+# Closes the gap noted in audit Session B invariant 1: the npm script was removed,
+# but nothing stopped a direct `npx drizzle-kit push`.
+#
+# Matching is invocation-shaped: quoted strings and heredoc bodies are stripped first,
+# so commit messages, issue bodies, and docs may mention db:push without tripping the
+# guard (v1 blocked its own GitHub issue for this).
+cmd=$(jq -r '.tool_input.command // empty' 2>/dev/null)
+stripped=$(printf '%s\n' "$cmd" | awk '
+  inHd { if ($0 == hd) inHd = 0; next }
+  {
+    line = $0
+    if (match(line, /<<-?[[:space:]]*['"'"'"]?[A-Za-z_][A-Za-z0-9_]*/)) {
+      hd = substr(line, RSTART, RLENGTH)
+      sub(/<<-?[[:space:]]*/, "", hd)
+      gsub(/['"'"'"]/, "", hd)
+      inHd = 1
+    }
+    gsub(/'"'"'[^'"'"']*'"'"'/, "", line)
+    gsub(/"[^"]*"/, "", line)
+    print line
+  }')
+if printf '%s' "$stripped" | grep -qE '(^|[;&|([:space:]])(npx[[:space:]]+)?drizzle-kit[[:space:]]+push([[:space:]]|$)|(^|[;&|([:space:]])(npm[[:space:]]+run|yarn|pnpm([[:space:]]+run)?)[[:space:]]+db:push([[:space:]]|$)'; then
+  cat <<'JSON'
+{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"Blocked by ADL-15: drizzle-kit push is forbidden in this repo. Use npm run db:generate + npm run db:migrate (CLAUDE.md > Schema changes)."}}
+JSON
+  exit 0
+fi
+exit 0

--- a/.claude/hooks/typecheck.sh
+++ b/.claude/hooks/typecheck.sh
@@ -1,11 +1,17 @@
 #!/usr/bin/env bash
-# PostToolUse hook — incremental TypeScript type check on every .ts/.tsx edit.
+# PostToolUse hook — full TypeScript type check (frontend or backend project,
+# routed by file path) on every .ts/.tsx edit.
 # Reads tool data from stdin (Claude Code JSON format).
 # Outputs nothing on clean; outputs tsc errors on failure.
-# Appends a perf entry to typecheck-perf.log for the first week of monitoring.
+# Appends a perf entry to typecheck-perf.log (capped at 500 lines, rotated below).
 
 WORKSPACE="/workspace"
 LOG="$WORKSPACE/.claude/hooks/typecheck-perf.log"
+
+# Cap the perf log — it appended unbounded from 2026-03 to 2026-07 (audit Session B).
+if [ -f "$LOG" ] && [ "$(wc -l < "$LOG" 2>/dev/null || echo 0)" -gt 500 ]; then
+  tail -n 250 "$LOG" > "$LOG.tmp" 2>/dev/null && mv "$LOG.tmp" "$LOG" 2>/dev/null || true
+fi
 
 # Parse file_path from stdin JSON
 INPUT=$(cat)

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -3,6 +3,17 @@
     "defaultMode": "bypassPermissions"
   },
   "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash /workspace/.claude/hooks/block-db-push.sh"
+          }
+        ]
+      }
+    ],
     "PostToolUse": [
       {
         "matcher": "Write|Edit",

--- a/.claude/skills/coo-startup/SKILL.md
+++ b/.claude/skills/coo-startup/SKILL.md
@@ -18,7 +18,32 @@ description: COO session startup audit. Invoked by the COO at the start of every
 
 ## Startup procedure
 
-Work through these five checks in order. Surface any issues to the user before doing anything else.
+Work through these checks in order. Surface any issues to the user before doing anything else.
+
+### 0. Hook canary
+
+The `.claude/hooks/*.sh` hooks fail silently by design (`|| true`, `exit 0` paths) — if
+one breaks, its protection just stops with no error (audit Session B, invariant 30). Prove
+they work rather than trusting silence:
+
+```bash
+# db:push guard must emit a deny decision
+echo '{"tool_input":{"command":"npx drizzle-kit push"}}' \
+  | bash /workspace/.claude/hooks/block-db-push.sh | grep -q '"deny"' \
+  && echo "db:push guard OK" || echo "FAIL: db:push guard broken"
+
+# typecheck hook must append a perf-log line end-to-end
+before=$(wc -l < /workspace/.claude/hooks/typecheck-perf.log)
+echo '{"tool_input":{"file_path":"/workspace/src/backend/server.ts"}}' \
+  | bash /workspace/.claude/hooks/typecheck.sh >/dev/null
+after=$(wc -l < /workspace/.claude/hooks/typecheck-perf.log)
+[ "$after" -gt "$before" ] && echo "typecheck hook OK" || echo "FAIL: typecheck hook broken"
+```
+
+Any FAIL → fix the hook before doing anything else this session. Secondary tell for the
+drift ledger: an editing session that produced zero new ledger entries means the
+PostToolUse hooks are silently broken — investigate before trusting this session's
+typecheck feedback.
 
 ### 1. Main CI health check
 

--- a/_project/STATUS.md
+++ b/_project/STATUS.md
@@ -3,7 +3,7 @@
 > **Generated** from `_project/tracker.json` — do not edit by hand.
 > Regenerate with `npm run status`. Staleness is gated by `npm run status:check` (pre-push).
 
-_Tracker last updated: 2026-07-18 (OP-12 dashboard + stale-status sweep)_
+_Tracker last updated: 2026-07-18 (OP-13 hook hardening)_
 
 ## Phases
 
@@ -53,7 +53,7 @@ _Tracker last updated: 2026-07-18 (OP-12 dashboard + stale-status sweep)_
 | requirement | `███████████████████░` 29/30 | 29 | 1 | 5 |
 | bug | `████████████████████` 24/24 | 24 | 0 | 3 |
 | task | `████████████████████` 8/8 | 8 | 0 | 0 |
-| chore | `██████████░░░░░░░░░░` 1/2 | 1 | 1 | 0 |
+| chore | `█████████████░░░░░░░` 2/3 | 2 | 1 | 0 |
 
 <details>
 <summary>Deferred (8)</summary>
@@ -82,4 +82,4 @@ _Tracker last updated: 2026-07-18 (OP-12 dashboard + stale-status sweep)_
 
 ---
 
-_85 done · 8 deferred · 1 closed · 12 open — 106 tracked items_
+_86 done · 8 deferred · 1 closed · 12 open — 107 tracked items_

--- a/_project/tracker.json
+++ b/_project/tracker.json
@@ -2,7 +2,7 @@
   "meta": {
     "project": "Travel Tracker",
     "version": "1.0",
-    "updated": "2026-07-18 (OP-12 dashboard + stale-status sweep)"
+    "updated": "2026-07-18 (OP-13 hook hardening)"
   },
   "items": [
 
@@ -744,6 +744,17 @@
       "brdRefs": [],
       "phase": 4,
       "notes": "PO direction 2026-03-09. Schedule after Phase 1 sign-off. Beta provides working baseline for UX review."
+    },
+    {
+      "id": "OP-13",
+      "type": "chore",
+      "title": "Hook hardening — db:push PreToolUse guard, hook canary, typecheck.sh tidy",
+      "status": "done",
+      "owner": "coo",
+      "priority": "P2",
+      "brdRefs": [],
+      "phase": 4,
+      "notes": "GitHub issue #131. Audit Session B dispositions (invariants 1 + 30): PreToolUse guard blocks all drizzle-kit push forms with invocation-shaped matching (quoted/heredoc prose exempt); /coo-startup check 0 canary proves hooks work end-to-end (they fail silent by design); typecheck.sh comment fixed + perf log capped at 500 lines. Guard proven live in-session (blocked a matching command, then correctly allowed prose after refinement)."
     },
     {
       "id": "OP-12",


### PR DESCRIPTION
Closes #131

Audit Session B disposition items (invariants 1 and 30), part of the audit-findings close-out:

- **db:push guard**: new PreToolUse hook denies every invocation form of drizzle-kit push (ADL-15). The npm script was removed long ago but nothing stopped a direct npx call — this closes that. Matching is invocation-shaped (quoted strings + heredoc bodies stripped first) so prose mentions in commit messages/issue bodies don't false-positive — v1 blocked its own GitHub issue creation, which was both embarrassing and an excellent live test. 9-case test matrix passes; guard proven live in-session (denied a matching command, allowed prose).
- **Hook canary** (/coo-startup check 0): hooks fail silent by design — if one breaks, its protection just stops. The canary pipes synthetic payloads through both hooks each session start and expects observable output.
- **typecheck.sh tidy**: comment said incremental (it runs a full project check); perf log was appending unbounded "for the first week of monitoring" since March — now capped at 500 lines with rotation.

Verification: full pre-push suite green (Biome, typecheck, 470+89 tests, status:check); typecheck hook re-verified end-to-end after the edit.

Note: known one-line merge conflict with PR #130 on tracker.json meta.updated — will resolve at whichever merges second.

🤖 Generated with [Claude Code](https://claude.com/claude-code)