### PR TITLE
chore(OP-14): install COO skills — coo-merge-and-close + record-decision (#133)

### DIFF
--- a/.claude/skills/coo-merge-and-close/SKILL.md
+++ b/.claude/skills/coo-merge-and-close/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: coo-merge-and-close
+description: COO procedure for merging PRs and closing a session — squash merge, branch hygiene, main-CI verification, inbox triage, tracker + STATUS.md update, park doc. Use alongside /coo-startup (startup audits inherited state; this closes out the session's own).
+---
+
+Installed 2026-07-18 from the Session C draft (audits/session-c-workflow-extraction.md,
+`chore/audit-questions` branch), updated for BUG-23's fix and the OP-12 dashboard.
+
+## Merging each PR
+
+1. Review the diff. Reject (or fix forward in-session) if the PR changes a fact asserted
+   by a status/verdict document without updating that document in the same PR — this
+   review moment is the enforcement point for the document-lifecycle rule (CLAUDE.md);
+   missed here, verdicts rot silently (the OP-06 failure class).
+2. Confirm the PR's CI is green — **by reading the actual job results, not an agent's
+   self-report.** If the PR adds a NEW CI job, open that job's own log: all pre-existing
+   jobs can be green while the new one fails (OP-11 first-round PR: 30/36 E2E specs
+   failing behind a green-looking check list; caught only by reading the raw log).
+3. Merge:
+   ```bash
+   gh pr merge <n> --repo ryanv11/travel-tracker --squash --delete-branch
+   git checkout main && git pull
+   git branch -D <branch-name>        # force-delete expected with squash merges
+   ```
+4. Post-merge verification (mandatory, before the next merge or session end):
+   ```bash
+   gh run list --repo ryanv11/travel-tracker --branch main --limit 4
+   ```
+   A green PR does not guarantee a green main — two individually-green PRs can compose
+   to a red main via squash-merge races (BUG-24). If main goes red, fixing it is the
+   immediate next action; never leave it for a future session without a tracked issue.
+5. After the merge batch: `git branch` must list only `main` (plus any branches with
+   open PRs awaiting review).
+
+## Session close checklist
+
+1. **Inbox triage:** process `jobs/COO/inbox/*.md`; `git mv` handled reports to
+   `jobs/COO/inbox/read/`. A completion report is only acceptable if the work it reports
+   is committed and merged — agents must never leave deliverables as uncommitted
+   working-tree changes.
+2. **Tracker + STATUS.md:** update `_project/tracker.json` statuses and notes directly
+   (the file is JSONC — its `// ───` section headers are intentional). Then regenerate
+   the derived dashboard and validate in one step:
+   ```bash
+   npm run status          # regenerates _project/STATUS.md; fails on invalid JSONC
+   ```
+   Commit STATUS.md with the tracker change — `npm run status:check` gates staleness in
+   /pre-push and CI. New issues raised this session: tracker ID in the issue title,
+   issue number back in the tracker `notes` (CLAUDE.md cross-referencing rule).
+3. **BRD reconciliation (only if the BRD changed this session):** every new requirement
+   ID has a tracker entry and stated success criteria, and the BRD **header** version
+   matches the latest changelog entry (the header lagged from v2.5 to v2.7 once). See
+   /record-decision for the full BRD-bump procedure.
+4. **Park doc:** write `jobs/COO/park-docs/YYYYMMDD_HHMM-COO-park.txt` — session
+   summary, state of play, open threads, suggested next actions (this is what the next
+   /coo-startup reads). Point at the roadmap/tracker for work queues rather than
+   restating them.
+5. **Drift ledger:** `.planning/drift-ledger.jsonl` is appended automatically by the
+   PostToolUse hook — commit whatever accumulated. Canary: an editing session that
+   produced ZERO new ledger entries means the hooks are silently broken — investigate
+   before trusting this session's typecheck feedback (see /coo-startup check 0).
+6. Close-out commit goes on a `chore/<slug>` branch → PR, like all work (never direct
+   to main).
+
+## Definition of done
+
+- [ ] Main's own CI green after the final merge (`gh run list --branch main`)
+- [ ] `git branch` shows only `main` + branches with open PRs awaiting review
+- [ ] `jobs/COO/inbox/` triaged; handled reports in `read/`
+- [ ] tracker.json statuses match merged reality; STATUS.md regenerated in same commit
+- [ ] Park doc written; drift ledger committed (and non-empty if files were edited)
+- [ ] If BRD touched: header version == changelog version; every new ID has tracker
+      entry + success criteria

--- a/.claude/skills/record-decision/SKILL.md
+++ b/.claude/skills/record-decision/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: record-decision
+description: Record an architecture decision (ADL entry) or bump the BRD — numbering, supersession stamps, open-question closure, tracker sync. Load before editing the ADL log, a standalone ADL file, or the BRD.
+---
+
+Installed 2026-07-18 from the Session C draft (audits/session-c-workflow-extraction.md,
+`chore/audit-questions` branch). Every guard below corresponds to a failure that actually
+happened — sources noted inline.
+
+## ADL entries
+
+1. **Number:** last entry + 1 — but check BOTH the main log
+   (`jobs/architect/tech/20260307-architecture-decisions-log.md`) AND the standalone
+   `jobs/architect/tech/ADL-*.md` files; numbering has skipped the log before (ADL-28
+   exists only as a standalone file).
+2. **The main log always gets the entry** — date, trigger (what inbox item / issue /
+   incident prompted it), decision, alternatives considered, implementation implications.
+   A standalone `ADL-NN-<slug>.md` file is fine for a long design, but it supplements the
+   log entry (summary + pointer), never replaces it. ADL-24's merge banner is the
+   exemplar for retiring a standalone file into the log.
+3. **Implementation status:** state whether the decision is implemented or pending in the
+   entry itself, and update it when the implementing PR merges (same-PR rule). "Decided"
+   with no status marker is how ADL-28 became indistinguishable from shipped work.
+4. **Supersession:** if this decision replaces an earlier ADL or invalidates a spec
+   section, the same PR stamps the superseded text:
+   `> SUPERSEDED (YYYY-MM-DD) by ADL-NN — retained for history.`
+   (ADL-17 → ADL-20 is the exemplar.) Check specifically: security-spec.md, the tech
+   blueprint, the map-shading spec — the three documents the audits found silently
+   outrun by decisions.
+5. **Open-question closure:** if the decision answers an open question in the BRD (§10)
+   or a spec, record the resolution there in the same PR. (OQ-01/OQ-02 sat open for
+   months after being answered; closed 2026-07-18 in the v3.0 bump.)
+6. File pointers in implications must name real paths — verify each one exists before
+   writing it (ADL-27/29 shipped with wrong file paths that survived review).
+
+## BRD version bumps
+
+1. Edit the body sections AND add the §13 changelog entry AND bump the **header** version
+   field — three places, and the header is the one that has been forgotten (stuck at 2.5
+   through v2.7).
+2. Changelog author/approval: every accepted entry lists the PO as approver. Do not treat
+   COO-only sign-off as an accepted pattern (v2.7 is the outlier — its retroactive PO
+   approval is still an open item, audit Q7). Identity-level rewrites get their own PO
+   approval gate: the PR is the adoption mechanism and the PO merges or explicitly
+   approves it (v3.0 exemplar).
+3. Every new requirement ID must state measurable success criteria before any brief
+   dispatches from it, and must get a tracker entry before session close (both CLAUDE.md
+   gates — this is the procedural reminder, not the rule's home).
+
+## Definition of done
+
+- [ ] Main ADL log contains the entry (not only a standalone file); numbering contiguous
+- [ ] Implementation status stated in the entry
+- [ ] Superseded ADL entries / spec sections stamped in the same PR
+- [ ] Answered open questions closed in their home document
+- [ ] BRD: header version == latest changelog version; PO approval recorded
+- [ ] Each new requirement ID: success criteria stated + tracker entry exists
+- [ ] All file paths cited in the entry verified to exist

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,28 +110,18 @@ gh run view <run-id> --log-failed   # if any job failed
 - Do not consider a task complete until CI passes (all jobs green)
 - Fix any CI failures before filing your completion report
 
-### Merging a PR (COO only)
-```bash
-gh pr merge <number> --repo ryanv11/travel-tracker --squash --delete-branch
-git checkout main && git pull
-git branch -D <branch-name>   # force-delete local branch (expected with squash merges)
-```
-- GitHub is configured to auto-delete remote branches on merge (`delete_branch_on_merge=true`)
-- Squash merge is standard — one clean commit per PR on `main`
-- Local branch must be manually deleted after merge — do not leave stale local branches
-- Run `git branch` after every merge session to confirm no branches remain except `main`
+### Merging a PR and closing a session (COO only)
+The COO merges via the `/coo-merge-and-close` skill — squash merge, branch hygiene,
+and the full session-close checklist live there. Two rules bind regardless:
+- Squash merge is standard; no stale local branches after a merge session
+- **Post-merge verification is mandatory**: main's own CI must go green after every
+  merge (`gh run list --branch main`) — a green PR does not guarantee a green main
+  (BUG-24). Red main is fixed immediately, never left unowned.
 
-### Post-merge verification (mandatory)
-After every merge, confirm **main's own CI runs go green** before the next merge or
-session end:
-```bash
-gh run list --repo ryanv11/travel-tracker --branch main --limit 4
-```
-A PR being green does not guarantee main stays green — two individually-green PRs can
-compose to a red main via squash-merge races (this is exactly how BUG-24's Type Check
-failure landed and sat undetected from 2026-03-24 to 2026-07-07). If main goes red after
-a merge, fixing it is the immediate next action — it is never left for a future session
-without a tracked issue. `/coo-startup` check 1 is the backstop, not the primary control.
+### Recording decisions (ADL entries, BRD bumps)
+Load the `/record-decision` skill before editing the ADL log, a standalone ADL file,
+or the BRD — numbering, supersession stamps, open-question closure, and the
+three-places BRD version bump live there.
 
 ## Environment
 - Running inside a devcontainer (Docker) — workspace at `/workspace`

--- a/_project/STATUS.md
+++ b/_project/STATUS.md
@@ -3,7 +3,7 @@
 > **Generated** from `_project/tracker.json` — do not edit by hand.
 > Regenerate with `npm run status`. Staleness is gated by `npm run status:check` (pre-push).
 
-_Tracker last updated: 2026-07-18 (OP-12 dashboard + stale-status sweep)_
+_Tracker last updated: 2026-07-18 (OP-14 COO skills installed, OP-15 deferred-skills design pass)_
 
 ## Phases
 
@@ -16,7 +16,7 @@ _Tracker last updated: 2026-07-18 (OP-12 dashboard + stale-status sweep)_
 | PHASE-4 | QA & Documentation | 🔄 In progress |
 | PHASE-5 | Integrations — Notification Engine | ⬜ Pending |
 
-## Open work (12)
+## Open work (13)
 
 ### P0 — Blockers (1)
 
@@ -37,10 +37,11 @@ _Tracker last updated: 2026-07-18 (OP-12 dashboard + stale-status sweep)_
 | BRD-PH03 | Photo management accessible from trip detail header (PH-03) | frontend | ◐ Partial |
 | BRD-FL04 | Flight number lookup — auto-populate fields from flight number + date (FL-04) | backend | ⬜ Pending |
 
-### P3 — Minor (3)
+### P3 — Minor (4)
 
 | ID | Title | Owner | Status |
 |---|---|---|---|
+| OP-15 | Design pass for deferred skills — schema-change + backend-route-change | coo | ⬜ Pending |
 | FUTURE-01 | Import booking confirmations — flights, hotels, etc. | coo | ⬜ Pending |
 | FUTURE-02 | Companion endorsements — tag who added place/item, allow endorsements | coo | ⬜ Pending |
 | QUAL-02 | Test assertion strength and edge case gaps (QA follow-up) | backend | ⬜ Pending |
@@ -53,7 +54,7 @@ _Tracker last updated: 2026-07-18 (OP-12 dashboard + stale-status sweep)_
 | requirement | `███████████████████░` 29/30 | 29 | 1 | 5 |
 | bug | `████████████████████` 24/24 | 24 | 0 | 3 |
 | task | `████████████████████` 8/8 | 8 | 0 | 0 |
-| chore | `██████████░░░░░░░░░░` 1/2 | 1 | 1 | 0 |
+| chore | `██████████░░░░░░░░░░` 2/4 | 2 | 2 | 0 |
 
 <details>
 <summary>Deferred (8)</summary>
@@ -82,4 +83,4 @@ _Tracker last updated: 2026-07-18 (OP-12 dashboard + stale-status sweep)_
 
 ---
 
-_85 done · 8 deferred · 1 closed · 12 open — 106 tracked items_
+_86 done · 8 deferred · 1 closed · 13 open — 108 tracked items_

--- a/_project/tracker.json
+++ b/_project/tracker.json
@@ -2,7 +2,7 @@
   "meta": {
     "project": "Travel Tracker",
     "version": "1.0",
-    "updated": "2026-07-18 (OP-12 dashboard + stale-status sweep)"
+    "updated": "2026-07-18 (OP-14 COO skills installed, OP-15 deferred-skills design pass)"
   },
   "items": [
 
@@ -744,6 +744,28 @@
       "brdRefs": [],
       "phase": 4,
       "notes": "PO direction 2026-03-09. Schedule after Phase 1 sign-off. Beta provides working baseline for UX review."
+    },
+    {
+      "id": "OP-14",
+      "type": "chore",
+      "title": "Install COO skills — coo-merge-and-close + record-decision (Session C, Q21)",
+      "status": "done",
+      "owner": "coo",
+      "priority": "P2",
+      "brdRefs": [],
+      "phase": 4,
+      "notes": "GitHub issue #133. PO decision 2026-07-18 on the four Session-C skill drafts: install the two COO-lane skills, updated to current repo state (BUG-23 warnings replaced with status:check validation; OP-11 read-the-CI-log lesson institutionalised). CLAUDE.md merge/close sections slimmed to pointers (audit Q24, scoped). schema-change + backend-route-change deferred to OP-15; W5 frontend skill deferred until PHASE-6 friction data."
+    },
+    {
+      "id": "OP-15",
+      "type": "chore",
+      "title": "Design pass for deferred skills — schema-change + backend-route-change",
+      "status": "pending",
+      "owner": "coo",
+      "priority": "P3",
+      "brdRefs": [],
+      "phase": 4,
+      "notes": "PO direction 2026-07-18: these two Session-C drafts need more consideration and planning before installing. Prerequisites: (a) Q22 test-DDL consolidation lands first — it removes the schema skill's most error-prone step (13 hand-mirrored DDL copies); (b) Q3/Q8 lock/PATCH fixes land so the backend skill's carve-out warnings can be written as settled rules; (c) decide the brief-template enforcement mechanism (skills only work if COO briefs consistently instruct agents to load them). Drafts remain in audits/session-c-workflow-extraction.md on chore/audit-questions. W5 frontend skill: extract from real PHASE-6 friction, not speculatively."
     },
     {
       "id": "OP-12",


### PR DESCRIPTION
Closes #133

PO decision on the Session-C skill drafts (audit Q21), 2026-07-18: install the two COO-lane skills now; defer the two implementation-agent skills.

## Installed (updated from the five-month-old drafts)
- **`.claude/skills/coo-merge-and-close`** — merge procedure + session-close checklist. Draft's BUG-23 trap warnings ("no mechanical validation possible") replaced with the `npm run status` / `status:check` path that exists since #128; STATUS.md regeneration added to the close checklist; the OP-11 lesson institutionalised: read a new CI job's own log, never accept an agent's green self-report.
- **`.claude/skills/record-decision`** — ADL entries + BRD bumps. Every guard maps to a demonstrated failure (ADL-28 log gap, header-version lag, unclosed OQs, wrong file paths in ADL-27/29).

## CLAUDE.md slimming (audit Q24 — scoped to installed skills only)
Merge/post-merge and decision-recording procedure replaced with skill pointers. Binding rules stay inline (squash standard, mandatory post-merge main verification, red-main-never-unowned). The schema and security-checklist sections are untouched — their skills are deferred.

## Deferred (OP-15, pending)
schema-change + backend-route-change need a design pass first, with stated prerequisites: Q22 test-DDL consolidation (removes the schema skill's most error-prone step), Q3/Q8 fixes (settles the lock carve-out warnings), and a decision on brief-template enforcement. W5 frontend skill: extract from real PHASE-6 friction rather than draft speculatively.

Verification: full pre-push suite green (Biome, typecheck, 470+89 tests, status:check). Both skills confirmed live in the harness skill listing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)