### PR TITLE
chore(OP-16): close main-CI push-trigger stall as transient — ADL-31

### DIFF
--- a/_project/STATUS.md
+++ b/_project/STATUS.md
@@ -17,7 +17,7 @@ _Tracker last updated: 2026-07-19 (session close: BUG-27/28/29/10 done, OP-16 ra
 | PHASE-5 | Integrations — Notification Engine | ⬜ Pending |
 | PHASE-6 | v3 Planning-First Delivery | ⬜ Pending |
 
-## Open work (23)
+## Open work (22)
 
 ### P0 — Blockers (1)
 
@@ -33,12 +33,11 @@ _Tracker last updated: 2026-07-19 (session close: BUG-27/28/29/10 done, OP-16 ra
 | BRD-CU0103 | Shell trips — fast historic catch-up entry (CU-01–03) | fullstack | ⬜ Pending |
 | BRD-NF09 | Hosted deployment for personal use (NF-09) | architect | ⬜ Pending |
 
-### P2 — Important (13)
+### P2 — Important (12)
 
 | ID | Title | Owner | Status |
 |---|---|---|---|
 | OP-07 | UI/UX expert review of frontend | coo | ⬜ Pending |
-| OP-16 | Main branch push-triggered CI runs stopped firing after OP-13 merge | architect | ⬜ Pending |
 | FUTURE-03 | Companion model — linked/unlinked users with invite flow | coo | ⬜ Pending |
 | BRD-IT0809 | Rating sort and filter in item list views, cross-trip by city (IT-08/09) | frontend | 🔄 In progress |
 | BRD-AD07 | Map shading configuration is per-user (AD-07) | backend | 🔄 In progress |
@@ -68,7 +67,7 @@ _Tracker last updated: 2026-07-19 (session close: BUG-27/28/29/10 done, OP-16 ra
 |---|---|---|---|---|
 | feature | `███████████▓▓▓░░░░░░` 23/41 | 23 | 18 | 1 |
 | requirement | `███████████████████░` 29/31 | 29 | 2 | 5 |
-| bug | `███████████████████░` 29/30 | 29 | 1 | 3 |
+| bug | `████████████████████` 30/30 | 30 | 0 | 3 |
 | task | `████████████████████` 8/8 | 8 | 0 | 0 |
 | chore | `█████████████░░░░░░░` 4/6 | 4 | 2 | 0 |
 
@@ -99,4 +98,4 @@ _Tracker last updated: 2026-07-19 (session close: BUG-27/28/29/10 done, OP-16 ra
 
 ---
 
-_93 done · 8 deferred · 1 closed · 23 open — 125 tracked items_
+_94 done · 8 deferred · 1 closed · 22 open — 125 tracked items_

--- a/_project/tracker.json
+++ b/_project/tracker.json
@@ -782,12 +782,12 @@
       "id": "OP-16",
       "type": "bug",
       "title": "Main branch push-triggered CI runs stopped firing after OP-13 merge",
-      "status": "pending",
+      "status": "done",
       "owner": "architect",
       "priority": "P2",
       "brdRefs": [],
       "phase": 4,
-      "notes": "GitHub issue #144. Found 2026-07-19 during post-merge verification: push-triggered CI/Security Checks runs on main stopped after commit 911eccf; 5 subsequent merges produced no push-triggered run. Ruled out: workflow file changes, Actions permissions, branch protection, authorship, general outage (feature-branch and PR-triggered runs fire normally throughout). Main's tip confirmed functionally green via a throwaway no-op PR probe (9/9 checks). Looks GitHub-side, not a code problem — flagged for Architect/infra review, outside COO scope. Interim mitigation: post-merge verification now falls back to a throwaway-PR probe when gh run list shows nothing new for main."
+      "notes": "GitHub issue #144 (closed). CLOSED AS TRANSIENT GitHub-side incident per ADL-31 (Architect ruling, no code change). Found 2026-07-19: push-triggered CI/Security Checks on main stopped after commit 911eccf; 5 merges (~18:02-18:18 UTC) produced no push run. Ruled out (all repo-side causes): workflow file changes, Actions permissions, branch protection, authorship, general outage (feature-branch and PR-triggered runs fired throughout). Resumed on its own with BUG-27 #140 (2026-07-19 23:50 UTC) — earlier than first noticed. Spot-check confirmed 5 consecutive clean push-triggered runs since (#140/#145/#147/#148/#149, all success) with zero recurrence, correlated with a confirmed same-night GitHub Actions API incident (503s across actions/runs, actions/jobs/logs, actions/workflows endpoints). Repo-config hypothesis eliminated + external correlate confirmed + self-resolution + no recurrence = transient. Interim mitigation RETAINED as standing insurance: post-merge verification falls back to a throwaway-PR probe when gh run list shows nothing new for main. Recurrence-reopen clause: if it stalls again, reopen — original ruling-outs stand and would warrant GitHub Support. NOT correlated with OP-17/#146 (Gitleaks: missing GITLEAKS_LICENSE secret, distinct root cause; that correlation was retracted)."
     },
     {
       "id": "OP-17",

--- a/jobs/architect/tech/20260307-architecture-decisions-log.md
+++ b/jobs/architect/tech/20260307-architecture-decisions-log.md
@@ -1346,3 +1346,71 @@ with mandatory re-verification of the four patched SQLite bugs.
   section in the same PR (accepted residuals recorded with rationale). Full checklist in
   ADL-30 §Instructions.
 - `db:push` remains forbidden; Node/CI runner versions untouched (out of scope).
+
+---
+
+## ADL-31 — OP-16: main-branch push-triggered CI stall ruled transient GitHub-side incident
+
+**Date:** 2026-07-19
+**Status:** Decided — issue closed, no code change
+**Tracker:** OP-16 | **GitHub:** #144 (closed) | **Related:** OP-17/#146 (distinct root cause, see note)
+
+**Decision:** Close OP-16 as a **transient GitHub-side incident**, not a repo defect. On
+`main`, push-triggered `CI` and `Security Checks` runs (`on: push: branches: ["**"]`) stopped
+firing after commit 911eccf (OP-13, 2026-07-19 05:18 UTC). Five squash-merges over the next
+~18.5 hours (OP-14 #134, BRD v3.0 #130, BUG-28 #139, BUG-10 #141, BUG-29 #142, all ~18:02–18:18 UTC)
+produced no push-triggered run on main. Delivery then resumed on its own with BUG-27 #140
+(2026-07-19 23:50 UTC) and has fired correctly for every subsequent merge — #140, #145, #147,
+#148, #149: **five consecutive clean push-triggered runs, all `success`**, spanning and closing
+the incident window. No repo-side change was made to cause the resumption.
+
+**Why transient and not a config defect — the evidence combination, not the count alone:**
+- The original COO report exhaustively eliminated every repo-controllable cause: workflow
+  files byte-identical across the gap, both workflows `state: active`, Actions permissions
+  `enabled: true`/`allowed_actions: all`, no branch protection on main, identical authorship
+  (ryanv11) to the last commit that *did* trigger, and not a general outage (PR-triggered and
+  feature-branch push-triggered runs fired normally throughout). With no repo-side lever left,
+  the residual explanation is provider-side by elimination.
+- A confirmed same-night GitHub Actions API incident correlates: repeated 503s
+  ("No server is currently available") across `actions/runs/{id}`, `actions/jobs/{id}/logs`,
+  and `actions/workflows/{id}` while the plain REST API responded normally — i.e. degradation
+  isolated to the Actions subsystem, the same subsystem that delivers push-trigger events.
+- The symptom was a binary ON→OFF→ON state change with a well-defined start and a
+  self-resolution requiring no intervention — the signature of an incident, not a latent
+  misconfiguration (which would not spontaneously heal).
+- Zero recurrence across five consecutive merges after resumption.
+
+This is why 5-for-5 is sufficient here and a larger N is not required: this is not a flaky-test
+false-positive-rate problem where samples buy statistical confidence. The repo-config hypothesis
+was already dead (nothing repo-side changed, yet behaviour changed twice); what remained was to
+confirm the OFF state neither persisted nor recurred, and five clean fires across the incident's
+close does exactly that. Confidence: High that this is not a repo-config defect; High that no
+further action is warranted. The one honest residual is the *specific* attribution to that
+night's Actions incident — a strong confirmed correlation, not proof of causation — which does
+not change the disposition.
+
+**Alternatives considered:**
+- Longer observation window (e.g. 10–15 more merges) before closing — rejected: the marginal
+  evidence is low-value once the repo-config hypothesis is eliminated and the external correlate
+  is confirmed; the recurrence-reopen clause below already covers the tail risk at zero cost.
+- Escalate to GitHub Support now — rejected: the incident self-resolved and left no reproducer;
+  support has nothing actionable to investigate. Re-escalation is warranted only on recurrence.
+- Keep open indefinitely as "unexplained" — rejected: "started working again" plus an eliminated
+  repo-side cause and a confirmed external correlate is an adequate explanation for a P2 CI
+  observability issue; an open ticket with no owner action is worse hygiene than a documented close.
+
+**Implications:**
+- Interim mitigation is **retained as cheap standing insurance**: post-merge verification falls
+  back to a throwaway no-op PR probe against main's tip when `gh run list --branch main` shows
+  nothing new since the last known-good run. This costs nothing and de-risks any future silent
+  stall regardless of cause. (Documented in the OP-16 tracker note and the COO post-merge check.)
+- **Recurrence-reopen clause:** if push-triggered main CI silently stalls again, reopen OP-16;
+  the original report's repo-side ruling-outs still stand, and recurrence would move this from
+  "transient incident" to a reproducible pattern warranting direct Architect + GitHub Support
+  investigation.
+- No source, workflow, or config change. `.github/workflows/ci.yml` and `security.yml` untouched.
+- OP-17/#146 (Gitleaks license failure) is explicitly **not** correlated evidence for OP-16: its
+  root cause is a missing `GITLEAKS_LICENSE` secret after a gitleaks-action breaking change, fixed
+  by running the pinned OSS binary directly. The 503 the Gitleaks action surfaced was incidental;
+  the job would have failed regardless of Actions API health. That correlation was raised and then
+  retracted by the PO on #144 — recorded here so it is not silently re-conflated later.


### PR DESCRIPTION
Closes #144

## Summary
- Rules the 2026-07-19 main-branch push-triggered CI stall a transient GitHub-side incident (correlated with the confirmed same-night Actions API 503 incident), not a repo defect.
- Spot-check requested in the issue's own closure criterion: 5 consecutive clean push-triggered runs on main since resumption (#140/#145/#147/#148/#149), all success, zero recurrence.
- Repo-side causes were already exhaustively ruled out in the original report (workflow files, Actions permissions, branch protection, authorship, general outage).
- ADL-31 recorded in the decisions log; OP-16 tracker entry flipped pending → done.
- Interim throwaway-PR-probe mitigation retained as standing insurance; recurrence-reopen clause documented.

## Test plan
- Docs/tracker-only change, no code affected.
- Verify ADL-31 entry renders correctly and tracker.json is valid.