### PR TITLE
chore(OP-19): mandate isolation:worktree for git-touching agent dispatches

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,20 @@ Run `/pre-push` before every `git push` and iterate until all checks pass.
 - PR title and description must reference the GitHub issue number (`Closes #N`) and BRD section if applicable
 - **COO reviews and merges PRs** — agents do not merge their own PRs
 
+### Agent dispatch isolation (mandatory)
+Adopted 2026-07-20 after a live collision: an Architect agent dispatched without
+`isolation: "worktree"` shared the COO session's own working tree, and the COO's
+concurrent `git checkout` moved `HEAD` out from under the agent mid-task. Its commit
+landed on the COO's branch instead of its own; caught and recovered manually before
+anything was pushed, but the failure mode is real and will recur without isolation.
+
+**Every Agent-tool dispatch of a role agent that will do git work (commits, branches,
+PRs) must pass `isolation: "worktree"`.** This is what makes the branch-per-brief rule
+above actually hold — a shared working tree means "each brief gets its own branch" is
+true in name only, since two concurrent processes fight over the same `HEAD`, index,
+and working directory. Read-only dispatches (research, review, investigation with no
+commits) don't need it.
+
 ### BRD → tracker rule (mandatory)
 Whenever the BRD is updated (a changelog entry is written), the COO must create tracker
 entries for every new requirement ID introduced before closing the session. No BRD version

--- a/_project/STATUS.md
+++ b/_project/STATUS.md
@@ -69,7 +69,7 @@ _Tracker last updated: 2026-07-19 (session close: BUG-27/28/29/10 done, OP-16 ra
 | requirement | `███████████████████░` 29/31 | 29 | 2 | 5 |
 | bug | `████████████████████` 30/30 | 30 | 0 | 3 |
 | task | `████████████████████` 8/8 | 8 | 0 | 0 |
-| chore | `█████████████░░░░░░░` 4/6 | 4 | 2 | 0 |
+| chore | `██████████████░░░░░░` 5/7 | 5 | 2 | 0 |
 
 <details>
 <summary>Deferred (8)</summary>
@@ -98,4 +98,4 @@ _Tracker last updated: 2026-07-19 (session close: BUG-27/28/29/10 done, OP-16 ra
 
 ---
 
-_94 done · 8 deferred · 1 closed · 22 open — 125 tracked items_
+_95 done · 8 deferred · 1 closed · 22 open — 126 tracked items_

--- a/_project/tracker.json
+++ b/_project/tracker.json
@@ -812,6 +812,17 @@
       "notes": "Resolves D-01/D-02 from jobs/COO/open-dialogues.md (raised 2026-07-19, resolved 2026-07-20, PR #148, merged squash). No separate GitHub issue raised — this was direct COO-session work, fully captured by the PR diff and the open-dialogues.md resolution entries. D-01: refreshed all 8 role system prompts' git workflow (stale git-push-to-main → branch/pre-push/PR/CI-log-read, matching the 2026-03-21 branch workflow) and added a completion report format to the 5 roles missing one; created .claude/agents/{architect,backend,database,frontend,qa,docs,ux,integrations}.md as thin wrappers (persona summary + model tier in frontmatter) pointing at the system-prompt.txt files, so dispatch uses subagent_type instead of general-purpose + a hand-typed persona. D-02: ratified model tiering — Architect on Opus 4.8, other 7 roles on Sonnet 5, COO-lane background tasks on Haiku 4.5."
     },
     {
+      "id": "OP-19",
+      "type": "chore",
+      "title": "Mandate isolation: worktree for git-touching agent dispatches",
+      "status": "done",
+      "owner": "coo",
+      "priority": "P2",
+      "brdRefs": [],
+      "phase": 4,
+      "notes": "Live collision 2026-07-20: an Architect agent dispatched for OP-16 without isolation:\"worktree\" shared the COO session's own working tree; a concurrent `git checkout` by COO moved HEAD out from under the agent mid-task and its commit landed on the wrong branch. Caught and recovered manually before anything was pushed (relocated to chore/op16-close, pushed, PR #151) — no work lost, but the failure mode is real. Fix: CLAUDE.md Git workflow section now mandates isolation:\"worktree\" for every Agent-tool dispatch of a role agent doing git work (commits/branches/PRs); read-only dispatches exempted. No GitHub issue raised — direct COO-session process fix, no code/app impact."
+    },
+    {
       "id": "OP-12",
       "type": "requirement",
       "title": "Generated human-readable status dashboard (STATUS.md) from tracker.json",


### PR DESCRIPTION
## Summary
- Fixes a real collision from this session: an Architect agent dispatched for OP-16 without `isolation: "worktree"` shared the COO session's own working tree. A concurrent `git checkout` by COO moved HEAD out from under the agent mid-task, and its commit landed on the wrong branch. Caught and recovered manually before anything was pushed — no work lost, but the failure mode is real and will recur without isolation.
- CLAUDE.md's Git workflow section now mandates `isolation: "worktree"` for every Agent-tool dispatch of a role agent doing git work (commits/branches/PRs); read-only dispatches are exempted.
- OP-19 tracker entry added (done), STATUS.md regenerated in the same commit.

## Test plan
- Docs/tracker-only change, no code affected.