### PR TITLE
fix(BUG-10): trip-name field hard-restricts to 75 chars, shows inline error (#138)

### DIFF
--- a/jobs/COO/inbox/20260720_1100-FRONTEND-bug10-frontend-fix-complete.txt
+++ b/jobs/COO/inbox/20260720_1100-FRONTEND-bug10-frontend-fix-complete.txt
@@ -1,0 +1,38 @@
+BUG-10 · GitHub #138 (frontend half) · BRD TR-01 · Branch fix/bug10-name-limit-frontend
+
+WHAT WAS BUILT
+TripForm.tsx trip-name field: limit dropped from 200 to 75 chars (NAME_MAX_LENGTH
+constant), and a red inline "75 character limit reached" error now renders under the
+field once the limit is hit, matching the existing field-level error styling used in
+AddPlaceFlow.tsx / PlaceDateForm.tsx (bg-red-50/border-red-200/text-red-800/text-xs).
+Added a submit-time guard too, for trips with pre-existing names >75 chars from before
+this fix (maxLength alone won't retroactively trim a value set via props).
+
+ACCEPTANCE CRITERIA (per tracker.json BUG-10 corrected criteria)
+1. Limit is 75, not 200 — PASS
+2. Input hard-restricts typing/pasting past 75 AND shows a red inline error on hitting
+   the limit — PASS
+3. Backend defense-in-depth (.max(75) + message) — N/A to this brief, parallel backend
+   brief covers it; frontend already renders whatever the API returns via ErrorMessage.tsx
+   so no frontend change needed once backend lands.
+
+CI: gh pr checks pending at file time — will confirm green before treating this done;
+local pre-push checks all pass (biome, type:check:all, test:backend 523/1 skipped,
+status:check) except one PRE-EXISTING flaky frontend test unrelated to this change
+(see below).
+
+OPEN ISSUES / BLOCKERS
+- FLAG-F3 (new, not a blocker for this PR): CarryForwardModal.test.tsx "calls onClose
+  immediately when Skip is clicked" fails intermittently (onClose called 2-3x instead of
+  1x). Reproduced via git stash on a clean branch tip with no BUG-10 changes applied —
+  confirmed unrelated to this fix. Worth a QA/backend look separately.
+- Wording coordination: used "75 character limit reached" per tracker's suggested default.
+  If backend's parallel brief uses different phrasing for its 400 message, no frontend
+  code change is needed to reconcile — the frontend inline error is a distinct proactive
+  surface from the backend error rendered through the existing mutationError/ErrorMessage
+  path.
+
+WHAT IS NOW UNBLOCKED
+BUG-10 can close once the parallel backend brief (server-side .max(75) + boundary test
+updates) lands and QA verifies both halves together. Tracker status update (pending →
+done) left to COO per BUG-10 being COO-maintained.

--- a/jobs/frontend/context/current.txt
+++ b/jobs/frontend/context/current.txt
@@ -1,14 +1,30 @@
-FRONTEND CONTEXT — as of 2026-03-20 20:11
+FRONTEND CONTEXT — as of 2026-07-20
 
-STATUS: BUG-18 investigated — already resolved. No pending work. Awaiting next COO brief.
+STATUS: BUG-10 frontend half fixed (reopened UAT finding). PR open, awaiting COO review/merge.
 
-LAST COMMIT: 1fe7bc7 (fix(frontend): BUG-11/12/13 — cache invalidation, map click-through, search+sort)
+LAST COMMIT: ed2821c ([BUG-10] frontend: hard-restrict trip name to 75 chars with inline error)
 
-WHAT WAS DONE (this thread — 20260320_0030-COO-bug18-cache-invalidation)
-  BUG-18 (cache invalidation): Investigated useCreateTrip, useUpdateTripStatus, useLockTrip,
-    useUnlockTrip in src/frontend/hooks/useTrips.ts. All four hooks already invalidate
-    ['trips'] on success — this was applied in commit 1fe7bc7 (BUG-11 fix). No code
-    change required. type:check and test:frontend both pass (55/55).
+WHAT WAS DONE (this thread — dispatch: fix frontend half of reopened BUG-10, GitHub #138)
+  Reopened BUG-10 (PR #141's earlier fix silently truncated instead of erroring, and the
+  limit itself was wrong — 200 instead of the PO-corrected 75). Fixed in
+  src/frontend/components/TripDetail/TripForm.tsx:
+    - maxLength dropped from 200 to a named NAME_MAX_LENGTH = 75 constant.
+    - Added a red inline error ("75 character limit reached") shown once
+      name.length >= 75, styled to match the existing field-level error pattern
+      used in AddPlaceFlow.tsx / PlaceDateForm.tsx (bg-red-50/border-red-200/
+      text-red-800/text-xs), not the whole-form ErrorMessage box used elsewhere
+      in this same file for name-required/date validation.
+    - Added a submit-time guard (name.length > 75) as a safety net for any
+      pre-existing trip names >75 chars saved before this fix (maxLength alone
+      doesn't retroactively trim an already-long value set programmatically).
+  Branch: fix/bug10-name-limit-frontend. PR references Closes #138 + BRD TR-01.
+
+  NOTE: found a pre-existing flaky test unrelated to this change —
+  src/frontend/components/CarryForward/__tests__/CarryForwardModal.test.tsx
+  "calls onClose immediately when Skip is clicked" fails intermittently
+  (onClose called 2-3x instead of 1x) even on a clean checkout with no BUG-10
+  changes applied (verified via git stash). Flagged to COO in completion report;
+  not fixed here (out of scope, and QA/backend own that surface).
 
 KEY FILE LOCATIONS
   Entry point:        src/frontend/main.tsx
@@ -17,15 +33,20 @@ KEY FILE LOCATIONS
   Hooks:             src/frontend/hooks/{useTrips,usePlaces,useItems,useCities,useMapShading,useAdmin}.ts
   Types:             src/frontend/types/api.ts
   API client:        src/frontend/utils/apiClient.ts
-  URL sanitiser:     src/frontend/utils/urlSanitiser.ts (SEC-12)
-  Date formatter:    src/frontend/utils/formatDate.ts (FIX 1 from P0 session)
-  Config:            vite.config.ts, tsconfig.frontend.json, index.html
+  Trip form:         src/frontend/components/TripDetail/TripForm.tsx (BUG-10 fix here)
+  Shared error box:  src/frontend/components/shared/ErrorMessage.tsx (whole-form errors)
+  Field-level error pattern reference: AddPlaceFlow.tsx:316, PlaceDateForm.tsx:149
 
 OPEN FLAGS FOR COO
-  FLAG-F1: Item status names in API reference doc don't match Zod schema
-           (see original Phase 1 completion report for details)
-  FLAG-F2: No standalone GET /api/cities list endpoint exists (not needed currently)
+  FLAG-F1: Item status names in API reference doc don't match Zod schema (carried over,
+           unresolved from earlier session — see Phase 1 completion report for details)
+  FLAG-F2: No standalone GET /api/cities list endpoint exists (carried over, not needed
+           currently)
+  FLAG-F3 (new): CarryForwardModal.test.tsx has a flaky assertion (onClose call count)
+           reproducible on main without any BUG-10 changes — worth a QA/backend look,
+           not blocking this PR.
 
 NEXT STEPS (when resumed)
-  - Await Tailwind + shadcn/ui migration brief from COO
-  - No other outstanding frontend bugs
+  - Await COO merge of fix/bug10-name-limit-frontend (Closes #138)
+  - Coordinate wording with backend brief if their 400 message text differs from
+    "75 character limit reached" (this PR used that exact string per tracker guidance)

--- a/jobs/frontend/park-docs/20260720-FRONTEND-park.txt
+++ b/jobs/frontend/park-docs/20260720-FRONTEND-park.txt
@@ -1,0 +1,87 @@
+FRONTEND PARK DOC — 2026-07-20
+
+SESSION: fix frontend half of reopened BUG-10 (GitHub #138)
+
+CONTEXT
+Reopened at UAT 2026-07-20: PR #141's earlier BUG-10 fix (frontend maxLength=200) enforced
+a limit but did so by silently truncating on submit rather than rejecting with visible
+feedback, and the PO corrected the limit itself from 200 to 75. Corrected success criteria
+per tracker.json BUG-10 entry:
+  1. Limit is 75 chars, not 200.
+  2. Input hard-restricts typing/pasting past 75 (maxLength is acceptable for this) AND
+     shows a red inline error when the limit is hit — the actual gap being closed, since
+     the old behavior gave no feedback at all.
+  3. Backend (parallel brief) rejects >75 chars server-side as defense-in-depth.
+
+WHAT WAS BUILT
+File: src/frontend/components/TripDetail/TripForm.tsx
+
+  - New module constant: `const NAME_MAX_LENGTH = 75;` (replaces the literal 200 that was
+    inline on the `maxLength` prop).
+  - Input's `maxLength={200}` → `maxLength={NAME_MAX_LENGTH}`.
+  - New inline error block directly under the name input:
+      {name.length >= NAME_MAX_LENGTH && (
+        <div className="mt-1.5 px-3 py-2 bg-red-50 border border-red-200 rounded-md
+                         text-red-800 text-xs" role="alert">
+          {NAME_MAX_LENGTH} character limit reached
+        </div>
+      )}
+    Styling matches the codebase's existing FIELD-LEVEL error convention (not the
+    whole-form ErrorMessage.tsx box used lower in this same file for name-required/
+    date-order errors). The field-level pattern was found in AddPlaceFlow.tsx:316-318 and
+    PlaceDateForm.tsx:149 — same bg-red-50/border-red-200/text-red-800 palette as
+    ErrorMessage.tsx, just compact (text-xs, no padding-heavy full-width box) and placed
+    directly under the offending field rather than at the bottom of the form. I deliberately
+    did NOT reuse ErrorMessage.tsx here since it's form-scoped (one error, bottom of form)
+    and this needs to be field-scoped and appear live as the user types, not just on submit.
+  - Submit-time guard added: `if (name.length > NAME_MAX_LENGTH) { setValidationError(...);
+    return; }` — covers the edge case of a trip whose name was already >75 chars (e.g.
+    saved between 2026-03 and now when the limit was 200) being re-opened for edit without
+    the name field being touched. maxLength only blocks *further* typing; it does not
+    truncate a value already set via the `value` prop from existingTrip.name, so without
+    this guard a user could hit Save on an unedited overlong name and get a raw network
+    round-trip to the backend's 400 instead of immediate frontend feedback.
+
+WHY NOT A SEPARATE COMPONENT
+Considered extracting a `<LimitedTextInput maxLength label>` component since the pattern
+could recur (notes fields, etc. currently have no length limits enforced client-side per
+BRD). Decided against it for this brief — scope is exactly the BUG-10 fix, and only one
+field needs it right now. Worth revisiting if a second bounded-length field shows up (COO
+call, not mine to make unilaterally per BRD-only-implement rule).
+
+TESTING
+  - npm run type:check: clean (frontend + backend both, via type:check:all).
+  - npm run test:frontend: 100/101 pass. The 1 failure
+    (CarryForwardModal.test.tsx "calls onClose immediately when Skip is clicked") is
+    PRE-EXISTING and unrelated — reproduced with `git stash` (my diff removed) on the
+    same branch tip, so it's a flaky assertion on onClose call count (2-3x vs expected 1x),
+    not something this change touched or caused. Flagged to COO as FLAG-F3, not fixed here.
+  - npm run test:backend: 523 pass / 1 skipped — untouched by this change, confirms no
+    accidental backend regression.
+  - npm run check (biome): clean.
+  - npm run status:check: STATUS.md already in sync, no regeneration needed.
+  - Manual behavior check not run against a live dev server in this thread (no `npm run
+    dev` session started) — logic was verified by reading the render path; the field-level
+    error condition (`name.length >= NAME_MAX_LENGTH`) is a direct, unit-testable derivation
+    with no async/effect timing involved, and type:check + existing test suite cover the
+    surrounding form logic. If COO/QA want a screenshot-verified pass, that's a quick
+    /run or QA follow-up before merge.
+
+GIT
+  Branch: fix/bug10-name-limit-frontend
+  Commit: ed2821c ([BUG-10] frontend: hard-restrict trip name to 75 chars with inline error)
+  PR: opened against main, "Closes #138", cites BRD TR-01 and tracker BUG-10.
+  Did not merge — COO merges per /coo-merge-and-close.
+
+OPEN FLAGS FOR COO (see current.txt for full list)
+  FLAG-F3 (new): CarryForwardModal.test.tsx flaky onClose-count assertion, reproducible on
+  main independent of this change — recommend a QA/backend look, not a blocker for this PR.
+
+COORDINATION NOTE FOR BACKEND BRIEF
+Used the exact string "75 character limit reached" per tracker guidance (PO's example
+wording, tracker item 3: "otherwise '75 character limit reached' is a reasonable default").
+If backend's parallel brief lands on different wording, no code change needed on the
+frontend side to match unless COO wants the two surfaces to say byte-for-byte the same
+thing (frontend error is proactive/client-side; backend 400 message is a distinct fallback
+surface, not one displayed by name in this component currently — mutationError already
+renders whatever message the API returns via ErrorMessage.tsx).

--- a/src/frontend/components/TripDetail/TripForm.tsx
+++ b/src/frontend/components/TripDetail/TripForm.tsx
@@ -25,6 +25,9 @@ interface TripFormProps {
   onClose: () => void;
 }
 
+/** Hard cap on trip name length (BUG-10) — kept in sync with backend zName.max(75). */
+const NAME_MAX_LENGTH = 75;
+
 /**
  * Renders a modal form for creating or editing a trip.
  *
@@ -81,6 +84,10 @@ export function TripForm({ existingTrip, onClose }: TripFormProps) {
 
     if (!name.trim()) {
       setValidationError('Name is required.');
+      return;
+    }
+    if (name.length > NAME_MAX_LENGTH) {
+      setValidationError(`${NAME_MAX_LENGTH} character limit reached`);
       return;
     }
     if (!startDate) {
@@ -150,9 +157,17 @@ export function TripForm({ existingTrip, onClose }: TripFormProps) {
               className="w-full px-2.5 py-2 border border-gray-300 rounded-md text-sm bg-white focus:outline-none focus:ring-2 focus:ring-teal-500"
               value={name}
               onChange={(e) => setName(e.target.value)}
-              maxLength={200}
+              maxLength={NAME_MAX_LENGTH}
               required
             />
+            {name.length >= NAME_MAX_LENGTH && (
+              <div
+                className="mt-1.5 px-3 py-2 bg-red-50 border border-red-200 rounded-md text-red-800 text-xs"
+                role="alert"
+              >
+                {NAME_MAX_LENGTH} character limit reached
+              </div>
+            )}
           </div>
 
           <div className="grid grid-cols-2 gap-3 mb-4">


### PR DESCRIPTION
Closes #138
BRD §5.1 TR-01 (trip name), tracker BUG-10

## Summary
Fixes the frontend half of reopened BUG-10 (UAT 2026-07-20). PR #141's earlier fix
enforced a length limit but only by silently truncating on submit, giving the user no
feedback when they hit the wall, and the limit itself was later corrected by the PO
from 200 to 75 characters.

- `TripForm.tsx`: trip-name input's `maxLength` reduced from 200 to a named
  `NAME_MAX_LENGTH = 75` constant.
- Added a red inline error ("75 character limit reached") that renders directly under
  the name field once `name.length >= 75`, matching this codebase's existing
  field-level error styling (`bg-red-50 border-red-200 text-red-800`, compact `text-xs`)
  as seen in `AddPlaceFlow.tsx` and `PlaceDateForm.tsx` — distinct from the whole-form
  `ErrorMessage.tsx` box already used lower in the same form for name-required/date-order
  errors.
- Added a submit-time guard for the edge case of a trip whose name was already >75 chars
  from before this fix (maxLength only blocks further typing, it doesn't retroactively
  trim a pre-populated value).

A parallel backend brief handles the server-side `.max(75)` validation + matching 400
message as defense-in-depth; no frontend change needed to reconcile wording since the
inline error here is a distinct proactive client-side surface.

## Test plan
- [x] `npm run type:check:all` — clean
- [x] `npm run test:frontend` — 100/101 pass (1 pre-existing, unrelated flaky test in
      `CarryForwardModal.test.tsx`, reproduced on a clean branch tip with this diff
      stashed out — not caused by this change)
- [x] `npm run test:backend` — 523 pass / 1 skipped, unaffected
- [x] `npm run check` (biome) — clean
- [x] `npm run status:check` — STATUS.md already in sync