### PR TITLE
fix(BUG-31): trip detail never returned place arrived_on/departed_on (#155)

### DIFF
--- a/jobs/COO/inbox/20260720_1100-BACKEND-bug31-complete.txt
+++ b/jobs/COO/inbox/20260720_1100-BACKEND-bug31-complete.txt
@@ -1,0 +1,41 @@
+TO: COO
+FROM: BACKEND
+DATE: 2026-07-20 11:00
+RE: BUG-31 complete — GitHub #155, BRD DP-04/DP-05, branch fix/bug31-place-date-persist
+
+WHAT WAS BUILT
+Root cause was a backend read-path bug, not the write path: PATCH
+/api/trips/:tripId/places/:placeId already persisted arrived_on/departed_on
+correctly. GET /api/trips/:id — the endpoint TripDetail/PlaceSection actually
+renders from — never selected or returned those two columns on each place
+(tripRepository.getPlaces() + the route's places.map()), so
+resolvePlaceDateRange() always fell through to the trip-date fallback.
+Fixed both spots; no frontend changes were needed (frontend was already
+correctly built to ADL-24 §5 precedence).
+
+ACCEPTANCE CRITERIA
+- Place dates set via PATCH now appear in GET /api/trips/:id response: PASS
+- Place section displays place-specific range immediately after save (backed
+  by end-to-end PATCH-then-refetch regression test): PASS
+- No regression to hotel-derived or trip-fallback display paths (both
+  precedence branches unchanged, existing resolvePlaceDateRange tests pass): PASS
+- Existing PATCH validation (BUG-28 arrived<=departed) untouched: PASS
+
+SECURITY CHECKLIST
+No new routes added — GET /api/trips/:id and PATCH /:placeId already existed
+and were already correctly scoped/authed. No changes to auth middleware,
+userId scoping, or FK constraints in this fix.
+
+CI: PR not yet opened at time of writing this report — will confirm gh pr
+checks green before considering the thread closed (see next message if any
+failures need fixing).
+
+OPEN ISSUES / BLOCKERS: none.
+
+WHAT'S NOW UNBLOCKED
+BUG-28 (arrival<=departure PATCH validation) can now be re-verified by QA/PO
+— it was already correctly implemented but unverifiable while place dates
+never displayed. Also flagging (not actioned, out of scope): two stale
+backend inbox items dated 2026-03-21 (ADL-21/22 infra, ADL-23 trip-countries
+API) describe work already implemented in the current codebase but never
+moved to inbox/read/ — housekeeping debt for a future session.

--- a/jobs/backend/context/current.txt
+++ b/jobs/backend/context/current.txt
@@ -1,7 +1,9 @@
-BACKEND CONTEXT — 2026-03-20
+BACKEND CONTEXT — 2026-07-20
 PROJECT: Travel Tracker
-CURRENT STATUS: BUG-17 fix complete. Carry-forward trip status filter removed. CI green.
+CURRENT STATUS: BUG-31 fix complete (GET /api/trips/:id was missing arrived_on/
+  departed_on on each place — read-path bug, PATCH persistence was already correct).
+  Branch fix/bug31-place-date-persist, PR open, CI pending review.
 ACTIVE TASKS: None
-PENDING MESSAGES TO COO: 20260320_0215-BACKEND-bug17-complete.txt (sent)
-OPEN ISSUES: None
-LAST PARK DOC: jobs/backend/park-docs/20260320-BACKEND-bug17-park.txt
+PENDING MESSAGES TO COO: 20260720_1100-BACKEND-bug31-complete.txt (sent)
+OPEN ISSUES: None from this session. Unblocks BUG-28 UAT re-verification.
+LAST PARK DOC: jobs/backend/park-docs/20260720-BACKEND-bug31-park.txt

--- a/jobs/backend/park-docs/20260720-BACKEND-bug31-park.txt
+++ b/jobs/backend/park-docs/20260720-BACKEND-bug31-park.txt
@@ -1,0 +1,65 @@
+BACKEND PARK DOC — 2026-07-20
+SESSION: BUG-31 — place date-range edit doesn't persist/display
+
+WHAT WAS DONE
+
+BUG-31 (GitHub #155, P1, blocking BUG-28 UAT re-verification): setting an
+arrival/departure range on a trip place didn't visibly stick — the place
+section kept showing the trip's overall date range after save.
+
+Root cause traced end-to-end (PATCH route -> repository -> DB -> detail
+route -> frontend resolvePlaceDateRange). Confirmed it is a pure backend
+read-path bug, not a write-path bug and not a frontend bug:
+
+  - PATCH /api/trips/:tripId/places/:placeId (routes/places.ts) and
+    placeRepository.updateDates() were already correct — dates persist to
+    trip_places.arrived_on / departed_on exactly as ADL-24 specifies.
+  - GET /api/trips/:id (routes/trips.ts) is the endpoint TripDetail ->
+    PlaceSection actually renders from (via useTrip(), queryKey ['trips', id]).
+    Its places array never included arrived_on/departed_on at all —
+    tripRepository.getPlaces() didn't select those two columns, and the
+    route handler's places.map() didn't include them in the response object.
+  - Frontend (resolvePlaceDateRange, PlaceSection, PlaceDateForm, usePlaces
+    hooks) was already fully correct per ADL-24 §5 precedence (explicit >
+    hotel > trip) and needed zero changes — it just never received the data
+    to work with. Confirmed no frontend edit was needed.
+
+Changes made:
+  src/backend/repositories/trips.ts
+    - getPlaces(): added arrivedOn / departedOn to the select
+  src/backend/routes/trips.ts
+    - GET /:id handler: added arrived_on / departed_on (null-coalesced) to
+      the assembled places array
+  src/backend/repositories/__tests__/trips.test.ts
+    - 2 new getPlaces tests: dates set / dates null
+  src/backend/routes/__tests__/trips.crud.test.ts
+    - 3 new GET /:id tests: dates set via direct insert, dates null, and an
+      end-to-end PATCH-then-refetch test covering the exact broken user flow
+  jobs/backend/tech/20260307-api-reference.md
+    - Updated GET /api/trips/:id example response + added a note documenting
+      arrived_on/departed_on and the BUG-31 fix (doc predated ADL-24, never
+      showed these fields on this endpoint)
+
+TESTS
+  528 backend tests pass (5 new), 1 skipped (pre-existing, unrelated)
+  Frontend: 100/101 pass — 1 pre-existing flaky failure in
+    CarryForwardModal.test.tsx (different assertion fails on each isolated
+    run; no CarryForward file touched by this branch — confirmed unrelated)
+  Type check (frontend + backend): clean
+  Biome check: clean
+  status:check: STATUS.md in sync, no changes needed
+
+COMMIT: 377a232 (branch fix/bug31-place-date-persist)
+CI: see completion report for run status at time of filing
+
+STATE ON PARK
+  No active tasks. BUG-31 fix complete, PR opened, awaiting COO review.
+  BUG-28 (arrival<=departed validation) can now be re-verified by QA/PO —
+  it was already correctly implemented in the PATCH handler but was
+  unverifiable while dates never displayed.
+  Pre-existing stale inbox items noted but out of scope for this brief:
+  jobs/backend/inbox/20260321_2300-COO-adl21-adl22-infra.md and
+  20260321_2400-COO-adl23-trip-countries-api.md are dated 2026-03-21 and
+  describe work (Node 22 CI migration, trip_countries API) that is clearly
+  already implemented in the current codebase — never moved to inbox/read/.
+  Flagging for COO housekeeping, not actioned here (out of scope).

--- a/jobs/backend/tech/20260307-api-reference.md
+++ b/jobs/backend/tech/20260307-api-reference.md
@@ -277,6 +277,8 @@ Get a single trip with full nested data (places, cities, items).
     {
       "id": 1,
       "city_id": 1,
+      "arrived_on": "2026-06-01",
+      "departed_on": "2026-06-05",
       "created_at": "2026-03-07T14:31:00.000Z",
       "city": {
         "id": 1,
@@ -310,6 +312,14 @@ Get a single trip with full nested data (places, cities, items).
   ]
 }
 ```
+
+> **`arrived_on` / `departed_on` on each place (ADL-24 / BUG-31):** `null` when
+> not explicitly set on the place. These drive `resolvePlaceDateRange`'s
+> highest-precedence source on the frontend (explicit > hotel dates > trip
+> dates — ADL-24 §5). Fixed 2026-07-20 (BUG-31, #155): this endpoint's
+> `getPlaces()` query previously omitted both columns entirely, so explicit
+> place dates set via `PATCH /api/trips/:tripId/places/:placeId` never
+> reached the trip detail view even though they were persisted correctly.
 
 **Errors:**
 - `404` — trip not found

--- a/src/backend/repositories/__tests__/trips.test.ts
+++ b/src/backend/repositories/__tests__/trips.test.ts
@@ -474,6 +474,44 @@ describe('tripRepository.getPlaces', () => {
     expect(result[0].cityCountryCode).toBe('IT');
     expect(result[0].cityCountryName).toBe('Italy');
   });
+
+  // BUG-31: getPlaces previously omitted arrivedOn/departedOn from its select
+  // entirely, so explicit place dates set via PATCH never made it back out
+  // through GET /api/trips/:id (trip detail).
+  it('returns arrivedOn / departedOn when set on the place', async () => {
+    const db = testDb!;
+    await seedCountry(db, 'IT', 'Italy');
+    const city = await seedCity(db, 'IT', 'Rome');
+    const trip = await seedTrip(db);
+    await db.insert(schema.tripPlaces).values({
+      tripId: trip.id,
+      cityId: city.id,
+      userId: TEST_USER_ID,
+      arrivedOn: '2025-06-01',
+      departedOn: '2025-06-05',
+    });
+
+    const result = await tripRepository.getPlaces(trip.id);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].arrivedOn).toBe('2025-06-01');
+    expect(result[0].departedOn).toBe('2025-06-05');
+  });
+
+  it('returns null arrivedOn / departedOn when not set on the place', async () => {
+    const db = testDb!;
+    await seedCountry(db, 'IT', 'Italy');
+    const city = await seedCity(db, 'IT', 'Rome');
+    const trip = await seedTrip(db);
+    await db
+      .insert(schema.tripPlaces)
+      .values({ tripId: trip.id, cityId: city.id, userId: TEST_USER_ID });
+
+    const result = await tripRepository.getPlaces(trip.id);
+
+    expect(result[0].arrivedOn).toBeNull();
+    expect(result[0].departedOn).toBeNull();
+  });
 });
 
 // ----------------------------------------------------------------

--- a/src/backend/repositories/trips.ts
+++ b/src/backend/repositories/trips.ts
@@ -290,6 +290,13 @@ export const tripRepository = {
       .select({
         id: tripPlaces.id,
         cityId: tripPlaces.cityId,
+        // BUG-31: arrivedOn/departedOn were missing from this select entirely, so
+        // GET /api/trips/:id never surfaced explicit place dates even though the
+        // PATCH endpoint (placeRepository.updateDates) persisted them correctly —
+        // the frontend's resolvePlaceDateRange (ADL-24 §5) always saw them as
+        // undefined and fell through to the hotel/trip fallback.
+        arrivedOn: tripPlaces.arrivedOn,
+        departedOn: tripPlaces.departedOn,
         createdAt: tripPlaces.createdAt,
         cityName: cities.name,
         cityCountryCode: cities.countryCode,

--- a/src/backend/routes/__tests__/trips.crud.test.ts
+++ b/src/backend/routes/__tests__/trips.crud.test.ts
@@ -444,6 +444,78 @@ describe('GET /api/trips/:id', () => {
 
     expect(res.body.photo_album_ref).toBeNull();
   });
+
+  // BUG-31: GET /:id previously dropped arrived_on/departed_on when assembling
+  // the places array, even though they were persisted correctly by the PATCH
+  // endpoint — the trip detail view (which PlaceSection renders from) never
+  // saw the explicit dates and always displayed the trip fallback range.
+  async function seedCityForPlace(db: Awaited<ReturnType<typeof createTestDb>>) {
+    await db
+      .insert(schema.countries)
+      .values({ countryCode: 'IT', name: 'Italy' })
+      .onConflictDoNothing();
+    const [city] = await db
+      .insert(schema.cities)
+      .values({ countryCode: 'IT', name: 'Rome' })
+      .returning();
+    return city;
+  }
+
+  it('returns arrived_on / departed_on set on a place via direct DB insert', async () => {
+    const db = testDb!;
+    const trip = await seedTrip(db);
+    const city = await seedCityForPlace(db);
+    await db.insert(schema.tripPlaces).values({
+      tripId: trip.id,
+      cityId: city.id,
+      userId: TEST_USER_ID,
+      arrivedOn: '2025-06-01',
+      departedOn: '2025-06-05',
+    });
+
+    const res = await supertest(app).get(`/api/trips/${trip.id}`).expect(200);
+
+    expect(res.body.places).toHaveLength(1);
+    expect(res.body.places[0].arrived_on).toBe('2025-06-01');
+    expect(res.body.places[0].departed_on).toBe('2025-06-05');
+  });
+
+  it('trip detail place has null arrived_on / departed_on when not set', async () => {
+    const db = testDb!;
+    const trip = await seedTrip(db);
+    const city = await seedCityForPlace(db);
+    await db
+      .insert(schema.tripPlaces)
+      .values({ tripId: trip.id, cityId: city.id, userId: TEST_USER_ID });
+
+    const res = await supertest(app).get(`/api/trips/${trip.id}`).expect(200);
+
+    expect(res.body.places[0].arrived_on).toBeNull();
+    expect(res.body.places[0].departed_on).toBeNull();
+  });
+
+  // BUG-31 end-to-end: PATCH the place's dates, then re-fetch trip detail and
+  // confirm the new values are what's displayed — this is the exact user flow
+  // that was broken (set dates, save, section still shows trip range).
+  it('reflects PATCHed place dates on next trip detail fetch', async () => {
+    const db = testDb!;
+    const trip = await seedTrip(db);
+    const city = await seedCityForPlace(db);
+    const [place] = await db
+      .insert(schema.tripPlaces)
+      .values({ tripId: trip.id, cityId: city.id, userId: TEST_USER_ID })
+      .returning();
+
+    await supertest(app)
+      .patch(`/api/trips/${trip.id}/places/${place.id}`)
+      .send({ arrived_on: '2025-07-10', departed_on: '2025-07-14' })
+      .expect(200);
+
+    const res = await supertest(app).get(`/api/trips/${trip.id}`).expect(200);
+
+    expect(res.body.places[0].arrived_on).toBe('2025-07-10');
+    expect(res.body.places[0].departed_on).toBe('2025-07-14');
+  });
 });
 
 // ----------------------------------------------------------------

--- a/src/backend/routes/trips.ts
+++ b/src/backend/routes/trips.ts
@@ -223,6 +223,13 @@ tripsRouter.get(
     const places = placesRows.map((p) => ({
       id: p.id,
       city_id: p.cityId,
+      // BUG-31: these were previously omitted here even though placeRepository
+      // persists them correctly on PATCH — trip detail (the response PlaceSection
+      // renders from) never surfaced explicit place dates, so
+      // resolvePlaceDateRange (ADL-24 §5) always fell through to the hotel/trip
+      // fallback regardless of what was saved.
+      arrived_on: p.arrivedOn ?? null,
+      departed_on: p.departedOn ?? null,
       created_at: p.createdAt,
       city: {
         id: p.cityId,


### PR DESCRIPTION
Closes #155
BRD DP-04, DP-05

## Summary

BUG-31: setting an arrival/departure date range on a trip place didn't visibly
persist — the place section still showed the trip's overall date range after
saving.

Traced the full path (PATCH route → repository → DB → GET /:id trip detail →
frontend `resolvePlaceDateRange`). Root cause is a backend **read**-path bug,
not a write-path bug:

- `PATCH /api/trips/:tripId/places/:placeId` (`routes/places.ts` +
  `placeRepository.updateDates()`) was already correctly persisting
  `arrived_on`/`departed_on` to `trip_places`.
- `GET /api/trips/:id` — the endpoint `TripDetail`/`PlaceSection` actually
  renders from (`useTrip()`, queryKey `['trips', id]`) — never selected or
  returned those two columns on each place at all.
  `tripRepository.getPlaces()` omitted them from its `select`, and the route
  handler's `places.map()` in `routes/trips.ts` omitted them from the response
  object.
- Frontend (`resolvePlaceDateRange`, `PlaceSection`, `PlaceDateForm`,
  `usePlaces` hooks) was already fully correct per ADL-24 §5's
  explicit-dates > hotel-dates > trip-dates precedence — it simply never
  received the data. No frontend changes were needed.

## Changes

- `src/backend/repositories/trips.ts` — `getPlaces()` now selects `arrivedOn`/`departedOn`
- `src/backend/routes/trips.ts` — `GET /:id` now includes `arrived_on`/`departed_on` (null-coalesced) on each place
- `src/backend/repositories/__tests__/trips.test.ts` — 2 new `getPlaces` tests
- `src/backend/routes/__tests__/trips.crud.test.ts` — 3 new tests, including an
  end-to-end PATCH-then-refetch test covering the exact broken user flow
- `jobs/backend/tech/20260307-api-reference.md` — updated `GET /api/trips/:id`
  example + note (doc predated ADL-24 and never documented these fields here)

## Test plan
- [x] `npm run test:backend` — 528 passed, 1 skipped (pre-existing)
- [x] `npm run type:check:all` — clean
- [x] `npm run check` (biome) — clean
- [x] `npm run status:check` — STATUS.md in sync
- [x] `npm run test:frontend` — 100/101 pass; 1 pre-existing flaky failure in
      `CarryForwardModal.test.tsx` (different assertion fails per isolated
      run, no CarryForward file touched by this branch — confirmed unrelated)

## Note for QA/PO
This also unblocks BUG-28 re-verification (arrival<=departure PATCH
validation) — that validation was already correctly implemented but was
unverifiable while place dates never displayed.