### PR TITLE
fix(BUG-34): dedupe map city markers by coordinate, not id (#158)

### DIFF
--- a/src/frontend/components/Map/CityMarkers.tsx
+++ b/src/frontend/components/Map/CityMarkers.tsx
@@ -19,11 +19,31 @@ interface CityMarkersProps {
 }
 
 /**
+ * Rounds a coordinate to ~11m precision (4 decimal places) so that two city
+ * rows geocoded to the same real-world location collapse to one dedup key,
+ * even when they carry different city ids.
+ */
+function coordKey(lat: number, lng: number): string {
+  return `${lat.toFixed(4)},${lng.toFixed(4)}`;
+}
+
+/**
  * Builds a deduplicated GeoJSON FeatureCollection of resolved cities
  * from an array of trip summaries. Cities without coordinates are excluded.
+ *
+ * Dedup key is rounded coordinate, not city id (BUG-34): duplicate city rows
+ * for the same real-world place (e.g. two "Glasgow" rows — see BUG-33) share
+ * identical lat/long but different ids. Deduping by id alone rendered one
+ * icon per duplicate row stacked at the same pixel, which reads as a
+ * bolder/"standout" marker next to a normal single pin for any city without
+ * a duplicate — the inconsistency reported in BUG-34 is a rendering symptom
+ * of that upstream duplicate-row data issue, not a distinct icon-treatment
+ * bug. Deduping by coordinate means every resolved city — duplicated in the
+ * DB or not — renders exactly one marker, restoring consistent treatment
+ * across cities regardless of whether BUG-33's root cause has been fixed yet.
  */
-function buildCityGeoJSON(trips: TripSummary[]): GeoJSON.FeatureCollection {
-  const seen = new Set<number>();
+export function buildCityGeoJSON(trips: TripSummary[]): GeoJSON.FeatureCollection {
+  const seen = new Set<string>();
   const features: GeoJSON.Feature[] = [];
 
   for (const trip of trips) {
@@ -31,12 +51,13 @@ function buildCityGeoJSON(trips: TripSummary[]): GeoJSON.FeatureCollection {
       const city = place.city;
       if (
         city &&
-        !seen.has(city.id) &&
         city.geocode_status === 'resolved' &&
         city.latitude !== null &&
         city.longitude !== null
       ) {
-        seen.add(city.id);
+        const key = coordKey(city.latitude, city.longitude);
+        if (seen.has(key)) continue;
+        seen.add(key);
         features.push({
           type: 'Feature',
           geometry: {

--- a/src/frontend/components/Map/__tests__/CityMarkers.test.ts
+++ b/src/frontend/components/Map/__tests__/CityMarkers.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Tests for buildCityGeoJSON (BUG-34).
+ *
+ * Covers:
+ *   - One feature per uniquely-located resolved city.
+ *   - Cities that are pending / missing coordinates are excluded (GE-13).
+ *   - Two city rows geocoded to the same coordinate (e.g. duplicate "Glasgow"
+ *     rows from BUG-33) collapse to a single feature instead of stacking two
+ *     markers at the same pixel — the root cause of the BUG-34 report, where
+ *     the doubled-up marker read as a "standout" icon next to a normal single
+ *     pin for a city (Edinburgh) without a duplicate.
+ *
+ * Source: src/frontend/components/Map/CityMarkers.tsx
+ */
+
+import { describe, expect, it } from 'vitest';
+import type { City, TripSummary, TripSummaryPlace } from '../../../types/api.js';
+import { buildCityGeoJSON } from '../CityMarkers.js';
+
+function makeCity(overrides: Partial<City> = {}): City {
+  return {
+    id: 1,
+    name: 'Testville',
+    country_code: 'GB',
+    country_name: null,
+    region_id: null,
+    region_iso: null,
+    latitude: 51.5,
+    longitude: -0.1,
+    geocode_status: 'resolved',
+    ...overrides,
+  };
+}
+
+function makePlace(city: City, id = 1): TripSummaryPlace {
+  return { id, city_id: city.id, city };
+}
+
+function makeTrip(places: TripSummaryPlace[], overrides: Partial<TripSummary> = {}): TripSummary {
+  return {
+    id: 1,
+    name: 'Test Trip',
+    start_date: '2026-01-01',
+    end_date: '2026-01-05',
+    status: 'planning',
+    photo_album_ref: null,
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+    categories: [],
+    companions: [],
+    activities: [],
+    countries: [],
+    places,
+    ...overrides,
+  };
+}
+
+describe('buildCityGeoJSON', () => {
+  it('renders one feature per resolved city with distinct coordinates', () => {
+    const glasgow = makeCity({ id: 10, name: 'Glasgow', latitude: 55.8612, longitude: -4.2502 });
+    const edinburgh = makeCity({
+      id: 12,
+      name: 'Edinburgh',
+      latitude: 55.9533,
+      longitude: -3.1884,
+    });
+    const trip = makeTrip([makePlace(glasgow, 1), makePlace(edinburgh, 2)]);
+
+    const geojson = buildCityGeoJSON([trip]);
+
+    expect(geojson.features).toHaveLength(2);
+    const names = geojson.features.map((f) => f.properties?.name).sort();
+    expect(names).toEqual(['Edinburgh', 'Glasgow']);
+  });
+
+  it('excludes cities with pending geocode status (GE-13)', () => {
+    const pending = makeCity({
+      id: 20,
+      name: 'Pending City',
+      geocode_status: 'pending',
+      latitude: null,
+      longitude: null,
+    });
+    const trip = makeTrip([makePlace(pending, 1)]);
+
+    const geojson = buildCityGeoJSON([trip]);
+
+    expect(geojson.features).toHaveLength(0);
+  });
+
+  it('collapses duplicate city rows at the same coordinate to a single marker (BUG-34/BUG-33)', () => {
+    // Two distinct city ids (e.g. the BUG-33 duplicate "Glasgow" rows) resolved
+    // to the identical lat/long. Deduping by id alone would render both,
+    // stacking two icons at the same pixel and reading as a bolder/"standout"
+    // marker relative to any other, non-duplicated city.
+    const glasgowA = makeCity({ id: 10, name: 'Glasgow', latitude: 55.8612, longitude: -4.2502 });
+    const glasgowB = makeCity({ id: 11, name: 'Glasgow', latitude: 55.8612, longitude: -4.2502 });
+    const edinburgh = makeCity({
+      id: 12,
+      name: 'Edinburgh',
+      latitude: 55.9533,
+      longitude: -3.1884,
+    });
+    const trip = makeTrip([
+      makePlace(glasgowA, 1),
+      makePlace(glasgowB, 2),
+      makePlace(edinburgh, 3),
+    ]);
+
+    const geojson = buildCityGeoJSON([trip]);
+
+    // Exactly one Glasgow marker (not two) plus one Edinburgh marker.
+    expect(geojson.features).toHaveLength(2);
+    const names = geojson.features.map((f) => f.properties?.name).sort();
+    expect(names).toEqual(['Edinburgh', 'Glasgow']);
+  });
+
+  it('dedupes the same city referenced by multiple trips', () => {
+    const paris = makeCity({ id: 5, name: 'Paris', latitude: 48.8566, longitude: 2.3522 });
+    const tripA = makeTrip([makePlace(paris, 1)], { id: 1 });
+    const tripB = makeTrip([makePlace(paris, 2)], { id: 2 });
+
+    const geojson = buildCityGeoJSON([tripA, tripB]);
+
+    expect(geojson.features).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
Closes #158
BRD §5.2 GE-09

## Summary
Reported symptom: Glasgow shows a "standout" icon treatment on the map, Edinburgh (same trip) only shows a plain pin visible at high zoom.

## Investigation
`CityMarkers.tsx` has no icon differentiation logic at all — every resolved city renders the exact same `marker` icon. There is no BRD requirement for a "visited-state" icon variant, and no code path produces one.

Querying the dev DB for this trip found the actual cause: two city rows for "Glasgow" (ids 10 and 11) both geocoded to the identical lat/long, alongside a single correctly-resolved Edinburgh row. `buildCityGeoJSON` deduped by `city.id` only, so both Glasgow rows produced separate GeoJSON features stacked at the exact same pixel — two identical icons drawn on top of each other read as a bolder/"standout" marker, visually distinct from Edinburgh's normal single pin nearby. This is a rendering symptom of the duplicate-city-row bug tracked separately as **BUG-33** — not a distinct frontend icon-treatment defect. Per the brief, I have not attempted to fix BUG-33's root cause (duplicate city record creation) here.

## Fix
Changed the dedup key in `buildCityGeoJSON` from city id to a rounded coordinate (`lat.toFixed(4),lng.toFixed(4)`, ~11m precision). Any city resolved to the same real-world location now renders exactly one marker, regardless of how many duplicate rows point at it — restoring consistent treatment across cities whether or not BUG-33 has been fixed yet.

## Testing
Added `src/frontend/components/Map/__tests__/CityMarkers.test.ts` (4 tests) covering: normal distinct-coordinate rendering, GE-13 pending-geocode exclusion, the duplicate-coordinate collapse (the BUG-34 repro case), and cross-trip dedup of the same city. `buildCityGeoJSON` exported for direct unit testing.

## Checks
- `npm run check` — clean
- `npm run type:check:all` — clean
- `npm run test:backend` — 523 passed
- `npm run test:frontend` — new tests pass; one pre-existing/flaky failure in `CarryForwardModal.test.tsx` unrelated to this change (verified it fails identically with this diff stashed)
- `npm run status:check` — up to date