### PR TITLE
fix(BUG-10): correct trip-name limit to 75 chars (#138)

### DIFF
--- a/jobs/COO/inbox/20260720_1100-BACKEND-bug10-name-limit-complete.txt
+++ b/jobs/COO/inbox/20260720_1100-BACKEND-bug10-name-limit-complete.txt
@@ -1,0 +1,39 @@
+BUG-10 (backend half) · GitHub #138 · BRD TR-01 · Branch: fix/bug10-name-limit-backend
+
+Changed zName (src/backend/validation/common.ts) from .max(200) to .max(75) with
+error message updated to match; moved all boundary/over-boundary tests (contract +
+unit, create + update) from 200/201 to 75/76 chars.
+
+Acceptance criteria:
+1. Limit 200 -> 75: PASS
+2. Backend rejects (400) create/update over 75 chars with clear message: PASS
+   (validation already existed from PR #141 — only the number/message changed)
+3. Error message references 75, not 200: PASS
+4. Boundary + over-boundary tests updated (contract + unit): PASS
+
+Security checklist: N/A — no new routes added or modified, this is a validation
+schema constant change only. No auth/scoping/FK surface touched.
+
+CI: pushed and PR open, will confirm `gh run list` green before considering done —
+see PR for link. Local runs before push: test:backend 523 passed/1 skipped (pre-
+existing unrelated skip), type:check:backend clean, full test:contract 109 passed
+(ran backend locally with BYPASS_AUTH=true per the CI workflow's own pattern, since
+this worktree had no .env.local).
+
+Open issues/blockers:
+- zName is a shared Zod primitive also used by admin.schemas.ts (category/companion
+  /region names). The brief said to change zName itself, which I did — but that also
+  caps admin entity names at 75, not just trip names. Nothing broke (no admin test
+  asserts the old 200 boundary) but this wasn't explicitly scoped and is worth a
+  conscious call: fine as-is, or split zName into a shared + trip-specific schema
+  later. Full detail in park doc.
+- jobs/backend/tech/20260307-api-reference.md also has a stale "1-200 chars" line
+  for POST /api/cities `name` — pre-existing and unrelated (cities schema doesn't
+  use zName, has no max at all). Left untouched, flagged only.
+- GitHub issue #138 title still reads "200-character" — not renamed; PR body carries
+  the corrected number and Closes #138.
+
+What's unblocked: Frontend's parallel BUG-10 brief (hard-restrict typing at 75, red
+inline error) can proceed independently of this PR merging. Backend error copy is
+"Name must be 75 characters or fewer" — distinct from the frontend's live-typing
+notice wording, no collision expected but worth a quick cross-check before UAT.

--- a/jobs/backend/context/current.txt
+++ b/jobs/backend/context/current.txt
@@ -1,7 +1,17 @@
-BACKEND CONTEXT — 2026-03-20
+BACKEND CONTEXT — 2026-07-20
 PROJECT: Travel Tracker
-CURRENT STATUS: BUG-17 fix complete. Carry-forward trip status filter removed. CI green.
+CURRENT STATUS: BUG-10 reopened-UAT backend fix complete. zName max changed 200 -> 75
+  chars (src/backend/validation/common.ts), error message updated to match. Contract
+  + unit test boundaries moved from 200/201 to 75/76. API reference doc updated.
+  Frontend half (hard-restrict input at 75, red inline error) dispatched separately —
+  did not touch frontend files in this thread.
 ACTIVE TASKS: None
-PENDING MESSAGES TO COO: 20260320_0215-BACKEND-bug17-complete.txt (sent)
-OPEN ISSUES: None
-LAST PARK DOC: jobs/backend/park-docs/20260320-BACKEND-bug17-park.txt
+PENDING MESSAGES TO COO: 20260720_1100-BACKEND-bug10-name-limit-complete.txt (sent)
+OPEN ISSUES: zName is a shared primitive (src/backend/validation/common.ts) also used
+  by admin.schemas.ts for category/companion/region names. Changing it to 75 for BUG-10
+  also caps those admin entity names at 75 — this was the explicit brief instruction
+  ("find zName and change it to .max(75)"), but it wasn't scoped to trips-only. Flagging
+  in case that's an unintended side effect; no admin-schema tests currently assert a
+  200-char boundary so nothing broke, but COO/PO may want to confirm admin names are
+  fine at 75 or split zName into zName (shared) + a trip-specific variant later.
+LAST PARK DOC: jobs/backend/park-docs/20260720-BACKEND-bug10-name-limit-park.txt

--- a/jobs/backend/park-docs/20260720-BACKEND-bug10-name-limit-park.txt
+++ b/jobs/backend/park-docs/20260720-BACKEND-bug10-name-limit-park.txt
@@ -1,0 +1,87 @@
+BACKEND PARK DOC — 2026-07-20
+TOPIC: BUG-10 (reopened) — trip-name limit corrected 200 -> 75 chars, backend half
+GITHUB ISSUE: #138 (title still says "200-character" — not renamed in this thread;
+  original PR #141 merged 2026-07-19 against the 200 number, which the PO has now
+  corrected)
+BRANCH: fix/bug10-name-limit-backend
+BRD: TR-01 (trip creation fields)
+
+CONTEXT
+-------
+PR #141 (merged) added `.max(200)` to the shared zName Zod primitive
+(src/backend/validation/common.ts) plus contract/unit boundary tests at 200/201.
+UAT reopened BUG-10 2026-07-20: PO says (a) the number itself was wrong — should be
+75, not 200 — and (b) flagged a *frontend* silent-truncation problem (maxLength=200
+input truncating pasted text instead of showing an error). The backend validation
+itself was never the truncation culprit — zName has always rejected with a 400, not
+truncated. This thread's brief was backend-only: change the number and message from
+200 to 75, and move the test boundaries. Frontend hard-restrict + red inline error is
+a separate, parallel brief.
+
+WHAT CHANGED
+------------
+1. src/backend/validation/common.ts — zName: `.max(200, 'Name must be 200 characters
+   or fewer')` -> `.max(75, 'Name must be 75 characters or fewer')`.
+2. src/backend/validation/__tests__/common.test.ts — boundary tests moved from
+   200/201 chars to 75/76 chars; header comment updated.
+3. src/backend/validation/__tests__/trips.schemas.test.ts — CreateTripSchema and
+   UpdateTripSchema boundary tests moved from 200/201 to 75/76.
+4. tests/contract/trips.contract.test.ts — POST and PATCH boundary/over-boundary
+   tests moved from 200/201 to 75/76 chars; comment updated to cite BRD TR-01
+   instead of a stale "BRD §5.1" reference that doesn't exist in the current BRD.
+5. src/backend/routes/__tests__/qa-backend-fixes.test.ts — updated a stale comment
+   line referencing "zName max length 200".
+6. jobs/backend/tech/20260307-api-reference.md — POST /api/trips `name` field
+   validation column updated from "1–200 chars, trimmed" to "1–75 chars, trimmed
+   (BUG-10, corrected 2026-07-20 — was 200)".
+
+NOT CHANGED / OUT OF SCOPE
+--------------------------
+- jobs/backend/tech/20260307-api-reference.md line ~988 (POST /api/cities `name`
+  field) also says "1–200 chars, trimmed" but cities.schemas.ts does NOT use zName
+  (it's `z.string().trim().min(1)` with no max at all) — that doc line was already
+  wrong before this thread and is unrelated to the zName change. Left alone; flagging
+  as a separate, pre-existing doc/behavior mismatch if COO wants a follow-up.
+- Frontend maxLength / red inline error — separate brief, not touched here.
+- GitHub issue #138 title still says "200-character" — did not rename the issue;
+  the PR text explains the corrected number and `Closes #138` will close it
+  regardless of title wording.
+
+OPEN CONCERN — zName IS A SHARED PRIMITIVE
+-------------------------------------------
+zName (src/backend/validation/common.ts) is imported by BOTH
+trips.schemas.ts (trip name) AND admin.schemas.ts (category / companion / region
+names — CreateAdminItemSchema, UpdateAdminItemSchema, UpdateRegionSchema). The brief
+explicitly said "find the zName schema... and change it to .max(75)", which is what
+I did — but that also caps admin category/companion/region names at 75 chars, not
+just trip names. Nothing in the BRD or tracker scoped the 75-char limit to trips
+only, and no admin-schema tests currently assert a 200-char boundary, so nothing is
+broken. But this is worth a conscious COO/PO call: either 75 is fine for admin names
+too, or zName should eventually split into a shared primitive plus a
+trip-name-specific schema. Not blocking — flagged for awareness, not fixed
+unilaterally since it wasn't in the brief's scope.
+
+TESTS RUN
+---------
+- npm run test:backend — 523 passed | 1 skipped (pre-existing skip, unrelated)
+- npm run type:check:backend — clean
+- npm run test:contract (full suite, backend started locally with BYPASS_AUTH=true
+  per the CI workflow's own pattern) — 109 passed, including all 4 renumbered
+  BUG-10 boundary tests in trips.contract.test.ts
+
+CI
+--
+Pushed branch, opened PR, will confirm `gh run list` is green before filing the
+completion report (see completion report for the run details).
+
+WHAT'S NOW UNBLOCKED
+--------------------
+Frontend's parallel BUG-10 brief (hard-restrict input at 75, red inline error) can
+proceed independently — it doesn't depend on this PR merging first, since the
+frontend maxLength/validation is client-side UX and the backend 400 is defense in
+depth regardless of exact wording alignment. Suggested error copy from my side:
+"Name must be 75 characters or fewer" (backend message) vs. the tracker's suggested
+frontend wording "75 character limit reached" — these read as two different but
+compatible messages (one is a submit-time API error, one is a live typing-limit
+notice), so no copy collision expected, but worth a quick sanity check between the
+two threads before UAT.

--- a/jobs/backend/tech/20260307-api-reference.md
+++ b/jobs/backend/tech/20260307-api-reference.md
@@ -216,7 +216,7 @@ Create a new trip.
 
 | Field | Type | Required | Validation |
 |-------|------|----------|------------|
-| `name` | string | **Yes** | 1–200 chars, trimmed |
+| `name` | string | **Yes** | 1–75 chars, trimmed (BUG-10, corrected 2026-07-20 — was 200) |
 | `start_date` | string | **Yes** | YYYY-MM-DD format |
 | `end_date` | string | **Yes** | YYYY-MM-DD format; must be ≥ `start_date` |
 | `photo_album_ref` | string \| null | No | URL or reference string |

--- a/src/backend/routes/__tests__/qa-backend-fixes.test.ts
+++ b/src/backend/routes/__tests__/qa-backend-fixes.test.ts
@@ -1,6 +1,6 @@
 /**
  * Integration tests for QA backend findings:
- *   BUG-10 — zName max length 200 (covered in common.test.ts)
+ *   BUG-10 — zName max length 75 (covered in common.test.ts)
  *   BUG-A  — PATCH /api/trips/:id end_date bypass (#25)
  *   BUG-B  — Admin list endpoints return snake_case (#26)
  *   SEC-01 — GET /api/cities/:id/items userId filter (#27)

--- a/src/backend/validation/__tests__/common.test.ts
+++ b/src/backend/validation/__tests__/common.test.ts
@@ -5,7 +5,8 @@
  * any backend running.
  *
  * Source:  src/backend/validation/common.ts
- * BUG-10:  zName max length fixed to 200 (was 255) to match BRD spec.
+ * BUG-10:  zName max length corrected to 75 (was 200 per PR #141, itself
+ *          fixed from an earlier 255) per PO clarification 2026-07-20.
  */
 import { describe, expect, it } from 'vitest';
 import {
@@ -54,21 +55,21 @@ describe('zName', () => {
     fails(zName, '   ');
   });
 
-  it('accepts a name of exactly 200 characters', () => {
-    const name = 'A'.repeat(200);
+  it('accepts a name of exactly 75 characters', () => {
+    const name = 'A'.repeat(75);
     expect(passes(zName, name)).toBe(name);
   });
 
-  it('BUG-10: rejects a name longer than 200 characters', () => {
-    const name = 'A'.repeat(201);
+  it('BUG-10: rejects a name longer than 75 characters', () => {
+    const name = 'A'.repeat(76);
     fails(zName, name);
   });
 
   it('BUG-10: over-limit rejection carries a clear message', () => {
-    const result = zName.safeParse('A'.repeat(201));
+    const result = zName.safeParse('A'.repeat(76));
     expect(result.success).toBe(false);
     if (!result.success) {
-      expect(result.error.issues[0]?.message).toBe('Name must be 200 characters or fewer');
+      expect(result.error.issues[0]?.message).toBe('Name must be 75 characters or fewer');
     }
   });
 });

--- a/src/backend/validation/__tests__/trips.schemas.test.ts
+++ b/src/backend/validation/__tests__/trips.schemas.test.ts
@@ -93,14 +93,14 @@ describe('CreateTripSchema', () => {
     expect(result.name).toBe('Japan 2024');
   });
 
-  it('BUG-10: accepts a name of exactly 200 characters', () => {
-    const name = 'A'.repeat(200);
+  it('BUG-10: accepts a name of exactly 75 characters', () => {
+    const name = 'A'.repeat(75);
     const result = passes(CreateTripSchema, { ...valid, name });
     expect(result.name).toBe(name);
   });
 
-  it('BUG-10: rejects a name of 201 characters', () => {
-    fails(CreateTripSchema, { ...valid, name: 'A'.repeat(201) });
+  it('BUG-10: rejects a name of 76 characters', () => {
+    fails(CreateTripSchema, { ...valid, name: 'A'.repeat(76) });
   });
 });
 
@@ -145,14 +145,14 @@ describe('UpdateTripSchema', () => {
     fails(UpdateTripSchema, { name: '' });
   });
 
-  it('BUG-10: accepts a name of exactly 200 characters', () => {
-    const name = 'B'.repeat(200);
+  it('BUG-10: accepts a name of exactly 75 characters', () => {
+    const name = 'B'.repeat(75);
     const result = passes(UpdateTripSchema, { name });
     expect(result.name).toBe(name);
   });
 
-  it('BUG-10: rejects a name of 201 characters', () => {
-    fails(UpdateTripSchema, { name: 'B'.repeat(201) });
+  it('BUG-10: rejects a name of 76 characters', () => {
+    fails(UpdateTripSchema, { name: 'B'.repeat(76) });
   });
 });
 

--- a/src/backend/validation/common.ts
+++ b/src/backend/validation/common.ts
@@ -8,12 +8,12 @@
 
 import { z } from 'zod';
 
-/** Non-empty trimmed string, max 200 chars (BUG-10, BRD TR-01) */
+/** Non-empty trimmed string, max 75 chars (BUG-10, BRD TR-01) */
 export const zName = z
   .string()
   .trim()
   .min(1, 'Name must not be empty')
-  .max(200, 'Name must be 200 characters or fewer');
+  .max(75, 'Name must be 75 characters or fewer');
 
 /** ISO 8601 date string YYYY-MM-DD */
 export const zIsoDate = z

--- a/tests/contract/trips.contract.test.ts
+++ b/tests/contract/trips.contract.test.ts
@@ -83,9 +83,9 @@ describe('POST /api/trips', () => {
     expect(res.body).toHaveProperty('error');
   });
 
-  it('BUG-10 — 201 when name is exactly 200 chars (boundary accepted)', async () => {
-    // BRD §5.1 and API reference specify max 200 chars — 200 is valid.
-    const name = 'x'.repeat(200);
+  it('BUG-10 — 201 when name is exactly 75 chars (boundary accepted)', async () => {
+    // BRD TR-01 and API reference specify max 75 chars (corrected 2026-07-20) — 75 is valid.
+    const name = 'x'.repeat(75);
     const res = await api
       .post('/api/trips')
       .send({ name, start_date: '2026-06-01', end_date: '2026-06-15' })
@@ -94,10 +94,10 @@ describe('POST /api/trips', () => {
     expect(res.body.name).toBe(name);
   });
 
-  it('BUG-10 — 400 when name exceeds 200 chars', async () => {
+  it('BUG-10 — 400 when name exceeds 75 chars', async () => {
     const res = await api
       .post('/api/trips')
-      .send({ name: 'x'.repeat(201), start_date: '2026-06-01', end_date: '2026-06-15' })
+      .send({ name: 'x'.repeat(76), start_date: '2026-06-01', end_date: '2026-06-15' })
       .expect(400);
 
     expect(res.body).toHaveProperty('error');
@@ -198,16 +198,16 @@ describe('PATCH /api/trips/:id', () => {
     expect(res.body.id).toBe(tripId);
   });
 
-  it('BUG-10 — 200 when updated name is exactly 200 chars (boundary accepted)', async () => {
-    const name = 'y'.repeat(200);
+  it('BUG-10 — 200 when updated name is exactly 75 chars (boundary accepted)', async () => {
+    const name = 'y'.repeat(75);
     const res = await api.patch(`/api/trips/${tripId}`).send({ name }).expect(200);
     expect(res.body.name).toBe(name);
   });
 
-  it('BUG-10 — 400 when updated name exceeds 200 chars', async () => {
+  it('BUG-10 — 400 when updated name exceeds 75 chars', async () => {
     const res = await api
       .patch(`/api/trips/${tripId}`)
-      .send({ name: 'y'.repeat(201) })
+      .send({ name: 'y'.repeat(76) })
       .expect(400);
 
     expect(res.body).toHaveProperty('error');


### PR DESCRIPTION
Closes #138
BRD TR-01 · Tracker BUG-10 (reopened)

## Summary
PR #141 enforced a 200-char trip-name limit, but UAT reopened BUG-10: the PO
corrected the limit itself to **75 characters** (not 200) and separately flagged
that the *frontend* silently truncates instead of erroring (a parallel frontend
brief is fixing that half — hard-restrict typing/paste at 75, red inline error).

This PR is the backend half only:
- `zName` (`src/backend/validation/common.ts`) `.max(200)` → `.max(75)`, message
  updated from "200 characters or fewer" to "75 characters or fewer"
- Contract test boundaries (`tests/contract/trips.contract.test.ts`, POST + PATCH)
  moved from 200/201 to 75/76 chars
- Unit test boundaries (`common.test.ts`, `trips.schemas.test.ts`) moved from
  200/201 to 75/76 chars
- API reference doc (`jobs/backend/tech/20260307-api-reference.md`) updated for
  POST /api/trips `name` field

The 400-rejection behavior itself already existed from PR #141 (zName has always
rejected over-limit names with a 400, never truncated) — this change is the number
and message only, not new validation logic.

**Note for reviewer:** `zName` is a shared primitive also used by
`admin.schemas.ts` for category/companion/region names, so this also caps those at
75 chars. That's what the brief explicitly asked for (change zName itself), but it
wasn't scoped to trips-only — flagged in the park doc
(`jobs/backend/park-docs/20260720-BACKEND-bug10-name-limit-park.txt`) for a
conscious call on whether that's fine or whether zName should eventually split.

## Test plan
- [x] `npm run test:backend` — 523 passed / 1 skipped (pre-existing unrelated skip)
- [x] `npm run type:check:backend` / `type:check:all` — clean
- [x] `npm run check` (biome) — clean
- [x] `npm run test:frontend` — 101 passed (unaffected, sanity check)
- [x] `npm run test:contract` (full suite, backend run locally with
      `BYPASS_AUTH=true` per the CI workflow's own pattern) — 109 passed, including
      all 4 renumbered BUG-10 boundary tests
- [x] `npm run status:check` — STATUS.md in sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)