### PR TITLE
fix(BUG-35): admin region-tier checkbox tooltip (#159)

### DIFF
--- a/src/frontend/components/Admin/CountryTab.tsx
+++ b/src/frontend/components/Admin/CountryTab.tsx
@@ -59,8 +59,17 @@ export function CountryTab() {
               </span>
             )}
 
-            {/* Toggle */}
-            <label className="flex items-center gap-1.5 flex-shrink-0 text-[13px] text-gray-700 cursor-pointer">
+            {/* Toggle — BUG-35: title attribute explains what the checkbox does,
+                matching the app's existing hover-tooltip convention (native title
+                attribute, see PlaceSection.tsx "Edit arrival / departure dates"). */}
+            <label
+              className="flex items-center gap-1.5 flex-shrink-0 text-[13px] text-gray-700 cursor-pointer"
+              title={
+                country.region_tier_label
+                  ? `Show a ${country.region_tier_label} tier for ${country.name} — Country → ${country.region_tier_label} → City instead of Country → City`
+                  : `Show a state/province/territory tier for ${country.name} — Country → Region → City instead of Country → City`
+              }
+            >
               <input
                 type="checkbox"
                 checked={country.region_tier_enabled}

--- a/src/frontend/components/Admin/__tests__/CountryTab.test.tsx
+++ b/src/frontend/components/Admin/__tests__/CountryTab.test.tsx
@@ -1,0 +1,76 @@
+/**
+ * Tests for CountryTab (BUG-35).
+ *
+ * Mocks:
+ *   - useCountries() / useUpdateCountry() from hooks/useAdmin
+ *
+ * Covers:
+ *   - Region tier checkbox exposes an explanatory hover tooltip (title attribute)
+ *     naming the country's region tier label (AD-05/GE-03).
+ *   - Falls back to a generic "state/province/territory" wording when the
+ *     country has no region_tier_label configured.
+ *
+ * Source: src/frontend/components/Admin/CountryTab.tsx
+ */
+
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import type { Country } from '../../../types/api.js';
+import { CountryTab } from '../CountryTab.js';
+
+const mockUseCountries = vi.fn();
+const mockUseUpdateCountry = vi.fn();
+
+vi.mock('../../../hooks/useAdmin.js', () => ({
+  useCountries: () => mockUseCountries(),
+  useUpdateCountry: () => mockUseUpdateCountry(),
+}));
+
+function makeCountry(overrides: Partial<Country> = {}): Country {
+  return {
+    country_code: 'US',
+    name: 'United States',
+    region_tier_enabled: true,
+    region_tier_label: 'State',
+    ...overrides,
+  };
+}
+
+describe('CountryTab', () => {
+  it('shows a tooltip naming the region tier label when one is configured', () => {
+    mockUseCountries.mockReturnValue({ data: [makeCountry()], isLoading: false, error: null });
+    mockUseUpdateCountry.mockReturnValue({ mutateAsync: vi.fn(), isPending: false, error: null });
+
+    render(<CountryTab />);
+
+    const label = screen.getByText('Region tier').closest('label');
+    expect(label).toHaveAttribute(
+      'title',
+      'Show a State tier for United States — Country → State → City instead of Country → City',
+    );
+  });
+
+  it('falls back to generic wording when the country has no region tier label', () => {
+    mockUseCountries.mockReturnValue({
+      data: [
+        makeCountry({
+          country_code: 'FR',
+          name: 'France',
+          region_tier_enabled: false,
+          region_tier_label: null,
+        }),
+      ],
+      isLoading: false,
+      error: null,
+    });
+    mockUseUpdateCountry.mockReturnValue({ mutateAsync: vi.fn(), isPending: false, error: null });
+
+    render(<CountryTab />);
+
+    const label = screen.getByText('Region tier').closest('label');
+    expect(label).toHaveAttribute(
+      'title',
+      'Show a state/province/territory tier for France — Country → Region → City instead of Country → City',
+    );
+  });
+});


### PR DESCRIPTION
Closes #159
BRD §5.10 AD-05, §5.2 GE-03

## Summary
The Region tier checkbox in the admin Countries tab had no explanatory hovertext — a user unfamiliar with the feature has no way to learn what toggling it does short of trial and error.

## Fix
Added a `title` attribute to the checkbox's `<label>` in `src/frontend/components/Admin/CountryTab.tsx`, following the app's existing hover-tooltip convention (native `title` attribute — see `PlaceSection.tsx` "Edit arrival / departure dates") rather than introducing a new tooltip component.

Tooltip text is dynamic:
- When the country has a configured region tier label (e.g. "State"): `Show a State tier for United States — Country → State → City instead of Country → City`
- When it doesn't: falls back to generic `Show a state/province/territory tier for <country> — Country → Region → City instead of Country → City`

## Testing
Added `src/frontend/components/Admin/__tests__/CountryTab.test.tsx` (2 tests) covering both the labeled and fallback tooltip text.

## Checks
- `npm run check` — clean
- `npm run type:check:all` — clean
- `npm run test:backend` — 523 passed
- `npm run test:frontend` — 103 passed
- `npm run status:check` — up to date