### PR TITLE
fix(BUG-32): remove-place cascade fix + confirm existing DELETE route (#156)

### DIFF
--- a/jobs/COO/inbox/20260720_1100-BACKEND-bug32-complete.txt
+++ b/jobs/COO/inbox/20260720_1100-BACKEND-bug32-complete.txt
@@ -1,0 +1,48 @@
+FROM: Backend
+DATE: 2026-07-20
+RE: BUG-32 / GitHub #156 — remove a place from a trip (backend half)
+BRANCH: fix/bug32-remove-place-api
+
+WHAT WAS BUILT
+DELETE /api/trips/:tripId/places/:placeId already existed since Phase 1 — confirmed via
+code read, not missing as UAT assumed (frontend just never wired an affordance to it).
+It already met the mandatory security checklist and was already the 7th of 15 rows in
+lock-matrix.test.ts (added with the BUG-27 fix, PR #140). No new route was needed.
+
+The real gap was cascade behavior for items under a deleted place (checklist item 4):
+deleting a place with an item attached threw an unhandled 500 under FK enforcement
+(verified empirically), and would silently orphan items.trip_place_id in production
+(PRAGMA foreign_keys is never enabled there — see open issues). Fixed by reassigning
+those items to trip-level (trip_place_id = null) atomically with the place delete.
+
+ACCEPTANCE CRITERIA
+- DELETE /api/trips/:tripId/places/:placeId returns 204 on success: PASS (pre-existing)
+- 403 on locked trip: PASS (pre-existing, in lock-matrix.test.ts)
+- 404 if not found / not owned: PASS (pre-existing)
+- Cascade behavior for items decided + implemented: PASS (reassign to null, new)
+- Contract unchanged for Frontend (204/403/404 as specified): PASS
+
+SECURITY CHECKLIST (route pre-existing, re-confirmed; repository logic modified)
+1. Auth middleware: requireAuth applied globally in server.ts (app.use('/api/',
+   requireAuth)) — confirmed present, no requireOwner needed (trip-owner model, matches
+   PATCH/DELETE trip precedent).
+2. userId scoping: placeRepository.assertWritable scopes via eq(trips.userId, userId)
+   before any read/write — confirmed present, unchanged.
+3. New user-data FK notNull: N/A — no new columns added. items.trip_place_id remains
+   nullable by design (documented trip-level-item state); no migration required.
+Reference: jobs/architect/tech/OP-06-hardening-checklist.md §2, ADL-27.
+
+CI: gh pr checks — pending, will confirm green before considering thread closed.
+
+OPEN ISSUES / BLOCKERS
+- Production DB connection never runs PRAGMA foreign_keys = ON (src/backend/db/index.ts
+  createLibSQLDb) — every ON DELETE CASCADE/RESTRICT in schema.ts is decorative outside
+  tests. Pre-existing, out of scope for BUG-32 (my fix doesn't depend on DB-level
+  cascade), but flagging for an Architect ADL review — it's a wider correctness gap.
+- security.access-matrix.test.ts has no cross-user 404 case for DELETE places
+  specifically (only DELETE trip). Pre-existing coverage gap, not introduced here.
+
+WHAT'S UNBLOCKED
+Frontend's BUG-32 UI brief can proceed against the confirmed contract: DELETE
+/api/trips/:tripId/places/:placeId → 204 / 403 (locked) / 404 (not found/not owned).
+No contract changes needed on their end.

--- a/jobs/COO/inbox/20260720_1100-BACKEND-bug32-complete.txt
+++ b/jobs/COO/inbox/20260720_1100-BACKEND-bug32-complete.txt
@@ -10,10 +10,19 @@ It already met the mandatory security checklist and was already the 7th of 15 ro
 lock-matrix.test.ts (added with the BUG-27 fix, PR #140). No new route was needed.
 
 The real gap was cascade behavior for items under a deleted place (checklist item 4):
-deleting a place with an item attached threw an unhandled 500 under FK enforcement
-(verified empirically), and would silently orphan items.trip_place_id in production
-(PRAGMA foreign_keys is never enabled there — see open issues). Fixed by reassigning
-those items to trip-level (trip_place_id = null) atomically with the place delete.
+deleting a place with an item attached threw an unhandled 500 (verified empirically —
+libSQL's @libsql/client enforces PRAGMA foreign_keys ON by default even with no
+explicit pragma call, so this reproduces in production too, not just under a
+test-only pragma). Frontend independently hit the same defect building the parallel UI
+brief (jobs/COO/inbox/20260720_1746-FRONTEND-bug32-blocker-place-delete-fk-cascade.txt,
+merged as part of #170) and proposed a different fix (onDelete: 'cascade' on the
+schema FK). I'd already implemented and tested reassignment before reading their
+report — kept reassignment over cascade-delete since it preserves logged items
+(flights, hotels, ratings, notes) instead of destroying them as a side effect of
+removing a place; NULL trip_place_id is already a first-class "trip-level item" state
+per schema.ts. Fixed by reassigning affected items to trip-level (trip_place_id = null)
+atomically with the place delete via db.batch(). Recommend not opening a separate
+BUG-37 for this — it's resolved in this PR, same route Frontend flagged.
 
 ACCEPTANCE CRITERIA
 - DELETE /api/trips/:tripId/places/:placeId returns 204 on success: PASS (pre-existing)
@@ -32,17 +41,18 @@ SECURITY CHECKLIST (route pre-existing, re-confirmed; repository logic modified)
    nullable by design (documented trip-level-item state); no migration required.
 Reference: jobs/architect/tech/OP-06-hardening-checklist.md §2, ADL-27.
 
-CI: gh pr checks — pending, will confirm green before considering thread closed.
+CI: green (both push and pull_request events, after two main-merges this session).
 
 OPEN ISSUES / BLOCKERS
-- Production DB connection never runs PRAGMA foreign_keys = ON (src/backend/db/index.ts
-  createLibSQLDb) — every ON DELETE CASCADE/RESTRICT in schema.ts is decorative outside
-  tests. Pre-existing, out of scope for BUG-32 (my fix doesn't depend on DB-level
-  cascade), but flagging for an Architect ADL review — it's a wider correctness gap.
 - security.access-matrix.test.ts has no cross-user 404 case for DELETE places
   specifically (only DELETE trip). Pre-existing coverage gap, not introduced here.
+- Correction to my own earlier report: I originally (incorrectly) flagged production
+  as never enforcing PRAGMA foreign_keys. Verified empirically that libSQL's
+  @libsql/client enforces it by default — withdrawing that open issue, no Architect
+  ADL needed on that specific point.
 
 WHAT'S UNBLOCKED
-Frontend's BUG-32 UI brief can proceed against the confirmed contract: DELETE
+Frontend's BUG-32 UI brief already merged (#170) against the confirmed contract: DELETE
 /api/trips/:tripId/places/:placeId → 204 / 403 (locked) / 404 (not found/not owned).
-No contract changes needed on their end.
+No contract changes were needed on their end. Both halves of BUG-32 are now complete
+once this PR merges.

--- a/jobs/backend/context/current.txt
+++ b/jobs/backend/context/current.txt
@@ -1,7 +1,22 @@
-BACKEND CONTEXT — 2026-03-20
+BACKEND CONTEXT — 2026-07-20
 PROJECT: Travel Tracker
-CURRENT STATUS: BUG-17 fix complete. Carry-forward trip status filter removed. CI green.
+CURRENT STATUS: BUG-32 backend half complete. DELETE /api/trips/:tripId/places/:placeId
+  already existed (Phase 1) with correct auth/ownership/lock enforcement — confirmed via
+  code read, not missing as UAT assumed. Fixed a real latent bug found while confirming
+  cascade behavior: deleting a place with items attached threw an unhandled 500 (FK
+  constraint violation) under FK enforcement, and would have left dangling
+  items.trip_place_id references where FK enforcement is off (prod). Fix: items under a
+  deleted place are now reassigned to trip-level (trip_place_id = null) atomically with
+  the place delete via db.batch().
 ACTIVE TASKS: None
-PENDING MESSAGES TO COO: 20260320_0215-BACKEND-bug17-complete.txt (sent)
-OPEN ISSUES: None
-LAST PARK DOC: jobs/backend/park-docs/20260320-BACKEND-bug17-park.txt
+PENDING MESSAGES TO COO: 20260720_1100-BACKEND-bug32-complete.txt (sent)
+OPEN ISSUES:
+  - Production DB connection (src/backend/db/index.ts createLibSQLDb) never runs
+    PRAGMA foreign_keys = ON. All ON DELETE CASCADE/RESTRICT declarations in schema.ts
+    are effectively decorative outside tests (tests always set the pragma explicitly).
+    This is a pre-existing, wider gap discovered incidentally — out of scope for BUG-32
+    (my fix doesn't rely on DB-level cascade at all) but worth an Architect ADL review.
+  - security.access-matrix.test.ts / owner-access.test.ts do not cover cross-user 404
+    for DELETE places specifically (only DELETE trip is covered there). Pre-existing
+    coverage gap, not introduced by this change.
+LAST PARK DOC: jobs/backend/park-docs/20260720-BACKEND-bug32-park.txt

--- a/jobs/backend/park-docs/20260720-BACKEND-bug32-park.txt
+++ b/jobs/backend/park-docs/20260720-BACKEND-bug32-park.txt
@@ -1,0 +1,74 @@
+BACKEND PARK DOC — 2026-07-20
+SESSION: BUG-32 — remove a place from a trip (GitHub #156)
+
+WHAT WAS DONE
+
+Brief assumed DELETE /api/trips/:tripId/places/:placeId was missing (UAT found no UI
+affordance). Confirmed via code read that the route has existed since Phase 1
+(src/backend/routes/places.ts, commit 5853b6d) and already satisfies the mandatory
+security checklist:
+  - requireAuth applied globally at app.use('/api/', requireAuth) in server.ts
+  - placeRepository.assertWritable(userId, tripId) scopes by eq(trips.userId, userId)
+    (trip-owner model, matching PATCH/DELETE trip — not app-owner requireOwner)
+  - Ownership checked before lock status (NotFoundError before LockError) — audit
+    invariant 17
+  - Already the 7th of 15 rows in lock-matrix.test.ts's LOCKED_WRITE_MATRIX (added
+    alongside the BUG-27 fix, PR #140) — no 16th route to add, it was already there.
+
+So this was a confirm-not-missing task, not a build-from-scratch task. The real gap was
+item 4 of the brief — cascade behavior for items under a deleted place. Investigated and
+found a genuine bug:
+  - items.trip_place_id has no onDelete set in schema.ts (by design — nullable,
+    documented as "trip-level items ... not tied to a specific city").
+  - Production's DB connection (createLibSQLDb, src/backend/db/index.ts) never runs
+    PRAGMA foreign_keys = ON. Tests always do (see every __tests__/*.ts createTestDb).
+  - Empirically verified (scratch test, since removed): deleting a place with an item
+    attached threw an unhandled 500 (SQLite FK constraint violation) under the test
+    harness's FK-enforced connection. In production (FK enforcement off), the same
+    delete would have silently succeeded, leaving the item's trip_place_id dangling
+    (pointing at a deleted row) — silent data corruption.
+
+FIX: src/backend/repositories/places.ts placeRepository.delete — before deleting the
+place, reassigns any items under it to trip-level (trip_place_id = null) via db.batch()
+(atomic with the place delete). db.batch() chosen over db.transaction() per the existing
+comment in tripRepository.replaceAssociations — transaction() breaks libSQL :memory:
+test clients.
+
+Decision: reassign, not cascade-delete. Cascade-deleting logged items (flights, hotels,
+ratings, notes) as a side effect of removing a place would be a surprising, destructive
+UX — NULL trip_place_id is already a first-class "trip-level item" state per schema.ts,
+so reassignment is the natural, non-destructive choice. No migration needed — the FK's
+onDelete stays unset; the reassignment is owned by application code, now documented in
+both schema.ts and the route/repository comments.
+
+Contract confirmed unchanged for Frontend: DELETE /api/trips/:tripId/places/:placeId,
+204 on success, 403 if locked, 404 if not found/not owned.
+
+Changes made:
+  src/backend/repositories/places.ts — delete() reassigns items.tripPlaceId to null via
+    db.batch(), doc comment added
+  src/backend/routes/places.ts — doc comment added above the DELETE handler
+  src/backend/db/schema.ts — doc comment addendum on items.tripPlaceId re: BUG-32
+  src/backend/routes/__tests__/places.test.ts — new regression test: deleting a place
+    with an item attached returns 204, item survives with trip_place_id null, place gone
+
+TESTS
+  525 backend tests pass (1 new), 1 pre-existing skip unrelated to this change
+  Type check clean (type:check:backend)
+  lock-matrix.test.ts: all 21 tests still pass unchanged (DELETE places already covered)
+
+OPEN ISSUES (flagged to COO, not fixed here — out of scope for BUG-32)
+  1. PRAGMA foreign_keys is never enabled on the production libSQL connection. This
+     means every ON DELETE CASCADE/RESTRICT in schema.ts is untested-in-production;
+     only the test harness enforces them. Worth an Architect ADL review — this predates
+     BUG-32 and affects far more than trip_places/items.
+  2. security.access-matrix.test.ts / owner-access.test.ts don't have a cross-user 404
+     case for DELETE places specifically (only DELETE trip). Pre-existing coverage gap.
+
+COMMIT: (see PR)
+CI: pending — see completion report
+
+STATE ON PARK
+  No active tasks. Inbox empty (no unread messages besides this session's brief, which
+  came directly from COO/orchestrator, not via inbox file).
+  Awaiting next COO dispatch.

--- a/jobs/backend/park-docs/20260720-BACKEND-bug32-park.txt
+++ b/jobs/backend/park-docs/20260720-BACKEND-bug32-park.txt
@@ -20,13 +20,31 @@ item 4 of the brief — cascade behavior for items under a deleted place. Invest
 found a genuine bug:
   - items.trip_place_id has no onDelete set in schema.ts (by design — nullable,
     documented as "trip-level items ... not tied to a specific city").
-  - Production's DB connection (createLibSQLDb, src/backend/db/index.ts) never runs
-    PRAGMA foreign_keys = ON. Tests always do (see every __tests__/*.ts createTestDb).
   - Empirically verified (scratch test, since removed): deleting a place with an item
-    attached threw an unhandled 500 (SQLite FK constraint violation) under the test
-    harness's FK-enforced connection. In production (FK enforcement off), the same
-    delete would have silently succeeded, leaving the item's trip_place_id dangling
-    (pointing at a deleted row) — silent data corruption.
+    attached threw an unhandled 500 (SQLite FK constraint violation).
+
+CORRECTION (post-first-push): this park doc originally claimed production's libSQL
+connection never enables PRAGMA foreign_keys and so the delete would "silently succeed"
+in prod, leaving a dangling reference. That was wrong. Frontend independently hit the
+same defect building the parallel UI brief and, per
+jobs/COO/inbox/20260720_1746-FRONTEND-bug32-blocker-place-delete-fk-cascade.txt,
+verified with an isolated @libsql/client script that this driver enforces
+`foreign_keys` ON by default even with no explicit PRAGMA call — I reproduced that same
+check myself and confirmed it. So the bug is CRITICAL, not latent: every delete of a
+place with any item attached 500s in production too, not just in FK-enforced tests.
+This doesn't change the fix (it explicitly reassigns before deleting, so it's correct
+regardless of the FK-enforcement default either way) — it changes the severity and
+corrects the "open issue" below. Fixed in the second commit to this branch, after
+reconciling with Frontend's independent report on the second main-merge.
+
+Frontend's report proposed a different fix — onDelete: 'cascade' on items.trip_place_id
+(destroy the items with the place) — flagged for "whoever owns the parallel backend
+brief." I'd already implemented and tested the reassign-to-null approach before reading
+their report (found the same bug independently, same day). Keeping reassignment: it
+preserves logged items (flights, hotels, ratings, notes) instead of destroying them as
+a side effect of removing a place, and NULL trip_place_id is already a first-class
+"trip-level item" state per schema.ts. Recommend COO does not open a separate BUG-37 for
+this — it's resolved in this PR, same feature/route Frontend was flagging against.
 
 FIX: src/backend/repositories/places.ts placeRepository.delete — before deleting the
 place, reassigns any items under it to trip-level (trip_place_id = null) via db.batch()
@@ -58,14 +76,14 @@ TESTS
   lock-matrix.test.ts: all 21 tests still pass unchanged (DELETE places already covered)
 
 OPEN ISSUES (flagged to COO, not fixed here — out of scope for BUG-32)
-  1. PRAGMA foreign_keys is never enabled on the production libSQL connection. This
-     means every ON DELETE CASCADE/RESTRICT in schema.ts is untested-in-production;
-     only the test harness enforces them. Worth an Architect ADL review — this predates
-     BUG-32 and affects far more than trip_places/items.
-  2. security.access-matrix.test.ts / owner-access.test.ts don't have a cross-user 404
+  1. security.access-matrix.test.ts / owner-access.test.ts don't have a cross-user 404
      case for DELETE places specifically (only DELETE trip). Pre-existing coverage gap.
 
-COMMIT: (see PR)
+(No longer an open issue: PRAGMA foreign_keys enforcement — corrected above. libSQL
+enforces it by default; no Architect ADL needed on that specific point.)
+
+COMMIT: (see PR) — includes a merge-conflict resolution pass (two main-merges during
+this session; second one required this correction)
 CI: pending — see completion report
 
 STATE ON PARK

--- a/src/backend/db/schema.ts
+++ b/src/backend/db/schema.ts
@@ -394,7 +394,10 @@ export const tripCountries = sqliteTable(
  *
  * item_type determines which extension table (if any) holds additional fields.
  * trip_place_id is NULL for trip-level items (e.g. a flight attached to the trip,
- * not a specific city).
+ * not a specific city). This is also the target state when a place is deleted —
+ * BUG-32: placeRepository.delete reassigns trip_place_id to NULL for any items
+ * under the deleted place rather than cascade-deleting them (no onDelete is set
+ * on this FK deliberately — application code owns this reassignment).
  *
  * Carry-forward pattern (ADL-13, IT-07):
  *   is_carried_forward = 1 AND carried_from_item_id IS NOT NULL → carried item

--- a/src/backend/repositories/places.ts
+++ b/src/backend/repositories/places.ts
@@ -10,6 +10,7 @@ import {
   activities,
   cities,
   getDb,
+  items,
   tripPlaceActivitiesMap,
   tripPlaces,
   trips,
@@ -170,6 +171,16 @@ export const placeRepository = {
   /**
    * Deletes a place. Verifies the parent trip is writable and the place belongs to it.
    * Returns true if deleted, false if not found.
+   *
+   * BUG-32: items logged under this place (items.trip_place_id) are reassigned to
+   * trip-level (trip_place_id = NULL) rather than cascade-deleted. NULL is already a
+   * valid, meaningful state for trip_place_id — schema.ts documents it as "trip-level
+   * items ... not tied to a specific city" — so this preserves logged items (flights,
+   * hotels, ratings, notes) instead of silently destroying user data as a side effect
+   * of removing a place from the itinerary. The reassignment and the place delete are
+   * batched atomically via db.batch() (not db.transaction() — see
+   * tripRepository.replaceAssociations for why transaction() is unsafe with libSQL
+   * :memory: clients used in tests).
    */
   async delete(userId: string, tripId: number, placeId: number): Promise<boolean> {
     await this.assertWritable(userId, tripId);
@@ -182,7 +193,10 @@ export const placeRepository = {
       .limit(1);
     if (!existing.length) return false;
 
-    await db.delete(tripPlaces).where(eq(tripPlaces.id, placeId));
+    await db.batch([
+      db.update(items).set({ tripPlaceId: null }).where(eq(items.tripPlaceId, placeId)),
+      db.delete(tripPlaces).where(eq(tripPlaces.id, placeId)),
+    ]);
     return true;
   },
 

--- a/src/backend/routes/__tests__/places.test.ts
+++ b/src/backend/routes/__tests__/places.test.ts
@@ -602,6 +602,48 @@ describe('DELETE /api/trips/:tripId/places/:placeId', () => {
 
     expect(res.body).toHaveProperty('error');
   });
+
+  // BUG-32: items logged under a place must survive the place's deletion —
+  // reassigned to trip-level (trip_place_id = NULL), not cascade-deleted.
+  // Before this fix, deleting a place with items attached threw an unhandled
+  // FK constraint violation (500) under FK enforcement, and would have left
+  // a dangling trip_place_id reference where enforcement is off.
+  it('reassigns items under the deleted place to trip-level (trip_place_id = null)', async () => {
+    const db = testDb!;
+    const city = await seedCity(db, 'FR', 'Nice');
+    const trip = await seedTrip(db);
+    const [place] = await db
+      .insert(schema.tripPlaces)
+      .values({ tripId: trip.id, cityId: city.id, userId: TEST_USER_ID })
+      .returning();
+    const now = new Date().toISOString();
+    const [item] = await db
+      .insert(schema.items)
+      .values({
+        tripId: trip.id,
+        tripPlaceId: place.id,
+        itemType: 'experience',
+        status: 'consider',
+        isCarriedForward: 0,
+        userId: TEST_USER_ID,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .returning();
+
+    await supertest(app).delete(`/api/trips/${trip.id}/places/${place.id}`).expect(204);
+
+    const { eq } = await import('drizzle-orm');
+    const itemsAfter = await db.select().from(schema.items).where(eq(schema.items.id, item.id));
+    expect(itemsAfter).toHaveLength(1);
+    expect(itemsAfter[0].tripPlaceId).toBeNull();
+
+    const placesAfter = await db
+      .select()
+      .from(schema.tripPlaces)
+      .where(eq(schema.tripPlaces.id, place.id));
+    expect(placesAfter).toHaveLength(0);
+  });
 });
 
 // ----------------------------------------------------------------

--- a/src/backend/routes/places.ts
+++ b/src/backend/routes/places.ts
@@ -103,6 +103,11 @@ placesRouter.post(
 // ----------------------------------------------------------------
 // DELETE /api/trips/:tripId/places/:placeId
 // ----------------------------------------------------------------
+// Removes a place from a trip (BUG-32). 204 on success; 404 if the place
+// doesn't exist or isn't owned by the requesting user (via placeRepository's
+// trip-ownership check); 403 if the parent trip is locked (BUG-27).
+// Items previously logged under this place are reassigned to trip-level
+// (trip_place_id = null), not deleted — see placeRepository.delete.
 // nosemgrep: travel-tracker.express-route-no-auth -- reason: requireAuth applied globally via app.use('/api/', requireAuth) in server.ts
 placesRouter.delete(
   '/:placeId',


### PR DESCRIPTION
Closes #156

## Context
BUG-32 UAT found no UI affordance to remove a place from a trip. Before assuming the
API was missing, I confirmed the code: `DELETE /api/trips/:tripId/places/:placeId` has
existed since the Phase 1 implementation (commit 5853b6d) and already satisfies the
mandatory security checklist (CLAUDE.md → Security checklist for Backend briefs):

1. **Auth**: `requireAuth` applied globally via `app.use('/api/', requireAuth)` in
   `server.ts`. No `requireOwner` needed — this is a trip-owner operation, matching the
   existing pattern for `PATCH`/`DELETE /api/trips/:id` (both scope via
   `tripRepository.findByIdOrThrow(userId, tripId)`, not app-owner middleware).
2. **userId scoping**: `placeRepository.assertWritable(userId, tripId)` scopes via
   `eq(trips.userId, userId)` before any read/write, and ownership is checked *before*
   the lock check (audit invariant 17: `NotFoundError` before `LockError`).
3. **FK notNull**: N/A — no new user-data columns added.
4. **Lock enforcement (BUG-27)**: already the 7th of 15 rows in
   `lock-matrix.test.ts`'s `LOCKED_WRITE_MATRIX` (added alongside the BUG-27 fix, PR
   #140). No 16th route needed — it was already there.

So this PR is **not** "add a new route" — it's "confirm existing route, then fix a real
bug found while confirming point 4 of the brief" (cascade behavior for items under a
deleted place).

## The bug found and fixed
`items.trip_place_id` has no `onDelete` set in `schema.ts` (nullable by design — the
schema already documents `NULL` as "trip-level items ... not tied to a specific city").

Deleting a place that has items attached throws an unhandled 500 (SQLite FK constraint
violation). **This reproduces in production, not just under tests** — `@libsql/client`
enforces `PRAGMA foreign_keys` ON by default even with no explicit pragma call
(verified empirically). An earlier revision of this PR's description incorrectly
claimed production didn't enforce FKs and would silently orphan rows instead; that was
wrong, and I've corrected it here and in the park doc. The correction doesn't lower the
severity — if anything it's worse than first described: this 500s for every real user,
every time, since a place with logged items is the normal case.

**Frontend independently hit this same defect** while building the parallel UI brief
for BUG-32 (see `jobs/COO/inbox/20260720_1746-FRONTEND-bug32-blocker-place-delete-fk-cascade.txt`,
merged as part of #170) and proposed a different fix: `onDelete: 'cascade'` on
`items.trip_place_id` (delete the items along with the place). I'd already implemented
and tested the fix below before reading their report — reconciling here rather than
re-deciding from scratch.

**Fix**: `placeRepository.delete` (`src/backend/repositories/places.ts`) reassigns
affected items to trip-level (`trip_place_id = null`) atomically with the place
delete, via `db.batch()` — not `db.transaction()`, per the existing precedent/comment
in `tripRepository.replaceAssociations` (transaction() breaks libSQL `:memory:` test
clients). **Kept reassignment over Frontend's cascade-delete proposal**: destroying
logged items (flights, hotels, ratings, notes) as a side effect of removing a place
would be a surprising, destructive UX, and `NULL` is already a valid "trip-level item"
state per schema.ts — reassignment is non-destructive and consistent with that existing
semantic. No migration required — the FK's `onDelete` intentionally stays unset; the
reassignment is an application-level decision, documented in `schema.ts`, `places.ts`
(route), and `places.ts` (repository). Recommend COO not open a separate BUG-37 for
this (as Frontend's report suggested) — it's resolved here, same route they flagged.

## Contract (unchanged, confirmed for parallel Frontend brief — already merged as #170)
`DELETE /api/trips/:tripId/places/:placeId` → `204` success / `403` locked trip / `404`
not found or not owned.

## Testing
- New regression test: deleting a place with an item attached → `204`, item survives
  with `trip_place_id: null`, place is gone.
- Full backend suite: 530 tests pass (1 new), 1 pre-existing skip.
- `lock-matrix.test.ts`: all 21 tests pass unchanged.
- Type check clean (backend + frontend).
- Frontend suite: 119/119 pass.

## Open issues flagged to COO (not fixed here — out of scope for BUG-32)
- `security.access-matrix.test.ts` has no cross-user 404 case for `DELETE places`
  specifically (only `DELETE trip`). Pre-existing coverage gap.

## Merge history note
This branch required two merges from `main` during review (BUG-30/31/10 backend
threads, then BUG-32-frontend/BUG-10-backend landing concurrently). Both resolved
cleanly — the only recurring conflict was `jobs/backend/context/current.txt` (a status
doc shared across backend sessions), reconciled by keeping all threads' updates rather
than dropping either side. No conflicts in any source file.

BRD: no specific TR maps to place removal; `Place` entity defined in BRD glossary (§
"Place: A country and/or city visited within a trip").