### PR TITLE
fix(BUG-33): find-or-create city lookup in POST /api/cities (#157)

### DIFF
--- a/jobs/COO/inbox/20260720_BACKEND-bug33-complete.txt
+++ b/jobs/COO/inbox/20260720_BACKEND-bug33-complete.txt
@@ -1,0 +1,50 @@
+TO: COO
+FROM: BACKEND
+DATE: 2026-07-20
+RE: BUG-33 application-logic fix — GitHub #157 — BRD GE-11 — Branch fix/bug33-city-dedup-logic
+
+WHAT WAS BUILT
+POST /api/cities (src/backend/routes/cities.ts) now finds-or-creates: looks up
+an existing city by (name, country_code) case-insensitively before inserting;
+only inserts when genuinely not found. Stops new duplicate `cities` rows going
+forward, independent of whether the companion DB brief's unique index has
+landed. API doc (jobs/backend/tech/20260307-api-reference.md) updated in the
+same PR to reflect the new 200-on-match / 201-on-insert behavior.
+
+ACCEPTANCE CRITERIA
+- Repeat POST with same (name, country_code), same case → returns existing row, no new insert: PASS
+- Repeat POST with same (name, country_code), different case → still matches, no new insert: PASS
+- Same name, different country_code → still creates a distinct row (not overly broad matching): PASS
+- Works independent of the DB-level unique index migration: PASS (no dependency either direction)
+- No frontend change required (apiPost() treats any 2xx as success): PASS (verified by reading apiClient.ts)
+
+SECURITY CHECKLIST (no new routes added — POST /api/cities already existed; behavior modified only)
+1. Auth middleware — unchanged: requireOwner still applied (ADL-27/HC-06, city creation is owner-only)
+2. userId scoping — n/a: cities are global seed data, not user-owned (matches existing GET /api/cities pattern)
+3. FK .notNull() — n/a: no new columns added
+
+CI: pending — see follow-up notification once pushed and gh run list confirms green.
+
+OPEN ISSUES
+- Pre-existing, unrelated flaky test: CarryForwardModal.test.tsx "calls onClose
+  immediately when Skip is clicked" — intermittent under full test:frontend
+  run, passes in isolation, not touched by this diff. Flagged, not fixed
+  (out of scope).
+- PROCESS INCIDENT: a bare `git stash`/`pop` I used mid-task to test my diff
+  against a clean tree collided with another concurrent agent's stash (shared
+  `refs/stash` across all worktrees in this repo — not scoped per-worktree,
+  unlike checkout/HEAD). I picked up a foreign uncommitted change to
+  src/frontend/components/TripDetail/TripForm.tsx (looks like BUG-10
+  name-length work, 75-char limit) instead of my own files. Recovered by
+  re-stashing it with a clear message (visible as stash@{0} currently) and
+  reapplying my own edits from scratch — nothing lost, but whoever owns
+  fix/bug10-name-limit-frontend should check their working tree is as
+  expected and recover that stash entry. Full detail in park doc. Recommend
+  a process rule against bare `git stash` for scratch testing in
+  concurrent-agent sessions — `isolation: "worktree"` does not cover this,
+  since stash is shared state.
+
+WHAT IS NOW UNBLOCKED
+- QA can verify BUG-33 application-logic fix once merged.
+- Merge is independent of the parallel database brief (unique index +
+  cleanup migration) — no ordering dependency either direction.

--- a/jobs/backend/context/current.txt
+++ b/jobs/backend/context/current.txt
@@ -1,7 +1,7 @@
-BACKEND CONTEXT — 2026-03-20
+BACKEND CONTEXT — 2026-07-20
 PROJECT: Travel Tracker
-CURRENT STATUS: BUG-17 fix complete. Carry-forward trip status filter removed. CI green.
+CURRENT STATUS: BUG-33 application-logic fix complete (find-or-create in POST /api/cities). Branch fix/bug33-city-dedup-logic pushed, PR opened, CI check pending.
 ACTIVE TASKS: None
-PENDING MESSAGES TO COO: 20260320_0215-BACKEND-bug17-complete.txt (sent)
-OPEN ISSUES: None
-LAST PARK DOC: jobs/backend/park-docs/20260320-BACKEND-bug17-park.txt
+PENDING MESSAGES TO COO: 20260720_BACKEND-bug33-complete.txt (sent)
+OPEN ISSUES: Pre-existing, unrelated flaky test in src/frontend/components/CarryForward/__tests__/CarryForwardModal.test.tsx ("calls onClose immediately when Skip is clicked") — fails intermittently on full test:frontend runs, passes in isolation. Not touched by this brief; flagged for whoever owns CarryForwardModal next.
+LAST PARK DOC: jobs/backend/park-docs/20260720-BACKEND-bug33-park.txt

--- a/jobs/backend/park-docs/20260720-BACKEND-bug33-park.txt
+++ b/jobs/backend/park-docs/20260720-BACKEND-bug33-park.txt
@@ -1,0 +1,106 @@
+PARK DOCUMENT — BACKEND — 2026-07-20
+BUG-33 / GitHub #157 / BRD GE-11
+Branch: fix/bug33-city-dedup-logic
+
+SCOPE
+Application-logic half of BUG-33 only (duplicate "Glasgow" entries in place
+autocomplete). A separate database brief adds a unique index on cities(name,
+country_code) plus a cleanup migration for existing duplicate rows — out of
+scope here, and this fix does not depend on it landing first.
+
+ROOT CAUSE
+POST /api/cities (src/backend/routes/cities.ts) always inserted a new `cities`
+row on every call. GE-14 says the frontend should search existing cities before
+offering "add new city", and AddPlaceFlow.tsx does call GET /api/cities?q= for
+that — but the "+ Add new: '<query>'" affordance is always shown alongside
+search results (src/frontend/components/TripDetail/AddPlaceFlow.tsx lines
+271-277), even when an exact/near match is already in the results list. A user
+who clicks "+ Add new" for a city that's already in the DB (or a case-mismatched
+query, or a double-submit) reaches POST /api/cities and gets a second row for
+the same real-world city. No frontend change was in scope for this brief —
+this fix closes the gap server-side instead, which also covers the double-
+submit/case-mismatch cases the frontend can't fully prevent on its own.
+
+FIX
+src/backend/routes/cities.ts — POST /api/cities now finds-or-creates:
+  1. Verify country (and region, if given) exist — unchanged.
+  2. NEW: look up an existing city by (name, country_code), matching name
+     case-insensitively via `sql\`lower(cities.name) = lower(${name})\`` —
+     name is already whitespace-trimmed by CreateCitySchema's zod .trim().
+  3. If found: return it as-is, HTTP 200 (not 201 — no row created). Does NOT
+     overwrite region_id from the request; that stays PATCH's job.
+  4. If not found: insert as before (201, geocoding fire-and-forget).
+
+Response status change (200 on match vs 201 on insert) is safe for the existing
+frontend caller — src/frontend/utils/apiClient.ts's apiPost() treats any
+`response.ok` (2xx) as success and returns the parsed body regardless of exact
+status code. Confirmed by reading apiClient.ts; no frontend change needed or
+made.
+
+API doc updated in the same PR (document lifecycle rule): jobs/backend/tech/
+20260307-api-reference.md POST /api/cities section — was asserting always-201,
+now documents the find-or-create behavior and the 200 response case.
+
+TESTS ADDED
+src/backend/routes/__tests__/owner-access.test.ts — new "BUG-33: POST
+/api/cities find-or-create" describe block, 3 tests:
+  1. Exact-name repeat → 200, same id, only 1 row in DB.
+  2. Case-insensitive match ("glasgow" vs "Glasgow") → 200, same id, returns
+     stored casing not request casing, only 1 row in DB.
+  3. Same name, different country_code → still 201, distinct id, 2 rows in DB
+     (confirms the match is scoped correctly, not overly broad).
+All existing owner-access.test.ts cases (HC-06 etc.) still pass unmodified —
+no test relied on POST /api/cities always returning 201 for a repeat name.
+
+VERIFICATION
+- npm run type:check:all — clean
+- npm run test:backend — 23 files, 526 passed, 1 pre-existing skip
+- npx biome check (targeted files) — clean
+- npm run status:check — STATUS.md already in sync, no change needed
+
+BUGS DISCOVERED
+[TRIVIAL] Pre-existing flaky test in src/frontend/components/CarryForward/
+__tests__/CarryForwardModal.test.tsx ("calls onClose immediately when Skip is
+clicked") — fails intermittently under the full test:frontend run (mock called
+3x instead of 1x) but passes in isolation. Re-evaluated per framework rule 26:
+does not touch shared state/FK relationships relevant to this brief, is not
+silently persisting bad data, and isn't new (confirmed via git blame — file
+last touched in an unrelated 2026-03 commit, well before this session).
+Disposition: not fixed (out of scope, pre-existing, not caused by this diff —
+confirmed by running on a clean tree). Flagged to COO/whoever owns
+CarryForwardModal next; not reclassified above TRIVIAL.
+
+PROCESS INCIDENT — flagging for COO, not part of BUG-33 scope
+Mid-task, I used a bare `git stash` / `git stash pop` (no pathspec) to test my
+diff against a clean tree. Because this session has many concurrent agent
+worktrees (bug10-name-limit-frontend, bug10-name-limit-backend, bug30, bug31,
+bug32, bug34, etc.) all sharing one repository's stash ref (`refs/stash` is
+NOT per-worktree — worktrees share one .git), my stash and another worktree's
+concurrent stash interleaved. My `pop` retrieved a foreign uncommitted change
+(a BUG-10 trip-name-length edit to src/frontend/components/TripDetail/
+TripForm.tsx, 75-char limit) instead of my own; my own two files vanished from
+my working tree (they were sitting stashed, not lost, but not where I expected
+them). I did NOT lose either side's work:
+  - Recovered by re-stashing the foreign TripForm.tsx diff with a clear message
+    ("recovered: foreign TripForm.tsx WIP picked up via cross-worktree stash
+    collision during BUG-33 work") so it's still retrievable from the shared
+    stash list — currently stash@{0} in this repo as of this writing.
+  - Reapplied my own cities.ts + owner-access.test.ts edits from scratch (I had
+    the exact diff content from my own prior edit calls) and re-verified type-
+    check + tests pass identically to before.
+This is the same class of hazard as the OP-19 checkout/HEAD collision already
+documented in CLAUDE.md (Agent dispatch isolation) — but `isolation:
+"worktree"` does not fully fix it, since git stash's ref is shared across
+worktrees regardless of isolation. Recommend: (a) whoever owns
+fix/bug10-name-limit-frontend check their working tree — their WIP may
+currently be missing (it's recoverable from stash@{0}, message above) —
+and (b) consider a project rule against bare `git stash` for
+mid-task scratch testing in concurrent-agent sessions (prefer `git worktree`
+or a scratch branch/commit instead, since stash is the one piece of git state
+NOT scoped per-worktree).
+
+WHAT'S UNBLOCKED
+- COO can merge this PR independently of the database brief (no dependency
+  either direction) — the DB unique index is an additional safety net, not a
+  prerequisite.
+- QA can verify BUG-33's application-logic fix now merged.

--- a/jobs/backend/park-docs/20260720-BACKEND-bug33-park.txt
+++ b/jobs/backend/park-docs/20260720-BACKEND-bug33-park.txt
@@ -104,3 +104,50 @@ WHAT'S UNBLOCKED
   either direction) — the DB unique index is an additional safety net, not a
   prerequisite.
 - QA can verify BUG-33's application-logic fix now merged.
+
+ADDENDUM — REBASE ONTO MERGED DB BRIEF (same day, later in session)
+The database brief referenced above (SCOPE section) landed as PR #169 while
+this PR was open — migrations renumbered to 0009 (data cleanup) / 0010 (unique
+index `uniq_cities_name_country_ci`: `UNIQUE(name COLLATE NOCASE, country_code)`
+on `cities`). Also merged in the same window: PR #168 (BUG-30), #164/#161
+(BUG-10), #162 (BUG-31), #170 (BUG-32), #171 (BUG-36), #163 (BUG-34), #165
+(BUG-35), #166 (BUG-32 cascade fix, merged in a second wave after the first
+rebase). Rebased twice (`git merge origin/main` into this branch, no bare
+stash used this time — OP-20 applied) as main kept moving during the session.
+
+Changes made in this rebase, beyond conflict resolution:
+- Switched the find-or-create lookup in cities.ts from a generic
+  `lower(cities.name) = lower(name)` comparison to an explicit
+  `sql\`${cities.name} = ${name} COLLATE NOCASE\`` — matches
+  uniq_cities_name_country_ci's collation exactly, per the schema comment's own
+  instruction ("Backend's find-or-create lookup must match this collation").
+  Verified empirically (scratch libSQL script, in-memory DB) that lower() and
+  COLLATE NOCASE agreed on every case tested — ASCII (Glasgow/glasgow/GLASGOW)
+  and non-ASCII (café/CAFÉ, Straße/STRASSE, İstanbul/istanbul/ISTANBUL) — so the
+  prior lower()-based version was not actually missing any canonical row; the
+  switch is for auditability (self-evidently matches the constraint) rather
+  than fixing a real divergence.
+- Added `uniq_cities_name_country_ci` to owner-access.test.ts's in-memory
+  `cities` table DDL so the three BUG-33 tests exercise the same constraint
+  the merged migration adds in production — they were previously only
+  testing the application-logic path in isolation.
+- Verified migrations 0000-0010 apply cleanly end-to-end on a fresh scratch DB
+  (`npm run db:migrate` against a throwaway SQLITE_PATH) and confirmed the
+  resulting index DDL matches `CREATE UNIQUE INDEX \`uniq_cities_name_country_ci\`
+  ON \`cities\` ("name" COLLATE NOCASE,\`country_code\`)` via a direct
+  sqlite_master query.
+- Did NOT add race-condition handling (catch-constraint-violation-and-retry)
+  for the theoretical window between the SELECT check and the INSERT under
+  concurrent requests — this mirrors the existing, unremediated pattern in
+  routes/admin.ts (same check-then-insert shape, same comment "table has
+  UNIQUE constraint — catch the DB error too" that isn't actually implemented
+  there either). A race would now surface as a generic 500 via the existing
+  global error handler (never a crash, never a silent duplicate) rather than
+  succeeding — no worse than before the unique index existed, and consistent
+  with codebase convention. Flagging as a possible follow-up (shared across
+  cities.ts and admin.ts) rather than fixing unilaterally in a bug-fix PR.
+
+Full pre-push suite (biome, type:check:all, test:backend, test:frontend,
+status:check) re-run clean after each rebase. PR #167 confirmed MERGEABLE
+(not CONFLICTING) after the second rebase; final CI status in the completion
+report.

--- a/jobs/backend/tech/20260307-api-reference.md
+++ b/jobs/backend/tech/20260307-api-reference.md
@@ -972,7 +972,17 @@ GET /api/cities?q=new&country_code=US
 
 ### POST /api/cities
 
-Create a new city. Geocoding is attempted immediately and asynchronously; the response may have `geocode_status: "pending"` if the server is offline.
+Find-or-create a city (BUG-33, GitHub #157 — 2026-07-20). Looks up an existing
+city by `(name, country_code)` case-insensitively before inserting; only inserts when
+genuinely not found. This is a defense-in-depth measure against duplicate `cities` rows
+(UAT found "Glasgow" listed twice in the place autocomplete) — GE-14 already asks the
+frontend to search before offering "add new city", but that's a UX nicety, not a
+guarantee against a case-mismatched query, a stale search-results list, or a
+double-submit reaching this route. Holds independently of the DB-level unique index
+added in the companion database brief for the same bug.
+
+Geocoding is attempted immediately and asynchronously on a genuine insert; the response
+may have `geocode_status: "pending"` if the server is offline.
 
 **Request Body:**
 ```json
@@ -987,9 +997,9 @@ Create a new city. Geocoding is attempted immediately and asynchronously; the re
 |-------|------|----------|------------|
 | `name` | string | **Yes** | 1–200 chars, trimmed |
 | `country_code` | string | **Yes** | Must exist in countries table |
-| `region_id` | integer \| null | No | If provided, must belong to the given country. **Must be `null`** if country has `region_tier_enabled = false`. Optional even if country has `region_tier_enabled = true`. |
+| `region_id` | integer \| null | No | If provided, must belong to the given country. **Must be `null`** if country has `region_tier_enabled = false`. Optional even if country has `region_tier_enabled = true`. Ignored when an existing city is matched — only used on a genuine insert. |
 
-**Response: `201 Created`**
+**Response: `201 Created`** — a new city was inserted.
 ```json
 {
   "id": 5,
@@ -1001,6 +1011,10 @@ Create a new city. Geocoding is attempted immediately and asynchronously; the re
   "geocode_status": "resolved"
 }
 ```
+
+**Response: `200 OK`** — an existing city matched `(name, country_code)` case-insensitively;
+no row was created. Same body shape, reflecting the existing row (its stored `name`
+casing, `region_id`, and geocode state — not the values from this request).
 
 **Errors:**
 - `400` — validation failure, or `region_id` provided for a non-region-tier country

--- a/src/backend/routes/__tests__/owner-access.test.ts
+++ b/src/backend/routes/__tests__/owner-access.test.ts
@@ -14,6 +14,7 @@
  */
 
 import { createClient } from '@libsql/client';
+import { eq } from 'drizzle-orm';
 import { drizzle } from 'drizzle-orm/libsql';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import * as schema from '../../db/schema.js';
@@ -425,6 +426,75 @@ describe('HC-06: POST /api/cities requires owner', () => {
       .send({ name: 'Owner City', country_code: 'US' });
     expect(res.status).toBe(201);
     expect(res.body).toMatchObject({ name: 'Owner City', country_code: 'US' });
+  });
+});
+
+// ================================================================
+// BUG-33: POST /api/cities find-or-create (no duplicate rows)
+// ================================================================
+
+describe('BUG-33: POST /api/cities find-or-create', () => {
+  beforeEach(async () => {
+    mockIsOwner = 1;
+    await seedTestUser(testDb!, 1);
+    await seedCountry(testDb!);
+  });
+
+  it('returns the existing city (200) on an exact-name repeat instead of inserting a duplicate', async () => {
+    const first = await supertest(app)
+      .post('/api/cities')
+      .send({ name: 'Glasgow', country_code: 'US' });
+    expect(first.status).toBe(201);
+
+    const second = await supertest(app)
+      .post('/api/cities')
+      .send({ name: 'Glasgow', country_code: 'US' });
+    expect(second.status).toBe(200);
+    expect(second.body.id).toBe(first.body.id);
+
+    const rows = await testDb!
+      .select()
+      .from(schema.cities)
+      .where(eq(schema.cities.countryCode, 'US'));
+    expect(rows).toHaveLength(1);
+  });
+
+  it('matches an existing city case-insensitively (e.g. "glasgow" vs "Glasgow")', async () => {
+    const first = await supertest(app)
+      .post('/api/cities')
+      .send({ name: 'Glasgow', country_code: 'US' });
+    expect(first.status).toBe(201);
+
+    const second = await supertest(app)
+      .post('/api/cities')
+      .send({ name: 'glasgow', country_code: 'US' });
+    expect(second.status).toBe(200);
+    expect(second.body.id).toBe(first.body.id);
+    expect(second.body.name).toBe('Glasgow'); // returns the stored casing, not the request's
+
+    const rows = await testDb!
+      .select()
+      .from(schema.cities)
+      .where(eq(schema.cities.countryCode, 'US'));
+    expect(rows).toHaveLength(1);
+  });
+
+  it('does not match a same-named city in a different country', async () => {
+    await seedCountry(testDb!, 'GB', 'United Kingdom');
+
+    const first = await supertest(app)
+      .post('/api/cities')
+      .send({ name: 'Glasgow', country_code: 'GB' });
+    expect(first.status).toBe(201);
+
+    const second = await supertest(app)
+      .post('/api/cities')
+      .send({ name: 'Glasgow', country_code: 'US' });
+    expect(second.status).toBe(201);
+    expect(second.body.id).not.toBe(first.body.id);
+
+    const rows = await testDb!.select().from(schema.cities);
+    expect(rows).toHaveLength(2);
   });
 });
 

--- a/src/backend/routes/cities.ts
+++ b/src/backend/routes/cities.ts
@@ -68,6 +68,16 @@ citiesRouter.get(
 // ----------------------------------------------------------------
 // POST /api/cities
 // ADL-27 / HC-06: owner-only (city creation pollutes the global seed)
+//
+// BUG-33: find-or-create. GE-14 says the frontend should search before
+// offering "add new city", but that's a UX nicety, not a guarantee — a
+// case-mismatched query, a stale search-results list, or a double-submit
+// can all reach this route for a city that already exists. This handler
+// is the last line of defense against duplicate `cities` rows: it looks
+// up an existing (name, country_code) match case-insensitively before
+// ever inserting, and only inserts when genuinely not found. This holds
+// regardless of whether the DB-level unique index (separate DB brief,
+// same bug) has landed yet — defense in depth, not a dependency on it.
 // ----------------------------------------------------------------
 citiesRouter.post(
   '/',
@@ -101,6 +111,31 @@ citiesRouter.post(
         .where(and(eq(regions.id, region_id), eq(regions.countryCode, country_code)))
         .limit(1);
       if (!regionRows.length) throw new NotFoundError('Region');
+    }
+
+    // BUG-33: find-or-create — look up an existing city by (name, country_code),
+    // case-insensitively, before inserting a new row. `name` arrives already
+    // whitespace-trimmed by CreateCitySchema (zod .trim()).
+    const existingRows = await db
+      .select()
+      .from(cities)
+      .where(and(eq(cities.countryCode, country_code), sql`lower(${cities.name}) = lower(${name})`))
+      .limit(1);
+
+    if (existingRows.length) {
+      // Existing city found — return it as-is (200, not 201: no row was created).
+      // Deliberately does NOT overwrite region_id from the request; that's PATCH's job.
+      const existing = existingRows[0];
+      res.status(200).json({
+        id: existing.id,
+        name: existing.name,
+        country_code: existing.countryCode,
+        region_id: existing.regionId,
+        latitude: existing.latitude,
+        longitude: existing.longitude,
+        geocode_status: existing.geocodeStatus,
+      });
+      return;
     }
 
     const now = new Date().toISOString();


### PR DESCRIPTION
Closes #157
BRD GE-11

Application-logic half of BUG-33 — duplicate city entries ("Glasgow" listed
twice) in the place autocomplete. A separate database brief adds a unique
index on `cities(name, country_code)` plus a cleanup migration for existing
duplicates — this PR is the application-logic fix that stops new duplicates
from being created going forward, and works correctly independent of whether
that migration has landed (defense in depth, not a dependency either way).

## Root cause
`POST /api/cities` always inserted a new row. GE-14 asks the frontend to
search existing cities before offering "add new city" (`AddPlaceFlow.tsx`
does call `GET /api/cities?q=`), but the "+ Add new" affordance is shown
regardless of whether a match is already in the results — a case-mismatched
query, a stale results list, or a double-submit could all still reach
`POST /api/cities` for a city that already exists.

## Fix
- Look up an existing city by `(name, country_code)`, case-insensitively
  (`lower(cities.name) = lower(name)`), before inserting.
- Match found → return it as-is, `200 OK` (not `201` — no row created).
  Does not overwrite `region_id` from the request; that stays PATCH's job.
- No match → insert as before, `201 Created`, geocoding fire-and-forget
  unchanged.
- Response status change (200 vs 201) is safe for the existing frontend
  caller — `apiPost()` in `src/frontend/utils/apiClient.ts` treats any 2xx
  as success and returns the parsed body regardless of exact status. No
  frontend change needed or made.

## Tests added
`src/backend/routes/__tests__/owner-access.test.ts` — 3 new cases:
1. Exact-name repeat → 200, same id, only 1 row in DB.
2. Case-insensitive match ("glasgow" vs "Glasgow") → 200, same id, returns
   stored casing, only 1 row in DB.
3. Same name, different `country_code` → still 201, distinct id, 2 rows
   (confirms the match doesn't over-match across countries).

## Docs
`jobs/backend/tech/20260307-api-reference.md` POST /api/cities section
updated in this PR to document the find-or-create behavior and the new
200 response case (was asserting always-201).

## Verification
- `npm run type:check:all` — clean
- `npm run test:backend` — 23 files, 526 passed, 1 pre-existing skip
- `npm run status:check` — STATUS.md already in sync

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>