### PR TITLE
fix(BUG-30): seed GB as region-tier-enabled with UK constituent countries (#154)

### DIFF
--- a/data/countries.json
+++ b/data/countries.json
@@ -233,7 +233,7 @@
   { "country_code": "UG", "name": "Uganda", "region_tier_enabled": 0, "region_tier_label": null },
   { "country_code": "UA", "name": "Ukraine", "region_tier_enabled": 0, "region_tier_label": null },
   { "country_code": "AE", "name": "United Arab Emirates", "region_tier_enabled": 0, "region_tier_label": null },
-  { "country_code": "GB", "name": "United Kingdom", "region_tier_enabled": 0, "region_tier_label": null },
+  { "country_code": "GB", "name": "United Kingdom", "region_tier_enabled": 1, "region_tier_label": "Constituent Country" },
   { "country_code": "UM", "name": "United States Minor Outlying Islands", "region_tier_enabled": 0, "region_tier_label": null },
   { "country_code": "US", "name": "United States of America", "region_tier_enabled": 1, "region_tier_label": "State" },
   { "country_code": "UY", "name": "Uruguay", "region_tier_enabled": 0, "region_tier_label": null },

--- a/data/regions.json
+++ b/data/regions.json
@@ -70,5 +70,9 @@
   { "country_code": "CA", "name": "Prince Edward Island", "iso_3166_2": "CA-PE" },
   { "country_code": "CA", "name": "Northwest Territories", "iso_3166_2": "CA-NT" },
   { "country_code": "CA", "name": "Yukon", "iso_3166_2": "CA-YT" },
-  { "country_code": "CA", "name": "Nunavut", "iso_3166_2": "CA-NU" }
+  { "country_code": "CA", "name": "Nunavut", "iso_3166_2": "CA-NU" },
+  { "country_code": "GB", "name": "England", "iso_3166_2": "GB-ENG" },
+  { "country_code": "GB", "name": "Scotland", "iso_3166_2": "GB-SCT" },
+  { "country_code": "GB", "name": "Wales", "iso_3166_2": "GB-WLS" },
+  { "country_code": "GB", "name": "Northern Ireland", "iso_3166_2": "GB-NIR" }
 ]

--- a/jobs/COO/inbox/20260720_1100-DATABASE-bug30-uk-region-seed-complete.txt
+++ b/jobs/COO/inbox/20260720_1100-DATABASE-bug30-uk-region-seed-complete.txt
@@ -1,0 +1,63 @@
+TO: COO
+FROM: DATABASE
+DATE: 2026-07-20 11:00
+RE: BUG-30 fix complete
+
+Tracker: BUG-30 · GitHub #154 · BRD §5.2 GE-04/GE-05/GE-06 · Branch: fix/bug30-uk-region-seed
+
+WHAT WAS BUILT: GB was seeded with region_tier_enabled=0 (no region tier), so
+Scotland/England/Wales/Northern Ireland — regions under GB, not ISO 3166-1
+countries — never surfaced. Fixed data/countries.json (GB now
+region_tier_enabled=1, label "Constituent Country") and data/regions.json
+(added the 4 UK regions with real ISO 3166-2 codes GB-SCT/GB-ENG/GB-WLS/
+GB-NIR), plus a data-only custom migration (0008_bug30_uk_region_seed.sql)
+to patch installs that already ran the first-launch seed.
+
+ACCEPTANCE CRITERIA:
+  GB region_tier_enabled=1 + label set — PASS
+  4 UK regions seeded with correct ISO 3166-2 codes — PASS
+  db:generate --custom + db:migrate only, no db:push (ADL-15) — PASS
+  Migration idempotent — PASS
+  Fresh-install path also fixed (JSON seed files) — PASS
+  No regression to existing US/AU/CA regions — PASS (verified both fresh-
+    install and already-seeded paths explicitly, see below)
+  type:check:backend / type:check:all — PASS
+  test:backend (23 files, 523 tests) — PASS, 1 skipped (expected)
+  biome check — PASS
+  test:frontend — 1 pre-existing failure, confirmed unrelated (fails
+    identically with this thread's changes stashed out — CarryForwardModal
+    BUG-03 test, not a DB/seed issue)
+  status:check — FAILS, but pre-existing: this worktree already had
+    uncommitted tracker.json/STATUS.md/BRD.md/drift-ledger/uat-log changes
+    before this thread started (not part of this brief). Left untouched,
+    not committed to this branch.
+
+MIGRATION VERIFIED: db:generate --custom + db:migrate ran; verified against
+dev.db AND a from-scratch fresh-install simulation (migrate on empty db,
+then seedCountries/seedRegions replay: 250 countries, 76 regions incl. all
+4 GB + all 51 US, GB row correct). Never used db:push.
+
+SELF-CAUGHT BUG (fixed pre-commit): first draft's region INSERTs were
+guarded only per-row, which would have inserted into an empty regions table
+on fresh installs and tripped seedRegions()'s "non-empty -> skip" guard,
+silently starving every future fresh install of all 72 non-GB regions. Added
+a `WHERE EXISTS (SELECT 1 FROM regions LIMIT 1)` guard so the migration only
+patches already-seeded installs. Full detail in park doc.
+
+TOOLING FLAG (non-blocking): drizzle-kit CLI's `migrate` command transiently
+dropped the freshly-generated custom migration's journal entry on its first
+run this thread (worked around, not reproduced since). Possible 5th
+drizzle-kit@0.31.9 bug alongside the four in patches/drizzle-kit+0.31.9.patch
+— worth a look if it recurs. Detail in jobs/database/context/current.txt.
+
+CI: PR not yet opened as of this report — will push branch, open PR
+referencing #154 and BRD §5.4/5.2, and confirm gh run list is green before
+considering this closed. (Report filed now per park/report ordering; will
+follow up if CI surfaces anything.)
+
+OPEN ISSUES: none blocking. Frontend test failure and status:check failure
+above are both pre-existing/out of scope, noted for visibility only.
+
+UNBLOCKED: Backend/Frontend can now rely on GB having a working Region tier;
+QA can re-verify BUG-30 once merged. PO can re-run the Scotland dogfood
+trial (BRD-PL0104 trigger) mentioned in the tracker note.

--- a/jobs/database/context/current.txt
+++ b/jobs/database/context/current.txt
@@ -1,64 +1,104 @@
-DATABASE CONTEXT — 2026-03-07
+DATABASE CONTEXT — 2026-07-20
 PROJECT: Travel Tracker
-CURRENT STATUS: Phase 1 complete — all deliverables verified, COO and BACKEND notified
+CURRENT STATUS: BUG-30 fix complete — branch fix/bug30-uk-region-seed pushed, PR open
 
 ================================================================================
-COMPLETED DELIVERABLES
+LATEST THREAD — BUG-30 (GitHub #154)
 ================================================================================
 
-  1. src/backend/db/schema.ts
-     19-table Drizzle ORM schema. All constraints, indexes, FKs, and type
-     exports matching ER schema v1.1 exactly.
+Bug: UK constituent countries (Scotland, England, Wales, Northern Ireland)
+unavailable when adding a place. Root cause: GB was present in the countries
+seed but with region_tier_enabled=0 — those four are ISO 3166-2 regions under
+GB, not ISO 3166-1 countries themselves (GE-01/GE-02), so the Region tier
+never surfaced for GB.
 
-  2. src/backend/db/index.ts
-     Connection factory (singleton). DB_TYPE=sqlite → @libsql/client.
-     DB_TYPE=postgres → node-postgres.
-
-  3. drizzle.config.ts
-     Drizzle Kit config. Dialect driven by DB_TYPE.
-
-  4. src/backend/db/seed.ts
-     Idempotent seed loader. trip_categories (11), activities (17),
-     companions (7), map_shading_config (6).
-
-  5. src/backend/migrations/0000_open_electro.sql
-     Generated migration. Verified correct SQL.
-
-================================================================================
-VERIFICATION RESULTS
-================================================================================
-
-  npm run db:push  → "✓ Changes applied"
-  npm run db:seed  → all 4 tables seeded, correct counts
-  Idempotency      → second seed run produces no errors or duplicates
-  Table count      → 19 application tables in dev.db
+Deliverables (branch fix/bug30-uk-region-seed):
+  1. data/countries.json — GB row: region_tier_enabled 0->1,
+     region_tier_label null -> 'Constituent Country'
+  2. data/regions.json — added England/GB-ENG, Scotland/GB-SCT, Wales/GB-WLS,
+     Northern Ireland/GB-NIR (real ISO 3166-2 codes, same shape as existing
+     US/AU/CA rows)
+  3. src/backend/migrations/0008_bug30_uk_region_seed.sql — data-only custom
+     migration (drizzle-kit generate --custom; no DDL diff since
+     region_tier_enabled/label and iso_3166_2 columns already exist from
+     migration 0001). UPDATEs the GB countries row and INSERTs the 4 regions,
+     guarded with `WHERE EXISTS (SELECT 1 FROM regions LIMIT 1)` so it is a
+     no-op on fresh installs (see IMPORTANT FINDING below).
+  4. src/backend/migrations/meta/_journal.json + 0008_snapshot.json —
+     generated migration metadata.
 
 ================================================================================
-DRIVER NOTE (flagged to COO)
+IMPORTANT FINDING — self-caught bug in my own first draft
 ================================================================================
 
-  Used @libsql/client instead of better-sqlite3 because better-sqlite3
-  v9.x fails to compile on Node.js v24. @libsql/client is pure JS,
-  fully Drizzle-compatible, and a cleaner solution overall.
+First draft of the migration inserted the 4 GB regions unconditionally
+(guarded only by `NOT EXISTS (... iso_3166_2 = ...)`, i.e. per-row dedup).
+Caught via a from-scratch fresh-install simulation (migrate() on an empty
+db, then replaying seedCountries()/seedRegions() from startup.service.ts):
+migrations always run before the server boots (db:migrate is a deploy step
+ahead of server start), so on a truly fresh install this migration would run
+against an EMPTY regions table and insert 4 rows — tripping
+seedRegions()'s "table already has >0 rows -> skip entirely" idempotency
+guard in src/backend/services/startup.service.ts. Fresh installs would end
+up with ONLY the 4 GB regions and NONE of the other 72 US/AU/CA ones.
+
+Fixed by adding `WHERE EXISTS (SELECT 1 FROM regions LIMIT 1)` to each
+region INSERT — scopes the migration's effect to installs that have already
+run the app-level seed at least once. Verified both paths explicitly:
+  - Fresh install simulation: migrate() on empty db -> 0 rows in
+    countries/regions immediately after -> full seedCountries()/seedRegions()
+    replay -> 250 countries, 76 regions (incl. all 4 GB + all 51 US), GB
+    row correct.
+  - Already-seeded path: existing dev.db (had GB region_tier_enabled=1 from
+    an earlier partial UAT-investigation edit, label=null, 0 GB regions,
+    but 72 pre-existing US/AU/CA regions) -> migration correctly set the
+    label and inserted exactly the 4 GB regions, idempotent on re-run.
 
 ================================================================================
-OUTBOX SENT
+TOOLING NOTE — drizzle-kit CLI `migrate` command journal instability
 ================================================================================
 
-  jobs/COO/inbox/20260307_1600-DATABASE-schema-complete.txt
-  jobs/backend/inbox/20260307_1600-DATABASE-schema-ready.txt
+Observed once during this thread: after `npx drizzle-kit generate --custom`
+created the 0008 journal entry + snapshot, the FIRST subsequent
+`npm run db:migrate` reported "migrations applied successfully" but neither
+touched dev.db NOR persisted the new journal entry (meta/_journal.json
+reverted to its pre-generate state, matching HEAD exactly, while the
+0008 .sql/snapshot files remained on disk). Not reproduced on later runs in
+this same thread once the journal entry was restored — worked cleanly and
+idempotently afterward, and drizzle-orm's own migrate() (imported directly,
+bypassing the drizzle-kit CLI wrapper) also worked correctly throughout.
+Root cause not confirmed — plausibly related to the drizzle-kit@0.31.9
+SQLite bugs already tracked in patches/drizzle-kit+0.31.9.patch (see
+MEMORY.md), but this symptom (journal entry silently dropped for a --custom
+migration with no schema diff) doesn't match any of the four documented
+bugs exactly. Flagging for Architect/COO awareness — not blocking, since the
+committed migration file + journal entry are verified correct and the
+normal `npm run db:generate` / `npm run db:migrate` workflow was used
+throughout (no db:push).
 
 ================================================================================
-LAST PARK DOC
+VERIFICATION
 ================================================================================
-
-  jobs/database/park-docs/20260307-DATABASE-park.txt
+  npm run type:check:backend    -> clean
+  npm run type:check:all        -> clean
+  npm run test:backend          -> 23 files, 523 passed, 1 skipped
+  npm run test:frontend         -> 1 pre-existing failure unrelated to this
+                                    change (CarryForwardModal BUG-03
+                                    regression test — confirmed failing on
+                                    HEAD with this thread's changes fully
+                                    stashed out; not caused by BUG-30 work)
+  npm run check (biome)         -> clean
+  npm run status:check          -> FAILS, but pre-existing/not-mine: this
+                                    worktree had uncommitted tracker.json /
+                                    STATUS.md / BRD.md / drift-ledger.jsonl /
+                                    uat-log.md changes already present before
+                                    this thread started (COO session state,
+                                    not part of this brief). Left untouched
+                                    and NOT committed on this branch — only
+                                    BUG-30-relevant files were staged/committed.
 
 ================================================================================
 NEXT DATABASE THREAD
 ================================================================================
-
-  Awaiting COO review and acceptance. No known defects.
-  Phase 2 (PostgreSQL schema + data migration script) when project moves
-  to hosted deployment.
-
+  None expected unless COO returns this PR with defects. Awaiting COO review
+  and merge via /coo-merge-and-close.

--- a/jobs/database/park-docs/20260720-DATABASE-park.txt
+++ b/jobs/database/park-docs/20260720-DATABASE-park.txt
@@ -1,0 +1,153 @@
+PARK DOCUMENT — DATABASE
+Date: 2026-07-20
+Thread: DATABASE Thread — BUG-30 UK region seed fix (GitHub #154)
+
+================================================================================
+THREAD SUMMARY
+================================================================================
+
+Dispatched to fix BUG-30: Scotland/England/Wales/Northern Ireland unavailable
+when adding a place to a trip. Root cause confirmed: GB was present in the
+countries seed data with region_tier_enabled=0. Those four are ISO 3166-2
+regions under GB (same tier as US states / AU states, GE-01/GE-02), not
+countries under ISO 3166-1 — they will never appear as a country to pick
+from, and the Region tier was never enabled to surface them under GB.
+
+================================================================================
+SOURCE DOCUMENTS READ
+================================================================================
+  - _shared/frameworks.txt
+  - _project/travel-tracker-BRD.md — §5.2 Geographic Hierarchy (GE-01..GE-15)
+  - jobs/architect/tech/ (ER schema, ADL log, ADL-24/26/27/28/30, OP-06)
+  - jobs/database/context/current.txt (prior state, 2026-03-07)
+  - jobs/database/inbox/20260321_2300-COO-adl23-trip-countries-migration.md
+    (stale/unrelated — earlier already-actioned thread, left in inbox/ not
+    inbox/read/; did not action it, not in scope for this thread)
+  - jobs/database/park-docs/20260307-DATABASE-park.txt
+  - src/backend/db/schema.ts (countries/regions table definitions)
+  - src/backend/migrations/0001_bug02_iso3166_seam_columns.sql (precedent for
+    ISO 3166-2 backfill pattern — AU/US/CA)
+  - src/backend/services/startup.service.ts (seedCountries/seedRegions —
+    first-launch seed guard logic, GE-04/05)
+  - data/countries.json, data/regions.json (actual seed source files; NOT
+    src/backend/db/seed-data.ts / seed.ts as the brief suggested — those only
+    hold trip_categories/activities/companions/map_shading_config. Countries
+    and regions are seeded from data/*.json via startup.service.ts, loaded at
+    server boot.)
+  - _project/tracker.json BUG-30 entry (confirmed label precedent:
+    "region_tier_label likely 'Constituent Country'")
+
+================================================================================
+DELIVERABLES PRODUCED
+================================================================================
+  1. data/countries.json — GB: region_tier_enabled 0->1, region_tier_label
+     null -> "Constituent Country"
+  2. data/regions.json — 4 new rows: England/GB-ENG, Scotland/GB-SCT,
+     Wales/GB-WLS, Northern Ireland/GB-NIR
+  3. src/backend/migrations/0008_bug30_uk_region_seed.sql — custom data-only
+     migration (via `drizzle-kit generate --custom`, since there is no schema
+     diff — region_tier_enabled/label and regions.iso_3166_2 already exist
+     from migration 0001). Patches already-seeded installs; no-op on fresh
+     installs (guard rationale documented in-file and in context/current.txt).
+  4. src/backend/migrations/meta/_journal.json (+1 entry, idx 8) and
+     meta/0008_snapshot.json (generated, no functional schema delta vs 0007).
+
+  All copied conceptually into jobs/database/context/current.txt (full
+  detail); tech/ folder not updated separately since no schema.ts change.
+
+================================================================================
+DECISIONS MADE THIS THREAD
+================================================================================
+
+  DECISION: region_tier_label = "Constituent Country" for GB.
+  REASON: BRD GE-02 says the tier "represents states, provinces, or
+  territories depending on the country" but has no UK precedent; England/
+  Scotland/Wales/Northern Ireland are officially termed "constituent
+  countries" of the UK. Tracker's BUG-30 note already flagged this as the
+  likely label ("region_tier_label likely 'Constituent Country'") — adopted
+  as-is, no BRD language conflicts with it.
+  ARCHITECT REVIEW NEEDED: No new table/column — region_tier_enabled and
+  region_tier_label already exist and are exactly what GE-04/07 spec for
+  per-country Region tier config. This is data only, not a schema change.
+
+  DECISION: Guard the migration's region INSERTs with
+  `WHERE EXISTS (SELECT 1 FROM regions LIMIT 1)`.
+  REASON: See "IMPORTANT FINDING" in context/current.txt — an unconditional
+  INSERT on a data-only migration would poison the "table empty = not yet
+  seeded" invariant that startup.service.ts's seedRegions() idempotency guard
+  relies on, permanently starving fresh installs of all 72 non-GB regions.
+  Caught via a from-scratch fresh-install simulation before committing.
+
+================================================================================
+ACCEPTANCE CRITERIA
+================================================================================
+  [x] GB seeded with region_tier_enabled=1 and a region_tier_label
+  [x] Scotland/England/Wales/Northern Ireland exist as regions under GB with
+      real ISO 3166-2 codes (GB-SCT, GB-ENG, GB-WLS, GB-NIR)
+  [x] Fix applied via db:generate --custom + db:migrate (never db:push,
+      ADL-15) — verified against a from-scratch fresh install AND the
+      already-seeded dev.db
+  [x] Migration is idempotent (re-run produces no errors, no duplicate rows)
+  [x] Fresh-install seed path (data/countries.json + data/regions.json) also
+      corrected so GE-04/05 holds without needing the migration
+  [x] No regression: existing US/AU/CA regions unaffected on both fresh and
+      already-seeded paths
+  [x] npm run type:check:backend / type:check:all clean
+  [x] npm run test:backend — 523 passed, 1 skipped, no regressions
+  [x] npm run check (biome) clean
+  [ ] npm run test:frontend — 1 pre-existing failure (CarryForwardModal
+      BUG-03 regression test), confirmed unrelated (fails identically with
+      this thread's changes fully stashed out)
+  [ ] npm run status:check — fails, but caused by pre-existing uncommitted
+      tracker.json/STATUS.md/BRD.md changes already in this worktree before
+      the thread started (COO session state, not this brief's scope); left
+      untouched, not committed to this branch
+
+================================================================================
+VERIFICATION LOG
+================================================================================
+  drizzle-kit generate --custom --name bug30_uk_region_seed
+    -> src/backend/migrations/0008_bug30_uk_region_seed.sql created
+  Manual SQL authored (UPDATE + 4x guarded INSERT)
+  npm run db:migrate -> applied against dev.db (after journal entry was
+    restored — see TOOLING NOTE in context/current.txt for one transient
+    drizzle-kit CLI issue this thread hit and worked around)
+  dev.db verification: GB region_tier_enabled=1, region_tier_label=
+    'Constituent Country', 4 GB regions present with correct ISO 3166-2 codes
+  Fresh-install simulation (separate throwaway db file): migrate() -> 0 rows
+    countries/regions -> seedCountries()/seedRegions() replay -> 250
+    countries, 76 regions (51 US + 8 AU + 13 CA + 4 GB), GB row correct
+  Re-run migrate (idempotency check): no duplicate rows, no errors
+
+================================================================================
+BUGS DISCOVERED
+================================================================================
+  [MAJOR, self-caught, fixed before commit] First draft of the migration's
+  region INSERTs used only a per-row `NOT EXISTS (iso_3166_2 = ...)` guard,
+  with no check on whether the table had been seeded at all. On a genuinely
+  fresh install this would have inserted the 4 GB rows into an empty regions
+  table, tripping seedRegions()'s "non-empty -> skip" idempotency guard and
+  silently dropping all other 72 regions (US/AU/CA) from every new install
+  going forward — a data-integrity regression far more severe than the bug
+  being fixed. INITIAL CLASSIFICATION: n/a (caught during my own
+  verification pass, before it reached a commit). ACTUAL CLASSIFICATION:
+  MAJOR (would have affected a core workflow — every fresh install's region
+  data — silently). Disposition: fixed in this same thread via the
+  `WHERE EXISTS (SELECT 1 FROM regions LIMIT 1)` guard, verified against a
+  from-scratch fresh-install simulation before commit. Not escalated to COO
+  since caught and fixed before landing anywhere.
+
+  [MINOR/tooling, deferred] drizzle-kit CLI `migrate` command transiently
+  dropped a freshly-generated custom migration's journal entry on its first
+  run (see TOOLING NOTE, context/current.txt). Not reproduced on subsequent
+  runs; worked around by re-adding the journal entry and applying via
+  drizzle-orm's migrate() directly (same underlying apply path the CLI uses).
+  Flagging to COO/Architect for awareness — may be a 5th drizzle-kit@0.31.9
+  bug alongside the four already tracked in patches/drizzle-kit+0.31.9.patch,
+  worth a closer look if it recurs on a future custom migration.
+
+================================================================================
+RECOMMENDED STARTING POINT FOR NEXT DATABASE THREAD
+================================================================================
+  None expected unless COO returns this PR with defects, or the drizzle-kit
+  CLI migrate-journal issue above recurs and needs root-causing.

--- a/src/backend/migrations/0008_bug30_uk_region_seed.sql
+++ b/src/backend/migrations/0008_bug30_uk_region_seed.sql
@@ -1,0 +1,64 @@
+-- BUG-30 (GitHub #154): UK constituent countries unavailable when adding a place.
+--
+-- Root cause: GB was present in the countries seed with region_tier_enabled = 0,
+-- so the Region tier (GE-01/GE-02) never surfaced Scotland/England/Wales/Northern
+-- Ireland — they are not ISO 3166-1 countries, they are regions under GB, same
+-- tier as US states / AU states (GE-02, GE-06).
+--
+-- This is a data-only fix (no DDL — countries.region_tier_enabled/label and
+-- regions.iso_3166_2 already exist per migration 0001_bug02_iso3166_seam_columns).
+-- Generated via `drizzle-kit generate --custom` since drizzle-kit only diffs
+-- schema.ts, not seed data (ADL-15 — db:push forbidden, but there is also no
+-- DDL diff here for `generate` to pick up automatically).
+--
+-- This migration only PATCHES INSTALLS THAT HAVE ALREADY RUN THE APP-LEVEL SEED
+-- (src/backend/services/startup.service.ts). data/countries.json and
+-- data/regions.json are corrected in this same PR so GE-04/05 ("ships
+-- pre-configured", "applied automatically on first launch") holds for brand
+-- new installs without this migration doing anything on them.
+--
+-- Guard rationale: seedCountries()/seedRegions() gate on "table already has
+-- >0 rows -> skip entirely" (idempotent first-launch seed). Migrations always
+-- run before the server boots (npm run db:migrate is a deploy step ahead of
+-- server start), so on a FRESH install this migration runs against EMPTY
+-- countries/regions tables. The countries UPDATE is naturally a no-op there
+-- (no GB row exists yet). But an unconditional regions INSERT would NOT be a
+-- no-op — it would seed 4 rows into an otherwise-empty regions table, tripping
+-- seedRegions()'s "non-empty -> skip" guard and permanently starving fresh
+-- installs of the other 72 US/AU/CA regions. The `WHERE EXISTS (SELECT 1 FROM
+-- regions LIMIT 1)` guard below keeps the INSERTs scoped to installs that have
+-- already been seeded at least once, leaving genuinely fresh installs to pick
+-- up all regions (incl. the 4 new GB ones) from the corrected JSON via the
+-- normal first-launch seed path.
+--
+-- Idempotent: safe to re-run.
+
+UPDATE countries
+SET region_tier_enabled = 1,
+    region_tier_label = 'Constituent Country',
+    updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now')
+WHERE country_code = 'GB';
+--> statement-breakpoint
+
+INSERT INTO regions (country_code, name, iso_3166_2)
+SELECT 'GB', 'England', 'GB-ENG'
+WHERE EXISTS (SELECT 1 FROM regions LIMIT 1)
+  AND NOT EXISTS (SELECT 1 FROM regions WHERE iso_3166_2 = 'GB-ENG');
+--> statement-breakpoint
+
+INSERT INTO regions (country_code, name, iso_3166_2)
+SELECT 'GB', 'Scotland', 'GB-SCT'
+WHERE EXISTS (SELECT 1 FROM regions LIMIT 1)
+  AND NOT EXISTS (SELECT 1 FROM regions WHERE iso_3166_2 = 'GB-SCT');
+--> statement-breakpoint
+
+INSERT INTO regions (country_code, name, iso_3166_2)
+SELECT 'GB', 'Wales', 'GB-WLS'
+WHERE EXISTS (SELECT 1 FROM regions LIMIT 1)
+  AND NOT EXISTS (SELECT 1 FROM regions WHERE iso_3166_2 = 'GB-WLS');
+--> statement-breakpoint
+
+INSERT INTO regions (country_code, name, iso_3166_2)
+SELECT 'GB', 'Northern Ireland', 'GB-NIR'
+WHERE EXISTS (SELECT 1 FROM regions LIMIT 1)
+  AND NOT EXISTS (SELECT 1 FROM regions WHERE iso_3166_2 = 'GB-NIR');

--- a/src/backend/migrations/meta/0008_snapshot.json
+++ b/src/backend/migrations/meta/0008_snapshot.json
@@ -1,0 +1,1788 @@
+{
+  "id": "acda55aa-248c-4e9a-9d80-d3f99fd70e8d",
+  "prevId": "4a3c56e3-acb4-4e5f-9b38-24fc8fa19dbf",
+  "version": "6",
+  "dialect": "sqlite",
+  "tables": {
+    "activities": {
+      "name": "activities",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "activities_name_unique": {
+          "name": "activities_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "chk_activities_is_active": {
+          "name": "chk_activities_is_active",
+          "value": "\"activities\".\"is_active\" IN (0, 1)"
+        }
+      }
+    },
+    "cities": {
+      "name": "cities",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "country_code": {
+          "name": "country_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "region_id": {
+          "name": "region_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "geocode_status": {
+          "name": "geocode_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "geocode_attempted_at": {
+          "name": "geocode_attempted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "idx_cities_country": {
+          "name": "idx_cities_country",
+          "columns": [
+            "country_code"
+          ],
+          "isUnique": false
+        },
+        "idx_cities_region": {
+          "name": "idx_cities_region",
+          "columns": [
+            "region_id"
+          ],
+          "isUnique": false
+        },
+        "idx_cities_geocode": {
+          "name": "idx_cities_geocode",
+          "columns": [
+            "geocode_status"
+          ],
+          "where": "\"cities\".\"geocode_status\" = 'pending'",
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "cities_country_code_countries_country_code_fk": {
+          "name": "cities_country_code_countries_country_code_fk",
+          "tableFrom": "cities",
+          "columnsFrom": [
+            "country_code"
+          ],
+          "tableTo": "countries",
+          "columnsTo": [
+            "country_code"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "cities_region_id_regions_id_fk": {
+          "name": "cities_region_id_regions_id_fk",
+          "tableFrom": "cities",
+          "columnsFrom": [
+            "region_id"
+          ],
+          "tableTo": "regions",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "chk_cities_geocode_status": {
+          "name": "chk_cities_geocode_status",
+          "value": "\"cities\".\"geocode_status\" IN ('pending', 'resolved')"
+        }
+      }
+    },
+    "companions": {
+      "name": "companions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "companions_name_unique": {
+          "name": "companions_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "chk_companions_is_active": {
+          "name": "chk_companions_is_active",
+          "value": "\"companions\".\"is_active\" IN (0, 1)"
+        }
+      }
+    },
+    "countries": {
+      "name": "countries",
+      "columns": {
+        "country_code": {
+          "name": "country_code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "region_tier_enabled": {
+          "name": "region_tier_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "region_tier_label": {
+          "name": "region_tier_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "chk_countries_region_tier_enabled": {
+          "name": "chk_countries_region_tier_enabled",
+          "value": "\"countries\".\"region_tier_enabled\" IN (0, 1)"
+        }
+      }
+    },
+    "item_car_rentals": {
+      "name": "item_car_rentals",
+      "columns": {
+        "item_id": {
+          "name": "item_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pickup_location": {
+          "name": "pickup_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dropoff_location": {
+          "name": "dropoff_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pickup_datetime": {
+          "name": "pickup_datetime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dropoff_datetime": {
+          "name": "dropoff_datetime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "booking_reference": {
+          "name": "booking_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vehicle_class": {
+          "name": "vehicle_class",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "item_car_rentals_item_id_items_id_fk": {
+          "name": "item_car_rentals_item_id_items_id_fk",
+          "tableFrom": "item_car_rentals",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "tableTo": "items",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "item_experiences": {
+      "name": "item_experiences",
+      "columns": {
+        "item_id": {
+          "name": "item_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "post_visit_notes": {
+          "name": "post_visit_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_item_experiences_rating": {
+          "name": "idx_item_experiences_rating",
+          "columns": [
+            "rating"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "item_experiences_item_id_items_id_fk": {
+          "name": "item_experiences_item_id_items_id_fk",
+          "tableFrom": "item_experiences",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "tableTo": "items",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "chk_item_experiences_rating": {
+          "name": "chk_item_experiences_rating",
+          "value": "\"item_experiences\".\"rating\" IS NULL OR (\"item_experiences\".\"rating\" BETWEEN 1 AND 5)"
+        }
+      }
+    },
+    "item_flights": {
+      "name": "item_flights",
+      "columns": {
+        "item_id": {
+          "name": "item_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "airline": {
+          "name": "airline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "flight_number": {
+          "name": "flight_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "departure_airport": {
+          "name": "departure_airport",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "arrival_airport": {
+          "name": "arrival_airport",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "departure_datetime": {
+          "name": "departure_datetime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "arrival_datetime": {
+          "name": "arrival_datetime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "booking_reference": {
+          "name": "booking_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "seat": {
+          "name": "seat",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "item_flights_item_id_items_id_fk": {
+          "name": "item_flights_item_id_items_id_fk",
+          "tableFrom": "item_flights",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "tableTo": "items",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "item_hotels": {
+      "name": "item_hotels",
+      "columns": {
+        "item_id": {
+          "name": "item_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "property_name": {
+          "name": "property_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "check_in_date": {
+          "name": "check_in_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "check_out_date": {
+          "name": "check_out_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "booking_reference": {
+          "name": "booking_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "confirmation_number": {
+          "name": "confirmation_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "post_visit_notes": {
+          "name": "post_visit_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_item_hotels_rating": {
+          "name": "idx_item_hotels_rating",
+          "columns": [
+            "rating"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "item_hotels_item_id_items_id_fk": {
+          "name": "item_hotels_item_id_items_id_fk",
+          "tableFrom": "item_hotels",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "tableTo": "items",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "chk_item_hotels_rating": {
+          "name": "chk_item_hotels_rating",
+          "value": "\"item_hotels\".\"rating\" IS NULL OR (\"item_hotels\".\"rating\" BETWEEN 1 AND 5)"
+        }
+      }
+    },
+    "item_restaurants": {
+      "name": "item_restaurants",
+      "columns": {
+        "item_id": {
+          "name": "item_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "neighbourhood_area": {
+          "name": "neighbourhood_area",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cuisine_type": {
+          "name": "cuisine_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "post_visit_notes": {
+          "name": "post_visit_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_item_restaurants_rating": {
+          "name": "idx_item_restaurants_rating",
+          "columns": [
+            "rating"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "item_restaurants_item_id_items_id_fk": {
+          "name": "item_restaurants_item_id_items_id_fk",
+          "tableFrom": "item_restaurants",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "tableTo": "items",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "chk_item_restaurants_rating": {
+          "name": "chk_item_restaurants_rating",
+          "value": "\"item_restaurants\".\"rating\" IS NULL OR (\"item_restaurants\".\"rating\" BETWEEN 1 AND 5)"
+        }
+      }
+    },
+    "items": {
+      "name": "items",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "trip_id": {
+          "name": "trip_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "trip_place_id": {
+          "name": "trip_place_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "item_type": {
+          "name": "item_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'consider'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_carried_forward": {
+          "name": "is_carried_forward",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "carried_from_item_id": {
+          "name": "carried_from_item_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "idx_items_trip": {
+          "name": "idx_items_trip",
+          "columns": [
+            "trip_id"
+          ],
+          "isUnique": false
+        },
+        "idx_items_trip_place": {
+          "name": "idx_items_trip_place",
+          "columns": [
+            "trip_place_id"
+          ],
+          "isUnique": false
+        },
+        "idx_items_type": {
+          "name": "idx_items_type",
+          "columns": [
+            "item_type"
+          ],
+          "isUnique": false
+        },
+        "idx_items_status": {
+          "name": "idx_items_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "idx_items_carried": {
+          "name": "idx_items_carried",
+          "columns": [
+            "carried_from_item_id"
+          ],
+          "where": "\"items\".\"carried_from_item_id\" IS NOT NULL",
+          "isUnique": false
+        },
+        "items_user_id_idx": {
+          "name": "items_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "items_trip_id_trips_id_fk": {
+          "name": "items_trip_id_trips_id_fk",
+          "tableFrom": "items",
+          "columnsFrom": [
+            "trip_id"
+          ],
+          "tableTo": "trips",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "items_trip_place_id_trip_places_id_fk": {
+          "name": "items_trip_place_id_trip_places_id_fk",
+          "tableFrom": "items",
+          "columnsFrom": [
+            "trip_place_id"
+          ],
+          "tableTo": "trip_places",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "items_carried_from_item_id_items_id_fk": {
+          "name": "items_carried_from_item_id_items_id_fk",
+          "tableFrom": "items",
+          "columnsFrom": [
+            "carried_from_item_id"
+          ],
+          "tableTo": "items",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "items_user_id_users_id_fk": {
+          "name": "items_user_id_users_id_fk",
+          "tableFrom": "items",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "chk_items_item_type": {
+          "name": "chk_items_item_type",
+          "value": "\"items\".\"item_type\" IN ('restaurant', 'hotel', 'flight', 'car_rental', 'experience', 'note')"
+        },
+        "chk_items_status": {
+          "name": "chk_items_status",
+          "value": "\"items\".\"status\" IN ('consider', 'confirmed', 'completed', 'cancelled', 'next_time')"
+        },
+        "chk_items_is_carried_forward": {
+          "name": "chk_items_is_carried_forward",
+          "value": "\"items\".\"is_carried_forward\" IN (0, 1)"
+        }
+      }
+    },
+    "map_shading_config": {
+      "name": "map_shading_config",
+      "columns": {
+        "state_key": {
+          "name": "state_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "color_hex": {
+          "name": "color_hex",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "chk_map_shading_state_key": {
+          "name": "chk_map_shading_state_key",
+          "value": "\"map_shading_config\".\"state_key\" IN ('active', 'planned', 'visited_once', 'visited_once_planning', 'visited_multiple', 'visited_multiple_planning')"
+        }
+      }
+    },
+    "regions": {
+      "name": "regions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "country_code": {
+          "name": "country_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "iso_3166_2": {
+          "name": "iso_3166_2",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "idx_regions_country": {
+          "name": "idx_regions_country",
+          "columns": [
+            "country_code"
+          ],
+          "isUnique": false
+        },
+        "uniq_regions_iso_3166_2": {
+          "name": "uniq_regions_iso_3166_2",
+          "columns": [
+            "iso_3166_2"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "regions_country_code_countries_country_code_fk": {
+          "name": "regions_country_code_countries_country_code_fk",
+          "tableFrom": "regions",
+          "columnsFrom": [
+            "country_code"
+          ],
+          "tableTo": "countries",
+          "columnsTo": [
+            "country_code"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "trip_activities_map": {
+      "name": "trip_activities_map",
+      "columns": {
+        "trip_id": {
+          "name": "trip_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "activity_id": {
+          "name": "activity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "trip_activities_map_trip_id_trips_id_fk": {
+          "name": "trip_activities_map_trip_id_trips_id_fk",
+          "tableFrom": "trip_activities_map",
+          "columnsFrom": [
+            "trip_id"
+          ],
+          "tableTo": "trips",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "trip_activities_map_activity_id_activities_id_fk": {
+          "name": "trip_activities_map_activity_id_activities_id_fk",
+          "tableFrom": "trip_activities_map",
+          "columnsFrom": [
+            "activity_id"
+          ],
+          "tableTo": "activities",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "trip_activities_map_trip_id_activity_id_pk": {
+          "columns": [
+            "trip_id",
+            "activity_id"
+          ],
+          "name": "trip_activities_map_trip_id_activity_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "trip_categories": {
+      "name": "trip_categories",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "trip_categories_name_unique": {
+          "name": "trip_categories_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "chk_trip_categories_is_active": {
+          "name": "chk_trip_categories_is_active",
+          "value": "\"trip_categories\".\"is_active\" IN (0, 1)"
+        }
+      }
+    },
+    "trip_categories_map": {
+      "name": "trip_categories_map",
+      "columns": {
+        "trip_id": {
+          "name": "trip_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_tcm_category": {
+          "name": "idx_tcm_category",
+          "columns": [
+            "category_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "trip_categories_map_trip_id_trips_id_fk": {
+          "name": "trip_categories_map_trip_id_trips_id_fk",
+          "tableFrom": "trip_categories_map",
+          "columnsFrom": [
+            "trip_id"
+          ],
+          "tableTo": "trips",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "trip_categories_map_category_id_trip_categories_id_fk": {
+          "name": "trip_categories_map_category_id_trip_categories_id_fk",
+          "tableFrom": "trip_categories_map",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "tableTo": "trip_categories",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "trip_categories_map_trip_id_category_id_pk": {
+          "columns": [
+            "trip_id",
+            "category_id"
+          ],
+          "name": "trip_categories_map_trip_id_category_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "trip_companions_map": {
+      "name": "trip_companions_map",
+      "columns": {
+        "trip_id": {
+          "name": "trip_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "companion_id": {
+          "name": "companion_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_tcpm_companion": {
+          "name": "idx_tcpm_companion",
+          "columns": [
+            "companion_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "trip_companions_map_trip_id_trips_id_fk": {
+          "name": "trip_companions_map_trip_id_trips_id_fk",
+          "tableFrom": "trip_companions_map",
+          "columnsFrom": [
+            "trip_id"
+          ],
+          "tableTo": "trips",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "trip_companions_map_companion_id_companions_id_fk": {
+          "name": "trip_companions_map_companion_id_companions_id_fk",
+          "tableFrom": "trip_companions_map",
+          "columnsFrom": [
+            "companion_id"
+          ],
+          "tableTo": "companions",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "trip_companions_map_trip_id_companion_id_pk": {
+          "columns": [
+            "trip_id",
+            "companion_id"
+          ],
+          "name": "trip_companions_map_trip_id_companion_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "trip_countries": {
+      "name": "trip_countries",
+      "columns": {
+        "trip_id": {
+          "name": "trip_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "country_code": {
+          "name": "country_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "idx_trip_countries_country": {
+          "name": "idx_trip_countries_country",
+          "columns": [
+            "country_code"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "trip_countries_trip_id_trips_id_fk": {
+          "name": "trip_countries_trip_id_trips_id_fk",
+          "tableFrom": "trip_countries",
+          "columnsFrom": [
+            "trip_id"
+          ],
+          "tableTo": "trips",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "trip_countries_country_code_countries_country_code_fk": {
+          "name": "trip_countries_country_code_countries_country_code_fk",
+          "tableFrom": "trip_countries",
+          "columnsFrom": [
+            "country_code"
+          ],
+          "tableTo": "countries",
+          "columnsTo": [
+            "country_code"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {
+        "trip_countries_trip_id_country_code_pk": {
+          "columns": [
+            "trip_id",
+            "country_code"
+          ],
+          "name": "trip_countries_trip_id_country_code_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "trip_place_activities_map": {
+      "name": "trip_place_activities_map",
+      "columns": {
+        "trip_place_id": {
+          "name": "trip_place_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "activity_id": {
+          "name": "activity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "trip_place_activities_map_trip_place_id_trip_places_id_fk": {
+          "name": "trip_place_activities_map_trip_place_id_trip_places_id_fk",
+          "tableFrom": "trip_place_activities_map",
+          "columnsFrom": [
+            "trip_place_id"
+          ],
+          "tableTo": "trip_places",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "trip_place_activities_map_activity_id_activities_id_fk": {
+          "name": "trip_place_activities_map_activity_id_activities_id_fk",
+          "tableFrom": "trip_place_activities_map",
+          "columnsFrom": [
+            "activity_id"
+          ],
+          "tableTo": "activities",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "trip_place_activities_map_trip_place_id_activity_id_pk": {
+          "columns": [
+            "trip_place_id",
+            "activity_id"
+          ],
+          "name": "trip_place_activities_map_trip_place_id_activity_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "trip_places": {
+      "name": "trip_places",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "trip_id": {
+          "name": "trip_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "city_id": {
+          "name": "city_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "arrived_on": {
+          "name": "arrived_on",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "departed_on": {
+          "name": "departed_on",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "uniq_trip_places_trip_city": {
+          "name": "uniq_trip_places_trip_city",
+          "columns": [
+            "trip_id",
+            "city_id"
+          ],
+          "isUnique": true
+        },
+        "idx_trip_places_trip": {
+          "name": "idx_trip_places_trip",
+          "columns": [
+            "trip_id"
+          ],
+          "isUnique": false
+        },
+        "idx_trip_places_city": {
+          "name": "idx_trip_places_city",
+          "columns": [
+            "city_id"
+          ],
+          "isUnique": false
+        },
+        "trip_places_user_id_idx": {
+          "name": "trip_places_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "trip_places_trip_id_trips_id_fk": {
+          "name": "trip_places_trip_id_trips_id_fk",
+          "tableFrom": "trip_places",
+          "columnsFrom": [
+            "trip_id"
+          ],
+          "tableTo": "trips",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "trip_places_city_id_cities_id_fk": {
+          "name": "trip_places_city_id_cities_id_fk",
+          "tableFrom": "trip_places",
+          "columnsFrom": [
+            "city_id"
+          ],
+          "tableTo": "cities",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "trip_places_user_id_users_id_fk": {
+          "name": "trip_places_user_id_users_id_fk",
+          "tableFrom": "trip_places",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "trips": {
+      "name": "trips",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'planning'"
+        },
+        "photo_album_ref": {
+          "name": "photo_album_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "idx_trips_status": {
+          "name": "idx_trips_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "idx_trips_start_date": {
+          "name": "idx_trips_start_date",
+          "columns": [
+            "start_date"
+          ],
+          "isUnique": false
+        },
+        "idx_trips_end_date": {
+          "name": "idx_trips_end_date",
+          "columns": [
+            "end_date"
+          ],
+          "isUnique": false
+        },
+        "trips_user_id_idx": {
+          "name": "trips_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "trips_user_id_users_id_fk": {
+          "name": "trips_user_id_users_id_fk",
+          "tableFrom": "trips",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "chk_trips_status": {
+          "name": "chk_trips_status",
+          "value": "\"trips\".\"status\" IN ('planning', 'active', 'review_pending', 'locked')"
+        }
+      }
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "clerk_id": {
+          "name": "clerk_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_owner": {
+          "name": "is_owner",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_clerk_id_unique": {
+          "name": "users_clerk_id_unique",
+          "columns": [
+            "clerk_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/src/backend/migrations/meta/_journal.json
+++ b/src/backend/migrations/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1774404520000,
       "tag": "0007_secret_quasimodo",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "6",
+      "when": 1784569572909,
+      "tag": "0008_bug30_uk_region_seed",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
Closes #154
BRD §5.4, §5.2 GE-04/GE-05/GE-06

## Problem

GB was present in the countries seed with `region_tier_enabled = 0`, so Scotland,
England, Wales, and Northern Ireland — which are ISO 3166-2 regions under GB, not
ISO 3166-1 countries in their own right (GE-01/GE-02) — never surfaced as a Region
tier option when adding a place under United Kingdom.

## Fix

- `data/countries.json` — GB: `region_tier_enabled` 0→1, `region_tier_label`
  `null` → `"Constituent Country"`
- `data/regions.json` — adds England (`GB-ENG`), Scotland (`GB-SCT`),
  Wales (`GB-WLS`), Northern Ireland (`GB-NIR`) — real ISO 3166-2 codes, same
  shape as the existing US/AU/CA rows
- `src/backend/migrations/0008_bug30_uk_region_seed.sql` — data-only custom
  migration (`drizzle-kit generate --custom`, no DDL diff since
  `region_tier_enabled`/`region_tier_label` and `regions.iso_3166_2` already
  exist from migration 0001) that patches installs which have already run the
  first-launch seed. Generated + applied via `db:generate` / `db:migrate` only
  — **no `db:push`** (ADL-15).

### Guard detail (self-caught issue, fixed pre-commit)

The migration's region `INSERT`s are guarded with
`WHERE EXISTS (SELECT 1 FROM regions LIMIT 1)` in addition to the per-row
`NOT EXISTS` dedup. Without it, since migrations always run before the server
boots, a genuinely fresh install would hit this migration against an **empty**
`regions` table, insert the 4 GB rows, and trip `seedRegions()`'s
"table already has rows → skip entirely" idempotency guard in
`startup.service.ts` — silently starving every future fresh install of the
other 72 US/AU/CA regions. Caught via a from-scratch fresh-install simulation
before committing; verified both paths:

- **Fresh install**: `migrate()` on an empty db → 0 rows in countries/regions
  immediately after → full `seedCountries()`/`seedRegions()` replay → 250
  countries, 76 regions (51 US + 8 AU + 13 CA + 4 GB), GB row correct.
- **Already-seeded**: existing dev.db → migration set the label and inserted
  exactly the 4 GB regions, idempotent on re-run.

## Test plan

- [x] `npm run type:check:backend` / `type:check:all` — clean
- [x] `npm run test:backend` — 23 files, 523 passed, 1 skipped
- [x] `npm run check` (biome) — clean
- [x] Migration verified via `db:generate --custom` + `db:migrate` against
      both a from-scratch fresh install and the existing dev.db; idempotent
      on re-run
- [ ] `npm run test:frontend` — 1 pre-existing failure
      (`CarryForwardModal` BUG-03 regression test), confirmed unrelated —
      fails identically with this PR's changes stashed out
- [ ] `npm run status:check` — fails due to pre-existing uncommitted
      tracker.json/STATUS.md/BRD.md state in the dispatch worktree, unrelated
      to this change and not part of this PR's diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)