### PR TITLE
fix(BUG-32): add remove-place affordance to trip detail (#156)

### DIFF
--- a/jobs/COO/inbox/20260720_1746-FRONTEND-bug32-blocker-place-delete-fk-cascade.txt
+++ b/jobs/COO/inbox/20260720_1746-FRONTEND-bug32-blocker-place-delete-fk-cascade.txt
@@ -1,0 +1,61 @@
+FROM: Frontend
+RE: BUG-32 (#156) — CRITICAL finding during implementation, flagging per frameworks.txt rule 8/29
+
+CONTEXT: Implementing the frontend delete-place affordance for BUG-32. The DELETE
+route documented in jobs/backend/tech/20260307-api-reference.md (line 522-537) already
+exists in src/backend/routes/places.ts + placeRepository.delete, and a frontend hook
+(useRemovePlace in src/frontend/hooks/usePlaces.ts) already exists too — it was just
+never wired to a UI control. So the actual gap was UI-only, not a missing route as the
+tracker note assumed. I proceeded to wire it up (see completion report), but found a
+real defect in the route itself while verifying the documented cascade behavior.
+
+INITIAL CLASSIFICATION: N/A — new discovery, not a reclassification.
+ACTUAL CLASSIFICATION: CRITICAL (breakage of a primary user-facing workflow — the exact
+  feature BUG-32 asks for, in the majority-case scenario where a place has items logged
+  under it, which is the normal case for a real trip).
+
+SYMPTOM: DELETE /api/trips/:tripId/places/:placeId documents "This also deletes all
+  items and activity tags associated with that place (CASCADE)." Activity tags do
+  cascade correctly. Items do not — attempting to delete a place that still has any
+  items attached fails with an unhandled SQLITE_CONSTRAINT_FOREIGNKEY error, which the
+  global error handler (src/backend/middleware/error-handler.ts) turns into a generic
+  500 "Internal server error". No items are deleted; the place is not deleted either
+  (the whole operation fails atomically, so no partial/corrupt state — but the feature
+  is simply broken for this case).
+
+ROOT CAUSE: src/backend/db/schema.ts — items.tripPlaceId has no onDelete action:
+    tripPlaceId: integer('trip_place_id').references(() => tripPlaces.id),
+  vs. tripPlaceActivities.tripPlaceId, which correctly has:
+    .references(() => tripPlaces.id, { onDelete: 'cascade' })
+  Migration SQL confirms: items.trip_place_id FK is `ON DELETE no action` while
+  trip_place_activities.trip_place_id FK is `ON DELETE cascade` (migrations/0000 and
+  0007). I confirmed empirically (isolated @libsql/client script, not guessing from
+  docs) that this client enforces foreign_keys ON BY DEFAULT even with no explicit
+  PRAGMA statement — so this isn't masked in production, it actively throws.
+
+SCOPE: Only affects DELETE on a trip_place that still has items attached — which is
+  the normal case (a place usually has logged items; that's the point of the app).
+  The existing places.test.ts DELETE suite (4 tests) never attaches an item before
+  deleting, so this gap has never been exercised by CI. No other route/table appears
+  to share this specific gap — activity tags cascade correctly, and trips->places /
+  trips->items both correctly specify onDelete: 'cascade'. This looks like a one-off
+  miss on the items.tripPlaceId column specifically.
+
+PROPOSED FIX (for whoever owns the parallel BUG-32 backend brief, or a follow-up):
+  Add onDelete: 'cascade' to items.tripPlaceId in schema.ts, generate a migration via
+  `npm run db:generate` (never db:push per ADL-15), and add a DELETE-with-items test
+  case to places.test.ts asserting the item is gone after the place delete. Given
+  IT-01 lets items live at trip-level (tripPlaceId NULL) or place-level, cascading on
+  place delete is consistent with "delete a place removes what's under it" and matches
+  the doc's existing claim — this is a bug in the schema, not the doc.
+
+BLOCKING: Does not block my own frontend PR — the delete affordance, confirmation, and
+  lock-gating are independently correct and I've built them to render any backend error
+  (including this 500) via the existing ErrorMessage component rather than failing
+  silently or crashing. But it does block BUG-32 being closed as fully working: right
+  now, clicking "Remove place" on any place with items will show a generic error
+  instead of removing anything. Recommend a tracker entry (next available BUG-37) and
+  routing the schema fix into the parallel backend brief (fix/bug32-remove-place-api)
+  if it hasn't already merged, since it's the same feature and same route.
+
+Full details also in my park doc: jobs/frontend/park-docs/20260720-FRONTEND-park.txt

--- a/jobs/frontend/context/current.txt
+++ b/jobs/frontend/context/current.txt
@@ -1,31 +1,91 @@
-FRONTEND CONTEXT — as of 2026-03-20 20:11
+FRONTEND CONTEXT — as of 2026-07-20 18:10
 
-STATUS: BUG-18 investigated — already resolved. No pending work. Awaiting next COO brief.
+STATUS: BUG-32 (#156) frontend done — Remove-place affordance wired up. PR open on
+  fix/bug32-remove-place-ui. A CRITICAL backend bug was found and flagged to COO during
+  verification (see OPEN FLAGS below) — it does not block this PR but blocks BUG-32
+  being fully closeable.
 
-LAST COMMIT: 1fe7bc7 (fix(frontend): BUG-11/12/13 — cache invalidation, map click-through, search+sort)
+NOTE ON STALENESS: this file was last updated 2026-03-20 and clearly missed several
+  frontend-touching threads since (e.g. BUG-26/#116 admin-nav owner gating per memory,
+  BUG-34 map icon assigned to frontend in the tracker). Whoever picks up frontend next
+  should treat KEY FILE LOCATIONS below as still accurate but treat the history above
+  the 2026-07-20 entry as an incomplete record, not a full log.
 
-WHAT WAS DONE (this thread — 20260320_0030-COO-bug18-cache-invalidation)
-  BUG-18 (cache invalidation): Investigated useCreateTrip, useUpdateTripStatus, useLockTrip,
-    useUnlockTrip in src/frontend/hooks/useTrips.ts. All four hooks already invalidate
-    ['trips'] on success — this was applied in commit 1fe7bc7 (BUG-11 fix). No code
-    change required. type:check and test:frontend both pass (55/55).
+LAST COMMIT: (this thread) — see fix/bug32-remove-place-ui branch, not yet merged.
+  Prior main commit: c4340ef (chore: session close-out — OP-16/OP-19, 2026-07-20)
+
+WHAT WAS DONE (this thread — BUG-32 / GitHub #156)
+  - Confirmed the documented DELETE /api/trips/:tripId/places/:placeId route and the
+    useRemovePlace hook (src/frontend/hooks/usePlaces.ts) already existed — the gap was
+    UI-only (tracker note assumed the route might be missing; it wasn't).
+  - src/frontend/components/TripDetail/PlaceSection.tsx: added a "Remove" button next to
+    "+ Add Item" / "Set dates" (hidden when isLocked, same pattern as the others), opening
+    a ConfirmDialog. Confirmation copy mentions the item count when the place has items
+    ("...along with the N items logged under it...") since deletion is meant to cascade.
+  - src/frontend/components/shared/ConfirmDialog.tsx: added optional `error` and
+    `isConfirming`/`confirmingLabel` props (all default to no-op, so ItemCard/ReviewPanel/
+    TripDetail's existing usages are unaffected) so a failed mutation keeps the dialog open
+    and shows why, instead of silently closing on a rejected promise (ItemCard's existing
+    delete-item flow has this same silent-failure gap — not fixed here, out of scope, but
+    worth a follow-up since it's the same shared component).
+  - src/frontend/hooks/usePlaces.ts: useRemovePlace's onSuccess invalidated only
+    ['trips', tripId] — found via live verification that the trip-list sidebar card (DP-01
+    shows place names per card) kept a stale place chip after a successful removal.
+    Fixed to invalidate ['trips'] (bare), matching the convention already used in
+    useTrips.ts (['trips'] is a prefix of ['trips', id], so one call covers both the list
+    and the detail query). Classified MINOR per frameworks.txt severity scale, fixed
+    directly (in-scope: same hook this PR newly wires up for the first time).
+  - New test file: src/frontend/components/TripDetail/__tests__/PlaceSection.test.tsx —
+    7 tests (hidden when locked, visible + opens dialog when unlocked, item-count copy
+    with/without items, cancel doesn't call mutation, confirm calls mutation with right
+    args, failed mutation keeps dialog open + shows error).
+
+VERIFICATION (ran the real app, not just tests)
+  Spun up backend + frontend dev servers with BYPASS_AUTH=true / VITE_BYPASS_AUTH=true on
+  scratch ports (3057/5188, to avoid colliding with any other session's 3001/5173) against
+  a scratch SQLite DB, then drove it with a throwaway Playwright script (not committed):
+    1. Place with 0 items: Remove → confirm → DELETE returns 204, place disappears from
+       trip detail AND (after the invalidation fix) the sidebar trip-list card.
+    2. Place with 1 item: Remove → confirm → DELETE returns 500 "Internal server error".
+       This is the CRITICAL bug below, confirmed live end-to-end (screenshots taken).
+       ConfirmDialog stayed open and showed "Internal server error" instead of silently
+       failing — this is exactly the failure mode the ConfirmDialog error-prop change
+       was built to handle gracefully.
+    3. Locked trip: Remove button correctly absent (locked-trip read-only banner shown,
+       same as every other write control).
+
+OPEN FLAGS FOR COO
+  FLAG-F1 (carried over, unresolved): Item status names in API reference doc don't match
+    Zod schema (see original Phase 1 completion report for details).
+  FLAG-F2 (carried over, unresolved): No standalone GET /api/cities list endpoint exists
+    (not needed currently).
+  FLAG-F3 (NEW, CRITICAL): DELETE /api/trips/:tripId/places/:placeId fails with a 500 when
+    the place has any items attached — items.tripPlaceId has no onDelete cascade in
+    src/backend/db/schema.ts (trip_place_activities.tripPlaceId does). Confirmed both via
+    an isolated @libsql/client script and live through the running app (screenshots).
+    Full bug report: jobs/COO/inbox/20260720_1746-FRONTEND-bug32-blocker-place-delete-fk-cascade.txt
+    Does not block this PR; blocks BUG-32 being fully closed. Recommend routing the schema
+    fix + migration into whichever backend brief is touching this route.
+  FLAG-F4 (NEW, MINOR, informational only — not fixed): ItemCard.tsx's delete-item flow
+    (ConfirmDialog usage) doesn't surface mutation errors — a failed item delete silently
+    closes/does nothing visible. Same class of gap as FLAG-F3's UX side, now that
+    ConfirmDialog supports an error prop it would be a small follow-up to wire it there too.
 
 KEY FILE LOCATIONS
   Entry point:        src/frontend/main.tsx
   Router / layout:   src/frontend/App.tsx
   Pages:             src/frontend/pages/{MapPage,TripsPage,TripDetailPage,AdminPage}.tsx
-  Hooks:             src/frontend/hooks/{useTrips,usePlaces,useItems,useCities,useMapShading,useAdmin}.ts
+  Hooks:             src/frontend/hooks/{useTrips,usePlaces,useItems,useCities,useMapShading,useAdmin,useMe,useGeocodeRetryQueue}.ts
   Types:             src/frontend/types/api.ts
   API client:        src/frontend/utils/apiClient.ts
   URL sanitiser:     src/frontend/utils/urlSanitiser.ts (SEC-12)
-  Date formatter:    src/frontend/utils/formatDate.ts (FIX 1 from P0 session)
+  Date formatter:    src/frontend/utils/formatDate.ts
+  Shared dialogs:    src/frontend/components/shared/{ConfirmDialog,ErrorMessage}.tsx
   Config:            vite.config.ts, tsconfig.frontend.json, index.html
 
-OPEN FLAGS FOR COO
-  FLAG-F1: Item status names in API reference doc don't match Zod schema
-           (see original Phase 1 completion report for details)
-  FLAG-F2: No standalone GET /api/cities list endpoint exists (not needed currently)
-
 NEXT STEPS (when resumed)
-  - Await Tailwind + shadcn/ui migration brief from COO
-  - No other outstanding frontend bugs
+  - Once FLAG-F3 (backend schema fix) merges, re-verify place removal with items attached
+    actually succeeds and cascades — this PR's UI/copy already assumes that will be true.
+  - Consider FLAG-F4 (ItemCard error surfacing) as a small follow-up.
+  - BUG-34 (map standout icon) and other 2026-07-20 UAT bugs are tracked but untouched by
+    this thread.

--- a/jobs/frontend/context/current.txt
+++ b/jobs/frontend/context/current.txt
@@ -22,6 +22,15 @@ WHAT WAS DONE (this thread — BUG-32 / GitHub #156)
     "+ Add Item" / "Set dates" (hidden when isLocked, same pattern as the others), opening
     a ConfirmDialog. Confirmation copy mentions the item count when the place has items
     ("...along with the N items logged under it...") since deletion is meant to cascade.
+    IMPORTANT (learned the hard way): this button intentionally has NO aria-label — an
+    earlier version added `aria-label={`Remove ${place.city.name} from trip`}` and it
+    broke two pre-existing E2E tests (places-items.spec.ts) whose fixture cities are named
+    "EditCity"/"DeleteCity", because Playwright's getByRole name match is substring-based
+    by default and "Remove EditCity from trip" contains "Edit". Caught by PR #170's first
+    CI run, fixed by dropping the aria-label (plain visible text "Remove" is the accessible
+    name, disambiguated from the dialog's own "Remove" button by the dialog being unmounted
+    until opened, not by name). Don't reintroduce a name-based aria-label on this button
+    without checking it against existing E2E fixture names first.
   - src/frontend/components/shared/ConfirmDialog.tsx: added optional `error` and
     `isConfirming`/`confirmingLabel` props (all default to no-op, so ItemCard/ReviewPanel/
     TripDetail's existing usages are unaffected) so a failed mutation keeps the dialog open

--- a/jobs/frontend/park-docs/20260720-FRONTEND-park.txt
+++ b/jobs/frontend/park-docs/20260720-FRONTEND-park.txt
@@ -1,0 +1,160 @@
+FRONTEND PARK DOCUMENT — 2026-07-20
+Thread: BUG-32 (#156) — Remove-place UI
+Branch: fix/bug32-remove-place-ui
+
+============================================================
+SCOPE OF THIS THREAD
+============================================================
+Brief: add a UI affordance to remove a place from a trip (BUG-32 / GitHub #156). Backend
+brief for the same bug was dispatched in parallel on fix/bug32-remove-place-api.
+
+============================================================
+WHAT I FOUND BEFORE WRITING ANY CODE
+============================================================
+Before touching anything I read jobs/backend/tech/20260307-api-reference.md and the actual
+backend source, because the tracker note for BUG-32 said "unclear if a DELETE route exists
+at all." It does:
+  - src/backend/routes/places.ts: DELETE /:placeId, calling placeRepository.delete
+  - src/backend/repositories/places.ts: delete() calls assertWritable (ownership then lock,
+    matching the BUG-27 ordering fix) then deletes the row. 404 if not found/owned, 403 if
+    locked, 204 on success — matches the documented contract exactly.
+  - src/frontend/hooks/usePlaces.ts: useRemovePlace already existed too, calling apiDelete.
+    It was never imported/called anywhere (grep confirmed zero usages before this thread).
+
+So the actual gap was narrower than the tracker note implied: wire the existing hook into
+the existing UI, nothing more, nothing on the backend needed for the happy path. That
+changed my plan from "build defensively against an uncertain contract" to "the contract is
+solid, implement against it directly" — until the FK-cascade issue below showed the "solid"
+read was incomplete for one specific case.
+
+============================================================
+WHAT I BUILT
+============================================================
+1. src/frontend/components/TripDetail/PlaceSection.tsx
+   - "Remove" button in the place-section header, same row as "Set dates"/"+ Add Item",
+     same `!isLocked &&` gating pattern already used for those two.
+   - Opens a ConfirmDialog. Title: "Remove {city}?". Message conditionally mentions the
+     item count when place.items.length > 0 (the documented contract says removal cascades
+     to items, so the copy tells the user that up front).
+   - handleConfirmRemove uses mutate() (not mutateAsync — no need to await in the caller)
+     with a call-level onSuccess that closes the dialog. Reset the mutation's error state
+     both on open (so a stale error from a previous attempt doesn't reappear) and on cancel.
+
+2. src/frontend/components/shared/ConfirmDialog.tsx
+   - Added three optional props: `error` (string | Error | null, rendered via the existing
+     ErrorMessage component), `isConfirming` (disables both buttons), `confirmingLabel`
+     (defaults to `${confirmLabel}…`). All optional with safe defaults — grep confirmed
+     3 other call sites (ItemCard, ReviewPanel, TripDetail) and none pass these props, so
+     none of their behavior changed. Verified via type:check + full test:frontend run.
+   - Motivation: ItemCard's existing delete-item flow calls mutateAsync with no try/catch
+     and doesn't render deleteItem.error anywhere — a failed delete just does nothing
+     visible (the promise rejection is swallowed). I did not want BUG-32's delete-place flow
+     to have the same silent-failure gap, especially once I found the FK-cascade bug below
+     that makes failure the ACTUAL outcome for the majority case (a place with items).
+     I did not change ItemCard.tsx itself — flagged as FLAG-F4, out of this brief's scope.
+
+3. src/frontend/hooks/usePlaces.ts
+   - useRemovePlace's onSuccess invalidated only ['trips', tripId]. Live verification (see
+     below) showed the trip-list sidebar card kept showing the removed place's city chip
+     after a successful delete — DP-01 says trip cards show place names, so this was a
+     real staleness bug, not cosmetic. useTrips.ts's four mutations already invalidate the
+     bare ['trips'] key (which is a prefix of ['trips', id], so it covers the list query
+     AND every mounted detail query) — I made useRemovePlace match that convention.
+     Classified MINOR (frameworks.txt severity scale — functional gap, not a core-workflow
+     break, no data integrity impact, self-contained to display staleness). Fixed directly
+     since it's the exact hook this PR wires up for the first time.
+
+4. src/frontend/components/TripDetail/__tests__/PlaceSection.test.tsx — new, 7 tests.
+   Mocks useRemovePlace (usePlaces.js) and useDeleteItem (useItems.js, ItemCard's
+   dependency, stubbed only so a place-with-items test doesn't need a real QueryClient).
+   Covers: hidden when locked, visible + opens dialog when unlocked, item-count copy with
+   and without items, cancel doesn't call the mutation, confirm calls it with
+   {tripId, placeId}, and a failed mutation keeps the dialog open with the error shown.
+
+============================================================
+CRITICAL BUG FOUND: DELETE fails when the place has items (FLAG-F3)
+============================================================
+While verifying the documented "This also deletes all items and activity tags associated
+with that place (CASCADE)" claim, I found it's only half true:
+
+  - trip_place_activities.trip_place_id → ON DELETE CASCADE (schema.ts, correct)
+  - items.trip_place_id → no onDelete action at all (schema.ts) → migration SQL emits
+    ON DELETE no action
+
+I confirmed @libsql/client enforces `PRAGMA foreign_keys` ON by default (empirically, via
+an isolated script — I did not assume this from reading SQLite's general docs, which
+default it OFF; libSQL's local-file client does not follow that default). So in the real
+running app, deleting a trip_place that still has any item referencing it throws
+SQLITE_CONSTRAINT_FOREIGNKEY, which src/backend/middleware/error-handler.ts turns into a
+generic 500 "Internal server error". No partial state — the whole operation fails
+atomically — but the feature simply does not work for a place with items, which is the
+normal case (a place usually has logged items).
+
+I verified this two ways:
+  1. Isolated node script against a bare @libsql/client table with the same FK shape.
+  2. End-to-end: ran the real backend + frontend (BYPASS_AUTH=true, scratch ports/DB),
+     created a trip → place → item via the API, then clicked "Remove" in the actual
+     rendered UI and confirmed. Network response: 500. Screenshot shows my ConfirmDialog
+     error-prop change doing its job — the dialog stayed open and displayed "Internal
+     server error" instead of silently failing.
+
+Full bug report (root cause, scope, proposed fix) sent to COO:
+  jobs/COO/inbox/20260720_1746-FRONTEND-bug32-blocker-place-delete-fk-cascade.txt
+
+This does NOT block this PR — my UI is correct against the documented/intended contract
+and fails gracefully when the backend doesn't yet deliver on it. It DOES mean BUG-32 can't
+be marked fully closed/UAT'd until the schema gets onDelete:'cascade' on items.tripPlaceId
+plus a migration (my proposed fix, COO/backend to action).
+
+============================================================
+VERIFICATION METHOD (for reproducibility)
+============================================================
+Ran the actual app rather than relying on unit tests alone:
+  - .env.local (scratch, not committed): DB_TYPE=sqlite, SQLITE_PATH to a scratch file,
+    BYPASS_AUTH=true / VITE_BYPASS_AUTH=true, OWNER_CLERK_ID=test_clerk_id (must match the
+    hardcoded bypass clerkId in src/backend/middleware/auth.ts or POST /api/cities 403s —
+    tripped over this once, fixed by matching it).
+  - Backend on PORT=3057, frontend Vite on --port 5188 — deliberately NOT the default
+    3001/5173, because another process was already bound to 3001 (this workspace runs
+    other concurrent sessions; ports are host-wide even though git worktrees are isolated).
+    ALLOWED_ORIGINS updated to include the 5188 origin (CORS, separate from the
+    BYPASS_AUTH JWT skip).
+  - Ad-hoc Playwright script (chromium, not the committed test suite) drove: create
+    trip/city/place/item via API, load the real trip detail page, click Remove, click
+    confirm, screenshot. Repeated for a place with no items (success path) and locked
+    trip (button hidden). Scripts and .env.local deleted before committing — not part of
+    the diff.
+
+============================================================
+BUGS DISCOVERED (frameworks.txt §"Bug tracking" format)
+============================================================
+[CRITICAL] DELETE /api/trips/:tripId/places/:placeId 500s when the place has items
+  (items.tripPlaceId missing onDelete:'cascade') — escalated to COO (FLAG-F3), not fixed
+  by me (schema change is Database/Backend + Architect territory per frameworks.txt §13).
+[MINOR] useRemovePlace's onSuccess missed invalidating the bare ['trips'] list query,
+  leaving a stale place chip on the trip-list sidebar card — fixed directly in this PR.
+[MINOR, not fixed — FLAG-F4] ItemCard's delete-item ConfirmDialog usage doesn't surface
+  mutation errors (silent failure on reject). Noted, not actioned — pre-existing, outside
+  BUG-32's scope, but now trivial to fix given ConfirmDialog supports `error` as of this PR.
+
+============================================================
+CI / CHECKS
+============================================================
+  npm run type:check       — pass
+  npm run lint              — pass (biome, 131 files, no issues)
+  npm run test:frontend     — 106-107/108 pass; 1 pre-existing flaky test in
+    CarryForwardModal.test.tsx ("calls onClose immediately when Skip is clicked") —
+    reproduces on main/baseline too (confirmed via git stash), unrelated to this change,
+    not touched.
+  gh checks on the PR — see completion report for the run status at time of filing.
+
+============================================================
+NEXT STEPS FOR WHOEVER PICKS THIS UP
+============================================================
+  - Once FLAG-F3 is fixed on the backend (onDelete:'cascade' + migration), re-run the same
+    "place with items" verification step above to confirm it now returns 204 and the items
+    are actually gone — this PR's copy already promises that, it just can't be true yet.
+  - FLAG-F4 (ItemCard error surfacing) is a small, low-risk follow-up now that ConfirmDialog
+    supports it.
+  - jobs/frontend/context/current.txt was 4 months stale before this thread — flagged in
+    the updated file itself so the gap isn't silently absorbed into "current state".

--- a/jobs/frontend/park-docs/20260720-FRONTEND-park.txt
+++ b/jobs/frontend/park-docs/20260720-FRONTEND-park.txt
@@ -72,6 +72,51 @@ WHAT I BUILT
    {tripId, placeId}, and a failed mutation keeps the dialog open with the error shown.
 
 ============================================================
+CI CAUGHT A REAL REGRESSION: aria-label collided with two E2E tests
+============================================================
+First push's CI run (PR #170) failed E2E Tests: 2 of 36 specs failed —
+places-items.spec.ts "edit item notes via Edit button" and "delete item with
+confirmation". Both are pre-existing tests I didn't touch. Root cause, found from the
+Playwright report artifact (page snapshot showed MY "Remove EditCity?" dialog open
+instead of the expected Edit/Delete modal):
+
+  My first version gave the Remove button `aria-label={`Remove ${place.city.name} from
+  trip`}` to disambiguate it from the ConfirmDialog's own "Remove" confirm button in my
+  unit tests. Playwright's getByRole name matching is a case-insensitive SUBSTRING match
+  by default (no exact:true) — the two E2E specs' fixture cities are literally named
+  "EditCity" and "DeleteCity" (places-items.spec.ts lines ~86, ~111), so my aria-label
+  became "Remove EditCity from trip" / "Remove DeleteCity from trip", which CONTAINS the
+  substring the tests were searching for ("Edit" / "Delete"). Both tests use
+  `.nth(1)`/`.first()` on that role query expecting to land on the item's own Edit/Delete
+  button — my button, sitting earlier in the DOM (place header, above the item list),
+  won the match instead, opening my dialog rather than theirs.
+
+  Fix: removed the aria-label entirely. The button's accessible name is now just its
+  visible text "Remove" (the `title` attribute is a tooltip only — it doesn't override
+  an element's accessible name when the element already has text content). This is
+  identical to the ConfirmDialog's own confirm-button name, which is fine: the dialog is
+  unmounted until opened, so there's never more than one "Remove"-named button on screen
+  until after the user has already clicked the first one — tests select the trigger by
+  plain name before opening, then scope the confirm click to the dialog container (the
+  same pattern places-items.spec.ts already uses for its own "Delete item?" dialog).
+  Updated PlaceSection.test.tsx to match (dropped the aria-label-based regex query).
+
+  Verification of the fix (couldn't run the official `npm run test:e2e` locally — its
+  playwright.config.ts hardcodes ports 3001/5173 with reuseExistingServer:false, and
+  another concurrent session in this workspace already had 5173 bound; not safe to kill
+  another session's process to free it). Instead: reproduced both scenarios exactly
+  (same fixture city names, same nth(1)/first() selector logic) against the real running
+  app on scratch ports, before and after the fix — confirmed the fix makes both resolve
+  to the correct modal ("Edit Item" heading / "Delete item?" heading), not mine.
+
+  Also caught by this same push: `exact: true` isn't a valid ByRoleOptions field in this
+  project's @testing-library/dom version (10.4.1) — that's a Playwright-locator convention
+  I carried over by mistake into an RTL test file. RTL's getByRole name matching already
+  does exact-string comparison for a plain string (no substring behavior to opt out of,
+  unlike Playwright) — removed `exact: true` from all 7 occurrences; type:check:all caught
+  this immediately, no runtime behavior was ever wrong.
+
+============================================================
 CRITICAL BUG FOUND: DELETE fails when the place has items (FLAG-F3)
 ============================================================
 While verifying the documented "This also deletes all items and activity tags associated
@@ -136,17 +181,35 @@ BUGS DISCOVERED (frameworks.txt §"Bug tracking" format)
 [MINOR, not fixed — FLAG-F4] ItemCard's delete-item ConfirmDialog usage doesn't surface
   mutation errors (silent failure on reject). Noted, not actioned — pre-existing, outside
   BUG-32's scope, but now trivial to fix given ConfirmDialog supports `error` as of this PR.
+[MAJOR — introduced by me, caught by CI, fixed same session] My Remove button's
+  aria-label (built from place.city.name) substring-collided with two pre-existing E2E
+  tests whose fixture cities are named "EditCity"/"DeleteCity", hijacking their
+  nth(1)/first() Edit/Delete clicks into my Remove dialog instead. Initial classification
+  would have been MAJOR had it reached main (breaks two passing E2E specs — a core-workflow
+  regression, not cosmetic) — caught before merge by the PR's own CI run, fixed by dropping
+  the aria-label (visible text "Remove" is sufficient), re-verified live against the exact
+  fixture scenario, and full pre-push suite re-run green. See the CI section above for
+  detail. Also fixed in the same pass: `exact: true` isn't valid on this project's
+  @testing-library/dom ByRoleOptions (Playwright-ism, not RTL) — type:check:all caught it,
+  no runtime impact, removed.
 
 ============================================================
 CI / CHECKS
 ============================================================
-  npm run type:check       — pass
-  npm run lint              — pass (biome, 131 files, no issues)
-  npm run test:frontend     — 106-107/108 pass; 1 pre-existing flaky test in
-    CarryForwardModal.test.tsx ("calls onClose immediately when Skip is clicked") —
-    reproduces on main/baseline too (confirmed via git stash), unrelated to this change,
-    not touched.
-  gh checks on the PR — see completion report for the run status at time of filing.
+  npm run check (biome ci)   — pass, 131 files
+  npm run type:check:all     — pass (frontend + backend)
+  npm run test:backend       — 523 passed, 1 skipped
+  npm run test:frontend      — 108/108 pass on the final run; 1 pre-existing flaky test
+    in CarryForwardModal.test.tsx ("calls onClose immediately when Skip is clicked") was
+    seen intermittently — reproduces on main/baseline too (confirmed via git stash),
+    unrelated to this change, not touched.
+  npm run status:check       — pass, STATUS.md in sync
+  PR #170 CI, first push: E2E Tests failed 2/36 (the aria-label regression above);
+    all 8 other jobs passed. Fixed, re-verified locally against the exact failing
+    scenarios (couldn't run the official E2E harness — port collision with another
+    concurrent session, see the CI section above), then re-ran the full pre-push suite
+    green before pushing the fix commit. See completion report for the second push's
+    gh checks output.
 
 ============================================================
 NEXT STEPS FOR WHOEVER PICKS THIS UP

--- a/jobs/frontend/tech/20260308-frontend-component-reference.md
+++ b/jobs/frontend/tech/20260308-frontend-component-reference.md
@@ -37,7 +37,8 @@ src/frontend/
     ├── shared/
     │   ├── StatusBadge.tsx     ← Coloured pill for trip/item status
     │   ├── RatingStars.tsx     ← 5-star clickable/readonly widget
-    │   ├── ConfirmDialog.tsx   ← Modal confirm overlay
+    │   ├── ConfirmDialog.tsx   ← Modal confirm overlay (BUG-32: optional error/isConfirming
+    │   │                          props — dialog stays open + shows error on a failed mutation)
     │   ├── LoadingSpinner.tsx  ← CSS spin, role="status"
     │   └── ErrorMessage.tsx    ← Red error box, role="alert"
     ├── Map/
@@ -51,7 +52,8 @@ src/frontend/
     ├── TripDetail/
     │   ├── TripDetail.tsx      ← Header, status transitions, PlaceSections
     │   ├── TripForm.tsx        ← Create/edit trip modal
-    │   ├── PlaceSection.tsx    ← Items grouped by city/place
+    │   ├── PlaceSection.tsx    ← Items grouped by city/place (BUG-32: "Remove" button +
+    │   │                          confirm dialog, hidden when trip is locked)
     │   ├── ItemCard.tsx        ← Single item display + edit/delete
     │   ├── ItemForm.tsx        ← Two-step add/edit form (6 item types)
     │   └── AddPlaceFlow.tsx    ← City search → add place → carry-forward check
@@ -81,7 +83,7 @@ src/frontend/
 | useLockTrip() | Mutation | invalidates ['trips', id] | PATCH /api/trips/:id/lock |
 | useUnlockTrip() | Mutation | invalidates ['trips', id] | PATCH /api/trips/:id/unlock |
 | useAddPlace() | Mutation | invalidates ['trips', tripId] | POST /api/trips/:id/places |
-| useRemovePlace() | Mutation | invalidates ['trips', tripId] | DELETE /api/trips/:id/places/:placeId |
+| useRemovePlace() | Mutation | invalidates ['trips'] (BUG-32, PR fix/bug32-remove-place-ui: was ['trips', tripId] only, which missed the trip-list card's stale place chip) | DELETE /api/trips/:id/places/:placeId |
 | useCarryForward() | Mutation | invalidates ['trips', tripId] | POST /api/trips/:id/places/:placeId/carry-forward |
 | useCreateItem() | Mutation | invalidates ['trips', tripId] | POST /api/trips/:id/items |
 | useUpdateItem() | Mutation | invalidates ['trips', tripId] | PATCH /api/trips/:id/items/:itemId |

--- a/src/frontend/components/TripDetail/PlaceSection.tsx
+++ b/src/frontend/components/TripDetail/PlaceSection.tsx
@@ -163,14 +163,26 @@ export function PlaceSection({
           )}
 
           {/* BUG-32: Remove place button (hidden when locked, consistent with the
-              other write controls above) */}
+              other write controls above).
+              Deliberately NOT using an aria-label built from place.city.name here:
+              an earlier version used aria-label={`Remove ${place.city.name} from trip`},
+              which broke two pre-existing E2E tests (places-items.spec.ts) whose fixture
+              cities are named "EditCity" / "DeleteCity" — Playwright's getByRole name
+              matching is a case-insensitive SUBSTRING match by default (no exact:true),
+              so "Remove EditCity from trip" matched name:'Edit' and "Remove DeleteCity
+              from trip" matched name:'Delete', hijacking .nth(1)/.first() clicks meant
+              for the item's own Edit/Delete buttons. The visible text "Remove" is the
+              accessible name here (title is a tooltip only, not a name source when
+              text content is present) — it's identical to the dialog's confirm button,
+              which is intentional and safe: they're never both mounted at once (the
+              dialog is unmounted until opened), so tests select the header button by
+              plain name before opening, then scope the confirm click to the dialog. */}
           {!isLocked && (
             <button
               type="button"
               onClick={handleOpenRemoveConfirm}
               className="px-2.5 py-1.5 border border-red-200 rounded-md bg-red-50 text-xs text-red-600 hover:bg-red-100 cursor-pointer"
               title="Remove this place from the trip"
-              aria-label={`Remove ${place.city.name} from trip`}
             >
               Remove
             </button>

--- a/src/frontend/components/TripDetail/PlaceSection.tsx
+++ b/src/frontend/components/TripDetail/PlaceSection.tsx
@@ -6,14 +6,17 @@
  *         falling back to trip start/end dates.
  *   D-04: Full country name shown in subtitle (joined from countries table — issue #5).
  *   UX-02: Explicit arrived_on / departed_on dates on place; edit dates via PATCH.
+ *   BUG-32: Remove-place affordance — confirmation required, hidden when trip is locked.
  *
  * Shows city name, country, activity tags, date range, and a list of ItemCards.
- * Contains the "Add Item" button (hidden when trip is locked).
+ * Contains the "Add Item" button and the "Remove" button (both hidden when trip is locked).
  */
 import { useState } from 'react';
+import { useRemovePlace } from '../../hooks/usePlaces';
 import type { Item, TripPlace } from '../../types/api';
 import { formatDate } from '../../utils/formatDate';
 import { resolvePlaceDateRange } from '../../utils/resolvePlaceDateRange';
+import { ConfirmDialog } from '../shared/ConfirmDialog';
 import { ItemCard } from './ItemCard';
 import { ItemForm } from './ItemForm';
 import { PlaceDateForm } from './PlaceDateForm';
@@ -61,11 +64,35 @@ export function PlaceSection({
   const [showAddItem, setShowAddItem] = useState(false);
   const [editingItem, setEditingItem] = useState<Item | null>(null);
   const [showEditDates, setShowEditDates] = useState(false);
+  const [showRemoveConfirm, setShowRemoveConfirm] = useState(false);
+
+  const removePlace = useRemovePlace();
 
   const handleEditItem = (item: Item) => setEditingItem(item);
   const handleCloseForm = () => {
     setShowAddItem(false);
     setEditingItem(null);
+  };
+
+  // BUG-32: opens the confirmation dialog and clears any previous attempt's error
+  const handleOpenRemoveConfirm = () => {
+    removePlace.reset();
+    setShowRemoveConfirm(true);
+  };
+
+  const handleCancelRemove = () => {
+    removePlace.reset();
+    setShowRemoveConfirm(false);
+  };
+
+  // Dialog stays open on failure so the user sees why (e.g. the trip locked
+  // between opening the confirm and clicking it, or a backend error) —
+  // it only closes after a confirmed success.
+  const handleConfirmRemove = () => {
+    removePlace.mutate(
+      { tripId, placeId: place.id },
+      { onSuccess: () => setShowRemoveConfirm(false) },
+    );
   };
 
   // UX-02: resolve date range using three-source precedence (ADL-24 §5)
@@ -134,6 +161,20 @@ export function PlaceSection({
               + Add Item
             </button>
           )}
+
+          {/* BUG-32: Remove place button (hidden when locked, consistent with the
+              other write controls above) */}
+          {!isLocked && (
+            <button
+              type="button"
+              onClick={handleOpenRemoveConfirm}
+              className="px-2.5 py-1.5 border border-red-200 rounded-md bg-red-50 text-xs text-red-600 hover:bg-red-100 cursor-pointer"
+              title="Remove this place from the trip"
+              aria-label={`Remove ${place.city.name} from trip`}
+            >
+              Remove
+            </button>
+          )}
         </div>
       </div>
 
@@ -179,6 +220,23 @@ export function PlaceSection({
           onClose={() => setShowEditDates(false)}
         />
       )}
+
+      {/* BUG-32: Remove place confirmation — cascades to items/activity tags server-side */}
+      <ConfirmDialog
+        isOpen={showRemoveConfirm}
+        title={`Remove ${place.city.name}?`}
+        message={
+          place.items.length > 0
+            ? `This permanently removes ${place.city.name} from the trip, along with the ` +
+              `${place.items.length} item${place.items.length === 1 ? '' : 's'} logged under it. This cannot be undone.`
+            : `This permanently removes ${place.city.name} from the trip. This cannot be undone.`
+        }
+        confirmLabel="Remove"
+        onConfirm={handleConfirmRemove}
+        onCancel={handleCancelRemove}
+        error={removePlace.error}
+        isConfirming={removePlace.isPending}
+      />
     </div>
   );
 }

--- a/src/frontend/components/TripDetail/__tests__/PlaceSection.test.tsx
+++ b/src/frontend/components/TripDetail/__tests__/PlaceSection.test.tsx
@@ -132,12 +132,13 @@ describe('PlaceSection — remove place (BUG-32)', () => {
 
   it('shows the Remove button when the trip is unlocked', () => {
     render(<PlaceSection place={makePlace([])} isLocked={false} {...defaultProps} />);
-    expect(screen.getByRole('button', { name: /remove lisbon from trip/i })).toBeInTheDocument();
+    // Dialog is unmounted until opened, so this is the only "Remove"-named button here.
+    expect(screen.getByRole('button', { name: 'Remove' })).toBeInTheDocument();
   });
 
   it('opens a confirmation dialog on click, without mentioning items when there are none', async () => {
     render(<PlaceSection place={makePlace([])} isLocked={false} {...defaultProps} />);
-    await userEvent.click(screen.getByRole('button', { name: /remove lisbon from trip/i }));
+    await userEvent.click(screen.getByRole('button', { name: 'Remove' }));
 
     expect(screen.getByText('Remove Lisbon?')).toBeInTheDocument();
     expect(
@@ -148,14 +149,14 @@ describe('PlaceSection — remove place (BUG-32)', () => {
   it('mentions the item count in the confirmation message when the place has items', async () => {
     const place = makePlace([makeItem({ id: 1 }), makeItem({ id: 2 })]);
     render(<PlaceSection place={place} isLocked={false} {...defaultProps} />);
-    await userEvent.click(screen.getByRole('button', { name: /remove lisbon from trip/i }));
+    await userEvent.click(screen.getByRole('button', { name: 'Remove' }));
 
     expect(screen.getByText(/along with the 2 items logged under it/)).toBeInTheDocument();
   });
 
   it('cancel closes the dialog without calling the mutation', async () => {
     render(<PlaceSection place={makePlace([])} isLocked={false} {...defaultProps} />);
-    await userEvent.click(screen.getByRole('button', { name: /remove lisbon from trip/i }));
+    await userEvent.click(screen.getByRole('button', { name: 'Remove' }));
     await userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
 
     expect(screen.queryByText('Remove Lisbon?')).not.toBeInTheDocument();
@@ -164,7 +165,7 @@ describe('PlaceSection — remove place (BUG-32)', () => {
 
   it('confirm calls the mutation with tripId and placeId', async () => {
     render(<PlaceSection place={makePlace([])} isLocked={false} {...defaultProps} />);
-    await userEvent.click(screen.getByRole('button', { name: /remove lisbon from trip/i }));
+    await userEvent.click(screen.getByRole('button', { name: 'Remove' }));
 
     // Two "Remove" buttons now exist (row button + dialog confirm) — the dialog's
     // is scoped inside the modal, found via its distinct accessible role ordering.
@@ -180,7 +181,7 @@ describe('PlaceSection — remove place (BUG-32)', () => {
   it('keeps the dialog open and shows the error when the mutation fails', async () => {
     mockRemovePlace.error = new Error('Internal server error');
     render(<PlaceSection place={makePlace([])} isLocked={false} {...defaultProps} />);
-    await userEvent.click(screen.getByRole('button', { name: /remove lisbon from trip/i }));
+    await userEvent.click(screen.getByRole('button', { name: 'Remove' }));
 
     await waitFor(() => {
       expect(screen.getByText('Internal server error')).toBeInTheDocument();

--- a/src/frontend/components/TripDetail/__tests__/PlaceSection.test.tsx
+++ b/src/frontend/components/TripDetail/__tests__/PlaceSection.test.tsx
@@ -1,0 +1,190 @@
+/**
+ * Scenario tests for PlaceSection's remove-place affordance (BUG-32).
+ *
+ * Mocks:
+ *   - useRemovePlace() from hooks/usePlaces — controls mutation state
+ *   - useDeleteItem() from hooks/useItems — ItemCard's dependency, stubbed so
+ *     rendering a place with items doesn't require a real QueryClient
+ *
+ * Covers:
+ *   - Remove button hidden when trip is locked
+ *   - Remove button visible + opens confirmation dialog when unlocked
+ *   - Confirmation copy mentions cascading item removal when the place has items
+ *   - Confirmation copy omits item count when the place has none
+ *   - Cancel closes the dialog without calling the mutation
+ *   - Confirm calls the mutation with the right args; success closes the dialog
+ *   - A failed mutation keeps the dialog open and surfaces the error message
+ *
+ * Source: src/frontend/components/TripDetail/PlaceSection.tsx
+ */
+
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Item, TripPlace } from '../../../types/api.js';
+import { PlaceSection } from '../PlaceSection.js';
+
+// ----------------------------------------------------------------
+// Mock hooks
+// ----------------------------------------------------------------
+
+const mockMutate = vi.fn();
+const mockRemovePlace = {
+  mutate: mockMutate,
+  isPending: false,
+  error: null as string | Error | null,
+  reset: vi.fn(),
+};
+
+vi.mock('../../../hooks/usePlaces.js', () => ({
+  useRemovePlace: () => mockRemovePlace,
+}));
+
+// ItemCard (rendered per item) depends on useDeleteItem — stub it so tests that
+// include items don't need a real QueryClient wired up.
+vi.mock('../../../hooks/useItems.js', () => ({
+  useDeleteItem: () => ({ mutateAsync: vi.fn(), isPending: false, error: null }),
+}));
+
+// ----------------------------------------------------------------
+// Test data builders
+// ----------------------------------------------------------------
+
+function makeItem(overrides: Partial<Item> = {}): Item {
+  return {
+    id: Math.floor(Math.random() * 10000),
+    trip_place_id: 1,
+    item_type: 'restaurant',
+    status: 'consider',
+    notes: null,
+    name: 'Test Restaurant',
+    neighbourhood_area: null,
+    cuisine_type: null,
+    source: null,
+    property_name: null,
+    address: null,
+    check_in_date: null,
+    check_out_date: null,
+    booking_reference: null,
+    confirmation_number: null,
+    airline: null,
+    flight_number: null,
+    departure_airport: null,
+    arrival_airport: null,
+    departure_datetime: null,
+    arrival_datetime: null,
+    seat: null,
+    provider: null,
+    pickup_location: null,
+    dropoff_location: null,
+    pickup_datetime: null,
+    dropoff_datetime: null,
+    vehicle_class: null,
+    rating: null,
+    post_visit_notes: null,
+    is_carried_forward: false,
+    carried_from_item_id: null,
+    created_at: '2024-01-01T00:00:00Z',
+    updated_at: '2024-01-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+function makePlace(items: Item[], overrides: Partial<TripPlace> = {}): TripPlace {
+  return {
+    id: 1,
+    city_id: 5,
+    activities: [],
+    city: {
+      id: 5,
+      name: 'Lisbon',
+      country_code: 'PT',
+      country_name: 'Portugal',
+      region_id: null,
+      region_iso: null,
+      latitude: null,
+      longitude: null,
+      geocode_status: 'pending' as const,
+    },
+    items,
+    created_at: '2024-01-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+const defaultProps = {
+  tripId: 10,
+  tripStartDate: '2024-04-01',
+  tripEndDate: '2024-04-14',
+};
+
+describe('PlaceSection — remove place (BUG-32)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRemovePlace.isPending = false;
+    mockRemovePlace.error = null;
+  });
+
+  it('hides the Remove button when the trip is locked', () => {
+    render(<PlaceSection place={makePlace([])} isLocked={true} {...defaultProps} />);
+    expect(screen.queryByRole('button', { name: /remove/i })).not.toBeInTheDocument();
+  });
+
+  it('shows the Remove button when the trip is unlocked', () => {
+    render(<PlaceSection place={makePlace([])} isLocked={false} {...defaultProps} />);
+    expect(screen.getByRole('button', { name: /remove lisbon from trip/i })).toBeInTheDocument();
+  });
+
+  it('opens a confirmation dialog on click, without mentioning items when there are none', async () => {
+    render(<PlaceSection place={makePlace([])} isLocked={false} {...defaultProps} />);
+    await userEvent.click(screen.getByRole('button', { name: /remove lisbon from trip/i }));
+
+    expect(screen.getByText('Remove Lisbon?')).toBeInTheDocument();
+    expect(
+      screen.getByText('This permanently removes Lisbon from the trip. This cannot be undone.'),
+    ).toBeInTheDocument();
+  });
+
+  it('mentions the item count in the confirmation message when the place has items', async () => {
+    const place = makePlace([makeItem({ id: 1 }), makeItem({ id: 2 })]);
+    render(<PlaceSection place={place} isLocked={false} {...defaultProps} />);
+    await userEvent.click(screen.getByRole('button', { name: /remove lisbon from trip/i }));
+
+    expect(screen.getByText(/along with the 2 items logged under it/)).toBeInTheDocument();
+  });
+
+  it('cancel closes the dialog without calling the mutation', async () => {
+    render(<PlaceSection place={makePlace([])} isLocked={false} {...defaultProps} />);
+    await userEvent.click(screen.getByRole('button', { name: /remove lisbon from trip/i }));
+    await userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(screen.queryByText('Remove Lisbon?')).not.toBeInTheDocument();
+    expect(mockMutate).not.toHaveBeenCalled();
+  });
+
+  it('confirm calls the mutation with tripId and placeId', async () => {
+    render(<PlaceSection place={makePlace([])} isLocked={false} {...defaultProps} />);
+    await userEvent.click(screen.getByRole('button', { name: /remove lisbon from trip/i }));
+
+    // Two "Remove" buttons now exist (row button + dialog confirm) — the dialog's
+    // is scoped inside the modal, found via its distinct accessible role ordering.
+    const removeButtons = screen.getAllByRole('button', { name: 'Remove' });
+    await userEvent.click(removeButtons[removeButtons.length - 1]);
+
+    expect(mockMutate).toHaveBeenCalledWith(
+      { tripId: 10, placeId: 1 },
+      expect.objectContaining({ onSuccess: expect.any(Function) }),
+    );
+  });
+
+  it('keeps the dialog open and shows the error when the mutation fails', async () => {
+    mockRemovePlace.error = new Error('Internal server error');
+    render(<PlaceSection place={makePlace([])} isLocked={false} {...defaultProps} />);
+    await userEvent.click(screen.getByRole('button', { name: /remove lisbon from trip/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Internal server error')).toBeInTheDocument();
+    });
+    expect(screen.getByText('Remove Lisbon?')).toBeInTheDocument();
+  });
+});

--- a/src/frontend/components/shared/ConfirmDialog.tsx
+++ b/src/frontend/components/shared/ConfirmDialog.tsx
@@ -1,3 +1,5 @@
+import { ErrorMessage } from './ErrorMessage';
+
 interface ConfirmDialogProps {
   /** Whether the dialog is visible. */
   isOpen: boolean;
@@ -13,6 +15,19 @@ interface ConfirmDialogProps {
   onConfirm: () => void;
   /** Called when the user clicks cancel or the backdrop. */
   onCancel: () => void;
+  /**
+   * Optional error to render below the message (e.g. a failed mutation).
+   * When set, the dialog stays open so the user sees why the action failed
+   * instead of the dialog silently closing on a rejected promise.
+   */
+  error?: string | Error | null;
+  /**
+   * When true, disables both buttons (action in flight) — prevents a
+   * double-submit while the mutation is pending.
+   */
+  isConfirming?: boolean;
+  /** Confirm-button label while isConfirming is true (default: confirmLabel + "…"). */
+  confirmingLabel?: string;
 }
 
 /**
@@ -26,6 +41,9 @@ export function ConfirmDialog({
   cancelLabel = 'Cancel',
   onConfirm,
   onCancel,
+  error,
+  isConfirming = false,
+  confirmingLabel,
 }: ConfirmDialogProps) {
   if (!isOpen) return null;
 
@@ -40,20 +58,27 @@ export function ConfirmDialog({
       >
         <h3 className="m-0 mb-3 text-base font-semibold text-gray-900">{title}</h3>
         <p className="m-0 text-gray-600 leading-relaxed text-sm">{message}</p>
+        {error && (
+          <div className="mt-3">
+            <ErrorMessage error={error} />
+          </div>
+        )}
         <div className="flex gap-3 justify-end mt-5">
           <button
             type="button"
             onClick={onCancel}
-            className="px-4 py-2 border border-gray-300 rounded-md bg-white text-sm text-gray-700 hover:bg-gray-50 cursor-pointer"
+            disabled={isConfirming}
+            className="px-4 py-2 border border-gray-300 rounded-md bg-white text-sm text-gray-700 hover:bg-gray-50 disabled:opacity-60 cursor-pointer"
           >
             {cancelLabel}
           </button>
           <button
             type="button"
             onClick={onConfirm}
-            className="px-4 py-2 border-none rounded-md bg-red-600 text-white text-sm font-semibold hover:bg-red-700 cursor-pointer"
+            disabled={isConfirming}
+            className="px-4 py-2 border-none rounded-md bg-red-600 text-white text-sm font-semibold hover:bg-red-700 disabled:opacity-60 cursor-pointer"
           >
-            {confirmLabel}
+            {isConfirming ? (confirmingLabel ?? `${confirmLabel}…`) : confirmLabel}
           </button>
         </div>
       </div>

--- a/src/frontend/hooks/usePlaces.ts
+++ b/src/frontend/hooks/usePlaces.ts
@@ -69,7 +69,12 @@ export function useAddPlace() {
 
 /**
  * Removes a place from a trip via DELETE /api/trips/:tripId/places/:placeId.
- * On success, invalidates the trip detail query.
+ * On success, invalidates the trip detail query and the trip list query — a
+ * trip card shows the names of its places (DP-01), so removing one must
+ * refresh both, not just the detail view (BUG-32 verification caught the
+ * trip-list card holding a stale place chip when only ['trips', tripId] was
+ * invalidated; ['trips'] alone already covers both per useTrips.ts's
+ * established convention, since ['trips', tripId] is a suffix of it).
  *
  * @returns useMutation result. Call mutateAsync({ tripId, placeId }) to submit.
  */
@@ -78,8 +83,8 @@ export function useRemovePlace() {
   return useMutation({
     mutationFn: ({ tripId, placeId }: { tripId: number; placeId: number }) =>
       apiDelete(`/api/trips/${tripId}/places/${placeId}`),
-    onSuccess: (_result, vars) => {
-      void qc.invalidateQueries({ queryKey: ['trips', vars.tripId] });
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: ['trips'] });
       void qc.invalidateQueries({ queryKey: ['map', 'shading'] });
     },
   });


### PR DESCRIPTION
Closes #156

## Summary
- The DELETE /api/trips/:tripId/places/:placeId route and the useRemovePlace hook already existed but were never wired to any UI control — this PR adds the missing "Remove" button to PlaceSection.tsx, gated behind a confirmation dialog and hidden when the trip is locked (same pattern as "Set dates"/"+ Add Item").
- ConfirmDialog (src/frontend/components/shared/ConfirmDialog.tsx) gains optional `error`/`isConfirming`/`confirmingLabel` props (default no-op — existing 3 call sites unaffected) so a failed removal keeps the dialog open and shows why, instead of silently closing.
- useRemovePlace's onSuccess now invalidates the bare `['trips']` query (was `['trips', tripId]` only) to match useTrips.ts's established convention — live verification showed the trip-list sidebar card kept a stale place chip otherwise (DP-01: cards show place names).

## CRITICAL backend bug found during verification (does not block this PR)
While verifying the documented "removal cascades to items" behavior, I found `items.trip_place_id` has no `onDelete: 'cascade'` in `src/backend/db/schema.ts` (unlike `trip_place_activities.trip_place_id`, which is correct). Confirmed both via an isolated `@libsql/client` script and live through the running app: deleting a place that still has any item attached throws `SQLITE_CONSTRAINT_FOREIGNKEY`, surfaced as a generic 500. Full report sent to COO: `jobs/COO/inbox/20260720_1746-FRONTEND-bug32-blocker-place-delete-fk-cascade.txt`. My UI handles this gracefully (dialog stays open, shows the error) but BUG-32 can't be fully closed/UAT'd until the schema gets the cascade + a migration.

BRD: no dedicated requirement ID (tracker BUG-32 has empty brdRefs — this is a bug fix, not a new requirement).

## Test plan
- [x] `npm run type:check:all` — pass
- [x] `npm run lint` / `npm run check` — pass
- [x] `npm run test:backend` — 523 passed, 1 skipped
- [x] `npm run test:frontend` — 108/108 passed (new PlaceSection.test.tsx: 7 tests)
- [x] Live-verified against the running app (BYPASS_AUTH, scratch ports/DB, ad-hoc Playwright script — not committed): place-with-items delete surfaces the FK-cascade 500 gracefully; place-with-no-items delete succeeds (204) and disappears from both the trip detail and the trip-list sidebar; Remove button correctly hidden on a locked trip.