### PR TITLE
fix(BUG-36): trip-level Add Item entry point for Flight/Car Rental (#160)

### DIFF
--- a/src/frontend/components/TripDetail/ItemForm.tsx
+++ b/src/frontend/components/TripDetail/ItemForm.tsx
@@ -26,6 +26,13 @@ interface ItemFormProps {
   tripPlaceId: number | null;
   /** When set, the form is in edit mode and pre-populated. */
   existingItem?: Item;
+  /**
+   * Restricts the Step 1 type picker to a subset of item types (create only).
+   * Defaults to all 6 types. BUG-36: the trip-level entry point passes
+   * ['flight', 'car_rental'] — restaurant/hotel/experience are inherently
+   * tied to a specific city and don't make sense without a place.
+   */
+  allowedTypes?: ItemType[];
   /** Called when the modal should close. */
   onClose: () => void;
 }
@@ -100,10 +107,20 @@ void fieldLabel;
  * @param tripId - Parent trip ID.
  * @param tripPlaceId - Parent place ID (null for trip-level items).
  * @param existingItem - Pre-populates form when editing.
+ * @param allowedTypes - Restricts the Step 1 type picker (create only). Defaults to all types.
  * @param onClose - Called on success or cancel.
  */
-export function ItemForm({ tripId, tripPlaceId, existingItem, onClose }: ItemFormProps) {
+export function ItemForm({
+  tripId,
+  tripPlaceId,
+  existingItem,
+  allowedTypes,
+  onClose,
+}: ItemFormProps) {
   const isEditing = !!existingItem;
+  const selectableTypes = allowedTypes
+    ? ITEM_TYPES.filter((t) => allowedTypes.includes(t.value))
+    : ITEM_TYPES;
 
   const [itemType, setItemType] = useState<ItemType | null>(existingItem?.item_type ?? null);
   const [status, setStatus] = useState<ItemStatus>(existingItem?.status ?? 'consider');
@@ -265,7 +282,7 @@ export function ItemForm({ tripId, tripPlaceId, existingItem, onClose }: ItemFor
             <div>
               <p className="m-0 mb-3.5 text-sm text-gray-600">Select item type:</p>
               <div className="grid grid-cols-3 gap-2.5">
-                {ITEM_TYPES.map((t) => (
+                {selectableTypes.map((t) => (
                   <button
                     key={t.value}
                     type="button"

--- a/src/frontend/components/TripDetail/TripDetail.tsx
+++ b/src/frontend/components/TripDetail/TripDetail.tsx
@@ -21,6 +21,7 @@ import { StatusBadge } from '../shared/StatusBadge';
 import { AddPlaceFlow } from './AddPlaceFlow';
 import { PlaceSection } from './PlaceSection';
 import { TripForm } from './TripForm';
+import { TripItemsSection } from './TripItemsSection';
 
 interface TripDetailProps {
   /** Full trip detail data including places and items. */
@@ -225,6 +226,11 @@ export function TripDetail({ trip }: TripDetailProps) {
         )}
 
         {statusError && <ErrorMessage error={statusError} />}
+
+        {/* Trip-level items (BUG-36/IT-01) — flights and car rentals that aren't
+            tied to a specific place. Rendered above Places since transport
+            typically bookends the trip. */}
+        <TripItemsSection tripId={trip.id} isLocked={isLocked} />
 
         {/* Places — sorted by arrived_on ascending, nulls last (UX-02 / ADL-24) */}
         <div className="mb-4">

--- a/src/frontend/components/TripDetail/TripItemsSection.tsx
+++ b/src/frontend/components/TripDetail/TripItemsSection.tsx
@@ -1,0 +1,117 @@
+/**
+ * TripItemsSection — trip-level items (no associated place) within a TripDetail.
+ *
+ * BUG-36 / IT-01: flights (and car rentals, per PO decision) are trip-wide —
+ * they don't belong to one city, so they shouldn't be forced into a
+ * PlaceSection. This mirrors PlaceSection's header + item-list + "+ Add Item"
+ * pattern for consistency, restricted to the Flight and Car Rental item
+ * types (the trip-level-appropriate subset — Restaurant/Hotel/Experience
+ * are inherently tied to a specific city and stay under PlaceSection).
+ *
+ * Data comes from useTripLevelItems, which reads GET /api/trips/:tripId/items
+ * (unfiltered) rather than the nested GET /api/trips/:id response — the
+ * latter currently drops trip-level items from its `places[].items` shape
+ * entirely (see useItems.ts for the flagged backend contract gap).
+ */
+import { useState } from 'react';
+import { useTripLevelItems } from '../../hooks/useItems';
+import type { Item, ItemType } from '../../types/api';
+import { ErrorMessage } from '../shared/ErrorMessage';
+import { ItemCard } from './ItemCard';
+import { ItemForm } from './ItemForm';
+
+interface TripItemsSectionProps {
+  /** Parent trip ID. */
+  tripId: number;
+  /** When true, all edit/delete/add controls are hidden. */
+  isLocked: boolean;
+}
+
+/** Item types offered at trip level — see module doc for rationale. */
+const TRIP_LEVEL_ITEM_TYPES: ItemType[] = ['flight', 'car_rental'];
+
+/**
+ * Renders the trip-level items section, including its own "+ Add Item" entry
+ * point restricted to Flight and Car Rental.
+ *
+ * @param tripId - Parent trip ID for item queries/mutations.
+ * @param isLocked - When true, hides all write controls.
+ */
+export function TripItemsSection({ tripId, isLocked }: TripItemsSectionProps) {
+  const { data: items = [], isLoading, error } = useTripLevelItems(tripId);
+  const [showAddItem, setShowAddItem] = useState(false);
+  const [editingItem, setEditingItem] = useState<Item | null>(null);
+
+  const handleEditItem = (item: Item) => setEditingItem(item);
+  const handleCloseForm = () => {
+    setShowAddItem(false);
+    setEditingItem(null);
+  };
+
+  // Nothing to add and nothing to show — don't render an empty box.
+  if (!isLoading && !error && items.length === 0 && isLocked) return null;
+
+  return (
+    <div
+      className="border border-gray-200 rounded-lg overflow-hidden mb-4 shadow-sm"
+      data-testid="trip-items-section"
+    >
+      {/* Section header */}
+      <div className="bg-gray-100 px-4 py-3 flex justify-between items-center border-b border-gray-200">
+        <span className="font-semibold text-sm text-gray-900">Trip Items</span>
+
+        {!isLocked && (
+          <button
+            type="button"
+            onClick={() => setShowAddItem(true)}
+            className="px-3.5 py-1.5 bg-teal-600 text-white text-xs font-medium rounded-md hover:bg-teal-700 cursor-pointer"
+          >
+            + Add Item
+          </button>
+        )}
+      </div>
+
+      {/* Items list */}
+      <div className="px-4 py-3 flex flex-col gap-2">
+        {isLoading && <p className="text-gray-400 text-xs m-0">Loading trip items…</p>}
+        {error && <ErrorMessage error={error} />}
+        {!isLoading && !error && items.length === 0 && (
+          <p className="text-gray-400 text-xs m-0">
+            No trip-level items yet. Use "+ Add Item" for a flight or car rental that isn't tied to
+            a specific city.
+          </p>
+        )}
+        {items.map((item) => (
+          <ItemCard
+            key={item.id}
+            item={item}
+            tripId={tripId}
+            isLocked={isLocked}
+            onEdit={handleEditItem}
+          />
+        ))}
+      </div>
+
+      {/* Add item modal — restricted to trip-level-appropriate types */}
+      {showAddItem && (
+        <ItemForm
+          tripId={tripId}
+          tripPlaceId={null}
+          allowedTypes={TRIP_LEVEL_ITEM_TYPES}
+          onClose={handleCloseForm}
+        />
+      )}
+
+      {/* Edit item modal */}
+      {editingItem && (
+        <ItemForm
+          tripId={tripId}
+          tripPlaceId={null}
+          existingItem={editingItem}
+          allowedTypes={TRIP_LEVEL_ITEM_TYPES}
+          onClose={handleCloseForm}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/frontend/components/TripDetail/TripItemsSection.tsx
+++ b/src/frontend/components/TripDetail/TripItemsSection.tsx
@@ -3,10 +3,18 @@
  *
  * BUG-36 / IT-01: flights (and car rentals, per PO decision) are trip-wide —
  * they don't belong to one city, so they shouldn't be forced into a
- * PlaceSection. This mirrors PlaceSection's header + item-list + "+ Add Item"
+ * PlaceSection. This mirrors PlaceSection's header + item-list + Add Item
  * pattern for consistency, restricted to the Flight and Car Rental item
  * types (the trip-level-appropriate subset — Restaurant/Hotel/Experience
  * are inherently tied to a specific city and stay under PlaceSection).
+ *
+ * The trigger button is labelled "+ Add Trip Item", not "+ Add Item" —
+ * deliberately distinct from PlaceSection's per-place "+ Add Item" button.
+ * Two buttons sharing one accessible name on the same page is itself a
+ * usability smell (ambiguous for screen-reader users tabbing through, and
+ * exactly what broke `.first()` in the pre-existing places-items.spec.ts
+ * E2E tests once this section started rendering above the Places list —
+ * the label collision, not the DOM position, was the real defect).
  *
  * Data comes from useTripLevelItems, which reads GET /api/trips/:tripId/items
  * (unfiltered) rather than the nested GET /api/trips/:id response — the
@@ -31,8 +39,8 @@ interface TripItemsSectionProps {
 const TRIP_LEVEL_ITEM_TYPES: ItemType[] = ['flight', 'car_rental'];
 
 /**
- * Renders the trip-level items section, including its own "+ Add Item" entry
- * point restricted to Flight and Car Rental.
+ * Renders the trip-level items section, including its own "+ Add Trip Item"
+ * entry point restricted to Flight and Car Rental.
  *
  * @param tripId - Parent trip ID for item queries/mutations.
  * @param isLocked - When true, hides all write controls.
@@ -66,7 +74,7 @@ export function TripItemsSection({ tripId, isLocked }: TripItemsSectionProps) {
             onClick={() => setShowAddItem(true)}
             className="px-3.5 py-1.5 bg-teal-600 text-white text-xs font-medium rounded-md hover:bg-teal-700 cursor-pointer"
           >
-            + Add Item
+            + Add Trip Item
           </button>
         )}
       </div>
@@ -77,8 +85,8 @@ export function TripItemsSection({ tripId, isLocked }: TripItemsSectionProps) {
         {error && <ErrorMessage error={error} />}
         {!isLoading && !error && items.length === 0 && (
           <p className="text-gray-400 text-xs m-0">
-            No trip-level items yet. Use "+ Add Item" for a flight or car rental that isn't tied to
-            a specific city.
+            No trip-level items yet. Use "+ Add Trip Item" for a flight or car rental that isn't
+            tied to a specific city.
           </p>
         )}
         {items.map((item) => (

--- a/src/frontend/components/TripDetail/__tests__/TripItemsSection.test.tsx
+++ b/src/frontend/components/TripDetail/__tests__/TripItemsSection.test.tsx
@@ -1,0 +1,126 @@
+/**
+ * Tests for TripItemsSection (BUG-36 / IT-01).
+ *
+ * Mocks:
+ *   - useTripLevelItems / useCreateItem / useUpdateItem / useDeleteItem from hooks/useItems
+ *
+ * Covers:
+ *   - Renders trip-level items with an ItemCard each.
+ *   - Empty state prompts the user to add a flight or car rental.
+ *   - "+ Add Item" opens ItemForm restricted to Flight and Car Rental only
+ *     (no Restaurant/Hotel/Experience/Note options at trip level).
+ *   - Locked trips hide the add button; an empty+locked trip renders nothing.
+ *
+ * Source: src/frontend/components/TripDetail/TripItemsSection.tsx
+ */
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import type { Item } from '../../../types/api.js';
+import { TripItemsSection } from '../TripItemsSection.js';
+
+const mockUseTripLevelItems = vi.fn();
+const mockUseCreateItem = vi.fn();
+const mockUseUpdateItem = vi.fn();
+const mockUseDeleteItem = vi.fn();
+
+vi.mock('../../../hooks/useItems.js', () => ({
+  useTripLevelItems: () => mockUseTripLevelItems(),
+  useCreateItem: () => mockUseCreateItem(),
+  useUpdateItem: () => mockUseUpdateItem(),
+  useDeleteItem: () => mockUseDeleteItem(),
+}));
+
+function makeFlight(overrides: Partial<Item> = {}): Item {
+  return {
+    id: 1,
+    item_type: 'flight',
+    status: 'confirmed',
+    notes: null,
+    is_carried_forward: false,
+    carried_from_item_id: null,
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+    trip_place_id: null,
+    airline: 'Test Air',
+    flight_number: 'TA123',
+    departure_airport: 'LHR',
+    arrival_airport: 'JFK',
+    ...overrides,
+  } as Item;
+}
+
+const idleMutation = { mutateAsync: vi.fn(), isPending: false, error: null };
+
+describe('TripItemsSection', () => {
+  it('renders one ItemCard per trip-level item', () => {
+    mockUseTripLevelItems.mockReturnValue({
+      data: [makeFlight({ id: 1 }), makeFlight({ id: 2, item_type: 'car_rental' })],
+      isLoading: false,
+      error: null,
+    });
+    mockUseCreateItem.mockReturnValue(idleMutation);
+    mockUseUpdateItem.mockReturnValue(idleMutation);
+    mockUseDeleteItem.mockReturnValue(idleMutation);
+
+    render(<TripItemsSection tripId={1} isLocked={false} />);
+
+    expect(screen.getByText('LHR → JFK')).toBeInTheDocument();
+    expect(screen.getByText('Trip Items')).toBeInTheDocument();
+  });
+
+  it('shows an empty-state prompt when there are no trip-level items', () => {
+    mockUseTripLevelItems.mockReturnValue({ data: [], isLoading: false, error: null });
+    mockUseCreateItem.mockReturnValue(idleMutation);
+    mockUseUpdateItem.mockReturnValue(idleMutation);
+    mockUseDeleteItem.mockReturnValue(idleMutation);
+
+    render(<TripItemsSection tripId={1} isLocked={false} />);
+
+    expect(screen.getByText(/No trip-level items yet/)).toBeInTheDocument();
+  });
+
+  it('restricts the Add Item type picker to Flight and Car Rental only', async () => {
+    mockUseTripLevelItems.mockReturnValue({ data: [], isLoading: false, error: null });
+    mockUseCreateItem.mockReturnValue(idleMutation);
+    mockUseUpdateItem.mockReturnValue(idleMutation);
+    mockUseDeleteItem.mockReturnValue(idleMutation);
+
+    render(<TripItemsSection tripId={1} isLocked={false} />);
+    await userEvent.click(screen.getByText('+ Add Item'));
+
+    expect(screen.getByText('Flight')).toBeInTheDocument();
+    expect(screen.getByText('Car Rental')).toBeInTheDocument();
+    expect(screen.queryByText('Restaurant')).not.toBeInTheDocument();
+    expect(screen.queryByText('Hotel')).not.toBeInTheDocument();
+    expect(screen.queryByText('Experience')).not.toBeInTheDocument();
+    expect(screen.queryByText('Note')).not.toBeInTheDocument();
+  });
+
+  it('hides the Add Item button when the trip is locked', () => {
+    mockUseTripLevelItems.mockReturnValue({
+      data: [makeFlight()],
+      isLoading: false,
+      error: null,
+    });
+    mockUseCreateItem.mockReturnValue(idleMutation);
+    mockUseUpdateItem.mockReturnValue(idleMutation);
+    mockUseDeleteItem.mockReturnValue(idleMutation);
+
+    render(<TripItemsSection tripId={1} isLocked={true} />);
+
+    expect(screen.queryByText('+ Add Item')).not.toBeInTheDocument();
+  });
+
+  it('renders nothing when locked with no trip-level items', () => {
+    mockUseTripLevelItems.mockReturnValue({ data: [], isLoading: false, error: null });
+    mockUseCreateItem.mockReturnValue(idleMutation);
+    mockUseUpdateItem.mockReturnValue(idleMutation);
+    mockUseDeleteItem.mockReturnValue(idleMutation);
+
+    const { container } = render(<TripItemsSection tripId={1} isLocked={true} />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/src/frontend/components/TripDetail/__tests__/TripItemsSection.test.tsx
+++ b/src/frontend/components/TripDetail/__tests__/TripItemsSection.test.tsx
@@ -7,8 +7,10 @@
  * Covers:
  *   - Renders trip-level items with an ItemCard each.
  *   - Empty state prompts the user to add a flight or car rental.
- *   - "+ Add Item" opens ItemForm restricted to Flight and Car Rental only
- *     (no Restaurant/Hotel/Experience/Note options at trip level).
+ *   - "+ Add Trip Item" opens ItemForm restricted to Flight and Car Rental only
+ *     (no Restaurant/Hotel/Experience/Note options at trip level). Labelled
+ *     distinctly from PlaceSection's "+ Add Item" so the two never collide
+ *     under an accessible-name query (see TripItemsSection.tsx module doc).
  *   - Locked trips hide the add button; an empty+locked trip renders nothing.
  *
  * Source: src/frontend/components/TripDetail/TripItemsSection.tsx
@@ -88,7 +90,7 @@ describe('TripItemsSection', () => {
     mockUseDeleteItem.mockReturnValue(idleMutation);
 
     render(<TripItemsSection tripId={1} isLocked={false} />);
-    await userEvent.click(screen.getByText('+ Add Item'));
+    await userEvent.click(screen.getByText('+ Add Trip Item'));
 
     expect(screen.getByText('Flight')).toBeInTheDocument();
     expect(screen.getByText('Car Rental')).toBeInTheDocument();
@@ -110,7 +112,7 @@ describe('TripItemsSection', () => {
 
     render(<TripItemsSection tripId={1} isLocked={true} />);
 
-    expect(screen.queryByText('+ Add Item')).not.toBeInTheDocument();
+    expect(screen.queryByText('+ Add Trip Item')).not.toBeInTheDocument();
   });
 
   it('renders nothing when locked with no trip-level items', () => {

--- a/src/frontend/hooks/useItems.ts
+++ b/src/frontend/hooks/useItems.ts
@@ -3,9 +3,9 @@
  *
  * Handles creating, updating, and deleting items of all types.
  */
-import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import type { Item, ItemStatus, ItemType } from '../types/api';
-import { apiDelete, apiPatch, apiPost } from '../utils/apiClient';
+import { apiDelete, apiGet, apiPatch, apiPost } from '../utils/apiClient';
 
 /** Body for POST /api/trips/:tripId/items */
 export interface CreateItemData {
@@ -49,6 +49,43 @@ export type UpdateItemData = Partial<
     post_visit_notes?: string | null;
   }
 >;
+
+// ============================================================
+// QUERIES
+// ============================================================
+
+/**
+ * Fetches trip-level items (items with no associated place, trip_place_id
+ * IS NULL) for a trip — BUG-36 / IT-01.
+ *
+ * GET /api/trips/:tripId/items (unfiltered) returns every item on the trip
+ * including trip-level ones; the nested GET /api/trips/:id response used to
+ * hydrate TripDetail only surfaces items nested under `places[].items` and
+ * currently drops trip-level items entirely (see src/backend/routes/trips.ts
+ * buildTripResponse / the `/:id` handler — `allItems` is filtered per-place
+ * with no branch for trip_place_id === null). Flagged to Backend/COO as a
+ * contract gap; this hook works around it using the flat items endpoint,
+ * which already returns the full set correctly, so trip-level items are
+ * visible today without waiting on that fix.
+ *
+ * Query key is nested under ['trips', tripId, ...] so the existing
+ * invalidation in useCreateItem/useUpdateItem/useDeleteItem (which
+ * invalidates ['trips', tripId] with the default fuzzy/prefix match)
+ * refreshes this list too — no changes needed to those mutations.
+ *
+ * @param tripId - Parent trip ID. Pass undefined to disable the query.
+ * @returns React Query result containing only items where trip_place_id is null.
+ */
+export function useTripLevelItems(tripId: number | undefined) {
+  return useQuery({
+    queryKey: ['trips', tripId, 'items', 'trip-level'],
+    queryFn: async () => {
+      const items = await apiGet<Item[]>(`/api/trips/${tripId}/items`);
+      return items.filter((item) => item.trip_place_id === null);
+    },
+    enabled: tripId !== undefined,
+  });
+}
 
 // ============================================================
 // MUTATIONS


### PR DESCRIPTION
Closes #160
BRD §5.5 IT-01

## Summary
IT-01 already permits items at the trip level — `items.tripPlaceId` is nullable by design (schema.ts: "NULL for trip-level items e.g. a flight attached to the trip") and `ItemForm` already accepted `tripPlaceId: number | null`. The gap was purely UI: `PlaceSection.tsx` was the only component rendering an Add Item button, and it always passed a concrete `place.id` — flights and car rentals had no way to be logged without being forced into a city.

## Fix
- New `TripItemsSection.tsx`, mirroring `PlaceSection`'s header + item-list + "+ Add Item" pattern for visual consistency. Rendered in `TripDetail` above the Places list (transport typically bookends a trip).
- `ItemForm` gains an optional `allowedTypes` prop restricting the Step 1 type picker (create only). The trip-level entry point passes `['flight', 'car_rental']` — per PO decision, car rental reuses this same mechanism rather than a separate toggle. Restaurant/Hotel/Experience/Note stay under `PlaceSection` since they're inherently tied to a specific city.
- New `useTripLevelItems` hook in `useItems.ts`.

## Backend contract gap found (flagging, not fixing — Backend's lane)
While building this I found `GET /api/trips/:id` (the endpoint `TripDetail` uses) **silently drops trip-level items from its response**. Reading `src/backend/routes/trips.ts`: `allItems` (fetched via `fetchItemsWithExtensions`, correctly includes items with `trip_place_id IS NULL`) is only ever assigned into the response via `places[i].items = allItems.filter(i => i.trip_place_id === p.id)` — there's no top-level `items` key, so anything with `trip_place_id === null` is fetched and then discarded before serialization.

I verified this empirically against the real Express app + an in-memory DB (throwaway test, not committed): POST creates the trip-level item fine (`trip_place_id: null` in the 201 response); the unfiltered `GET /api/trips/:tripId/items` correctly returns it; but `GET /api/trips/:id` for that same trip has no top-level `items` key and an empty `places` array — the item is completely unreachable via the endpoint the UI actually uses.

**Workaround shipped in this PR:** `useTripLevelItems` reads the flat `GET /api/trips/:tripId/items` endpoint (which already works correctly) and filters client-side to `trip_place_id === null`, so the feature is fully functional today without waiting on a backend fix. Existing mutation invalidation (`invalidateQueries({ queryKey: ['trips', tripId] })` in `useCreateItem`/`useUpdateItem`/`useDeleteItem`) already covers the new query key via TanStack Query's default prefix-match, so no mutation changes were needed.

**Recommend a follow-up Backend brief** to add trip-level items directly to the nested `GET /api/trips/:id` response (e.g. a top-level `items` array alongside `places`), so the frontend can eventually drop the flat-endpoint workaround and rely on one query for the full trip detail.

## Testing
Added `src/frontend/components/TripDetail/__tests__/TripItemsSection.test.tsx` (5 tests): renders items, empty state, type picker restricted to Flight/Car Rental only, add button hidden when locked, section hidden entirely when locked + empty.

## Checks
- `npm run check` — clean
- `npm run type:check:all` — clean
- `npm run test:backend` — 523 passed
- `npm run test:frontend` — 106 passed
- `npm run status:check` — up to date