### PR TITLE
chore(ADL-32): hosted deployment decision — Railway + Turso, resolves OQ-04

### DIFF
--- a/_project/STATUS.md
+++ b/_project/STATUS.md
@@ -31,7 +31,7 @@ _Tracker last updated: 2026-07-19 (session close: BUG-27/28/29/10 done, OP-16 ra
 |---|---|---|---|
 | BRD-PL0104 | Planning core — idea pool → shortlist → booked across all item types (PL-01–04) | fullstack | ⬜ Pending |
 | BRD-CU0103 | Shell trips — fast historic catch-up entry (CU-01–03) | fullstack | ⬜ Pending |
-| BRD-NF09 | Hosted deployment for personal use (NF-09) | architect | ⬜ Pending |
+| BRD-NF09 | Hosted deployment for personal use (NF-09) | backend | ⬜ Pending |
 
 ### P2 — Important (14)
 

--- a/_project/tracker.json
+++ b/_project/tracker.json
@@ -1525,11 +1525,11 @@
       "type": "requirement",
       "title": "Hosted deployment for personal use (NF-09)",
       "status": "pending",
-      "owner": "architect",
+      "owner": "backend",
       "priority": "P1",
-      "brdRefs": ["NF-09"],
+      "brdRefs": ["NF-09", "NF-03"],
       "phase": 6,
-      "notes": "BRD v3.0 §6. Hosting before multi-user; supersedes local-only NF-01 and OneDrive NF-04. BLOCKED on OQ-04 (platform + hosted-libSQL vs file DB) — Architect ADL required first, per infrastructure guardrail."
+      "notes": "BRD v3.0 §6, success criteria added v3.2. Hosting before multi-user; supersedes local-only NF-01 and OneDrive NF-04. UNBLOCKED 2026-07-20: OQ-04 resolved by ADL-32 (Railway + Turso, staging DB for PR preview environments). Owner reassigned architect->backend for implementation; open risk noted in ADL-32 §6 (Clerk origin config for dynamic Railway preview URLs) must be verified during the brief. Awaiting PO provisioning (Railway account/project, two Turso databases) before COO dispatches the Backend/Database briefs."
     },
     {
       "id": "BUG-30",

--- a/_project/travel-tracker-BRD.md
+++ b/_project/travel-tracker-BRD.md
@@ -1,6 +1,6 @@
 # Business Requirements Document
 ## Travel Tracker Application
-**Version:** 3.1
+**Version:** 3.2
 **Date:** July 2026
 **Author:** Claude (BSA/COO) / Ryan V (Product Owner)
 **Status:** Approved
@@ -311,13 +311,19 @@ booking details and gets directions. The laptop travels on every trip for everyt
 |----|-------------|
 | NF-01 | ~~Local Mac desktop app — no internet connection required for core features~~ **SUPERSEDED (2026-07-18) by NF-09** — retained for history |
 | NF-02 | Map view requires internet connection to render |
-| NF-03 | Data is stored as a file-based database (SQLite/libSQL); hosting may move this to a hosted libSQL service (e.g. Turso) — Architect decision, see OQ-04 |
+| NF-03 | Data is stored via libSQL (Drizzle). **RESOLVED (2026-07-20) by ADL-32** — hosted deployment uses Turso (hosted libSQL) for the production database and a separate staging Turso database for PR preview environments; local development stays file-based (`SQLITE_PATH=file:...`) |
 | NF-04 | ~~Database file can be stored in OneDrive for single-user sync across personal devices~~ **SUPERSEDED (2026-07-18) by NF-09** — hosting replaces file-sync |
 | NF-05 | Architecture must support migration to a hosted web app without a data model rebuild — **promoted from future-proofing to near-term requirement in v3.0** |
 | NF-06 | Architecture must support future migration to an iOS mobile app without a data model rebuild (iOS remains aspirational — mobile browser reference mode §5.15 is the near-term answer) |
 | NF-07 | Architecture must support trip companion access (read-only and edit) — target ~6 months for co-planning (PL-06) |
 | NF-08 | Architecture must support future notification engine without structural changes |
 | NF-09 | The app is deployed as a hosted web app for personal use, reachable from the user's devices over the internet with real authentication (Clerk). Local development remains fully supported *(added v3.0)* |
+
+> **NF-09 success criteria (added 2026-07-20 per ADL-32):** production URL reachable over
+> HTTPS from a phone browser on cellular data; Clerk sign-in works end-to-end against
+> production; data persists across a deploy; a PR preview environment deploys
+> automatically and is confirmed isolated from the production database; CI green + deploy
+> succeeds on merge to `main`. Full hosting architecture (Railway + Turso) in ADL-32.
 
 ---
 
@@ -372,7 +378,7 @@ The following are explicitly out of scope for MVP but must not be architecturall
 | OQ-01 | ~~Mapping library — Google Maps API vs open-source alternative~~ | **RESOLVED** — MapLibre GL + MapTiler tiles shipped in Phase 3 (see ADL record); bundled boundary polygons per GE-10 |
 | OQ-02 | ~~Desktop app framework — Electron, Tauri, or local web server in browser~~ | **RESOLVED (2026-07-18)** — v3.0 direction is a hosted web app accessed via browser (NF-09); packaged .app dropped. Supersedes the earlier packaged-.app direction |
 | OQ-03 | Shell trips (§5.14): historic trips may lack exact dates. Do we need approximate/partial dates (year-only, month-only), and how do they interact with map shading and chronological ordering? | PO + Architect — resolve before CU-01 is briefed |
-| OQ-04 | Hosting platform and database: where is the app hosted for personal use (NF-09), and does SQLite move to hosted libSQL (Turso) or stay file-based on the host? | Architect — ADL required before hosting work is briefed |
+| OQ-04 | ~~Hosting platform and database: where is the app hosted for personal use (NF-09), and does SQLite move to hosted libSQL (Turso) or stay file-based on the host?~~ | **RESOLVED (2026-07-20)** — Railway (compute) + Turso (database), production and a separate staging instance for PR preview environments. See ADL-32 |
 | OQ-05 | `trip_places` enforces one row per (trip, city) (`uniq_trip_places_trip_city`). Realistic itineraries revisit the same city more than once within a trip (e.g. Glasgow → day trip to Edinburgh → back to Glasgow), which this constraint currently disallows. Does the model move to one-row-per-visit, and what are the knock-on effects on map shading, chronological ordering (DP-05/DP-06), and item attachment (`trip_place_id`)? | Architect — resolve before any brief touching trip-place identity |
 
 ---
@@ -418,5 +424,6 @@ The following examples illustrate the intended use of the notes field across ite
 | 2.7 | March 2026 | COO | Added §5.11 Security and Access Control (SE-01–SE-07) — formalises the NR-14/OP-06 hardening gate requirements: three-role access model, user data scoping, owner-only admin, JWT issuer validation, opaque error responses, BYPASS_AUTH production block, NOT NULL ownership constraints |
 | 3.0 | July 2026 | COO / Ryan V (PO) | **Planning-first identity rewrite** from PO requirements interview 2026-07-18. §1–§3 rewritten around three pillars: Plan (primary), Look back (major), Catch up (supporting). New sections with success criteria: §5.12 Planning PL-01–06 (idea pool → shortlist → booked across all item types; day-itinerary Phase 2; co-planning Phase 3), §5.13 Looking Back LB-01–03 (destination recommendations, stats, shareable highlights), §5.14 Historic Catch-up CU-01–03 (shell trips), §5.15 Mobile Reference MB-01–02 (phone as reference device). New item status Shortlisted (IT-03 amended). NF-09 hosting for personal use added; NF-01/NF-04 superseded (local-only + OneDrive sync dropped). §9 promotions stamped. OQ-01/OQ-02 closed; OQ-03 (approximate dates) and OQ-04 (hosting platform) opened. Trigger for the planning sections: Scotland trip dogfood trial (planned 2026-07 week) |
 | 3.1 | July 2026 | COO / Ryan V (PO) | UAT session 2026-07-20 findings. Added DP-06 (first place added to a trip inherits the trip's date range). Added IT-10 (optional Google Maps URL per item — one-click map/directions link; schema change pending Architect review). Added OQ-05 (`trip_places` one-row-per-city constraint vs. realistic same-city revisits within a trip — Architect to resolve). BUG-10 reopened separately in the tracker: prior fix truncated over-limit trip names instead of rejecting them, and the limit itself is corrected to 75 characters (was 200) |
+| 3.2 | July 2026 | Architect / Ryan V (PO) | Resolved OQ-04 (ADL-32): hosted deployment is Railway (compute) + Turso (hosted libSQL, production and a separate staging instance for PR preview environments). Updated NF-03 (RESOLVED, points to ADL-32); added success criteria to NF-09 (none existed previously — required before BRD-NF09 can be briefed/closed per the success-criteria gate) |
 
 *Document status: Approved. This document is the authoritative requirements reference for all team members. Changes must be approved by the product owner and recorded in the change log.*

--- a/jobs/architect/context/current.txt
+++ b/jobs/architect/context/current.txt
@@ -1,115 +1,99 @@
-ARCHITECT CONTEXT — 2026-03-21
+ARCHITECT CONTEXT — 2026-07-20
 PROJECT: Travel Tracker
-CURRENT STATUS: BRD v2.4 technical review complete (TR-11, TR-10, DP-04). NR-14 auth direction revised — Clerk assessment complete, ADL-20 logged
+CURRENT STATUS: OQ-04 resolved (ADL-32) — hosted deployment platform + database decided.
+BRD-NF09 unblocked, owner reassigned architect -> backend for implementation.
 
 ================================================================================
 WORK COMPLETED THIS THREAD
 ================================================================================
 
-Received query: 20260320_1000-COO-auth-managed-platform-query.txt
-PO direction: Clerk as managed auth platform (consumer, Google/Apple/email OAuth)
+PO request: work through a hosted deployment plan (BRD-NF09 / OQ-04).
 
-Assessed Clerk against four questions from COO:
-  1. Express/req.user compatibility — no blocker, standard JWKS verification
-  2. Electron/iOS Capacitor — no blocker, same patterns as ADL-17 specified
-  3. Lock-in risk — moderate but contained; seam rule defined (no @clerk/* in backend)
-  4. Schema implications — users table kept (clerk_id replaces oauth_provider/subject);
-     refresh_tokens table dropped (Clerk owns token lifecycle)
+Presented options brief covering compute platform (Fly.io, Railway, Render, VPS) and
+database (file-based+volume vs Turso). PO asked for Railway vs Fly.io comparison
+specifically; surfaced Railway's per-PR preview environments as the differentiator
+relevant to a recurring project pain point (changes that work locally/in CI but break
+only once actually deployed as a live server). PO confirmed Railway is worth the
+~$5/mo over Fly's ~$0-3/mo for that reason (plus no cold starts, simpler deploy DX).
 
-ADL-17 superseded by ADL-20:
-  ADL-17: OAuth PKCE + jose roll-your-own → SUPERSEDED 2026-03-20
-  ADL-20: Clerk managed auth — jose JWKS verification, no Clerk SDK in backend
+Raised a design question the PO hadn't considered: PR preview environments must not
+point at the production Turso database. PO confirmed a separate shared staging Turso
+database (seeded via existing db:seed), not local ephemeral SQLite per preview — the
+staging DB tests the real Turso connection path, which is exactly the class of bug
+previews are meant to catch.
 
-Response sent to COO:
-  jobs/COO/inbox/20260320_1100-ARCHITECT-clerk-auth-assessment.txt
+PO flagged Railway's pricing page mid-session ("free tier, kind of") — verified via
+WebFetch: it's a one-time $5 trial credit, not a recurring free tier. Confirmed the
+ADL's $5/mo Hobby-plan cost figure is accurate as the real ongoing cost.
 
-================================================================================
-OPEN QUESTIONS
-================================================================================
+ADL-32 logged in jobs/architect/tech/20260307-architecture-decisions-log.md:
+  Decision: Railway (compute, Hobby plan ~$5/mo) + Turso (database — production
+  instance + separate staging instance for PR previews)
+  Confirms ADL-25 unaffected (still LibSQLDb via @libsql/client, remote URL + authToken
+  only — no dialect union, no schema change)
+  Flagged open implementation risk (§6): whether Clerk's allowed-origin config supports
+  Railway's dynamic per-PR preview URLs — unverified, must be checked during the brief
+  Added success criteria for NF-09 (none existed previously — required by the
+  success-criteria-before-dispatch gate)
 
-  1. COO/PO: Create Clerk account, configure providers (Google, Apple, email),
-     supply CLERK_PUBLISHABLE_KEY and CLERK_JWKS_URI environment variables.
-     → This unblocks both backend middleware and frontend SDK install.
+BRD bumped to v3.2 (_project/travel-tracker-BRD.md):
+  NF-03: RESOLVED, points to ADL-32
+  NF-09: success criteria added (blockquote note under §6 table)
+  OQ-04: RESOLVED, points to ADL-32
+  §13 changelog entry added, header version bumped 3.1 -> 3.2
 
-  2. DATABASE spec update needed from COO:
-     - users table: new shape (clerk_id replaces oauth_provider/oauth_subject)
-     - refresh_tokens: DO NOT CREATE
-     (COO to issue updated DB brief before DATABASE begins NR-14 work)
+Tracker updated (_project/tracker.json): BRD-NF09 unblocked, owner architect -> backend,
+notes reference ADL-32 and the open Clerk-origin risk.
 
-  3. Schema anomaly (ADL-19) — undocumented columns — still pending removal.
-     Decision: remove via migration. Awaiting COO approval and DATABASE action.
-
-  4. trip_places user_id — still awaiting COO/PO confirmation of addition.
-
-  5. BRD v2.4 technical review sent to COO (2026-03-21):
-     TR-11, TR-10, DP-04 — all resolved, no backend schema changes. Response at
-     jobs/COO/inbox/20260321_0900-ARCHITECT-brd-v24-technical-review.md
-
-================================================================================
-PENDING — AWAITING DOWNSTREAM ACTION
-================================================================================
-
-  COO (before DATABASE or BACKEND can proceed):
-  - Create Clerk account + configure OAuth providers
-  - Provide CLERK_PUBLISHABLE_KEY and CLERK_JWKS_URI
-  - Issue updated DATABASE spec reflecting ADL-20 schema changes
-  - Approve removal of undocumented columns (ADL-19)
-
-  DATABASE (after COO spec update):
-  - Create users table: id (UUID PK), clerk_id (UNIQUE), email, display_name, created_at
-  - Do NOT create refresh_tokens table
-  - Add user_id TEXT NOT NULL REFERENCES users(id) to: trips, items, trip_places
-  - Add indexes: idx_trips_user_id, idx_items_user_id, idx_trip_places_user_id
-  - Remove undocumented columns (pending COO approval)
-
-  BACKEND:
-  - Implement authenticate middleware (jose only — no @clerk/* imports)
-  - Implement userRepository.findOrCreateByClerkId(clerkId, email)
-  - Create src/backend/repositories/ (trips, items, tripPlaces) per ADL-18
-  - Refactor all trip/place/item routes through repository layer
-  - No /api/auth/callback, /refresh, or /logout routes required
-
-  FRONTEND:
-  - Install @clerk/react
-  - Use useAuth().getToken() for API Authorization header
-  - Use Clerk hosted sign-in page (redirect flow) rather than embedded components
+Branch: chore/adl-32-hosted-deployment (not yet merged — awaiting PO review/merge).
 
 ================================================================================
-NR-14 GATE SECURITY REVIEW
+OPEN QUESTIONS / PENDING
 ================================================================================
 
-Gate review areas updated for Clerk:
-  - Backend: authenticate middleware imports jose only (not @clerk/* — enforce seam rule)
-  - Backend: findOrCreateByClerkId upsert is idempotent and safe
-  - Frontend: getToken() called per-request, not stored in state/localStorage
-  - Electron Phase 1: custom URL scheme handler does not leak session token to logs
-  - Repository layer completeness (ADL-18 — all user-scoped tables covered)
-  - Postgres RLS readiness (withUserContext design in db/index.ts)
+  1. PO/Ryan: create Railway account + project; create two Turso databases
+     (production, staging); obtain connection URLs and auth tokens. Blocks dispatch of
+     the implementing briefs below.
+
+  2. COO: once provisioning above exists, dispatch:
+     - Backend brief: express.static serving of dist/ + SPA fallback (does not exist
+       today — dev is Vite/Express two-process split only); db/index.ts authToken
+       support for Turso (createClient({ url, authToken }) — currently url only, see
+       src/backend/db/index.ts:110); resolve the Clerk dynamic-preview-origin question
+       (ADL-32 §6) — verify against Railway's actual generated preview URL pattern and
+       Clerk's dashboard options; fallback if unsupported is scoping BYPASS_AUTH=true to
+       preview environments only, which narrows what previews can catch for auth-related
+       changes — flag this tradeoff back to COO/PO if it comes to that.
+     - Database brief: provision the staging Turso database, define a seed/reset
+       cadence so preview environments don't accumulate cruft over time.
+
+  3. Not yet resolved (carried over, unrelated to this thread): OQ-03 (shell trip
+     approximate dates), OQ-05 (trip_places one-row-per-city constraint vs realistic
+     same-city revisits).
 
 ================================================================================
 TECH FILES
 ================================================================================
 
-  jobs/architect/tech/20260307-ER-schema.md           v1.1 (unchanged)
-  jobs/architect/tech/20260307-tech-blueprint.md       v1.0 (unchanged)
-  jobs/architect/tech/20260307-map-shading-spec.md     v1.0 (unchanged)
   jobs/architect/tech/20260307-architecture-decisions-log.md
-                                                       ADL-01 through ADL-20
-                                                       ADL-17 superseded by ADL-20
+                                                       ADL-01 through ADL-32
+  jobs/architect/tech/OP-06-hardening-checklist.md     unchanged, 13/13 PASS (NR-14 closed)
 
 ================================================================================
 LAST PARK DOC
 ================================================================================
 
-  jobs/architect/park-docs/20260320-ARCHITECT-park.txt
+  jobs/COO/park-docs/20260716_0330-COO-park.txt (no architect-specific park doc since
+  20260320; this session's work is captured above instead)
 
 ================================================================================
 NEXT ARCHITECT THREAD — RECOMMENDED STARTING POINT
 ================================================================================
 
-  1. Check jobs/architect/inbox/ for COO response (Clerk account confirmation)
-  2. Review DATABASE's updated users table migration when submitted
-  3. Verify DATABASE did NOT create refresh_tokens table
-  4. Review BACKEND authenticate middleware — confirm no @clerk/* imports (seam rule)
-  5. Conduct NR-14 gate security review when brief arrives from COO
-
+  1. Check whether chore/adl-32-hosted-deployment has been merged; if not, that's
+     still open
+  2. Check whether PO has completed Railway/Turso account provisioning (item 1 above)
+  3. If Backend's implementing brief surfaces a real answer on the Clerk
+     dynamic-preview-origin question (ADL-32 §6), record the resolution as an ADL-32
+     addendum or a new short ADL, whichever the answer's shape warrants
+  4. OQ-03 and OQ-05 remain open and unrelated to hosting — pick up independently

--- a/jobs/architect/tech/20260307-architecture-decisions-log.md
+++ b/jobs/architect/tech/20260307-architecture-decisions-log.md
@@ -1389,6 +1389,161 @@ further action is warranted. The one honest residual is the *specific* attributi
 night's Actions incident — a strong confirmed correlation, not proof of causation — which does
 not change the disposition.
 
+---
+
+## ADL-32 — Hosted deployment: Railway (compute) + Turso (database), resolves OQ-04
+
+**Date:** 2026-07-20
+**Status:** Decided — pending implementation
+**Tracker:** BRD-NF09 | **BRD ref:** NF-09, NF-03, OQ-04
+
+**Triggered by:** PO request (2026-07-20) to work through a hosted deployment plan.
+BRD v3.0 promoted hosting (NF-09) to the near-term roadmap and opened OQ-04 (hosting
+platform + hosted-libSQL vs. file DB) as a precondition — per the BRD gate rule, BRD-NF09
+cannot be briefed until OQ-04 is resolved by an Architect ADL.
+
+### 1. Problem
+
+The app currently runs as two local dev processes (Vite on 5173, Express on 3001) against
+a local SQLite file (`SQLITE_PATH=file:./dev.db`). NF-09 requires this to become a hosted
+web app reachable from the PO's devices over the internet with real Clerk authentication,
+while keeping local development fully supported. Two decisions were open: (a) which
+compute platform hosts the Express service, and (b) whether the database stays file-based
+on that host or moves to a hosted libSQL provider (Turso), per NF-03.
+
+### 2. Compute platform — options considered
+
+| Option | Cost (personal, low-traffic) | Assessment |
+|---|---|---|
+| Fly.io | ~$0–3/mo, usage-based | Cheapest; autostop/autostart has a short (~1–2s) cold-start on wake; GH Actions deploy is hand-rolled (`flyctl deploy` step) |
+| **Railway** | ~$5/mo flat (Hobby plan) | No cold starts on Hobby; native GitHub integration (auto-deploy `main`, **automatic PR preview environments**); less deploy glue to hand-write |
+| Render | $0 free / $7/mo always-on | Free tier sleeps after 15min idle with ~30–60s cold start — conflicts with MB-01/MB-02 (phone lookup while travelling); ruled out |
+| VPS (Hetzner/DO) | ~$4–6/mo | Full control, but owner carries OS patching, TLS, process supervision — pure ops burden with no benefit for a single-user app |
+
+**Decision: Railway (Hobby plan).** Render is ruled out by its own cold-start behaviour
+against MB-01/MB-02. A VPS adds ops burden with no compensating benefit for a one-user
+app. Fly.io is marginally cheaper, but Railway's native per-PR preview environments are a
+direct answer to a recurring project pain point (changes that work locally but break only
+once actually deployed/running as a live server — CORS against a real origin, static-asset
+serving, migration behaviour against a real remote DB) that CI's test suites do not catch
+because they never run the app as a live hosted server. That capability, plus zero cold
+starts and less deploy glue to maintain, is judged worth the ~$5/mo over Fly.io's ~$0–3/mo.
+PO confirmed 2026-07-20.
+
+### 3. Database — options considered
+
+| Option | Assessment |
+|---|---|
+| Stay file-based (Railway volume) | Zero code change, but ties DB lifecycle to one compute instance/region and the owner must build their own backup/snapshot discipline for what becomes irreplaceable real trip data |
+| **Turso (hosted libSQL)** | Free tier is ample for personal use; managed backups/point-in-time recovery without building it; decouples DB from compute. Migration cost is trivial — `@libsql/client`'s `createClient()` already accepts a remote `libsql://` URL + `authToken` natively (`src/backend/db/index.ts:110`), so this is a one-line change to the existing SQLite branch, not a schema or ORM rewrite |
+
+**Decision: Turso**, for both the production database and a second, separate **staging**
+database used only by PR preview environments (see §6). This directly satisfies NF-03
+("hosting may move this to a hosted libSQL service (e.g. Turso)").
+
+### 4. Confirms ADL-25 is unaffected
+
+ADL-25 narrowed `getDb()` to return `LibSQLDb` (not the `AppDatabase` union) because there
+was no near-term Postgres deployment. Turso does not change this: it is still libSQL,
+still the same `@libsql/client` / `BaseSQLiteDatabase` type, reached via a remote URL
+instead of a local file path. No dialect union, no repository-layer changes, no schema
+changes. ADL-25's reasoning and `db:generate`/`db:migrate` workflow (ADL-15) both carry
+over unchanged to the hosted database.
+
+### 5. Deployment topology
+
+- **Single Railway service** serves both the API and the built frontend
+  (`express.static` on the Vite `dist/` build + SPA fallback for client-side routes) —
+  simplest topology for a single user; avoids a second static host with its own
+  CORS/domain surface.
+- **Production environment:** tracks `main`; env vars point at the production Turso
+  database.
+- **Preview environments:** Railway auto-deploys one per open PR; env vars point at a
+  **separate, shared staging Turso database**, seeded via the existing `npm run db:seed`.
+  Preview environments must never hold production Turso credentials — this is the
+  guardrail that keeps a broken preview build (or QA poking around in one) from touching
+  real trip history.
+- `HOST` is set to `0.0.0.0` in both hosted environments (the code comment in
+  `.env.example` already anticipated this: "Set 0.0.0.0 in Phase 2 behind proxy"). Local
+  dev is unaffected and stays `127.0.0.1`.
+- Migrations: `npm run db:migrate` runs before the server starts, in both production and
+  preview, against whichever Turso instance that environment's env vars target —
+  preserving the migrate-only rule (ADL-15, no `db:push`) in hosted environments too.
+
+### 6. Open implementation risk — Clerk origins for dynamic preview URLs
+
+Each Railway PR preview gets a unique generated URL. The backend's own CORS/`azp`
+allowlist (`ALLOWED_ORIGINS`, HC-02) can likely reference Railway's per-environment domain
+variable and be set dynamically per preview. **Unverified:** whether Clerk's own allowed
+origins/redirect configuration (a separate list, not `ALLOWED_ORIGINS`) supports dynamic
+or wildcard preview domains on the current Clerk plan. Whoever implements this brief must
+verify against Railway's actual generated URL pattern and Clerk's dashboard options. If
+Clerk cannot be configured for dynamic preview origins, the fallback is scoping
+`BYPASS_AUTH=true` to preview environments only (the same mechanism already used for
+contract tests/CI) — but that would mean preview environments don't exercise real auth,
+which narrows what they're useful for catching. This is flagged as an open risk, not a
+blocker to the platform decision.
+
+### 7. Env vars — new / changed
+
+- New: `TURSO_DATABASE_URL`, `TURSO_AUTH_TOKEN` (production); a second pair of the same
+  for the staging instance, scoped to the preview environment only
+- Changed: `SQLITE_PATH` becomes the Turso `libsql://` URL in hosted environments
+  (`DB_TYPE` stays `sqlite` — no change to the `DB_TYPE` switch in `db/index.ts`)
+- Changed: `HOST=0.0.0.0`, `NODE_ENV=production` in hosted environments
+- Changed: `ALLOWED_ORIGINS` includes the Railway-assigned domain per environment
+- Unchanged/carried over: `CLERK_JWKS_URI`, `CLERK_ISSUER`, `OWNER_CLERK_ID` — set per
+  environment via Railway's variable store, never in a committed file
+- `BYPASS_AUTH` remains unset in production (existing fatal-error guard on
+  `NODE_ENV === 'production'` stays as-is)
+
+### 8. Cost
+
+Railway Hobby: ~$5/mo flat (includes usage credit). Turso: $0 (both production and
+staging databases fit comfortably within the free tier for personal-use volumes).
+**Total: ~$5/month.**
+
+### 9. Implications
+
+- **BACKEND:**
+  - Add `express.static` serving of the Vite `dist/` build with SPA fallback routing (no
+    static serving exists today — dev only runs the two-process Vite/Express split)
+  - `src/backend/db/index.ts`: add `authToken` to the `createClient({ url, authToken })`
+    call in the SQLite branch, reading `TURSO_AUTH_TOKEN` from the environment (optional,
+    undefined for local file-based dev)
+  - Confirm `ALLOWED_ORIGINS` / `azp` validation (HC-02) works against a Railway-assigned
+    domain, and resolve the Clerk dynamic-preview-origin question in §6
+- **DATABASE:** Provision the staging Turso database and seed strategy (`db:seed` on
+  creation; document a reset cadence so preview environments don't accumulate cruft)
+- **No FRONTEND changes** beyond the existing `npm run build` output — the build step is
+  unchanged, only where it's served from is new
+
+### 10. Success criteria (BRD-NF09 / NF-09)
+
+Required before BRD-NF09 can be marked done — added per the "success criteria before
+dispatch" gate, since none existed for NF-09 previously:
+
+- [ ] Production URL reachable over HTTPS from a phone browser on cellular data (not
+      same-network/VPN)
+- [ ] Clerk sign-in works end-to-end against the production instance (owner account)
+- [ ] Data persists across a deploy — a trip created before a deploy is still present
+      after it
+- [ ] A PR preview environment deploys automatically for an open PR and is reachable at
+      its generated URL
+- [ ] Preview environment's database is confirmed isolated from production (writes made
+      in a preview never appear in the production Turso database)
+- [ ] CI green + Railway deploy succeeds on merge to `main`
+
+### 11. Next steps
+
+- **PO/Ryan:** create Railway account + project; create two Turso databases (production,
+  staging); obtain connection URLs and auth tokens
+- **COO:** dispatch a Backend brief (static serving, `db/index.ts` authToken support,
+  migrate-on-deploy, §6 Clerk-origin verification) and a Database brief (staging DB seed
+  strategy) once the above provisioning exists
+- **COO:** BRD version bump and tracker update for this decision (this session,
+  `chore/adl-32-hosted-deployment`)
+
 **Alternatives considered:**
 - Longer observation window (e.g. 10–15 more merges) before closing — rejected: the marginal
   evidence is low-value once the repo-config hypothesis is eliminated and the external correlate


### PR DESCRIPTION
## Summary
- Resolves OQ-04 (tracker BRD-NF09's blocking open question): compute platform is **Railway** (Hobby plan), database is **Turso** (hosted libSQL) — production instance plus a separate staging instance for PR preview environments
- Railway chosen over Fly.io specifically for native per-PR preview environments, which target a recurring project pain point (changes that work locally/in CI but only break once actually deployed as a live server)
- Preview environments get their own staging Turso DB — never production credentials
- Adds success criteria to NF-09 (none existed previously)
- Flags one open implementation risk for the Backend brief to verify: whether Clerk's allowed-origin config supports Railway's dynamic per-PR preview URLs (ADL-32 §6)

Closes: none (architecture decision, not a BRD requirement ID) — unblocks BRD-NF09

## Changes
- `jobs/architect/tech/20260307-architecture-decisions-log.md` — ADL-32
- `_project/travel-tracker-BRD.md` — v3.1 → v3.2 (NF-03/OQ-04 resolved, NF-09 success criteria, changelog)
- `_project/tracker.json` — BRD-NF09 unblocked, owner architect → backend
- `jobs/architect/context/current.txt` — session handoff for next architect thread

## Test plan
- [ ] PO reviews and confirms the Railway + Turso decision and the v3.2 changelog attribution
- [ ] PO provisions Railway account/project + two Turso databases before COO dispatches the implementing Backend/Database briefs
- N/A for automated CI — no application code changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)