### PR TITLE
feat(BRD-NF09): Turso authToken support + static frontend serving (ADL-32)

### DIFF
--- a/jobs/COO/inbox/20260721_1706-BACKEND-nf09-hosted-deployment-complete.txt
+++ b/jobs/COO/inbox/20260721_1706-BACKEND-nf09-hosted-deployment-complete.txt
@@ -1,0 +1,74 @@
+BACKEND COMPLETION REPORT
+Tracker: BRD-NF09 | PR: (see below, opening now) | BRD §NF-09 | ADL-32
+Branch: feat/nf09-hosted-deployment-backend
+
+WHAT WAS BUILT
+Implemented 2 of ADL-32's 3 backend scope items in src/backend/db/index.ts (Turso
+authToken support) and src/backend/server.ts (static frontend serving + SPA fallback).
+The 3rd item (Clerk origin verification for Railway) was investigation/documentation
+only per the brief — no code change, findings below need a COO/PO follow-up decision.
+
+ACCEPTANCE CRITERIA
+- Turso authToken support, TURSO_DATABASE_URL priority over SQLITE_PATH: PASS
+- DB_TYPE switch structure unchanged: PASS
+- Fatal error preserved when neither URL var set: PASS
+- express.static + SPA fallback added, gated on NODE_ENV=production && dist/ exists: PASS
+- /api/* excluded from SPA fallback (unmatched API routes still get normal 404, not
+  index.html): PASS
+- Local dev unaffected (two-process Vite/Express split, no dist/ present): PASS
+- npm run build + NODE_ENV=production local simulation serves built output correctly: PASS
+- Clerk origin findings documented (not implemented): PASS — see FOLLOW-UP DECISION below
+
+*** CLERK ORIGIN FINDINGS — NEEDS COO/PO FOLLOW-UP DECISION, NOT JUST A CODE CHANGE ***
+Backend side (ALLOWED_ORIGINS/azp, HC-02) is a non-issue: Railway supports reference-
+variable templating (${{RAILWAY_PUBLIC_DOMAIN}}), so setting
+ALLOWED_ORIGINS=https://${{RAILWAY_PUBLIC_DOMAIN}} on the Preview environment resolves
+to each PR's actual generated domain automatically — zero code change, pure Railway
+dashboard config for Ryan.
+UNVERIFIED (I have no Clerk dashboard access): whether Clerk's OWN allowed-origins/
+redirect config — a separate list from ALLOWED_ORIGINS, governs whether ClerkJS can even
+run from a given origin — supports wildcard/dynamic domains on Ryan's plan. This is
+commonly a paid-tier feature elsewhere; do not assume it's available.
+If Clerk can't support dynamic preview origins, ADL-32 §6's documented fallback is
+BYPASS_AUTH=true scoped to the Preview environment only (Production unaffected, the
+existing NODE_ENV=production fatal-error guard stays as backstop). Flagging explicitly:
+this is a tradeoff (previews stop exercising real auth), not a clean solution — needs a
+conscious COO/PO call once Ryan checks Clerk's dashboard, not a silent default.
+
+SECURITY CHECKLIST (mandatory)
+1. Auth middleware — N/A. Static assets/SPA shell are public by design (same as the
+   existing frontend build being publicly downloadable); no user-data route added.
+   /api/* is explicitly excluded from the new fallback so requireAuth's existing
+   coverage on /api/ is untouched.
+2. Repository queries scoped by userId — N/A, no new queries introduced.
+3. FK .notNull() — N/A, no new tables/columns.
+
+CI: PR not yet opened at time of writing this report — will open immediately after and
+confirm gh pr checks green before considering this done (per process, opening now).
+
+OPEN ISSUES / BLOCKERS
+- Clerk dashboard verification (above) — blocks a clean answer on Preview-environment
+  auth, not the PR itself.
+- PROCESS INCIDENT (contained, no data loss): mid-task local testing, I ran
+  `pkill -9 -f "tsx watch src/backend/server.ts"` to clean up a stray test server —
+  this pattern wasn't scoped to my worktree and matched another session's dev server
+  supervisor (running from /workspace, not my worktree). That session's actual server
+  process survived and is still serving on port 3001 (confirmed healthy after), but its
+  hot-reload supervisor is dead — whoever owns that session needs to restart
+  `npm run dev:api`. Full detail and the lesson (always scope pkill patterns to the
+  worktree path, or track PIDs explicitly) in this thread's park doc.
+- ADL-32 §10 success criteria (production URL reachable, Clerk sign-in e2e, data
+  persists across deploy, PR preview reachable + DB-isolated, CI+deploy green on merge)
+  require an actual Railway deploy — outside this code-only brief's scope. Someone needs
+  to verify these once this PR merges and Railway deploys.
+
+WHAT'S NOW UNBLOCKED
+- Railway can deploy main (once merged) with Ryan's already-provisioned Turso env vars
+  plus DB_TYPE=sqlite (his dashboard action per the brief) and should both connect to
+  Turso and serve the built frontend correctly.
+- Database brief (staging Turso seed strategy, ADL-32 §9) is independent, no shared
+  files, can proceed in parallel.
+- COO may want to update ADL-32 §9's Backend implications checklist to reflect this is
+  done, per the document lifecycle rule.
+
+Full detail: jobs/backend/park-docs/20260721-BACKEND-nf09-hosted-deployment-park.txt

--- a/jobs/backend/context/current.txt
+++ b/jobs/backend/context/current.txt
@@ -1,63 +1,47 @@
-BACKEND CONTEXT — 2026-07-20
+BACKEND CONTEXT — 2026-07-21
 PROJECT: Travel Tracker
-CURRENT STATUS: Four backend threads landed this UAT-triage round.
-  1. BUG-32 (PR #166, merged): DELETE /api/trips/:tripId/places/:placeId already
-     existed (Phase 1) with correct auth/ownership/lock enforcement — confirmed via
-     code read, not missing as UAT assumed. Fixed a real CRITICAL bug (independently
-     also found by Frontend while building the parallel UI brief — see
-     jobs/COO/inbox/20260720_1746-FRONTEND-bug32-blocker-place-delete-fk-cascade.txt,
-     merged as part of #170) confirming cascade behavior for items under a deleted
-     place: deleting a place with any item attached threw an unhandled 500 (FK
-     constraint violation) — libSQL's @libsql/client enforces `PRAGMA foreign_keys`
-     ON by default even with no explicit pragma call (verified empirically; corrects
-     an earlier wrong assumption in this file's previous revision that production
-     didn't enforce FKs — it does). Fix: items under a deleted place are reassigned to
-     trip-level (trip_place_id = null) atomically with the place delete via
-     db.batch(), rather than Frontend's proposed alternative (onDelete: 'cascade' on
-     the schema FK) — reassignment preserves logged items (flights, hotels, ratings)
-     instead of destroying them as a side effect of removing a place. See this
-     thread's park doc for the full reconciliation.
-  2. BUG-31 (merged to main, PR #162): GET /api/trips/:id was missing arrived_on/
-     departed_on on each place — read-path bug, PATCH persistence was already correct.
-  3. BUG-10 reopened-UAT (merged to main, PR #164): zName max changed 200 -> 75 chars
-     (src/backend/validation/common.ts), error message updated to match. Contract +
-     unit test boundaries moved from 200/201 to 75/76. API reference doc updated.
-  4. BUG-33 application-logic fix (this thread — PR #167): find-or-create in
-     POST /api/cities (src/backend/routes/cities.ts) — looks up an existing city by
-     (name, country_code) before inserting, stopping new duplicate `cities` rows
-     (UAT found "Glasgow" twice in the autocomplete). The companion DB brief
-     (PR #169, merged, migrations 0009/0010) added a `COLLATE NOCASE` unique index
-     + cleanup migration; this thread's lookup was updated to match that collation
-     exactly (COLLATE NOCASE, not a generic lower()) once #169 landed, and its
-     in-memory test schema now mirrors the real unique index too. Rebased onto main
-     twice this session as other PRs in the same UAT-triage round kept merging ahead
-     of it — see park doc for the process notes from that.
+CURRENT STATUS: BRD-NF09 hosted deployment backend implementation (ADL-32), this thread.
+  1. BRD-NF09 (PR pending — feat/nf09-hosted-deployment-backend): implemented 2 of
+     ADL-32's 3 backend scope items, investigated/documented the third.
+     - src/backend/db/index.ts: createLibSQLDb() now prefers TURSO_DATABASE_URL over
+       SQLITE_PATH and passes TURSO_AUTH_TOKEN as authToken when present. Local dev
+       unaffected (no TURSO_DATABASE_URL set locally, falls back to SQLITE_PATH).
+     - src/backend/server.ts: added express.static serving of dist/ + SPA fallback,
+       gated on NODE_ENV=production && dist/ exists. /api/* explicitly excluded from
+       the fallback. Two non-obvious bugs found and fixed along the way: (a) Express 5
+       removed bare `*` wildcard routes — used a path-less app.use() instead of
+       app.get('*', ...); (b) res.sendFile(absolutePath) without a `root` option 404s
+       if any ancestor directory starts with a dot (this repo's worktree paths live
+       under .claude/worktrees/...) — fixed with
+       res.sendFile('index.html', { root: DIST_DIR }), which is also just the more
+       correct pattern regardless of deployment path.
+     - Clerk origin verification (ADL-32 §6): investigated, no code change needed on
+       the backend side — ALLOWED_ORIGINS/azp (HC-02) can be set dynamically per
+       Railway Preview via Railway's ${{RAILWAY_PUBLIC_DOMAIN}} reference-variable
+       templating (Ryan's dashboard action, not code). Clerk's OWN dashboard allowed-
+       origins config is separate and unverified — flagged prominently to COO/PO as
+       the part of this brief needing a follow-up decision, not a code fix. See park
+       doc for full findings and the documented BYPASS_AUTH=true fallback tradeoff if
+       Clerk can't support dynamic preview origins.
 ACTIVE TASKS: None
 PENDING MESSAGES TO COO:
-  20260720_1100-BACKEND-bug32-complete.txt (sent)
-  20260720_1100-BACKEND-bug31-complete.txt (sent, processed — BUG-31 merged as #162)
-  20260720_1100-BACKEND-bug10-name-limit-complete.txt (sent, processed — merged as #164)
-  20260720_BACKEND-bug33-complete.txt (sent; rebase follow-up filed alongside)
+  20260721_1706-BACKEND-nf09-hosted-deployment-complete.txt (sent)
 OPEN ISSUES:
-  - From BUG-32: security.access-matrix.test.ts / owner-access.test.ts do not cover
-    cross-user 404 for DELETE places specifically (only DELETE trip is covered
-    there). Pre-existing coverage gap, not introduced by this change.
-  - From BUG-31: None. Unblocks BUG-28 UAT re-verification.
-  - From BUG-10: zName is a shared primitive (src/backend/validation/common.ts) also
-    used by admin.schemas.ts for category/companion/region names. Changing it to 75
-    for BUG-10 also caps those admin entity names at 75 — this was the explicit
-    brief instruction, but it wasn't scoped to trips-only. No admin-schema tests
-    currently assert a 200-char boundary so nothing broke, but COO/PO may want to
-    confirm admin names are fine at 75 or split zName into a trip-specific variant.
-  - From BUG-33: Pre-existing, unrelated flaky test in
-    src/frontend/components/CarryForward/__tests__/CarryForwardModal.test.tsx
-    ("calls onClose immediately when Skip is clicked") — fails intermittently on
-    full test:frontend runs, passes in isolation. Not touched by this brief.
-  - PROCESS INCIDENT (BUG-33 thread): a bare `git stash`/`pop` used mid-task to
-    test against a clean tree collided with another concurrent agent's stash
-    (refs/stash is shared across all worktrees in this repo, unlike checkout/HEAD).
-    Recovered without data loss; full detail in the BUG-33 park doc. COO has since
-    raised an OP-20 guardrail against bare git stash in concurrent-agent sessions.
-LAST PARK DOC: jobs/backend/park-docs/20260720-BACKEND-bug33-park.txt (see also
-  ...-bug32-park.txt, ...-bug31-park.txt and ...-bug10-name-limit-park.txt for the
-  other three threads)
+  - Clerk dashboard verification needed from Ryan (see park doc §3) — determines
+    whether Preview environments get real Clerk auth or fall back to
+    BYPASS_AUTH=true scoped to Preview only (ADL-32 §6 documented fallback,
+    explicitly flagged as a tradeoff not a clean solution).
+  - PROCESS INCIDENT (this thread, contained): a scoping mistake in a cleanup
+    `pkill -9 -f "tsx watch src/backend/server.ts"` matched another session's dev
+    server supervisor processes (running from /workspace, not my worktree) and
+    killed the tsx watch wrapper (hot-reload) for that session, though the actual
+    server process survived and kept serving on port 3001 (confirmed still healthy
+    after the incident). That other session's owner will need to restart
+    `npm run dev:api` to get hot-reload back. Full detail + lesson learned in this
+    thread's park doc. No data lost, no request dropped as far as verifiable.
+  - ADL-32 §10 success criteria (production URL reachable, Clerk sign-in e2e, data
+    persists across deploy, PR preview reachable, preview DB isolation, CI+deploy
+    green on merge) require an actual Railway deploy to verify — out of scope for
+    this code-only brief; someone (COO/PO) needs to verify these post-merge.
+LAST PARK DOC: jobs/backend/park-docs/20260721-BACKEND-nf09-hosted-deployment-park.txt
+  (see also ...-bug33-park.txt and earlier UAT-triage park docs for prior threads)

--- a/jobs/backend/park-docs/20260721-BACKEND-nf09-hosted-deployment-park.txt
+++ b/jobs/backend/park-docs/20260721-BACKEND-nf09-hosted-deployment-park.txt
@@ -1,0 +1,203 @@
+PARK DOC — BACKEND — 2026-07-21
+TRACKER: BRD-NF09 | BRD §NF-09 | ADL-32
+BRANCH: feat/nf09-hosted-deployment-backend
+
+SCOPE (ADL-32 §9, three items)
+1. Turso authToken support — src/backend/db/index.ts — DONE
+2. Static frontend serving + SPA fallback — src/backend/server.ts — DONE
+3. Clerk origin verification for Railway — investigation/documentation only — DONE (see
+   findings below; no code change, this is a COO/PO follow-up item)
+
+---
+
+## 1. Turso authToken support (src/backend/db/index.ts)
+
+createLibSQLDb() now resolves the connection URL as
+`process.env.TURSO_DATABASE_URL || process.env.SQLITE_PATH` and reads
+`TURSO_AUTH_TOKEN` (undefined if unset) as the `authToken` passed to
+`createClient()`. DB_TYPE switch structure untouched (still purely inside the
+sqlite branch, as instructed). Fatal-error-if-neither-set behavior preserved,
+message updated to mention both env vars.
+
+Local dev has no TURSO_DATABASE_URL set, so it falls through to SQLITE_PATH
+exactly as before, with authToken undefined (local SQLite files don't accept
+one) — verified by running dev:api locally and confirming
+`[DB] SQLite (libSQL) connected: file:./dev.db` still prints and the app
+starts normally.
+
+## 2. Static frontend serving + SPA fallback (src/backend/server.ts)
+
+Added `DIST_DIR = path.join(__dirname, '../../dist')` and
+`SERVE_STATIC = NODE_ENV === 'production' && fs.existsSync(DIST_DIR)` near the
+top-level config constants. Registered after all /api/* routers and /health
+(so those always win), before the global error handler:
+  1. `app.use(express.static(DIST_DIR))` — serves real built assets.
+  2. A path-less `app.use((req,res,next)=>{...})` SPA fallback: if the method
+     isn't GET or the path starts with `/api/`, calls `next()` (falls through
+     to Express's normal unmatched-route behavior, preserving existing
+     behavior for unmatched API routes); otherwise serves index.html.
+
+Two non-obvious things found and fixed during implementation, both worth
+flagging for whoever touches this next:
+
+a) **Express 5 removed the bare `*` wildcard route pattern.** `app.get('*',
+   handler)` — the naive way to write this fallback — throws at startup under
+   Express 5's path-to-regexp version (this repo is on express ^5.2.1). Used a
+   path-less `app.use()` with the exclusion done in code instead of route
+   syntax. If anyone reaches for `app.get('*', ...)` or `app.all('*', ...)`
+   anywhere else in this codebase in future work, same trap applies.
+
+b) **`res.sendFile(absolutePath)` without a `root` option 404s if any
+   ancestor directory in the path starts with a dot.** Discovered this the
+   hard way: in the dev worktree environment (paths under
+   `/workspace/.claude/worktrees/<name>/...`), a bare
+   `res.sendFile(path.join(DIST_DIR, 'index.html'))` was reliably 404ing with
+   `NotFoundError: Not Found` thrown from inside the `send` package's
+   `containsDotFile()` check (send/index.js) — when no `root` option is
+   passed, `send` splits the FULL absolute path on `/` and checks every
+   segment for a dot-prefix (default `dotfiles: 'ignore'` → 404s silently).
+   `.claude` is exactly such a segment. Fixed by using
+   `res.sendFile('index.html', { root: DIST_DIR })` instead — this is also
+   just the more correct/idiomatic pattern for res.sendFile regardless of
+   deployment path, so it's a strict improvement, not merely a workaround.
+   Confirmed this would NOT have been a Railway problem (Railway's build path
+   won't have a dot-segment) but would have silently broken any deploy target
+   whose path did — worth being aware of as a general res.sendFile gotcha.
+   Debugging process: isolated a minimal express.static+sendFile probe script
+   outside the full app to rule out helmet/CORS/rate-limiter interference,
+   then added a temporary sendFile error callback to surface the real
+   NotFoundError with its stack trace pointing at send's containsDotFile
+   check — removed the debug logging before the final commit.
+
+Verified end-to-end locally with `npm run build` + `NODE_ENV=production npm
+run dev:api` (against local dev.db, not real Turso creds, per the brief's
+instruction not to leave a Turso-connected process running):
+  - GET /                        → 200, serves dist/index.html
+  - GET /assets/<real-file>.js   → 200, correct content-type
+  - GET /trips/some-id (SPA route, no matching file) → 200, serves index.html
+  - GET /api/does-not-exist      → 401 (requireAuth still runs first; with
+    BYPASS_AUTH off this correctly does NOT fall through to index.html)
+  - GET /health                  → 200, unaffected
+Local dev (two dev servers, no dist/ built) re-confirmed unaffected after the
+change — full test:backend, test:frontend, test:contract, type:check:all all
+green (see completion report).
+
+## 3. Clerk origin verification for Railway (ADL-32 §6) — investigation only
+
+Read `src/backend/middleware/auth.ts` (HC-02 azp validation) and
+`src/backend/server.ts` (SEC-02 CORS allowlist) in full. Both independently
+parse the SAME `ALLOWED_ORIGINS` env var (comma-separated, `.split(',').map(
+trim)`), so there is exactly one knob to configure per environment, not two.
+
+**Production (static domain):** trivial. Railway assigns (or lets you attach)
+a fixed domain per service/environment for Production. Set
+`ALLOWED_ORIGINS=https://<production-domain>` (plus `http://localhost:3001`
+only if local curl/Postman-style same-origin API calls are still needed — not
+required for the browser flow). No code change needed; this is purely a
+Railway dashboard env var value, which is Ryan's action per the brief scope
+(he sets Railway env vars, not me).
+
+**Preview (dynamic per-PR domain):** ADL-32 §6 flagged this as unverified
+against Railway's actual generated URL pattern. Investigated:
+`ALLOWED_ORIGINS` is a plain string env var read at request time inside
+`getAuthorizedParties()` / at module load for CORS — the *code* has no
+wildcard-matching logic and doesn't need any, because **Railway supports
+reference-variable templating in its dashboard** (e.g.
+`${{RAILWAY_PUBLIC_DOMAIN}}`), which resolves to the actual generated domain
+of THAT SPECIFIC deployment at deploy time — so setting
+`ALLOWED_ORIGINS=https://${{RAILWAY_PUBLIC_DOMAIN}}` on the Preview
+environment's variable store means every new PR preview gets the literal
+correct value baked in automatically, with zero code change and zero manual
+per-PR configuration. This resolves the *backend-side* (CORS + azp/HC-02) half
+of the risk cleanly. **This is a Railway dashboard configuration action for
+Ryan, not something I can set from here** (matches the brief's framing that
+DB_TYPE etc. are dashboard-only).
+
+**Unverified — Clerk's own dashboard (separate from ALLOWED_ORIGINS):** Clerk
+maintains its own "allowed origins" / redirect URL configuration for its
+frontend SDK (ClerkJS) — this is what governs whether Clerk will let its
+JS run and issue tokens from a given browser origin in the first place, and
+is completely independent of the backend's ALLOWED_ORIGINS/azp check. I do
+not have access to Clerk's dashboard and could not verify:
+  - Whether Ryan's current Clerk plan supports a wildcard/dynamic pattern for
+    allowed origins (e.g. `https://*.up.railway.app` or similar), which is
+    what would be needed to cover an unbounded, unpredictable set of future
+    PR preview domains without editing Clerk's dashboard on every PR open.
+  - This is commonly a paid-tier feature on auth providers generally: it is
+    NOT safe to assume Ryan's plan supports it.
+
+**If Clerk cannot be configured for dynamic preview origins** (this needs
+checking in Clerk's dashboard directly — I cannot do this): the documented
+fallback per ADL-32 §6 is scoping `BYPASS_AUTH=true` to the Preview
+environment only, via Railway's environment-scoped variables (Production
+keeps BYPASS_AUTH unset — the existing NODE_ENV=production fatal-error guard
+in server.ts stays as the backstop regardless). **Flagging explicitly per the
+brief's instruction: this is a tradeoff, not a clean solution** — Preview
+environments would stop exercising real Clerk auth, narrowing exactly the
+class of bug ADL-32 §2 cited as Railway's main selling point over Fly.io
+(catching things that only break against a live, hosted server — CORS, static
+serving, real auth — which local dev/CI can't). This should not be adopted
+silently; it needs a COO/PO decision once Ryan has checked Clerk's dashboard
+options. **This is the part of this brief that needs a COO/PO follow-up
+decision, not just code** — flagged prominently in the completion report too.
+
+---
+
+## PROCESS INCIDENT during local testing (self-inflicted, contained)
+
+While cleaning up a stray local test server process, I ran
+`pkill -9 -f "tsx watch src/backend/server.ts"` — this pattern is NOT scoped
+to my worktree and matched the `tsx watch` supervisor wrapper processes
+(pid 59015 `sh -c tsx watch...`, pid 59016 `node .../tsx watch...`) belonging
+to a DIFFERENT session's dev server running from the shared `/workspace`
+checkout (not my worktree), which I have no business touching per the
+worktree isolation rule.
+
+Impact: the actual Express server process for that other session (a
+grandchild PID, 59027, whose full command line does not literally contain the
+string "tsx watch src/backend/server.ts") survived and is still listening on
+port 3001 (confirmed via `curl http://localhost:3001/health` → 200 after the
+incident) — so that other session's server did NOT go down and no request
+was dropped as far as I can tell. However, its `tsx watch` supervisor (the
+piece that auto-restarts on file save) is dead — if that other session edits
+a backend file expecting hot-reload, it will silently NOT reload anymore
+until someone restarts `npm run dev:api` there.
+
+I did not attempt to fix or restart that other session's server — it is not
+mine to manage, and guessing at its intended env vars risked making things
+worse. Flagging this to COO explicitly so whoever owns that other session's
+dev server is aware their hot-reload is currently dead and can restart
+`npm run dev:api` from `/workspace` themselves. Lesson for next time: never
+use `pkill -f` with a pattern that isn't scoped to the worktree's absolute
+path (e.g. `pkill -f "agent-a5864.*tsx watch"` or just track PIDs explicitly
+from the start, which is what I switched to for the rest of this session).
+
+---
+
+## OPEN ISSUES / FOLLOW-UPS FOR COO
+  - Clerk dashboard origin-config verification (§3 above) — needs Ryan to
+    check Clerk's dashboard for wildcard/dynamic origin support on his plan.
+    This determines whether Preview environments get real auth or fall back
+    to BYPASS_AUTH=true (Preview-scoped only) per ADL-32 §6's documented
+    fallback.
+  - Process incident above — the other session's dev:api hot-reload
+    supervisor (pid 59015/59016, /workspace checkout, port 3001) is dead;
+    that session's owner should restart `npm run dev:api` when convenient.
+  - ADL-32 §9 "Implications → BACKEND" checklist items are now implemented;
+    COO may want to mark these done in the ADL log per the document lifecycle
+    rule (this park doc + the PR are the source of truth for what changed).
+  - ADL-32 §10 success criteria (production URL reachable, Clerk sign-in
+    e2e, data persists across deploy, PR preview reachable, preview DB
+    isolation, CI+deploy green on merge) are NOT verifiable from this seat —
+    they require an actual Railway deploy, which is outside this brief's
+    scope (code-only). Someone (COO/PO) needs to verify these once Railway
+    auto-deploys this branch's PR / merges to main.
+
+## WHAT'S NOW UNBLOCKED
+  - Railway can deploy this branch (once merged) with DB_TYPE=sqlite (Ryan
+    sets in Railway dashboard, not committed) + the already-provisioned
+    TURSO_DATABASE_URL/TURSO_AUTH_TOKEN/HOST/NODE_ENV vars, and the server
+    should both connect to Turso and serve the built frontend correctly.
+  - Database brief (staging Turso seed strategy, per ADL-32 §9 DATABASE
+    implications) is independent of this work and can proceed in parallel —
+    no shared files.

--- a/src/backend/db/index.ts
+++ b/src/backend/db/index.ts
@@ -92,23 +92,32 @@ export function getDb(): LibSQLDb {
 /**
  * Creates a libSQL (SQLite-compatible) Drizzle instance.
  *
- * SQLITE_PATH must use the libSQL URL scheme:
- *   file:./dev.db                          — relative path
- *   file:/absolute/path/to/db.db           — absolute path (use for OneDrive)
+ * Connection URL resolution (ADL-32):
+ *   TURSO_DATABASE_URL, if set, takes priority — a remote libsql:// URL for a
+ *   hosted Turso database (Railway production/preview environments).
+ *   Otherwise falls back to SQLITE_PATH, which must use the libSQL URL scheme:
+ *     file:./dev.db                          — relative path
+ *     file:/absolute/path/to/db.db           — absolute path (use for OneDrive)
  *
- * @throws {Error} If SQLITE_PATH is not set.
+ * TURSO_AUTH_TOKEN, if set, is passed as the client authToken — required by
+ * Turso's remote databases, left undefined for local file-based dev (local
+ * SQLite files don't need/accept an auth token).
+ *
+ * @throws {Error} If neither TURSO_DATABASE_URL nor SQLITE_PATH is set.
  */
 function createLibSQLDb(): LibSQLDb {
-  const sqlitePath = process.env.SQLITE_PATH;
-  if (!sqlitePath) {
+  const url = process.env.TURSO_DATABASE_URL || process.env.SQLITE_PATH;
+  if (!url) {
     throw new Error(
-      '[DB] SQLITE_PATH is required when DB_TYPE=sqlite.\n' +
-        '     Set it to a libSQL URL, e.g. SQLITE_PATH=file:./dev.db',
+      '[DB] TURSO_DATABASE_URL or SQLITE_PATH is required when DB_TYPE=sqlite.\n' +
+        '     Set SQLITE_PATH to a libSQL URL for local dev, e.g. SQLITE_PATH=file:./dev.db\n' +
+        '     or TURSO_DATABASE_URL to a remote libsql:// URL for a hosted Turso database.',
     );
   }
+  const authToken = process.env.TURSO_AUTH_TOKEN || undefined;
 
-  const client = createClient({ url: sqlitePath });
-  console.info(`[DB] SQLite (libSQL) connected: ${sqlitePath}`);
+  const client = createClient({ url, authToken });
+  console.info(`[DB] SQLite (libSQL) connected: ${url}`);
   return drizzleLibSQL(client, { schema });
 }
 

--- a/src/backend/server.ts
+++ b/src/backend/server.ts
@@ -24,6 +24,7 @@ import { config } from 'dotenv';
 
 config({ path: '.env.local' }); // explicit .env.local load
 
+import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import cors from 'cors';
@@ -58,6 +59,14 @@ const ALLOWED_ORIGINS = (
 )
   .split(',')
   .map((o) => o.trim());
+
+// ADL-32: Hosted deployment (Railway) serves the built frontend from this same
+// process — express.static on the Vite dist/ build + an SPA fallback for
+// client-side routes. Gated on NODE_ENV=production AND the dist/ directory
+// actually existing, so local dev (two-process Vite/Express split, no dist/
+// build present) is completely unaffected.
+const DIST_DIR = path.join(__dirname, '../../dist');
+const SERVE_STATIC = process.env.NODE_ENV === 'production' && fs.existsSync(DIST_DIR);
 
 // ----------------------------------------------------------------
 // App setup
@@ -160,6 +169,41 @@ app.use('/api/me', meRouter); // BUG-26: identity endpoint for frontend owner ga
 
 // Health check (useful for development)
 app.get('/health', (_req, res) => res.json({ status: 'ok' }));
+
+// ----------------------------------------------------------------
+// Static frontend (ADL-32 — hosted deployment only)
+// ----------------------------------------------------------------
+//
+// Registered AFTER all /api/* routers and /health above, so those always take
+// priority. Two-part serving:
+//   1. express.static serves real built assets (JS/CSS/images) directly from
+//      dist/ when the request path matches a file on disk.
+//   2. The SPA fallback below catches everything else so client-side routing
+//      (React Router) works on refresh/deep-link — EXCEPT /api/* paths, which
+//      are explicitly excluded and passed through via next() so an unmatched
+//      API route still falls through to Express's normal 404 behaviour
+//      instead of incorrectly returning index.html.
+if (SERVE_STATIC) {
+  console.info(`[STARTUP] Serving static frontend build from ${DIST_DIR}`);
+  app.use(express.static(DIST_DIR));
+
+  // Path-less middleware (not app.get('*', ...)) — Express 5's path-to-regexp
+  // no longer accepts a bare '*' wildcard pattern, so the exclusion is done
+  // in code instead of route syntax.
+  app.use((req, res, next) => {
+    if (req.method !== 'GET' || req.path.startsWith('/api/')) {
+      next();
+      return;
+    }
+    // Pass `root` + a relative filename rather than a bare absolute path —
+    // send's dotfile check (invoked by res.sendFile) walks every segment of
+    // an absolute path when no `root` is given, which spuriously 404s if any
+    // ancestor directory in the deployment path starts with a dot. Using
+    // `root` also keeps this call inside DIST_DIR, which is simply correct
+    // practice for res.sendFile regardless of deployment path.
+    res.sendFile('index.html', { root: DIST_DIR });
+  });
+}
 
 // 7. Global error handler — MUST be last (SEC-06)
 app.use(errorHandler);


### PR DESCRIPTION
Closes BRD-NF09 backend implementation. BRD §NF-09, ADL-32.

## Summary
Implements 2 of ADL-32's 3 backend scope items; the 3rd is investigation/documentation only.

- **`src/backend/db/index.ts`**: `createLibSQLDb()` now prefers `TURSO_DATABASE_URL` over `SQLITE_PATH` and passes `TURSO_AUTH_TOKEN` as `authToken` when present, enabling connection to a hosted Turso database. Local dev is unaffected — no `TURSO_DATABASE_URL` set locally, falls back to `SQLITE_PATH` with `authToken` undefined, exactly as before. `DB_TYPE` switch structure untouched.
- **`src/backend/server.ts`**: adds `express.static` serving of the Vite `dist/` build plus an SPA fallback for client-side routing, gated on `NODE_ENV === 'production' && dist/ exists` so local dev (two-process Vite/Express split, no `dist/` build present) is unaffected. `/api/*` paths are explicitly excluded from the fallback so an unmatched API route still gets Express's normal 404 behaviour instead of incorrectly returning `index.html`.
- **Clerk origin verification (ADL-32 §6)**: investigated, no code change needed on the backend side — `ALLOWED_ORIGINS`/`azp` (HC-02) can be set dynamically per Railway Preview via Railway's `${{RAILWAY_PUBLIC_DOMAIN}}` reference-variable templating (a dashboard action for Ryan, not code). Clerk's own dashboard allowed-origins config is separate and unverified — flagged to COO/PO as needing a follow-up decision. Full findings in the completion report (`jobs/COO/inbox/20260721_1706-BACKEND-nf09-hosted-deployment-complete.txt`) and park doc (`jobs/backend/park-docs/20260721-BACKEND-nf09-hosted-deployment-park.txt`).

Two non-obvious bugs found and fixed along the way (documented in code comments and the park doc):
1. Express 5 removed the bare `*` wildcard route pattern — `app.get('*', ...)` throws at startup under this repo's `express ^5.2.1`. Used a path-less `app.use()` with the `/api/` exclusion done in code instead.
2. `res.sendFile(absolutePath)` without a `root` option 404s if any ancestor directory in the path starts with a dot (`send`'s dotfile check walks every path segment). Fixed with `res.sendFile('index.html', { root: DIST_DIR })`, which is also the more correct/idiomatic pattern regardless of deployment path.

## Security checklist
1. Auth middleware — N/A. Static assets/SPA shell are public by design (same as the existing frontend build being publicly downloadable); no user-data route added. `/api/*` is explicitly excluded from the new fallback so `requireAuth`'s existing coverage is untouched.
2. Repository queries scoped by `userId` — N/A, no new queries introduced.
3. FK `.notNull()` — N/A, no new tables/columns.

## Test plan
- [x] `npm run type:check:all` — clean
- [x] `npm run test:backend` — 532 passed, 1 skipped
- [x] `npm run test:frontend` — 119 passed
- [x] `npm run test:contract` — 109 passed (against a local instance with `BYPASS_AUTH=true`)
- [x] `npm run check` (Biome lint) — clean
- [x] `npm run status:check` — up to date
- [x] Local dev (`npm run dev:api` + `npm run dev`, no `NODE_ENV=production`) confirmed unaffected
- [x] `npm run build` + `NODE_ENV=production` local simulation: `/` and static assets served correctly, SPA fallback route serves `index.html`, unmatched `/api/*` route correctly does NOT get `index.html`

🤖 Generated with [Claude Code](https://claude.com/claude-code)