### PR TITLE
docs(UX): Waypoint redesign spec — Phase 1 + Phase 2, ready for BRD gate

### DIFF
--- a/jobs/COO/inbox/20260721_1500-UX-waypoint-spec-blocked.txt
+++ b/jobs/COO/inbox/20260721_1500-UX-waypoint-spec-blocked.txt
@@ -1,0 +1,58 @@
+FROM: UX
+TO:   COO
+DATE: 2026-07-21 15:00
+RE:   Waypoint redesign spec — BLOCKED, not delivered
+
+Tracker ID: n/a (no tracker entry — this thread produced no spec/BRD deliverable)
+GitHub PR: #194 (chore/waypoint-redesign-spec)
+BRD section: n/a — nothing added/changed
+Branch: chore/waypoint-redesign-spec
+
+WHAT WAS ASKED: Formalize the Waypoint claude.ai Design mockups (project
+8cc525c1-b678-4976-a207-57f7f489844b) into a two-phase spec (Phase 1 design-system
+tokens, Phase 2 Trips screen reskin) for Frontend to implement.
+
+FINDINGS: BLOCKED. The `DesignSync` tool named in the brief for reading the mockup
+files does not exist in this environment. Confirmed three ways: ToolSearch (several
+phrasings, no match), `claude mcp list` (only monday.com/Google Drive/Gmail/Calendar
+configured — no DesignSync entry, not even auth-pending), and a direct WebFetch to
+the claude.ai project URL (403, no session). No local copy of the mockups exists in
+the repo either. I did not fabricate the mockup's design tokens (oklch values, type
+pairings, icon glyphs, badge-hue mapping) to paper over this — the brief explicitly
+requires exact values, and a guessed spec would look complete while silently
+diverging from what Ryan approved. That's a worse outcome than an honest block.
+
+CONFLICTS FOUND (flagging per your ask, even though the spec itself is blocked):
+None yet identifiable against the mockup itself (can't read it). But two things
+worth your attention now, found while cross-referencing the *current* Trips
+implementation against the BRD/bug fixes you asked me to check:
+  1. DP-06 (first place inherits trip's date range) is tracker status "pending" —
+     not yet built. If the mockup only shows populated place-date states, the
+     follow-up spec needs to call out this still-open gap explicitly rather than
+     assume it's covered.
+  2. BUG-36's trip-level items section (flights/car rentals not tied to a place)
+     isn't mentioned anywhere in your brief's "what's in it" summary of the
+     mockups. Once the mockup is readable, this needs an explicit check — if it's
+     genuinely absent from the mockup, that's a real conflict (a shipped,
+     BRD-linked feature can't just disappear in a reskin), not something to
+     silently resolve.
+
+WHAT I DID INSTEAD: Full read of the current Trips screen implementation
+(TripsLayout, TripCard, TripDetail, PlaceSection, StatusBadge, ItemCard,
+TripItemsSection, App nav) and cross-referenced it against DP-04/DP-05/DP-06,
+BUG-31/32/34/36, IT-01 — plus confirmed current stack facts relevant to where
+Phase 1 tokens would live (Tailwind v4 CSS-first config, no shadcn/ui or icon
+library ever adopted despite the March plan assuming one). Full detail in
+jobs/ux/tech/20260721-UX-waypoint-spec-blocked.md. This should make the follow-up
+thread a single focused pass instead of a re-audit from scratch.
+
+CI: gh pr checks 194 — all 9 checks green (Backend/Frontend/Contract/E2E tests,
+Biome, Type Check, Dependency Scan, Secret Scanning, Semgrep).
+
+BLOCKERS: Yes — see above. To unblock, either (a) get the DesignSync MCP server
+connected for this environment, or (b) get the three .dc.html files' raw content
+into a channel UX already has access to (committed into the repo, or shared via
+the connected Google Drive MCP).
+
+WHAT'S UNBLOCKED: Nothing for Frontend yet — no spec exists to dispatch from.
+Re-run this brief once mockup access is restored.

--- a/jobs/COO/inbox/20260721_1500-UX-waypoint-spec-blocked.txt
+++ b/jobs/COO/inbox/20260721_1500-UX-waypoint-spec-blocked.txt
@@ -1,58 +1,78 @@
 FROM: UX
 TO:   COO
-DATE: 2026-07-21 15:00
-RE:   Waypoint redesign spec — BLOCKED, not delivered
+DATE: 2026-07-21 15:00 (updated 15:35 — unblocked, spec delivered)
+RE:   Waypoint redesign spec — DELIVERED
 
-Tracker ID: n/a (no tracker entry — this thread produced no spec/BRD deliverable)
+Tracker ID: n/a (spec deliverable — COO adds tracker/BRD entries after review, per
+the BRD-gate-before-dispatch rule)
 GitHub PR: #194 (chore/waypoint-redesign-spec)
-BRD section: n/a — nothing added/changed
+BRD section: n/a — this thread does not touch the BRD; COO does that after review
 Branch: chore/waypoint-redesign-spec
 
-WHAT WAS ASKED: Formalize the Waypoint claude.ai Design mockups (project
-8cc525c1-b678-4976-a207-57f7f489844b) into a two-phase spec (Phase 1 design-system
-tokens, Phase 2 Trips screen reskin) for Frontend to implement.
+UPDATE: This thread was initially blocked (DesignSync unavailable to a dispatched
+agent — confirmed via ToolSearch, `claude mcp list`, and a 403 WebFetch). You then
+confirmed DesignSync is main-session-only and supplied verbatim copies of the three
+mockup files directly into this worktree (jobs/ux/tech/waypoint-mockups/*.dc.html).
+I read all three in full and completed the spec in the same thread. Original blocker
+record retained and stamped RESOLVED at jobs/ux/tech/20260721-UX-waypoint-spec-blocked.md.
 
-FINDINGS: BLOCKED. The `DesignSync` tool named in the brief for reading the mockup
-files does not exist in this environment. Confirmed three ways: ToolSearch (several
-phrasings, no match), `claude mcp list` (only monday.com/Google Drive/Gmail/Calendar
-configured — no DesignSync entry, not even auth-pending), and a direct WebFetch to
-the claude.ai project URL (403, no session). No local copy of the mockups exists in
-the repo either. I did not fabricate the mockup's design tokens (oklch values, type
-pairings, icon glyphs, badge-hue mapping) to paper over this — the brief explicitly
-requires exact values, and a guessed spec would look complete while silently
-diverging from what Ryan approved. That's a worse outcome than an honest block.
+WHAT WAS SPECCED: Full Phase 1 (design-system foundation) + Phase 2 (Trips screen
+reskin, desktop + mobile) implementation spec — jobs/ux/tech/20260721-UX-waypoint-spec.md.
+Phase 1: exact oklch color tokens, Newsreader/Manrope type scale, 11 SVG icon glyphs
+with exact path data, badge/button/input styling, and where these tokens belong given
+this repo's Tailwind v4 CSS-first config. Phase 2: full desktop + mobile Trips layout
+(nav, left panel, trip cards, detail header, a NEW status-stepper component replacing
+today's flat status bar, place sections, item cards, empty states, mobile slide
+transition + bottom tab bar), cross-referenced line-by-line against DP-01..06,
+TR-09/11/12/13, BUG-31/32/34/36, IT-01, UX-02, FEAT-BD, NTH-01/03.
 
-CONFLICTS FOUND (flagging per your ask, even though the spec itself is blocked):
-None yet identifiable against the mockup itself (can't read it). But two things
-worth your attention now, found while cross-referencing the *current* Trips
-implementation against the BRD/bug fixes you asked me to check:
-  1. DP-06 (first place inherits trip's date range) is tracker status "pending" —
-     not yet built. If the mockup only shows populated place-date states, the
-     follow-up spec needs to call out this still-open gap explicitly rather than
-     assume it's covered.
-  2. BUG-36's trip-level items section (flights/car rentals not tied to a place)
-     isn't mentioned anywhere in your brief's "what's in it" summary of the
-     mockups. Once the mockup is readable, this needs an explicit check — if it's
-     genuinely absent from the mockup, that's a real conflict (a shipped,
-     BRD-linked feature can't just disappear in a reskin), not something to
-     silently resolve.
+CONFLICTS FOUND: Yes — 13 flagged (C1-C13), listed at the top of the spec doc, NOT
+silently resolved. The consequential ones:
+  C1: Both mockups rename the product to "Waypoint" in the nav — a real product
+      decision, not a styling choice. Needs an explicit yes/no from Ryan.
+  C2: The new status-stepper component (replacing today's flat status bar) has NO
+      Unlock affordance anywhere in either mockup — but the current app has a
+      working, tested Unlock button + confirm flow. Must be preserved as new chrome
+      the mockup doesn't show, not dropped.
+  C3: BUG-36's trip-level items section (flights/cars not tied to a place, shipped
+      2026-07-20, IT-01) is entirely absent from both mockups. Must be preserved.
+  C4: Place-section Edit-dates/Set-dates (UX-02) and Remove (BUG-32) buttons are
+      absent from the mockup's place header — only "+ Add Item" appears. Must be
+      preserved.
+  C5: The mockup's item card drops rating stars, the "carried forward" tag, and full
+      per-type subtext (hotel dates, flight number, cuisine type, notes) down to one
+      generic subtitle line. Must preserve full richness inside the new visual shell.
+  C6: The mockup only demonstrates the filtered-empty state ("no trips match"), not
+      the true first-run zero-trips state the current app already distinguishes
+      ("No trips yet. Create one with '+ New'."). Must preserve both messages.
+  C7: Bulk multi-select delete (FEAT-BD), the undo bar (NTH-01), per-status filter
+      counts (NTH-03), the sort control (TR-09), and the map-filter badge all have no
+      mockup equivalent. Must preserve all — reskinned, not removed.
+  C8: The mockup's own reference implementation renders icons via
+      `dangerouslySetInnerHTML` — a blocking defect in this codebase per
+      `_shared/frameworks.txt` rule 22. Frontend must use literal inline SVG JSX
+      instead (same visual result, compliant technique).
+  C9: The mobile bottom tab bar only appears in the list view, not the detail view
+      (back-button bar takes over there). Likely intentional (my read) but needs
+      Ryan's confirmation since it's a navigation-model decision, not styling.
+  C10-C13: Smaller precision flags — left-panel width (340px mockup vs 320px
+      current, a second change to the same value in under a year), a category-badge
+      color used in both Trips mockups but undocumented in the Design System file's
+      own token swatches, a Newsreader font-weight discrepancy (system doc says 500,
+      every real applied instance uses 600), and a button-radius discrepancy (system
+      doc says 10px, applied buttons measure 9px).
 
-WHAT I DID INSTEAD: Full read of the current Trips screen implementation
-(TripsLayout, TripCard, TripDetail, PlaceSection, StatusBadge, ItemCard,
-TripItemsSection, App nav) and cross-referenced it against DP-04/DP-05/DP-06,
-BUG-31/32/34/36, IT-01 — plus confirmed current stack facts relevant to where
-Phase 1 tokens would live (Tailwind v4 CSS-first config, no shadcn/ui or icon
-library ever adopted despite the March plan assuming one). Full detail in
-jobs/ux/tech/20260721-UX-waypoint-spec-blocked.md. This should make the follow-up
-thread a single focused pass instead of a re-audit from scratch.
+None of C1-C13 block Phase 1 (tokens only, no reskin yet). All must be resolved
+before Phase 2 is briefed to Frontend, per the spec's own success criteria.
 
-CI: gh pr checks 194 — all 9 checks green (Backend/Frontend/Contract/E2E tests,
-Biome, Type Check, Dependency Scan, Secret Scanning, Semgrep).
+CI: gh pr checks 194 — all 9 checks green on the final commit (Backend/Frontend/
+Contract/E2E tests, Biome, Type Check, Dependency Scan, Secret Scanning, Semgrep).
 
-BLOCKERS: Yes — see above. To unblock, either (a) get the DesignSync MCP server
-connected for this environment, or (b) get the three .dc.html files' raw content
-into a channel UX already has access to (committed into the repo, or shared via
-the connected Google Drive MCP).
+BLOCKING ISSUES: None remaining. (Historical: DesignSync access — resolved this
+thread via your direct file supply.)
 
-WHAT'S UNBLOCKED: Nothing for Frontend yet — no spec exists to dispatch from.
-Re-run this brief once mockup access is restored.
+WHAT'S UNBLOCKED: Frontend can be dispatched for Phase 1 once you've reviewed the
+spec and completed the BRD gate (new requirement IDs need a BRD home before
+dispatch, per CLAUDE.md). Phase 2 dispatch additionally needs C1-C13 resolved with
+Ryan first — recommend recording those decisions via the record-decision skill
+(BRD entries / ADL / tracker notes as appropriate per each item).

--- a/jobs/ux/context/current.txt
+++ b/jobs/ux/context/current.txt
@@ -1,7 +1,8 @@
-UX CONTEXT — 2026-07-21 (updated)
+UX CONTEXT — 2026-07-21 (updated, unblocked + completed)
 PROJECT: Travel Tracker
-CURRENT STATUS: Waypoint redesign spec BLOCKED — DesignSync tool unavailable in this
-environment. Preparatory groundwork done; formal Phase 1/Phase 2 spec not yet written.
+CURRENT STATUS: Waypoint redesign spec DELIVERED. Phase 1 (design-system foundation) +
+Phase 2 (Trips screen reskin, desktop + mobile) spec complete, with 13 flagged
+conflicts/open questions for COO/Ryan to resolve before Frontend dispatch.
 
 ================================================================================
 ROLE SUMMARY
@@ -25,73 +26,85 @@ PROJECT CONTEXT (verified 2026-07-21)
                 migration. Only the Tailwind half of that plan landed.
   Mapping:      MapLibre GL JS + react-map-gl + MapTiler tiles
   Current palette: Teal primary / amber (active/review) / violet (category
-                badges) / emerald (positive CTA) — NOT blue. A full rebrand
-                already happened once (see 20260321-UX-delivered-vs-mockup-delta.md).
-                The incoming "Waypoint" rebrand (warm paper neutrals + pine
-                primary) replaces THIS palette, not the original blue one.
-  Current icons: literal emoji throughout (ItemCard TYPE_ICONS: 🍽️🏨✈️🚗🎫📝,
-                plus 📷 Photos, 🔒 locked banner, 🗺 empty state) — exact match
-                to the icon set named in the Waypoint brief.
+                badges) / emerald (positive CTA) — being replaced by the
+                Waypoint palette (warm paper neutrals + deep pine primary,
+                oklch-based) per the new spec.
 
 ================================================================================
-ACTIVE THREAD — Waypoint redesign spec (2026-07-21)
+COMPLETED THREAD — Waypoint redesign spec (2026-07-21)
 ================================================================================
 
   Brief: formalize claude.ai Design project "Travel tracker design review"
   (projectId 8cc525c1-b678-4976-a207-57f7f489844b — Design System.dc.html,
-  Trips Desktop.dc.html, Trips Mobile.dc.html) into a two-phase briefable spec
-  (Phase 1 = design-system foundation tokens, Phase 2 = Trips screen reskin).
+  Trips Desktop.dc.html, Trips Mobile.dc.html) into a two-phase briefable spec.
 
-  BLOCKED: The `DesignSync` tool named in the brief does not exist in this
-  environment. Verified via ToolSearch (multiple query phrasings), `claude mcp
-  list` (only monday.com/Google Drive/Gmail/Calendar configured — no DesignSync
-  entry at all, not even auth-pending), and a direct WebFetch to the claude.ai
-  project URL (403, as expected, no session). No local copy of the mockup
-  files exists in the repo either (grep/find came back empty).
+  Initially BLOCKED: the `DesignSync` tool named in the brief is specific to the
+  main interactive session and unavailable to a dispatched agent (confirmed via
+  ToolSearch, `claude mcp list`, and a direct WebFetch 403 — see
+  jobs/ux/tech/20260721-UX-waypoint-spec-blocked.md for the full trail). Did NOT
+  fabricate mockup content to paper over this.
 
-  Did NOT fabricate oklch values / type pairings / icon glyphs / badge-hue
-  mapping to paper over the gap — the brief is explicit these must be exact,
-  not approximated, and a plausible-looking guess would be worse than an
-  honest block (Frontend would build the wrong thing with high confidence).
+  UNBLOCKED same thread: coordinator supplied verbatim copies of all three
+  mockup files into this worktree at jobs/ux/tech/waypoint-mockups/*.dc.html.
+  Read all three in full and produced the real spec:
+  jobs/ux/tech/20260721-UX-waypoint-spec.md
 
-  Instead, completed the half of the job that doesn't need the mockups:
-  - Full read of current Trips screen implementation (TripsLayout, TripCard,
-    TripDetail, PlaceSection, StatusBadge, ItemCard, TripItemsSection, App.tsx)
-  - Cross-referenced DP-04/DP-05/DP-06, BUG-31/32/34/36, IT-01 against the
-    actual code (not just tracker notes) — see full detail in
-    jobs/ux/tech/20260721-UX-waypoint-spec-blocked.md
-  - Flagged: DP-06 is tracker-status "pending" (not yet built) — a real gap,
-    not a display nuance; must not get silently papered over in Phase 2.
-  - Flagged: BUG-36's trip-level items section (TripItemsSection.tsx) isn't
-    mentioned in the brief's mockup summary at all — needs an explicit check
-    once the mockup can be read; if absent from the mockup that's a conflict
-    to raise with COO, not a silent removal.
-  - Flagged: FEAT-BD bulk multi-select delete, NTH-01 undo bar, NTH-03 status
-    counts, TR-09 sort control, map filter badge — all real current
-    functionality with no mention in the brief's "what's in it" summary.
-  - Flagged: if Waypoint's icon set implies an actual icon library dependency
-    (vs. hand-authored SVG), that's a new dependency needing a COO tradeoff
-    call — not pre-approved by the stale March Lucide recommendation (which
-    assumed a shadcn/ui migration that never happened).
-
-  Deliverable this thread: jobs/ux/tech/20260721-UX-waypoint-spec-blocked.md
-  (blocker record + full prep-work handoff, NOT the formal spec).
+  Deliverable contents:
+  - Phase 1: full oklch color token table (neutrals, brand, 7 status/category
+    hues), Newsreader/Manrope type scale, 11 SVG icon glyphs (8 item-type/status
+    + 4 nav/chrome) with exact path data — confirmed NO new icon-library
+    dependency needed (mockup icons are hand-authored SVG paths, not from a
+    named library), badge/button/input styling, and where these tokens should
+    live given this repo's Tailwind v4 CSS-first config. Recommended icon
+    replacement (emoji -> SVG) as the one immediate-apply exception; everything
+    else stays defined-but-unused until Phase 2 to avoid a half-migrated,
+    inconsistent state.
+  - Phase 2: full desktop + mobile Trips layout breakdown (nav, left panel,
+    trip cards, detail header, NEW status-stepper component replacing the flat
+    status bar, place sections, item cards, empty states, mobile slide
+    transition + bottom tab bar), cross-referenced line-by-line against
+    DP-01..06, TR-09/11/12/13, BUG-31/32/34/36, IT-01, UX-02, FEAT-BD, NTH-01/03.
+  - 13 flagged conflicts/open questions (C1-C13) requiring explicit COO/Ryan
+    decisions before Frontend dispatch — NOT silently resolved. Highlights:
+    * C1: mockup renames the product to "Waypoint" in the nav — real decision,
+      not styling.
+    * C2: mockup's status stepper has no Unlock affordance at all (current app
+      has a working, tested Unlock flow) — must be preserved, added to the new
+      stepper as chrome the mockup doesn't show.
+    * C3: BUG-36's trip-level items section (shipped 2026-07-20, IT-01) is
+      absent from both mockups entirely — must be preserved, not silently
+      dropped.
+    * C4: place-section Edit-dates/Remove buttons (UX-02, BUG-32) absent from
+      mockup place-header — must be preserved.
+    * C5: item card in mockup drops rating stars, carried-forward tag, and
+      full per-type subtext down to one generic line — must preserve full
+      richness inside the new visual shell.
+    * C6: mockup only shows the filtered-empty state, not the true first-run
+      zero-trips state current app already distinguishes — must preserve both.
+    * C7: FEAT-BD bulk delete, NTH-01 undo, NTH-03 filter counts, TR-09 sort,
+      map-filter badge all absent from mockup — must preserve all.
+    * C8: mockup's own reference implementation uses dangerouslySetInnerHTML
+      to render icons — blocking defect per _shared/frameworks.txt rule 22;
+      Frontend must use literal inline SVG JSX instead (same visual output).
+    * C9: mobile bottom tab bar only appears in list view, not detail view —
+      likely intentional (my read), needs Ryan confirmation since it's a nav
+      model decision.
+    * C10-C13: smaller precision flags (panel width 340 vs 320px, category
+      badge color undocumented in the system file itself, Newsreader weight
+      600 vs system doc's stated 500, button radius 10px vs mockups' applied
+      9px).
 
 ================================================================================
 NEXT ACTIONS
 ================================================================================
 
-  COO must either:
-   (a) get the DesignSync MCP server connected/configured for this
-       environment, or
-   (b) get the three .dc.html files' raw content into a channel UX already
-       has access to (committed into the repo, or shared via the connected
-       Google Drive MCP)
+  COO reviews jobs/ux/tech/20260721-UX-waypoint-spec.md, resolves C1-C13 with
+  Ryan (recording decisions per the document-lifecycle/record-decision rules —
+  BRD entries, ADL, or tracker notes as appropriate), adds any new requirement
+  IDs to the BRD (BRD-gate-before-dispatch rule), then dispatches Frontend:
+  Phase 1 first (verified/UAT'd before any reskin), then Phase 2.
 
-  Then re-dispatch a UX thread to actually write the Phase 1 + Phase 2 spec —
-  the prep work above means that thread should be a single focused pass, not
-  a re-audit from scratch.
-
-  Prior completed work (BRIEF-UX-01, DELTA docs) is historical reference only —
-  superseded in spirit by the incoming Waypoint rebrand, not yet formally
-  stamped as superseded since the new spec doesn't exist yet to point to.
+  Prior completed work (BRIEF-UX-01, DELTA docs) is now formally superseded in
+  intent by this spec for the Trips screen specifically — not yet stamped with
+  a formal supersession banner since that's the record-decision skill's job at
+  BRD-gate time, not mine to do unilaterally in this thread.

--- a/jobs/ux/context/current.txt
+++ b/jobs/ux/context/current.txt
@@ -1,6 +1,7 @@
-UX CONTEXT — 2026-03-19 23:59
+UX CONTEXT — 2026-07-21 (updated)
 PROJECT: Travel Tracker
-CURRENT STATUS: BRIEF-UX-01 complete. Full audit + design system delivered.
+CURRENT STATUS: Waypoint redesign spec BLOCKED — DesignSync tool unavailable in this
+environment. Preparatory groundwork done; formal Phase 1/Phase 2 spec not yet written.
 
 ================================================================================
 ROLE SUMMARY
@@ -11,53 +12,86 @@ implementation specs for Frontend. Reports to COO. Does not send change
 requests to Frontend directly.
 
 ================================================================================
-PROJECT CONTEXT
+PROJECT CONTEXT (verified 2026-07-21)
 ================================================================================
 
   App type:     Travel tracking — map-centric, data entry, workflow management
-  Frontend:     React 18 + TypeScript + Vite
-  Styling:      Plain CSS / inline CSSProperties (NO CSS files — all inline)
+  Frontend:     React 18 + TypeScript + Vite + React Router + TanStack Query
+  Styling:      Tailwind CSS v4, CSS-first config (@import "tailwindcss" in
+                src/frontend/index.css — no tailwind.config.js/.ts exists)
+  Component lib: NONE adopted. No shadcn/ui, no Radix, no icon library
+                (no lucide-react, no clsx/cva) in package.json as of 2026-07-21,
+                despite the March 2026 UX audit assuming a Tailwind+shadcn
+                migration. Only the Tailwind half of that plan landed.
   Mapping:      MapLibre GL JS + react-map-gl + MapTiler tiles
-  Target stack: Tailwind CSS + shadcn/ui (approved by COO/PO)
-  Phase status: Phase 3 (UI) code complete — awaiting Tailwind/shadcn migration
+  Current palette: Teal primary / amber (active/review) / violet (category
+                badges) / emerald (positive CTA) — NOT blue. A full rebrand
+                already happened once (see 20260321-UX-delivered-vs-mockup-delta.md).
+                The incoming "Waypoint" rebrand (warm paper neutrals + pine
+                primary) replaces THIS palette, not the original blue one.
+  Current icons: literal emoji throughout (ItemCard TYPE_ICONS: 🍽️🏨✈️🚗🎫📝,
+                plus 📷 Photos, 🔒 locked banner, 🗺 empty state) — exact match
+                to the icon set named in the Waypoint brief.
 
 ================================================================================
-COMPLETED WORK
+ACTIVE THREAD — Waypoint redesign spec (2026-07-21)
 ================================================================================
 
-  BRIEF-UX-01 — Full UI audit + design system spec
-  Date: 2026-03-19
+  Brief: formalize claude.ai Design project "Travel tracker design review"
+  (projectId 8cc525c1-b678-4976-a207-57f7f489844b — Design System.dc.html,
+  Trips Desktop.dc.html, Trips Mobile.dc.html) into a two-phase briefable spec
+  (Phase 1 = design-system foundation tokens, Phase 2 = Trips screen reskin).
 
-  Deliverables produced:
-    /workspace/jobs/ux/tech/20260319-UX-audit.md
-    /workspace/jobs/ux/tech/20260319-UX-design-system.md
-    /workspace/jobs/ux/tech/20260319-UX-backlog.md
-    /workspace/jobs/ux/tech/20260319-UX-migration-notes.md
+  BLOCKED: The `DesignSync` tool named in the brief does not exist in this
+  environment. Verified via ToolSearch (multiple query phrasings), `claude mcp
+  list` (only monday.com/Google Drive/Gmail/Calendar configured — no DesignSync
+  entry at all, not even auth-pending), and a direct WebFetch to the claude.ai
+  project URL (403, as expected, no session). No local copy of the mockup
+  files exists in the repo either (grep/find came back empty).
 
-  Key findings:
-    - 11 MAJOR issues found (including no focus styles, no toast feedback,
-      destructive colour on positive action, dates as raw ISO strings)
-    - 27 MINOR issues
-    - 3 architectural concerns flagged to COO (see completion report)
-    - Complete design system spec produced: geographic/teal colour language,
-      Inter typography, semantic tokens, full shadcn/ui component inventory
-    - Prioritised backlog: 5 P0, 20 P1, 13 P2 items
+  Did NOT fabricate oklch values / type pairings / icon glyphs / badge-hue
+  mapping to paper over the gap — the brief is explicit these must be exact,
+  not approximated, and a plausible-looking guess would be worse than an
+  honest block (Frontend would build the wrong thing with high confidence).
 
-================================================================================
-ACTIVE CONCERNS / FLAGS
-================================================================================
+  Instead, completed the half of the job that doesn't need the mockups:
+  - Full read of current Trips screen implementation (TripsLayout, TripCard,
+    TripDetail, PlaceSection, StatusBadge, ItemCard, TripItemsSection, App.tsx)
+  - Cross-referenced DP-04/DP-05/DP-06, BUG-31/32/34/36, IT-01 against the
+    actual code (not just tracker notes) — see full detail in
+    jobs/ux/tech/20260721-UX-waypoint-spec-blocked.md
+  - Flagged: DP-06 is tracker-status "pending" (not yet built) — a real gap,
+    not a display nuance; must not get silently papered over in Phase 2.
+  - Flagged: BUG-36's trip-level items section (TripItemsSection.tsx) isn't
+    mentioned in the brief's mockup summary at all — needs an explicit check
+    once the mockup can be read; if absent from the mockup that's a conflict
+    to raise with COO, not a silent removal.
+  - Flagged: FEAT-BD bulk multi-select delete, NTH-01 undo bar, NTH-03 status
+    counts, TR-09 sort control, map filter badge — all real current
+    functionality with no mention in the brief's "what's in it" summary.
+  - Flagged: if Waypoint's icon set implies an actual icon library dependency
+    (vs. hand-authored SVG), that's a new dependency needing a COO tradeoff
+    call — not pre-approved by the stale March Lucide recommendation (which
+    assumed a shadcn/ui migration that never happened).
 
-  ARCH-01: Sequential PATCH calls in bulk review completion (ReviewPanel)
-           — backend needs bulk-update endpoint
-  ARCH-02: City marker sprite relies on MapTiler sprite name — fragility risk
-  ARCH-03: ShadingTab fires mutations on colour picker drag (onChange vs onBlur)
+  Deliverable this thread: jobs/ux/tech/20260721-UX-waypoint-spec-blocked.md
+  (blocker record + full prep-work handoff, NOT the formal spec).
 
 ================================================================================
 NEXT ACTIONS
 ================================================================================
 
-  Awaiting COO to route BRIEF-UX-01 deliverables to Frontend for implementation.
-  Frontend should begin with P0 items, then P1 (Tailwind migration first).
-  See 20260319-UX-migration-notes.md for order of operations.
+  COO must either:
+   (a) get the DesignSync MCP server connected/configured for this
+       environment, or
+   (b) get the three .dc.html files' raw content into a channel UX already
+       has access to (committed into the repo, or shared via the connected
+       Google Drive MCP)
 
-================================================================================
+  Then re-dispatch a UX thread to actually write the Phase 1 + Phase 2 spec —
+  the prep work above means that thread should be a single focused pass, not
+  a re-audit from scratch.
+
+  Prior completed work (BRIEF-UX-01, DELTA docs) is historical reference only —
+  superseded in spirit by the incoming Waypoint rebrand, not yet formally
+  stamped as superseded since the new spec doesn't exist yet to point to.

--- a/jobs/ux/park-docs/20260721-UX-park.txt
+++ b/jobs/ux/park-docs/20260721-UX-park.txt
@@ -1,0 +1,62 @@
+UX PARK DOCUMENT — 2026-07-21
+================================================================================
+THREAD: Waypoint redesign spec (formalize claude.ai Design project
+8cc525c1-b678-4976-a207-57f7f489844b into a two-phase implementation spec)
+================================================================================
+
+OUTCOME: BLOCKED, not delivered. See jobs/ux/tech/20260721-UX-waypoint-spec-blocked.md
+for full detail. Summary:
+
+The brief required reading three mockup files via a `DesignSync` tool. That tool is
+not present in this environment — confirmed three ways (ToolSearch across several
+phrasings, `claude mcp list` showing only 4 unrelated MCP servers configured, and a
+direct WebFetch to the claude.ai project URL returning 403). No local copy of the
+mockups exists in the repo. This is an environment/access gap, not something I can
+resolve from inside the thread.
+
+I did not invent plausible-looking design tokens to fill the gap. The brief is
+explicit that oklch values, type pairings, icon glyphs, and badge-hue mapping must be
+carried over exactly — a guessed spec would look complete while silently diverging
+from what Ryan actually approved, and Frontend would implement the wrong thing with
+full confidence. An honest block is the better failure mode here.
+
+WHAT WAS DONE INSTEAD (full detail in the blocked-spec doc):
+- Full re-read of the current Trips screen implementation end to end (TripsLayout,
+  TripCard, TripDetail, PlaceSection, StatusBadge, ItemCard, TripItemsSection,
+  App.tsx nav).
+- Verified current stack facts that affect where Phase 1 tokens would live:
+  Tailwind v4 CSS-first config (no tailwind.config file), no shadcn/ui or Radix or
+  icon library adopted despite the March 2026 audit assuming that migration — only
+  the Tailwind half landed.
+- Cross-referenced DP-04/DP-05/DP-06, BUG-31/32/34/36, IT-01 against the actual code
+  (not just tracker notes), including one real functional gap (DP-06 is tracker
+  status "pending" — not yet built) and one section with no obvious mockup
+  counterpart per the brief's summary (BUG-36's trip-level items section).
+- Inventoried existing Trips-screen functionality with no mention in the brief's
+  mockup summary (bulk multi-select delete, undo bar, per-status filter counts,
+  sort control, map filter badge) so the follow-up thread checks for these
+  explicitly instead of assuming the mockup silently drops them.
+
+BUGS DISCOVERED: None this thread (no implementation work was done — audit/read-only).
+
+OPEN ISSUES / BLOCKERS:
+  [CRITICAL — blocks the whole brief] DesignSync tool unavailable in this
+  environment. COO must either get it connected, or get the three .dc.html files'
+  raw content into a channel UX already has access to (committed into the repo
+  under jobs/ux/tech/, or shared via the connected Google Drive MCP). Flagged in
+  completion report to COO inbox.
+
+WHAT'S UNBLOCKED FOR OTHER JOBS: Nothing yet — Frontend has no spec to implement
+from. Once mockup access is restored and a follow-up UX thread completes the actual
+Phase 1/Phase 2 spec, Frontend can be dispatched (after COO's BRD-gate step, per
+CLAUDE.md's "BRD gate before dispatching briefs" rule).
+
+GIT: Branch chore/waypoint-redesign-spec. Housekeeping commit only (context, park
+doc, blocked-spec record, completion report) — no source files touched, no code
+spec produced. PR opened documenting the blocker for COO visibility; COO reviews
+and merges as usual, does not need to route anything to Frontend from this PR.
+
+NEXT ACTIONS: See "Recommended next step" in
+jobs/ux/tech/20260721-UX-waypoint-spec-blocked.md and "NEXT ACTIONS" in
+jobs/ux/context/current.txt.
+================================================================================

--- a/jobs/ux/park-docs/20260721-UX-park.txt
+++ b/jobs/ux/park-docs/20260721-UX-park.txt
@@ -4,59 +4,71 @@ THREAD: Waypoint redesign spec (formalize claude.ai Design project
 8cc525c1-b678-4976-a207-57f7f489844b into a two-phase implementation spec)
 ================================================================================
 
-OUTCOME: BLOCKED, not delivered. See jobs/ux/tech/20260721-UX-waypoint-spec-blocked.md
-for full detail. Summary:
+OUTCOME: DELIVERED. jobs/ux/tech/20260721-UX-waypoint-spec.md is the full Phase 1
+(design-system foundation) + Phase 2 (Trips screen reskin, desktop + mobile) spec.
 
-The brief required reading three mockup files via a `DesignSync` tool. That tool is
-not present in this environment — confirmed three ways (ToolSearch across several
-phrasings, `claude mcp list` showing only 4 unrelated MCP servers configured, and a
-direct WebFetch to the claude.ai project URL returning 403). No local copy of the
-mockups exists in the repo. This is an environment/access gap, not something I can
-resolve from inside the thread.
+The thread started blocked: the `DesignSync` tool named in the brief for reading the
+mockup files is not available to a dispatched agent (confirmed three ways — ToolSearch,
+`claude mcp list`, a direct WebFetch 403 — see jobs/ux/tech/20260721-UX-waypoint-spec-blocked.md
+for that history, now stamped RESOLVED at the top). Rather than fabricate the mockup's
+design tokens to paper over the gap, I did the half of the job that didn't need the
+mockups (full current-Trips-screen audit, BRD/bug-fix cross-reference) and reported the
+blocker to COO.
 
-I did not invent plausible-looking design tokens to fill the gap. The brief is
-explicit that oklch values, type pairings, icon glyphs, and badge-hue mapping must be
-carried over exactly — a guessed spec would look complete while silently diverging
-from what Ryan actually approved, and Frontend would implement the wrong thing with
-full confidence. An honest block is the better failure mode here.
+The coordinator then confirmed DesignSync is main-session-only and supplied verbatim
+copies of all three mockup files directly into this worktree
+(jobs/ux/tech/waypoint-mockups/{design-system,trips-desktop,trips-mobile}.dc.html). I
+read all three in full and completed the real spec in the same thread, building
+directly on the prep work already done.
 
-WHAT WAS DONE INSTEAD (full detail in the blocked-spec doc):
-- Full re-read of the current Trips screen implementation end to end (TripsLayout,
-  TripCard, TripDetail, PlaceSection, StatusBadge, ItemCard, TripItemsSection,
-  App.tsx nav).
-- Verified current stack facts that affect where Phase 1 tokens would live:
-  Tailwind v4 CSS-first config (no tailwind.config file), no shadcn/ui or Radix or
-  icon library adopted despite the March 2026 audit assuming that migration — only
-  the Tailwind half landed.
-- Cross-referenced DP-04/DP-05/DP-06, BUG-31/32/34/36, IT-01 against the actual code
-  (not just tracker notes), including one real functional gap (DP-06 is tracker
-  status "pending" — not yet built) and one section with no obvious mockup
-  counterpart per the brief's summary (BUG-36's trip-level items section).
-- Inventoried existing Trips-screen functionality with no mention in the brief's
-  mockup summary (bulk multi-select delete, undo bar, per-status filter counts,
-  sort control, map filter badge) so the follow-up thread checks for these
-  explicitly instead of assuming the mockup silently drops them.
+WHAT'S IN THE SPEC (full detail in jobs/ux/tech/20260721-UX-waypoint-spec.md, not
+restated here per the completion-report format):
+- Phase 1: exact oklch color tokens (neutrals + brand + 7 status/category hues),
+  Newsreader/Manrope type scale, 11 SVG icon glyphs with exact path data (confirmed:
+  no new icon-library dependency needed — mockup icons are hand-authored inline SVG,
+  not sourced from a named library), badge/button/input styling, and where these
+  belong given this repo's Tailwind v4 CSS-first config (@theme block, not a JS
+  config file). Recommended icon replacement (emoji->SVG) as the one immediate-apply
+  exception to "Phase 1 doesn't reskin anything yet," with reasoning given.
+- Phase 2: full desktop + mobile Trips layout (nav, left panel, trip cards, detail
+  header, a NEW status-stepper component replacing today's flat status bar, place
+  sections, item cards, empty states, mobile slide transition + bottom tab bar),
+  cross-referenced line-by-line against DP-01..06, TR-09/11/12/13, BUG-31/32/34/36,
+  IT-01, UX-02, FEAT-BD, NTH-01/03.
+- 13 flagged conflicts (C1-C13) — NOT silently resolved. The consequential ones: the
+  mockup renames the product to "Waypoint" (C1, a real decision not a skin choice);
+  the new status stepper has no Unlock affordance at all where the current app has a
+  working tested one (C2); BUG-36's trip-level items section is entirely absent from
+  both mockups (C3); place-section Edit-dates/Remove buttons (UX-02/BUG-32) are
+  absent from the mockup's place header (C4); the mockup's item card drops rating
+  stars/carried-forward tag/full per-type subtext to one generic line (C5); the
+  mockup only shows the filtered-empty state, not the first-run zero-trips state the
+  current app already distinguishes (C6); bulk-delete/undo/sort/map-filter-badge have
+  no mockup equivalent (C7); the mockup's own reference implementation uses
+  `dangerouslySetInnerHTML` for icons, which is a blocking defect in this codebase
+  per `_shared/frameworks.txt` rule 22 (C8); the mobile bottom tab bar only appears in
+  list view, not detail view (C9, likely intentional, needs Ryan's confirmation).
+  C10-C13 are smaller precision flags (panel width, an undocumented category-badge
+  color, a font-weight and a button-radius discrepancy between the system doc and its
+  own applied mockups).
 
-BUGS DISCOVERED: None this thread (no implementation work was done — audit/read-only).
+BUGS DISCOVERED: None (spec/audit work only, no implementation).
 
-OPEN ISSUES / BLOCKERS:
-  [CRITICAL — blocks the whole brief] DesignSync tool unavailable in this
-  environment. COO must either get it connected, or get the three .dc.html files'
-  raw content into a channel UX already has access to (committed into the repo
-  under jobs/ux/tech/, or shared via the connected Google Drive MCP). Flagged in
-  completion report to COO inbox.
+OPEN ISSUES / BLOCKERS: None blocking Phase 1. All 13 conflicts (C1-C13) must be
+explicitly resolved — not silently — before Phase 2 is briefed to Frontend, per the
+spec's own success criteria. This is COO/Ryan's decision, not mine to make.
 
-WHAT'S UNBLOCKED FOR OTHER JOBS: Nothing yet — Frontend has no spec to implement
-from. Once mockup access is restored and a follow-up UX thread completes the actual
-Phase 1/Phase 2 spec, Frontend can be dispatched (after COO's BRD-gate step, per
-CLAUDE.md's "BRD gate before dispatching briefs" rule).
+WHAT'S UNBLOCKED FOR OTHER JOBS: Frontend can be dispatched for Phase 1 once COO
+reviews the spec and completes the BRD gate (any new requirement IDs need a BRD home
+before dispatch, per CLAUDE.md). Phase 2 dispatch additionally needs C1-C13 resolved
+first.
 
-GIT: Branch chore/waypoint-redesign-spec. Housekeeping commit only (context, park
-doc, blocked-spec record, completion report) — no source files touched, no code
-spec produced. PR opened documenting the blocker for COO visibility; COO reviews
-and merges as usual, does not need to route anything to Frontend from this PR.
+GIT: Branch chore/waypoint-redesign-spec (same branch as the earlier blocked-doc
+commit — coordinator's instruction was to update this branch, not open a new one).
+PR #194 picks up the new commits automatically. No source code touched — spec/docs
+only. Pre-push checklist re-run and green before this final push.
 
-NEXT ACTIONS: See "Recommended next step" in
-jobs/ux/tech/20260721-UX-waypoint-spec-blocked.md and "NEXT ACTIONS" in
+NEXT ACTIONS: See "CONFLICTS & OPEN QUESTIONS" at the top of
+jobs/ux/tech/20260721-UX-waypoint-spec.md and "NEXT ACTIONS" in
 jobs/ux/context/current.txt.
 ================================================================================

--- a/jobs/ux/tech/20260721-UX-waypoint-spec-blocked.md
+++ b/jobs/ux/tech/20260721-UX-waypoint-spec-blocked.md
@@ -1,0 +1,167 @@
+# Waypoint Redesign Spec — BLOCKED on mockup access
+
+**Date:** 2026-07-21
+**Author:** UX
+**Trigger:** COO brief — formalize the "Waypoint" Claude Design mockups (claude.ai Design
+project `8cc525c1-b678-4976-a207-57f7f489844b`, files `Design System.dc.html`,
+`Trips Desktop.dc.html`, `Trips Mobile.dc.html`) into a two-phase, briefable spec.
+
+**Status: NOT DELIVERED.** The formal Phase 1 / Phase 2 spec described in the brief could
+not be produced this thread. This document records why, what I verified before concluding
+it's a hard blocker, and the preparatory groundwork completed so a follow-up thread can move
+straight to spec-writing once access is restored.
+
+---
+
+## The blocker
+
+The brief instructs use of a `DesignSync` tool (`get_project`, `list_files`, `get_file`) to
+read the three mockup files. That tool does not exist in this environment:
+
+1. `ToolSearch` was queried multiple ways (`"DesignSync"`, `"design mockup project file sync
+   claude.ai"`, `"get_project get_file list_files"`, `"claude.ai design review file content
+   read"`, `"mcp"`) — no `DesignSync` tool surfaced in any result, deferred or otherwise.
+2. `claude mcp list` shows exactly four configured MCP servers in this environment: `claude.ai
+   monday.com` (needs auth), `claude.ai Google Drive` (connected), `claude.ai Gmail` (needs
+   auth), `claude.ai Google Calendar` (needs auth). There is no `DesignSync` entry at all —
+   not even one sitting in a needs-authentication state. This isn't an auth gate I can clear
+   from inside the thread; the server isn't wired up here.
+3. As a last check, I tried `WebFetch` directly against the claude.ai project URL
+   (`https://claude.ai/project/8cc525c1-b678-4976-a207-57f7f489844b`) — 403 Forbidden, as
+   expected for an authenticated claude.ai resource with no session.
+4. I searched the repo itself (`grep -ri waypoint`, `find *.dc.html`, `grep -i oklch`, `grep
+   8cc525c1`) in case the mockups had already been exported/committed somewhere — nothing.
+
+**I have not fabricated any of the requested spec content as a result.** The brief is explicit
+that the exact oklch values, type pairings, icon glyphs, and badge-hue mapping must be carried
+over precisely, and that the "what's in it" summary in the brief is a lead, not something to
+take as complete — it has to be verified against the actual files. Guessing plausible-looking
+values would produce a spec that looks complete but silently diverges from what Ryan actually
+approved, and Frontend would build the wrong thing with high confidence. That's a worse
+outcome than a blocked thread with an honest note.
+
+**What would unblock this:**
+- Get the `DesignSync` MCP server connected/configured for this environment (whatever COO/Ryan
+  used to originally read the project), or
+- Provide the three `.dc.html` files' raw content through a channel I already have access to
+  — e.g. paste/commit them into the repo (`jobs/ux/tech/waypoint-mockups/*.dc.html`) or share
+  them via the connected Google Drive MCP.
+
+Either path lets a follow-up UX thread read the actual markup/CSS/`<script type="text/x-dc">`
+logic and produce the real Phase 1/Phase 2 spec in one pass.
+
+---
+
+## Preparatory groundwork completed this thread
+
+To avoid losing the whole thread's budget to the blocker, I did the half of the job that
+doesn't depend on the mockups: a full read of the current Trips screen implementation and a
+cross-reference against every BRD/bug-fix item the brief called out. This is what the
+follow-up thread should start from.
+
+### Current stack facts relevant to Phase 1 token placement
+
+- **Tailwind v4, CSS-first config.** `src/frontend/index.css` uses `@import "tailwindcss"` —
+  there is no `tailwind.config.js`/`.ts` in the repo. Any Phase 1 token work (colors, type
+  scale, radius) belongs in an `@theme` block in `index.css` (or a new imported CSS file), not
+  a JS config object. Confirmed via `find` (no config file) and reading `package.json`
+  (`tailwindcss@^4.2.2`, `@tailwindcss/vite@^4.2.2`).
+- **No component library, no icon library.** `package.json` dependencies contain no
+  `lucide-react`, no `@radix-ui/*`, no `shadcn`-anything, no `clsx`/`class-variance-authority`.
+  The March 2026 UX audit (`jobs/ux/tech/20260319-UX-design-system.md`) had assumed a
+  Tailwind+shadcn/ui migration and recommended Lucide as the icon library — **that migration
+  never happened.** Only the Tailwind half landed; shadcn/ui and an icon library were never
+  adopted. `jobs/ux/context/current.txt` is stale on this point (still says "awaiting
+  Tailwind/shadcn migration" as of March, but Tailwind alone is now fully in place and has
+  been for months per the July PRs).
+  **Flag for whoever writes Phase 1:** if the Waypoint mockups' "filled-icon set" implies a
+  specific icon library (vs. hand-authored inline SVGs), that's a new dependency and needs a
+  COO tradeoff call per this role's standing instruction — don't assume it's pre-approved just
+  because the March audit once recommended Lucide for a different (shadcn-based) plan.
+- **Current palette is teal/amber/violet/emerald**, not blue — a full rebrand already happened
+  once (see `jobs/ux/tech/20260321-UX-delivered-vs-mockup-delta.md`, DELTA-01/02/03/13/17). The
+  Waypoint rebrand ("warm paper neutrals + deep pine primary") replaces *this* palette, not the
+  original blue one. Whoever writes Phase 1 should treat the current teal-based tokens as the
+  "before" state, not blue.
+- **Current icons are literal emoji**, confirmed in `src/frontend/components/TripDetail/
+  ItemCard.tsx` lines 27-34 (`TYPE_ICONS`): `restaurant: '🍽️'`, `hotel: '🏨'`, `flight: '✈️'`,
+  `car_rental: '🚗'`, `experience: '🎫'`, `note: '📝'` — this is an exact match to the brief's
+  list. Also emoji/symbol elsewhere: nav brand square already uses a plain `T` glyph (not an
+  emoji, already fixed per DELTA-17), Photos button uses `📷`, locked-trip banner uses `🔒`,
+  empty-state icon uses `🗺`. All of these are candidate Phase 1 icon-replacement targets.
+
+### BRD / bug-fix cross-reference (ready for Phase 2 conflict-checking)
+
+Read in full and summarized below so the follow-up thread doesn't need to re-derive them:
+
+- **DP-04** (BRD line 226): place section shows city + full country name + date range, derived
+  from hotel check-in/check-out, falling back to trip dates. **Implemented** —
+  `PlaceSection.tsx` line 116 (`place.city.country_name ?? place.city.country_code`) and
+  `resolvePlaceDateRange` utility (ADL-24 §5 precedence). Any mockup place-card layout must
+  preserve this exact precedence chain, not just the visual format.
+- **DP-05** (BRD line 227): places have optional arrival/departure dates; when set, places sort
+  chronologically by arrival date; when not set, insertion order is preserved. **Implemented**
+  — `TripDetail.tsx` lines 237-245, explicit sort with nulls-last, lexicographic YYYY-MM-DD
+  comparison.
+- **DP-06** (BRD line 228): first place added to a trip inherits the trip's date range;
+  subsequent edits are independent. Tracker shows `BRD-DP06` as a separate tracker entry,
+  **status "pending"** (not yet built) — this is a real gap, not just a display nuance. A
+  mockup place-card that assumes dates are always populated should be checked against this: is
+  the "no dates set yet" state shown anywhere in the mockup? If the mockup only shows populated
+  states, Phase 2 spec must call out the currently-still-open DP-06 gap explicitly so it isn't
+  silently dropped.
+- **BUG-31** (tracker, DP-04/DP-05): fixed 2026-07-20, PR #162 — root cause was a backend
+  read-path bug (GET didn't return `arrived_on`/`departed_on`), not display logic. No residual
+  UI risk, but confirms per-place date display is now reliable — safe to reskin.
+- **BUG-32**: "no way to remove a place" — fixed via DELETE route + confirm dialog + item
+  reassignment to trip-level on delete. Implemented in `PlaceSection.tsx` lines 165-189, 236-251
+  (`Remove` button, `ConfirmDialog`, message differs based on whether the place has items).
+  **Phase 2 must preserve this exact confirm-then-cascade-reassign flow** if the mockup's place
+  card doesn't show a remove affordance in its "static" state (mockups conventionally don't
+  render hover-only/confirm-only chrome) — don't let it be silently dropped for looking cleaner.
+- **BUG-34**: map standout-icon inconsistency — fixed in the **map layer**, not Trips screen.
+  Not in scope for this spec at all (Map screen is out of scope per Ryan's decision), but noting
+  it so nobody confuses it with a Trips-screen item.
+- **BUG-36 / IT-01** (BRD line 149, "user can log items against a trip or a specific place"):
+  trip-level Add Item entry point, restricted to Flight/Car Rental. **Implemented** as a whole
+  separate section, `TripItemsSection.tsx`, rendered above the Places list in `TripDetail.tsx`
+  line 233 — has its own header, its own "+ Add Trip Item" button (deliberately distinctly
+  labelled from PlaceSection's "+ Add Item" to avoid an accessible-name collision that broke
+  E2E tests once already). **This is a structural element with no obvious mockup equivalent**
+  unless the Waypoint mockup was built after BUG-36 landed (2026-07-20) — the brief's own "what's
+  in it" summary doesn't mention a trip-level items section at all. Whoever reads the actual
+  mockup must check explicitly whether `Trips Desktop.dc.html`/`Trips Mobile.dc.html` render
+  this section; if it's absent from the mockup, that is a **conflict to flag to COO**, not a
+  silent omission — trip-level items are a real, tested, BRD-linked feature and can't just
+  disappear in the reskin.
+
+### Existing UI surface not mentioned in the brief's "what's in it" summary
+
+These exist in the current Trips screen today and have no visible counterpart in the brief's
+summary of the mockups. Flagging now so the follow-up thread checks for them explicitly rather
+than assuming silence means "removed by design":
+
+- **FEAT-BD bulk multi-select delete** (`TripsLayout.tsx` lines 48-192): a "Select" mode toggle,
+  checkboxes on trip cards, a bulk action bar, 5-second undo window on delete. Substantial,
+  tested functionality.
+- **NTH-01 undo bar**, **NTH-03 per-status filter counts** (`(12)` next to each status chip).
+- **Sort control** (Newest/Oldest/Name A-Z/Name Z-A) — TR-09, in the left panel under search.
+- **Map filter badge** (`Country:`/`Region:`/`City:` — set when arriving from a Map-screen
+  click-through) with a clear (×) affordance.
+- **Geocoding-pending indicator** in the nav bar (NR-06) — not Trips-screen-specific but shares
+  the nav bar the mockups' bottom tab bar/nav will replace or coexist with on mobile.
+- **RequireOwner gate messaging** or nav — Admin link is owner-only, hidden until identity
+  resolves; relevant if the mockup's mobile bottom tab bar always shows an Admin tab regardless
+  of ownership (would be a real behavior change, not just a skin).
+
+None of the above is fabricated content about the mockups themselves — it's an inventory of
+what Phase 2 needs to reconcile once the mockups can actually be read.
+
+---
+
+## Recommended next step
+
+Re-run this brief once one of the two unblock paths above is available. Given the groundwork
+above is already done, the actual Phase 1 token enumeration + Phase 2 layout/state breakdown
+should be a single focused pass once the mockup files can be read — no need to re-audit the
+current implementation from scratch.

--- a/jobs/ux/tech/20260721-UX-waypoint-spec-blocked.md
+++ b/jobs/ux/tech/20260721-UX-waypoint-spec-blocked.md
@@ -1,4 +1,12 @@
-# Waypoint Redesign Spec — BLOCKED on mockup access
+# Waypoint Redesign Spec — BLOCKED on mockup access (RESOLVED same day)
+
+> **RESOLVED (2026-07-21) by `20260721-UX-waypoint-spec.md`** — the coordinator confirmed
+> `DesignSync` is specific to the main interactive session and unavailable to dispatched
+> agents, and supplied verbatim copies of the three mockup files directly into this worktree
+> at `jobs/ux/tech/waypoint-mockups/*.dc.html`. The formal Phase 1/Phase 2 spec was then
+> written from those files in the same thread. This document is retained for the history of
+> the blocker and the preparatory groundwork done while blocked (still accurate and useful —
+> the BRD/bug-fix cross-reference below fed directly into the real spec's conflict list).
 
 **Date:** 2026-07-21
 **Author:** UX
@@ -6,10 +14,11 @@
 project `8cc525c1-b678-4976-a207-57f7f489844b`, files `Design System.dc.html`,
 `Trips Desktop.dc.html`, `Trips Mobile.dc.html`) into a two-phase, briefable spec.
 
-**Status: NOT DELIVERED.** The formal Phase 1 / Phase 2 spec described in the brief could
-not be produced this thread. This document records why, what I verified before concluding
-it's a hard blocker, and the preparatory groundwork completed so a follow-up thread can move
-straight to spec-writing once access is restored.
+**Status at time of writing (superseded, see banner above): NOT DELIVERED.** The formal
+Phase 1 / Phase 2 spec described in the brief could not be produced this thread. This
+document records why, what I verified before concluding it's a hard blocker, and the
+preparatory groundwork completed so a follow-up thread can move straight to spec-writing
+once access is restored.
 
 ---
 

--- a/jobs/ux/tech/20260721-UX-waypoint-spec.md
+++ b/jobs/ux/tech/20260721-UX-waypoint-spec.md
@@ -1,0 +1,599 @@
+# Waypoint Redesign — Implementation Spec
+
+**Date:** 2026-07-21
+**Author:** UX
+**Status:** Ready for COO review → BRD gate → Frontend dispatch (phased: Phase 1 first, verified, then Phase 2)
+**Source:** claude.ai Design project "Travel tracker design review"
+(`8cc525c1-b678-4976-a207-57f7f489844b`), read directly from verbatim copies at
+`jobs/ux/tech/waypoint-mockups/{design-system,trips-desktop,trips-mobile}.dc.html`
+(see `jobs/ux/tech/20260721-UX-waypoint-spec-blocked.md` for the access-blocker history —
+resolved 2026-07-21, COO supplied verbatim file copies after the `DesignSync` tool proved
+unavailable to a dispatched agent).
+
+**Scope confirmed by Ryan:** Map and Admin screens are NOT redesigned in this drop — the
+mockups' nav/tab bar shows them only as existing destinations. This spec covers only the
+design-system foundation (Phase 1) and the Trips screen, desktop + mobile (Phase 2).
+
+**How to read this document:** Every color/size value below is copied verbatim from the
+`.dc.html` source (oklch values, px sizes, font weights) — I did not round or approximate
+anything. Where the mockup is ambiguous, silent, or in conflict with a real BRD requirement
+or shipped bug fix, I've said so explicitly in a **CONFLICT** or **GAP** callout rather than
+picking a resolution myself. COO adjudicates those; I have not.
+
+---
+
+## CONFLICTS & OPEN QUESTIONS — read this section first
+
+These need a decision before or during Frontend dispatch. Full detail on each is in the
+relevant Phase 2 subsection below; this is the index.
+
+| # | Issue | Why it matters | My recommendation |
+|---|---|---|---|
+| C1 | **Product name.** Both mockups render the nav brand as "Waypoint" (Newsreader wordmark + pin icon), not "Travel Tracker." | Renaming the product is a real decision, not a visual reskin detail — it touches the nav, page `<title>`, possibly docs/README/support materials. | Confirm with Ryan explicitly: is "Waypoint" the new product name, or just this design file's working title? Don't let Frontend infer a rename from a mockup file name. |
+| C2 | **Status stepper has no "Unlock" state.** The mockup's 4-step stepper (Plan→Active→Review→Locked) only defines a forward-progress CTA (`NEXT_STEP` has no `locked` entry) — no unlock affordance is shown anywhere in either mockup. | The current app has a real, tested Unlock button + confirm dialog (`TripDetail.tsx` lines 196-204) that returns a locked trip to `review_pending`. Dropping it would be a functional regression, not a skin change. | Preserve the existing Unlock button/flow; add it to the stepper card as new chrome the mockup doesn't show (e.g. an outlined "Unlock" button where the CTA slot would otherwise be empty). Flag to Frontend explicitly — don't let "the mockup doesn't show it" become "so we removed it." |
+| C3 | **BUG-36 trip-level items section is absent from both mockups.** Neither `trips-desktop.dc.html` nor `trips-mobile.dc.html` render anything resembling `TripItemsSection` (the "Trip Items" / "+ Add Trip Item" block for flights/car rentals not tied to a place). | This is a tested, BRD-linked (IT-01) feature that shipped 2026-07-20 (PR #171). The mockup may simply predate it, or Ryan may not have thought to include it in the design pass — either way it can't silently vanish. | Preserve `TripItemsSection` as its own reskinned block, positioned above Places exactly as today. Not a mockup omission Frontend should read as "remove this." |
+| C4 | **Place section's Edit-dates / Set-dates and Remove buttons are absent from both mockups.** Only "+ Add Item" appears in the place-header actions. | `UX-02` (per-place date editing) and `BUG-32` (remove-place, with cascade-reassign-to-trip-level and confirm dialog) are both shipped, tested features. | Preserve both buttons in the reskinned place header, alongside "+ Add Item." Recommend: `[Set/Edit dates] [+ Add Item] [Remove]` reading left-to-right by frequency of use, but this ordering is a minor call Frontend can make — the presence of both is not optional. |
+| C5 | **Item card in the mockup drops rating stars, the "carried forward" tag, and per-type subtext richness** (hotel check-in/out, flight number, cuisine type, notes excerpt) down to one generic `sub` line. | Ratings and the carried-forward indicator are real, shipped features (`RatingStars`, BUG-03 carry-forward). | Preserve today's full per-type subtext + rating stars + carried-forward tag inside the restyled item card shell (new icon tile, new badge colors) — the mockup's single-`sub`-string model is a demo simplification, not a spec to copy literally for this part. |
+| C6 | **Neither mockup shows the "no trips at all yet" first-run empty state** — only a "no trips match the filter" state (`hasTrips` toggles on the same filtered-list length in both cases). Current app already distinguishes the two ("No trips yet. Create one with '+ New'." vs "No trips match the current filters."). | Losing the first-run message would be a real UX regression for new users (a core "feedback" principle — don't let a blank list read as broken). | Preserve today's two-message distinction; apply the new icon/typography treatment to both. |
+| C7 | **FEAT-BD (bulk multi-select delete), NTH-01 (undo bar), NTH-03 (per-status filter counts), TR-09 sort control, and the map-filter badge have no mockup equivalent.** | All are real, shipped, tested functionality with no visual counterpart in either mockup — the mockups are demo-scoped to core browsing/detail viewing, not every toolbar feature. | Preserve all of them, reskinned with the new tokens (chip/button/badge styling from Phase 1). Do not remove on the theory that "the mockup doesn't have it." |
+| C8 | **Item icon rendering technique.** The mockup's own reference implementation uses `dangerouslySetInnerHTML` to inject icon SVG strings (`trips-desktop.dc.html` line 157, `trips-mobile.dc.html` line 145). | `_shared/frameworks.txt` rule 22 (binding project framework rule, restated in `CLAUDE.md`'s security spec references) makes `dangerouslySetInnerHTML` a **blocking defect** in this codebase, no exceptions without COO sign-off. | Frontend must implement icons as literal inline SVG JSX (`<svg>...</svg>` written directly in the component, or small dedicated icon components) using the exact path data below — same pixel output, zero banned API. This is not optional; flagging so it isn't missed as "just copy the mockup's approach." |
+| C9 | **Mobile bottom tab bar only appears in the list view, not the detail view** — the mockup's tab-bar markup lives inside the "LIST VIEW" wrapper only; the "DETAIL VIEW" wrapper has no tab bar, using the back-button bar instead. | Could be deliberate (more vertical space for content on a small screen once you've drilled in) or an oversight in the demo file. | My read: deliberate and good mobile practice — recommend keeping the tab bar hidden in detail view, back-button as primary nav there. Confirm with Ryan since it's a real navigation-model decision, not styling. |
+| C10 | **Left panel width mismatch.** Mockup desktop left panel is `340px`; current app is `320px` (already reduced once from an original `360px` per the March DELTA-11 fix). | Small but exact — my role doesn't treat pixel drift as "character." | Match the mockup: `340px`. Flagging since it's a second width change to the same panel in under a year — worth a beat of "is this the value we're keeping" before Frontend implements it a third time. |
+| C11 | **Category-badge color (hue 255, indigo-violet) is used in both Trips mockups but is not declared anywhere in `design-system.dc.html`'s own "Status & category badges" section** (which only shows PLANNING/ACTIVE/REVIEW/LOCKED/CONFIRMED/CANCELLED/CONSIDER). | The system doc is the nominal source of truth for tokens, but it's incomplete relative to what the Trips mockups actually use. | Treat the category-chip color as a real token anyway (documented below, sourced from application, not the system doc) — Frontend needs it regardless of which file "should" have declared it. Flag to whoever owns the Design System file that it's missing this swatch. |
+| C12 | **Newsreader heading weight: system doc says 500, both Trips mockups apply 600 everywhere a heading actually renders.** | Minor but exact per my role's standard — I don't let a font-weight drift pass as "close enough." | Use **600** — it's what's consistently applied in every real instance across both Trips mockups; the system doc's swatch appears to be the one that's slightly stale, not the applied files. |
+| C13 | **Button/input radius: system doc says "10px radius throughout," both Trips mockups apply 9px on nearly every button/input** (a couple of mobile-only elements use 10-11px). | Same category as C12 — a declared token that doesn't quite match its own application. | Use **10px** as the canonical Phase 1 token (per the system doc's explicit statement) and treat the mockups' 9px as sub-pixel drift from hand-authored inline styles, not an intentional second value. Frontend should standardize on one number; flagging so nobody "matches the mockup exactly" into a 9px/10px inconsistency across components. |
+
+None of the above blocks Phase 1 (tokens only). C1–C10 must be resolved (or explicitly accepted as "preserve current behavior," per my recommendations) before Phase 2 is briefed to Frontend, since they're all real functional/behavioral questions, not styling choices.
+
+---
+
+# PHASE 1 — Design System Foundation ("Waypoint" tokens)
+
+## Scope and non-goals
+
+Phase 1 delivers the primitives — color tokens, type tokens, the icon set, badge/status
+color mapping, and button/input styling — as reusable building blocks. **It does not reskin
+any existing screen.** Two exceptions, explained below.
+
+**Why gate the reskin to Phase 2:** applying only some of these tokens now (e.g. new button
+radius but old teal color, or new icons but old badge colors) would leave the app in a
+half-migrated state that's less consistent than either the old or new system alone —
+directly against the "consistency, not character" principle this role holds. Establishing
+the primitives in isolation, verifying them, then reskinning Trips as a complete pass in
+Phase 2 avoids that.
+
+**Exceptions I recommend applying immediately, in Phase 1:**
+1. **Icon replacement (emoji → SVG).** Swapping `TYPE_ICONS`'s emoji strings (`🍽️🏨✈️🚗🎫📝`)
+   and the standalone `📷`/`🔒`/`🗺` emoji for the new SVG icon components is low-risk: icons
+   are visually self-contained (no interaction with the surrounding color system), emoji
+   rendering is already inconsistent across platforms (a real, if minor, existing defect),
+   and doing it once now avoids touching `ItemCard.tsx` again in Phase 2. This does
+   constitute a small visible change to the *current* Trips screen ahead of the full reskin
+   — acceptable because it's a strict improvement in isolation, not a partial/inconsistent
+   application of the new palette.
+2. **Nothing else.** Colors, type, badges, and button/input styling all stay defined-but-unused
+   until Phase 2, specifically because half-applying any of them creates exactly the
+   inconsistency this role doesn't tolerate.
+
+## 1. Color
+
+Source: `design-system.dc.html` "Color" section. All values are oklch, copied verbatim.
+
+### Neutrals (warm paper)
+
+| Token | Value | Usage |
+|---|---|---|
+| `bg-page` | `oklch(97.5% 0.006 80)` | App/page background |
+| `bg-surface` | `oklch(99% 0.002 80)` | Card, panel, input backgrounds |
+| `border` | `oklch(89% 0.012 80)` | Default border color |
+| `ink-muted` | `oklch(48% 0.015 75)` | Secondary text, meta labels, muted body |
+| `ink` | `oklch(22% 0.02 75)` | Primary text |
+
+Additional neutral shades observed in application (not in the system doc's 5-swatch grid,
+but used repeatedly across both Trips mockups — include as tokens, not one-offs):
+
+| Token | Value | Usage |
+|---|---|---|
+| `bg-subtle` | `oklch(96% 0.008 80)` | Place-section header band, nav link hover, place/name chip background |
+| `bg-chip` | `oklch(93% 0.006 80)` | Trip-count badge, "Locked"/"Consider" badge background |
+| `ink-faint` | `oklch(65% 0.01 75)` | Lightest muted text (empty-state descriptions, disabled-ish labels) |
+| `ink-soft` | `oklch(40% 0.015 75)` | Empty-state heading color (between `ink` and `ink-muted`) |
+| `border-soft` | `oklch(92% 0.008 80)` | Item-card border (lighter than the standard `border` token) |
+
+### Brand
+
+| Token | Value | Usage |
+|---|---|---|
+| `primary` (pine) | `oklch(38% 0.07 195)` | Primary buttons, active nav, primary icons, focus outline, stepper "done"/"current" dot |
+| `primary-hover` | `oklch(33% 0.07 195)` | Hover state for pine-background buttons (observed via `style-hover` in both Trips mockups) |
+| `primary-subtle` | `oklch(94% 0.025 195)` | Planning badge bg, active-nav-link bg, item-icon tile bg, mobile next-step callout bg |
+| `primary-subtle-text` | `oklch(30% 0.07 195)` | Planning badge text, active-nav-link text, mobile next-step callout text |
+| `accent` (plum) | `oklch(45% 0.1 325)` | Declared in the system doc; not directly applied anywhere in the two Trips mockups I read — treat as reserved for future use, not required by this spec |
+
+### Status / category hues
+
+All status and category colors share the same lightness/chroma recipe per hue —
+confirmed against both the system doc's palette and every application in the Trips mockups:
+**background ≈ 93-95% L / 0.006-0.03 C, text ≈ 30-42% L / 0.07-0.13 C, same hue for both.**
+
+| Hue (°) | Background | Text | Used for |
+|---|---|---|---|
+| 195 (pine) | `oklch(94% 0.025 195)` | `oklch(30% 0.07 195)` | Trip status: **Planning** |
+| 75 (amber/gold) | `oklch(94% 0.03 75)` | `oklch(40% 0.12 75)` | Trip status: **Active** |
+| 325 (magenta/plum) | `oklch(94% 0.025 325)` | `oklch(38% 0.1 325)` | Trip status: **Review** |
+| 80 (neutral, ~0 chroma) | `oklch(93% 0.006 80)` | `oklch(40% 0.01 80)` | Trip status: **Locked**; item status: **Consider** |
+| 150 (green) | `oklch(94% 0.025 150)` | `oklch(38% 0.1 150)` | Item status: **Confirmed** *and* **Completed** (label "DONE") — see note below |
+| 25 (red) | `oklch(95% 0.03 25)` | `oklch(42% 0.13 25)` | Item status: **Cancelled** |
+| 255 (indigo-violet) | `oklch(94% 0.03 255)` | `oklch(42% 0.1 255)` | Category / activity chips (see C11 — not in the system doc's own swatch set, sourced from application in both Trips mockups) |
+
+**Note on Confirmed vs Completed sharing a hue:** the mockup's `STATUS_META` gives `confirmed`
+and `completed` the *identical* bg/fg pair (hue 150), differing only in label text
+("CONFIRMED" vs "DONE"). The current app visually distinguishes them (`green-100/green-800`
+vs `emerald-100/emerald-800` — two different hues). Collapsing them to one hue is a real,
+if minor, semantic change (you lose an at-a-glance visual distinction between "confirmed,
+not yet done" and "actually completed") — flagging so it's a decision, not a side effect of
+copying the mockup's `STATUS_META` table.
+
+**Badge shape note:** status pills use `border-radius: 20px` (full pill) at
+`padding: 5px 12px` (system doc) / `5px 13px` (desktop trip-detail) / `4-5px 10-12px`
+(various card contexts) — treat as "pill, ~5px vertical / ~10-13px horizontal padding,"
+not one fixed pixel pair; Frontend has latitude within that range for context-appropriate
+sizing. Category/place chips on trip **list cards** are NOT pills — `border-radius: 7px`
+(desktop) / `8px` (mobile), `padding: 3-4px 9-10px`. The same category color (hue 255)
+therefore appears in two shapes depending on context: pill in the trip-detail header meta
+row, rounded-rect chip on trip list cards. This is deliberate per the mockup (confirmed by
+consistent application in both files), not an inconsistency to normalize away.
+
+### Explicit rejection of the current palette
+
+Compare to today: teal-600 primary almost everywhere, amber for Active/Review (already
+close in spirit to the new hue-75/325 mapping — see below), violet-800 for categories
+(close to but not identical to the new hue-255), emerald for positive CTAs, red for
+destructive. The design-system file's own caption states the intent plainly: *"Compare to
+today's app: teal-600 on most screens, blue-600 in Admin, plus indigo/green/emerald/yellow
+scattered across statuses with no shared logic."* Phase 1's job is to replace all of this
+with the single hue-family system above — Phase 2 is where it actually gets applied to
+Trips.
+
+## 2. Typography
+
+Font families: **Newsreader** (serif, display/editorial) and **Manrope** (sans, UI/body).
+Loaded in the mockup via a Google Fonts `<link>`:
+`family=Newsreader:opsz,wght@6..72,400;6..72,500;6..72,600&family=Manrope:wght@400;500;600;700;800`.
+
+**Font-loading call for Frontend/COO:** the mockup pulls both fonts from Google's CDN at
+runtime. Given this app's hosted-web direction (NF-09) an external font CDN is viable, but
+I'd recommend self-hosting via `@fontsource/newsreader` + `@fontsource/manrope` (or local
+woff2 files) instead of a live Google Fonts `<link>`, consistent with this app otherwise
+having no external runtime dependencies. This is an implementation-cost tradeoff, not a
+pure design call — flagging for a decision, not deciding it myself.
+
+### Type scale
+
+| Context | Font | Weight | Size | Notes |
+|---|---|---|---|---|
+| Page title (desktop trip-detail `<h1>`) | Newsreader | 600 | 34px | `letter-spacing:-0.3px` |
+| Page title (mobile trip-detail `<h1>`) | Newsreader | 600 | 26px | `letter-spacing:-0.3px` |
+| Page title (design-system doc's own generic swatch) | Newsreader | 500 | 40px | See C12 — applied instances use 600, not 500; use 600 |
+| Panel header ("My Trips", desktop) | Newsreader | 600 | 22px | |
+| Panel header ("My Trips", mobile) | Newsreader | 600 | 28px | |
+| Trip/place name (desktop trip list card) | Newsreader | 600 | 16.5px | |
+| Trip/place name (mobile trip list card) | Newsreader | 600 | 18px | |
+| Place/city name (desktop place-section header) | Newsreader | 600 | 17px | |
+| Place/city name (mobile place-section header) | Newsreader | 600 | 16px | |
+| Section label / UI header | Manrope | 700 | 15px | System doc generic swatch — no direct 1:1 instance found in the two Trips mockups; treat as the token for future section headers |
+| Body / control text | Manrope | 500 | 14px | Buttons, general UI text |
+| Meta / label text (dates, tags uppercase) | Manrope | 600 | 12px | System doc sample shown uppercase with letter-spacing; applied instances (dates, subtitles) are sentence-case at 11.5-13px — treat 12px/600 as the token for genuinely label-like uppercase text (e.g. status badges use 700/11-11.5px with letter-spacing, see badge spec below — badges are their own case, not this generic token) |
+| Status/category badge text | Manrope | 700 | 11-11.5px | `letter-spacing: 0.2-0.3px`, uppercase (values render as `PLANNING`, `ACTIVE`, etc. — always-caps content, not a text-transform applied to mixed-case labels) |
+| Item label (item card) | Manrope | 700 | 13.5px | |
+| Meta text / dates / subtitles (general) | Manrope | 400/500 | 11.5-13px | `ink-muted` color |
+
+**Newsreader weight — use 600, not 500** for every heading-level instance per C12.
+**Line-height:** not explicitly declared anywhere in the source files (all headings render
+on effectively single lines in the mockup's fixed-width demo data) — recommend `1.1-1.2` for
+Newsreader display sizes (≥22px) and `1.4-1.5` for Manrope body/meta text, standard practice
+for a serif-display/sans-body pairing; the mockup gives no explicit value to carry over,
+so this is my recommendation, not a lifted token.
+
+## 3. Icons
+
+Eight glyphs, one consistent filled-SVG style, single fill color (`primary` pine,
+`oklch(38% 0.07 195)`) in every instance across both the system doc and the two Trips
+mockups. These replace the emoji set named in the brief: 🍽️🏨✈️🚗🎫📝🔒📷.
+
+| Icon (system-doc label) | Replaces (current emoji) | Maps to `item_type` | Exact SVG path (viewBox 0 0 24 24) |
+|---|---|---|---|
+| hotel | 🏨 | `hotel` | `M4 20V9.5L12 4l8 5.5V20a1 1 0 0 1-1 1h-5v-6h-4v6H5a1 1 0 0 1-1-1Z` |
+| flight | ✈️ | `flight` | `M21 15.5v-2l-8-5V4.5a1.5 1.5 0 0 0-3 0V8.5l-8 5v2l8-2.5V17l-2.5 2v1.5l3.5-1 3.5 1V19L13 17v-4.5l8 2.5Z` |
+| dining | 🍽️ | `restaurant` | `M6 3v7a2 2 0 0 0 2 2v9h1.5v-9a2 2 0 0 0 2-2V3H10v6H9V3H8v6H7V3H6Zm9.5 0c-1.4 0-2.5 2.1-2.5 5s1 5 2 5.6V21H16.5V3.05c-.35-.03-.68-.05-1-.05Z` |
+| car | 🚗 | `car_rental` | `M5 16.5V11l1.8-4.5A2 2 0 0 1 8.7 5h6.6a2 2 0 0 1 1.9 1.5L19 11v5.5a1 1 0 0 1-1 1H17a1 1 0 0 1-1-1V16H8v.5a1 1 0 0 1-1 1H6a1 1 0 0 1-1-1ZM7.5 14a1.2 1.2 0 1 0 0-2.4 1.2 1.2 0 0 0 0 2.4Zm9 0a1.2 1.2 0 1 0 0-2.4 1.2 1.2 0 0 0 0 2.4ZM7 10.5h10L15.7 7H8.3L7 10.5Z` |
+| experience | 🎫 | `experience` | `M3 8a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2v1.5a1.5 1.5 0 0 0 0 3V14a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-1.5a1.5 1.5 0 0 0 0-3V8Zm9-1v2h1.5V7H12Zm0 4v2h1.5v-2H12Zm0 4v2h1.5v-2H12Z` |
+| note | 📝 | `note` | `M5 3.5h14a1 1 0 0 1 1 1V20a1 1 0 0 1-1.45.9L12 18.4l-6.55 2.5A1 1 0 0 1 4 20V4.5a1 1 0 0 1 1-1ZM7 8h10V6.5H7V8Zm0 3.5h10V10H7v1.5Z` |
+| locked | 🔒 | *(trip status only, not an item type)* | `M7 10V7a5 5 0 0 1 10 0v3h.5A1.5 1.5 0 0 1 19 11.5v8A1.5 1.5 0 0 1 17.5 21h-11A1.5 1.5 0 0 1 5 19.5v-8A1.5 1.5 0 0 1 6.5 10H7Zm1.5 0h7V7a3.5 3.5 0 0 0-7 0v3Z` |
+| photos | 📷 | *(Photos button, not an item type)* | `M9.5 5h5l.9 1.5H18a1.5 1.5 0 0 1 1.5 1.5v9A1.5 1.5 0 0 1 18 18.5H6A1.5 1.5 0 0 1 4.5 17V8A1.5 1.5 0 0 1 6 6.5h2.6L9.5 5Zm2.5 4.5a3.5 3.5 0 1 0 0 7 3.5 3.5 0 0 0 0-7Z` (verified identical path used live in `trips-desktop.dc.html`'s Photos button) |
+
+**No new npm dependency required.** These are hand-authored inline SVG path data in the
+mockup, not output from a named icon library (I checked — they don't match Lucide,
+Heroicons, or Feather's equivalent glyphs). Frontend should implement each as a small inline
+SVG React component (or a single `<Icon name="hotel" />` component switching on path data)
+using the exact path strings above — **not** via `dangerouslySetInnerHTML` (see C8; that's
+how the mockup's own mini-framework renders them, and it's a blocking defect in this
+codebase per `_shared/frameworks.txt` rule 22).
+
+**Sizing:** not one fixed size — observed at 22px (system-doc swatch tile), 16px (desktop
+item-icon tile content), 15px (mobile item-icon tile content), 14px (desktop Photos-button
+icon). Recommend a small size scale: `16px` for inline-with-text/tile contexts, `20-22px`
+for standalone/showcase contexts, consistent with what's actually used rather than one
+magic number.
+
+**Two additional icons used only in the Trips mockups** (not in `design-system.dc.html`'s
+icon section — same "system doc is incomplete" situation as the category-badge color, C11):
+
+| Icon | Used for | Exact SVG (viewBox 0 0 24 24) |
+|---|---|---|
+| location pin (brand mark / Map tab / empty-state icon) | Nav brand, mobile Map tab, both desktop/mobile "select a trip" and "no trips" empty states | `<path d="M12 2C8.5 2 6 5 6 8.5C6 13 12 21 12 21C12 21 18 13 18 8.5C18 5 15.5 2 12 2Z" fill="[pine or muted border color, context-dependent]"/><circle cx="12" cy="8.5" r="2.6" fill="[bg color, creates a cutout]"/>` — the circle uses the surrounding background color to punch a hole, not a stroke |
+| trips/suitcase (mobile Trips tab) | Mobile bottom tab bar | `<rect x="5" y="8" width="14" height="10.5" rx="2" fill="currentColor"/><rect x="9" y="5" width="6" height="3.5" rx="1.5" fill="none" stroke="currentColor" stroke-width="1.8"/>` |
+| admin (mobile Admin tab) | Mobile bottom tab bar | `<rect x="4" y="5.2" width="16" height="2" rx="1" fill="currentColor" opacity="0.3"/><circle cx="15" cy="6.2" r="2.6" fill="currentColor"/><rect x="4" y="11" width="16" height="2" rx="1" fill="currentColor" opacity="0.3"/><circle cx="9" cy="12" r="2.6" fill="currentColor"/><rect x="4" y="16.8" width="16" height="2" rx="1" fill="currentColor" opacity="0.3"/><circle cx="17" cy="17.8" r="2.6" fill="currentColor"/>` (a 3-row settings-slider glyph) |
+| back chevron (mobile detail-view back button) | "‹ Trips" back navigation | `<path d="M15 5l-7 7 7 7" stroke="currentColor" stroke-width="2.2" fill="none" stroke-linecap="round" stroke-linejoin="round"/>` |
+
+## 4. Status & category badges — component spec
+
+One `Badge` (or continued `StatusBadge`) component, parameterized by hue per the table in
+§1. Shape/typography: `font: 700 11-11.5px Manrope; letter-spacing: 0.2-0.3px;
+border-radius: 20px (pill) or 7-8px (list-card chip context); padding: 5px 12-13px (pill) or
+3-4px 9-10px (chip)`. Label text is always upper-case content (not lower/mixed-case text
+with `text-transform: uppercase` — the mockup's data literally contains `'PLANNING'`,
+`'ACTIVE'`, etc.).
+
+## 5. Buttons & inputs
+
+Radius: **10px** throughout (see C13 re: the mockups' 9px application drift — standardize
+on the system doc's explicit 10px).
+
+| Variant | Background | Text | Border | Notes |
+|---|---|---|---|---|
+| Primary (e.g. "New Trip", "+ Add Item", next-step CTA) | `primary` `oklch(38% 0.07 195)` | white | none | Hover: `oklch(33% 0.07 195)` (darker pine) |
+| Secondary / default (e.g. "Edit", "Photos") | `bg-surface` `oklch(99% 0.002 80)` | `ink` `oklch(22% 0.02 75)` | 1px `border` `oklch(89% 0.012 80)` | Hover: `bg-subtle` `oklch(96% 0.008 80)` |
+| Destructive (e.g. "Delete") | `oklch(97% 0.02 25)` | `oklch(42% 0.13 25)` | 1px `oklch(89% 0.03 25)` | From `design-system.dc.html`'s own button row; not directly observed in the two Trips mockups (no destructive button appears in either) — carry over from the system doc as the destructive-button token for Phase 2's Remove/Delete buttons |
+| Ghost / dashed (e.g. "+ Add Place") | transparent | `ink-muted` | 2px dashed `oklch(85% 0.012 80)` | Hover: border `oklch(70% 0.012 80)`, text `oklch(38% 0.015 75)` |
+| Input (search, text) | `bg-surface` (desktop) or `oklch(97.5% 0.006 80)` (some contexts) | `ink` | 1px `border` | Focus: `outline: 2px solid primary; outline-offset: 1px` (confirmed in `trips-desktop.dc.html`'s global `<style>` block — this replaces the current app's Tailwind `focus:ring-2 focus:ring-teal-500` pattern) |
+
+Font for all button/input text: Manrope, weight 600-700 (buttons) / 400-500 (input values),
+13-14.5px depending on context (desktop buttons trend 12.5-14px, mobile slightly larger at
+15px for the search input).
+
+## 6. Where these tokens live in this repo
+
+Confirmed via reading `package.json` and `src/frontend/index.css`: this repo is on
+**Tailwind v4 with CSS-first config** (`@import "tailwindcss"` in `index.css`, no
+`tailwind.config.js`/`.ts` file exists). Recommend adding an `@theme` block (either inline in
+`index.css` or a new imported file, e.g. `theme-waypoint.css`) defining these as Tailwind v4
+theme variables — e.g. `--color-pine: oklch(38% 0.07 195);`, `--color-paper: oklch(97.5%
+0.006 80);`, `--font-display: 'Newsreader', serif;`, `--font-ui: 'Manrope', sans-serif;` —
+which Tailwind v4 automatically turns into utility classes (`bg-pine`, `font-display`, etc.)
+without any JS config. This is idiomatic for how this repo is already set up; no new
+tooling/dependency needed for the token layer itself.
+
+**Do not touch the global `body` font-family in Phase 1** (currently a system-font stack in
+`index.css`'s `@layer base`) — that's a Phase-2-scale visual change. Expose the new font
+tokens as opt-in utilities only.
+
+## Phase 1 success criteria
+
+Phase 1 is done when all of the following are independently verifiable, without any change
+to how the current Trips screen (or any other screen) looks *except* the icon-replacement
+exception above:
+
+1. Every color in the §1 tables exists as a Tailwind v4 `@theme` token (or CSS custom
+   property) with a stable, documented name — zero raw oklch/hex literals introduced
+   elsewhere in the codebase for these values.
+2. Newsreader and Manrope are loading (self-hosted or CDN, per the COO's call on the
+   font-loading question above) and available via named font-family utilities, without the
+   global body font changing.
+3. All 11 icons in §3 (8 item/status icons + 4 nav/chrome icons) exist as inline SVG React
+   components using the exact path data above — verified by grep: zero remaining instances
+   of the replaced emoji (🍽️🏨✈️🚗🎫📝🔒📷🗺) in `src/frontend/`, and zero new
+   `dangerouslySetInnerHTML` usages introduced to render them.
+4. The status/category badge hue table in §4 exists as reusable badge-variant logic (a
+   component prop or a lookup map), not yet wired into `StatusBadge.tsx`'s actual
+   `COLOR_CLASSES` (that wiring is Phase 2 — Phase 1 proves the primitive works in isolation,
+   e.g. a Storybook-less "kitchen sink" test page or a unit test asserting the color map, per
+   whatever this repo's existing test conventions support).
+5. Button/input variants in §5 exist as either a reusable `Button`/`Input` component or a
+   documented Tailwind class recipe, not yet swapped into existing call sites (again, Phase 2).
+6. `npm run test:frontend`, `npm run type:check:all`, and `npm run check` all pass with the
+   new tokens/components present but unused by existing screens.
+7. A UAT pass (per `CLAUDE.md`'s mandatory phase-completion gate) confirms the Trips screen
+   is pixel-identical to its pre-Phase-1 state except for the icon swap, which is visually
+   confirmed correct against the §3 table.
+
+---
+
+# PHASE 2 — Trips Screen Reskin
+
+Full breakdown of both mockups, cross-referenced against the current implementation. Where
+a mockup element has no current equivalent, or a current element has no mockup equivalent, I
+say so explicitly (see the Conflicts table above for the ones needing a decision).
+
+## Desktop layout (`trips-desktop.dc.html`)
+
+### Structure
+
+```
+[Nav bar — 100%, ~48px tall equivalent]
+  [Waypoint brand: pin icon + "Waypoint" wordmark]  [Map] [Trips (active)] [Admin]
+[Two-panel body — flex row, fills remaining height]
+  [Left panel — 340px fixed]        [Right panel — flex:1]
+    Header: "My Trips (N)" + New Trip button
+    Search input
+    Status filter chips (All/Planning/Active/Review/Locked)
+    Trip list (scrollable)
+      Trip cards
+    (empty state when filtered to 0)
+                                      Trip detail (scrollable), or "select a trip" empty state
+```
+
+### Nav bar
+
+Background `bg-surface oklch(99% 0.002 80)`, `border-bottom: 1px solid border`. Brand: pin
+icon (22px) + "Waypoint" in Newsreader 600/17px. Nav links (Map/Trips/Admin): Manrope
+600/13px, `ink-muted` color, `8px 14px` padding, `8px` radius; **active** link gets
+`primary-subtle` background + `primary-subtle-text` (700 weight) color; hover (inactive)
+gets `bg-subtle` background.
+
+**Cross-reference:** current `App.tsx` nav already has this general shape (brand mark +
+Map/Trips/Admin links, active-state pill). Changes needed: brand mark (square "T" tile →
+pin icon + serif wordmark — see C1 on the name itself), color tokens (teal → pine per §1),
+and preserve the existing owner-gated Admin link visibility (`RequireOwner`/`BUG-26` logic)
+— the mockup's static nav always shows all three links because its demo has no auth model;
+Frontend must keep the current conditional hide, not remove it because the mockup shows
+Admin unconditionally.
+
+### Left panel
+
+Width **340px** (see C10), `bg-surface`, `border-right: 1px solid border`.
+
+- **Header row:** "My Trips" (Newsreader 600/22px) + trip-count pill (`bg-chip`/`ink-muted`,
+  Manrope 700/11px, pill) inline via `display:flex;align-items:baseline` — matches current
+  DP-02 implementation's existing embedded-badge structure, just new tokens.
+- **"+ New Trip" button:** primary variant per §5, `8px 14px` padding, `9px` radius (see
+  C13), Manrope 700/12.5px.
+- **Search input:** placeholder **"Search trips or places…"** (note: differs from current
+  app's "Search trips…" — the longer placeholder correctly reflects that search already
+  matches place names too, per TR-13/`filterAndSortTrips` — this is a copy fix to make,
+  bringing the placeholder in line with existing, already-correct search behavior, not a
+  new feature).
+- **Status filter chips:** All/Planning/Active/Review/Locked, pill-shaped, Manrope
+  700/11.5px, active = `primary` bg + white text, inactive = `bg-subtle` + `ink-muted`.
+  Current app additionally shows a per-status count (`(12)`) next to each chip label
+  (NTH-03) — mockup chips show label only, no count. **Preserve the count** (C7) — it's
+  real, useful, shipped functionality with no mockup counterpart, not something to drop.
+- **Trip cards:** `14px` padding, `14px` radius, `bg-surface`, border `1px solid border`
+  (unselected) or `1.5px solid primary` + subtle pine box-shadow (selected — no `ring`
+  utility, a real box-shadow: `0 2px 10px oklch(38% 0.07 195 / 0.12)`). Hover (unselected):
+  box-shadow lift `0 4px 14px oklch(22% 0.02 75 / 0.14)` + border darkens to
+  `oklch(78% 0.012 80)`. Content: trip name (Newsreader 600/16.5px, truncates with ellipsis),
+  date range (`ink-muted`, 12px) below; status badge (pill, per §4) top-right; place-name
+  chips (rounded-rect, `bg-subtle`/`ink-muted`-ish `oklch(40% 0.015 75)`, 7px radius, 11px
+  text) and category chips (rounded-rect, hue-255, same 7px radius) in a wrapped row below.
+- **Empty state (filtered to zero):** centered pin icon (34px, `border`-color muted) + "No
+  trips match" (Newsreader 16px, `ink-soft`) + "Try a different search term or filter."
+  (12.5px, `ink-faint`). **Also needs the true first-run zero-trips message** (C6) — mockup
+  doesn't model it, current app's copy ("No trips yet. Create one with '+ New'.") should be
+  preserved under the same new visual treatment.
+
+**Not in the mockup, must be preserved (C7):** bulk multi-select ("Select" toggle,
+checkboxes, bulk action bar, 5-second undo), the undo bar itself, the sort control
+(Newest/Oldest/Name A-Z/Z-A), and the map-filter badge (Country:/Region:/City: with a clear
+affordance, set when arriving from a Map-screen click-through). Reskin all of these with
+the new tokens (chip/button styles per §4/§5) — none of them are being removed.
+
+### Right panel — trip detail
+
+`bg-page`, content max-width `820px` centered, `36px 40px 60px` padding.
+
+- **Header:** Title (Newsreader 600/34px) top-left; meta row below it: date range (13px
+  `ink-muted`) `·` companions (only if present, same style) `·` category/tag pills (hue-255,
+  **pill**-shaped here, unlike the rounded-rect version on list cards — see §1 badge-shape
+  note). Right-aligned: status badge (pill) + "Edit" button (secondary variant) + "Photos"
+  button (secondary variant, camera icon + "Photos" label — icon replaces the current 📷
+  emoji per Phase 1's icon set).
+
+  **Cross-reference:** current `TripDetail.tsx` already has the right structural order
+  (StatusBadge → Edit → Photos, per the already-fixed DELTA-04) and already collapses the
+  meta row into one inline line (per already-fixed DELTA-05) — good news, most of the
+  *structure* work here is already done; this is primarily a token/typography reskin, not a
+  layout rebuild. Two real differences: (a) current app uses `|` pipe separators throughout;
+  mockup uses a single `·` between dates and companions only, then tags render as separate
+  pills with no leading separator — adopt the mockup's punctuation exactly; (b) preserve the
+  existing `isLocked` conditional hiding of the Edit button — the mockup's static single
+  example doesn't model a locked trip's header, don't lose that conditional.
+
+- **Status stepper** (replaces today's flat status bar — this is new structural UI, not a
+  reskin of existing markup): a card (`bg-surface`, `border`, `14px` radius, `18px 22px`
+  padding) containing:
+  - A horizontal row of 4 step-dots (Plan/Active/Review/Locked), each `22px` circle +
+    `10.5px` Manrope 700 label below. Connected by `36px`-wide, `2px`-tall lines between
+    dots.
+  - Dot/line state logic (exact, from the mockup's `buildSteps()`): for step index `i` and
+    current status index `idx` — **done** (`i < idx`): pine-filled dot showing `✓`, pine
+    label text, pine connecting line to its right. **current** (`i === idx`): **same pine
+    fill as done**, but showing its ordinal number (`i+1`) instead of a checkmark — current
+    and done are visually identical in color, distinguished only by dot content. **upcoming**
+    (`i > idx`): neutral `bg-chip`-colored dot, `ink-faint` label, gray connecting line.
+    This is an exact behavior to replicate precisely — a Frontend implementation that gives
+    "current" a distinct highlight color (e.g. a ring, a different hue) would be a defect
+    against this spec, however reasonable it might look; the mockup deliberately doesn't
+    do that.
+  - Right-aligned (same card, no separate box on desktop): hint text (`ink-muted`, 11.5px,
+    right-aligned, `max-width:150px`) + primary CTA button (per §5) with the next-step
+    label. Both only render when a next step exists (`NEXT_STEP` has no `locked` entry —
+    see **C2**, must add an Unlock affordance here since the mockup provides none).
+  - **BRD cross-check (TR-12):** "persistent status bar showing current status + primary
+    next action, always visible regardless of scroll" — the stepper still satisfies this
+    structurally (same position between header and scrollable content, still shows current
+    status and next action) but is a materially richer widget than a "bar." Flagging so
+    COO/Ryan explicitly confirms the stepper is an acceptable (better, arguably) fulfillment
+    of TR-12, not an unreviewed scope creep past what TR-12 originally asked for.
+
+- **Trip-level items section (BUG-36/IT-01):** **not in either mockup at all** (C3) —
+  preserve `TripItemsSection` exactly as today, reskinned with the new place-section card
+  styling below (it already mirrors that pattern in the current code).
+
+- **Place sections:** card (`bg-surface`, `border`, `14px` radius, overflow hidden). Header
+  band `bg-subtle`, `16px 18px` padding: city name (Newsreader 600/17px) + subtitle
+  `{country} · {dateRange}` (12px, `ink-muted`) on the left; **"+ Add Item"** button
+  (primary, small: `7px 14px` padding, 11.5px text) top-right. **Missing from the mockup,
+  must preserve (C4):** the "Set dates"/"Edit dates" button (UX-02) and the "Remove" button
+  (BUG-32, with its confirm dialog and items-reassign-to-trip-level cascade message) — both
+  currently sit in this same header-actions area and must stay, just restyled.
+
+  Item list below (`14px 18px` padding, `10px` gap): each item is a row —
+  `32px` square icon tile (`8px` radius, `primary-subtle` background, icon centered, 16px)
+  + label (Manrope 700/13.5px) + status badge (pill, per §4) + optional one-line `sub` text
+  (12px `ink-muted`). Row background `bg-page`, border `border-soft`, `11px` radius.
+
+  **Must preserve, mockup simplifies away (C5):** rating stars (restaurant/hotel/experience
+  items), the "carried forward" tag, and full per-type subtext (hotel check-in/out dates,
+  flight number + airline + date, cuisine type, notes excerpt up to 100 chars) — the
+  mockup's single generic `sub` string is a demo simplification; the real item card keeps
+  all of today's per-type richness inside the new visual shell (new icon tile, new badge
+  colors, new card radius/border).
+
+- **"+ Add Place"** button: full-width, dashed ghost variant per §5, `16px` padding, `14px`
+  radius.
+
+### Empty state (no trip selected)
+
+Centered pin icon (48px, `border`-color muted) + "Select a trip" (Newsreader 18px,
+`ink-soft`) + "Choose a trip from the list to see its places and itinerary." (13px,
+`max-width: 240px`). Maps directly onto the current `App.tsx` empty state (already has the
+icon+heading+description structure) — token/copy update only. Minor copy difference
+(current: "view its details, places, and itinerary" vs mockup: "see its places and
+itinerary") — adopt the mockup's wording since Frontend should follow the spec verbatim for
+new copy.
+
+## Mobile layout (`trips-mobile.dc.html`)
+
+Modeled at a 390×844 frame (iPhone-class viewport), single scrollable column, no persistent
+two-panel — **list view** and **detail view** are two absolutely-positioned, full-bleed
+panels that cross-fade/slide between each other; nothing about this in the current codebase
+exists yet (there's no mobile-specific Trips layout today at all — this is genuinely new
+responsive work, not a reskin of an existing mobile view).
+
+### List view
+
+- Header: "My Trips (N)" (Newsreader 600/28px) + a small circular **"+"** FAB-style button
+  (36×36px, `11px` radius, primary bg, white `+`, 20px line-height) — replaces the desktop's
+  labeled "+ New Trip" button with an icon-only equivalent, appropriate for the narrower
+  viewport.
+- Search input: placeholder **"Search trips…"** (shorter than desktop's — mobile mockup
+  doesn't mention "or places" in the placeholder despite using the identical search-filter
+  logic; minor copy inconsistency between the two mockups, not necessarily a conflict —
+  recommend using the desktop's fuller "Search trips or places…" on mobile too for
+  consistency, since the underlying behavior is identical).
+- Status filter chips: same as desktop, horizontally scrollable (`overflow-x:auto`) rather
+  than wrapping, since mobile width can't fit all 5 chips without scrolling.
+- Trip cards: same content model as desktop (name, dates, status badge, place/category
+  chips) at slightly larger type (18px name vs 16.5px desktop) and `16px` padding/`16px`
+  radius (vs desktop's 14px/14px) — a deliberate, not accidental, size bump for touch
+  targets.
+- **Bottom tab bar** (Map/Trips/Admin): `10px 0 26px` padding (the extra bottom padding
+  accounts for the iOS home-indicator safe area), `border-top: 1px solid border`,
+  `bg-surface`. Each tab: icon (21px) + label (10.5px Manrope, 600 inactive/700 active)
+  stacked vertically. Active (Trips): `primary` color on both icon and label. Inactive:
+  `ink-faint oklch(65% 0.01 75)`.
+
+  **This tab bar exists only in the list view** (C9) — the detail view has no bottom tab
+  bar in the mockup, using a top back-button instead. See C9 for the flag on whether that's
+  intentional.
+
+### Detail view
+
+- **Back bar:** `‹ Trips` (chevron icon + "Trips" text, Manrope 600/15px, `primary` color),
+  `6px 16px 10px` padding, no border/background — sits above the content, replaces the
+  desktop's Edit/Photos-button-adjacent navigation model entirely on mobile (there's no
+  visible Edit/Photos button in the mobile detail mockup at all — **only the back button,
+  title, status badge, and stepper are shown**; Edit and Photos are conspicuously absent).
+  **This is a real gap to flag, not decide silently:** does mobile drop Edit/Photos
+  entirely, move them behind an overflow menu, or was this just cut from the demo for
+  space? My recommendation: don't drop functionality — add an overflow ("⋯") menu or a
+  compact icon-only Edit/Photos pair in the header row, but this needs Ryan's call since
+  the mockup gives zero guidance either way.
+- Title + status badge: same content as desktop, smaller type (26px vs 34px), badge to the
+  right of the title on the same row (not below it).
+- Meta row: same `·`-separated dates/companions/tags pattern as desktop.
+- **Status stepper:** same dot/line logic as desktop, smaller (18px dots vs 22px, 20px
+  connecting lines vs 36px). **Different CTA presentation from desktop:** on mobile, the
+  next-step hint + button live in their own **separate highlighted callout box**
+  (`primary-subtle` background, `14px` radius, `14px 16px` padding) below the stepper card —
+  not inline within the same card as desktop. This is a deliberate per-breakpoint difference,
+  not something to reconcile into "identical minus width" — implement both exactly as shown.
+- Place sections: same structure as desktop, `16px` radius (vs 14px desktop), slightly
+  smaller type throughout (city name 16px vs 17px, item label same 13.5px).
+
+### Slide/cross-fade transition
+
+Both list and detail views are absolutely positioned (`inset:0`) within the same relative
+container, fading and sliding simultaneously:
+- **List view**, when a trip is selected: `transform: translateX(-30%); opacity: 0;
+  pointer-events: none;`
+- **Detail view**, when a trip is selected: `transform: translateX(0); opacity: 1;`
+  (from a resting `translateX(30%); opacity: 0; pointer-events: none;` when nothing is
+  selected)
+- Both: `transition: all 0.25s ease;`
+
+This is a "drill-in" pattern (list recedes left + fades, detail arrives from the right +
+fades), not a true edge-to-edge push/pull — implement with exactly these transform/opacity
+values and duration, not a generic "slide" guess.
+
+## Cross-reference summary: BRD & bug-fix conflict check
+
+| Item | BRD/tracker ref | Mockup shows it? | Verdict |
+|---|---|---|---|
+| Two-panel desktop layout | TR-11 | Yes, matches | Reskin only |
+| Persistent status bar → stepper | TR-12 | Yes, richer widget | **Flag (see stepper note above)** — confirm stepper satisfies TR-12's intent |
+| Search matches trip + place names | TR-13 | Yes, matches (`filterAndSortTrips` already implements this) | Already aligned — copy-only change (placeholder text) |
+| Trip count badge | DP-02 | Yes, matches | Reskin only |
+| Place section: city/country/date-range | DP-04 | Yes, matches | Reskin only |
+| Place chronological ordering | DP-05 | Not visually distinguishable from insertion order in a static mockup (all example data is pre-sorted) | No conflict — behavior unaffected by reskin |
+| First place inherits trip dates | DP-06 | Not shown (all example places have explicit dates) — **and this requirement is tracker-status "pending," not yet built** | **Flag** — Phase 2 reskins the display of dates that exist; it does not (and per BRD-DP06's own tracker entry, currently cannot) address the underlying "first place inherits trip dates" gap. Don't let this PR accidentally get treated as closing that gap. |
+| Photos entry point | PH-03 | Yes (desktop); **absent in mobile detail view** | **Flag** — see mobile detail-view note above |
+| Trip-level items (flights/cars) | IT-01 / BUG-36 | **No** | **Flag (C3)** — preserve |
+| Remove place | BUG-32 | **No** | **Flag (C4)** — preserve |
+| Per-place date editing | UX-02 | **No** | **Flag (C4)** — preserve |
+| Map standout icon | BUG-34 | N/A — that fix lives in the Map screen, out of scope here | No action needed |
+| Ratings, carried-forward tag | (shipped features, `ItemCard.tsx`) | **No** (mockup's item card is simplified) | **Flag (C5)** — preserve |
+| Bulk delete, undo, sort, map-filter badge | FEAT-BD, NTH-01, NTH-03, TR-09, map filters | **No** | **Flag (C7)** — preserve |
+| First-run empty state (vs filtered-empty) | (existing UX, no formal BRD ID) | **No** — mockup only shows filtered-empty | **Flag (C6)** — preserve |
+| Unlock affordance | (existing UX, no formal BRD ID — inverse of TR-12's forward progression) | **No** | **Flag (C2)** — preserve |
+
+## Phase 2 success criteria
+
+Phase 2 is done when:
+
+1. Desktop and mobile Trips screens visually match this spec's layout/token/state
+   descriptions, verified by side-by-side comparison against the two `.dc.html` mockups for
+   every state enumerated above (empty list, filtered-empty, selected/unselected card,
+   locked/unlocked detail, each of the 4 stepper states, search, each status filter chip).
+2. Every item in the "Cross-reference summary" table above marked **Flag** has an explicit,
+   recorded resolution (not a silent drop) before this phase is considered closed — i.e. the
+   COO/Ryan decision for each of C1-C13 is captured (in the BRD, an ADL, or the tracker,
+   whichever is the right home per `CLAUDE.md`'s document-lifecycle rule) prior to sign-off.
+3. All currently-shipped Trips-screen functionality with no mockup counterpart (bulk delete,
+   undo, sort, map-filter badge, trip-level items, remove-place, per-place date editing,
+   ratings, carried-forward tag, Unlock) is present and working in the reskinned UI — a
+   Playwright/E2E pass covering these flows (not just visual/unit tests) is part of this
+   phase's Definition of Done, since these are exactly the flows a reskin-from-static-mockup
+   is most likely to accidentally regress.
+4. The mobile Trips view (list ↔ detail slide, bottom tab bar) exists and works at a
+   real mobile viewport width — this is net-new responsive surface, not present in the
+   current app at all, so its own test coverage (manual or E2E, per whatever this repo's
+   mobile-testing conventions turn out to be — flagging that `project_playwright_panel_scoping.md`
+   per project memory notes this as known scoping debt) is required, not assumed free from
+   the desktop pass.
+5. No `dangerouslySetInnerHTML` was introduced anywhere in the implementation (C8).
+6. `npm run test:frontend`, `npm run test:backend` (unaffected, but must still pass),
+   `npm run type:check:all`, and `npm run check` all pass; CI green on the implementing PR(s).
+7. UAT sign-off (mandatory per `CLAUDE.md`) against both desktop and mobile, at minimum
+   covering every row of the cross-reference table above.

--- a/jobs/ux/tech/waypoint-mockups/design-system.dc.html
+++ b/jobs/ux/tech/waypoint-mockups/design-system.dc.html
@@ -1,0 +1,174 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link href="https://fonts.googleapis.com/css2?family=Newsreader:opsz,wght@6..72,400;6..72,500;6..72,600&family=Manrope:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+  <style>
+    body { margin: 0; background: oklch(97.5% 0.006 80); }
+    ::selection { background: oklch(94% 0.025 195); }
+  </style>
+</helmet>
+
+<div style="max-width:1120px;margin:0 auto;padding:64px 40px 120px;font-family:'Manrope',sans-serif;color:oklch(22% 0.02 75);">
+
+  <!-- Header -->
+  <div style="margin-bottom:64px;">
+    <div style="display:flex;align-items:center;gap:10px;margin-bottom:18px;">
+      <svg width="30" height="30" viewBox="0 0 24 24" fill="none"><path d="M12 2C8.5 2 6 5 6 8.5C6 13 12 21 12 21C12 21 18 13 18 8.5C18 5 15.5 2 12 2Z" fill="oklch(38% 0.07 195)"/><circle cx="12" cy="8.5" r="2.6" fill="oklch(97.5% 0.006 80)"/></svg>
+      <span style="font-family:'Newsreader',serif;font-weight:600;font-size:20px;letter-spacing:0.2px;">Waypoint</span>
+    </div>
+    <h1 style="font-family:'Newsreader',serif;font-weight:500;font-size:44px;line-height:1.1;margin:0 0 12px;letter-spacing:-0.5px;">Design system</h1>
+    <p style="font-size:15px;color:oklch(48% 0.015 75);max-width:560px;line-height:1.6;margin:0;">A working palette, type scale and component set for Travel Tracker — proposed name "Waypoint." Restyle proof-of-concept for the Trips screen follows in two companion files.</p>
+  </div>
+
+  <!-- Color -->
+  <section style="margin-bottom:56px;">
+    <h2 style="font-family:'Newsreader',serif;font-weight:600;font-size:22px;margin:0 0 6px;">Color</h2>
+    <p style="font-size:13px;color:oklch(48% 0.015 75);margin:0 0 24px;">Warm paper neutrals + a deep pine primary. Status/category accents share the same lightness and chroma, varying only hue — so meaning comes from color, not intensity.</p>
+
+    <div style="display:grid;grid-template-columns:repeat(5,1fr);gap:12px;margin-bottom:16px;">
+      <div>
+        <div style="height:64px;border-radius:10px;background:oklch(97.5% 0.006 80);border:1px solid oklch(89% 0.012 80);"></div>
+        <div style="font-size:11px;margin-top:6px;color:oklch(48% 0.015 75);">bg-page</div>
+      </div>
+      <div>
+        <div style="height:64px;border-radius:10px;background:oklch(99% 0.002 80);border:1px solid oklch(89% 0.012 80);"></div>
+        <div style="font-size:11px;margin-top:6px;color:oklch(48% 0.015 75);">bg-surface</div>
+      </div>
+      <div>
+        <div style="height:64px;border-radius:10px;background:oklch(89% 0.012 80);"></div>
+        <div style="font-size:11px;margin-top:6px;color:oklch(48% 0.015 75);">border</div>
+      </div>
+      <div>
+        <div style="height:64px;border-radius:10px;background:oklch(48% 0.015 75);"></div>
+        <div style="font-size:11px;margin-top:6px;color:oklch(48% 0.015 75);">ink-muted</div>
+      </div>
+      <div>
+        <div style="height:64px;border-radius:10px;background:oklch(22% 0.02 75);"></div>
+        <div style="font-size:11px;margin-top:6px;color:oklch(48% 0.015 75);">ink</div>
+      </div>
+    </div>
+
+    <div style="display:grid;grid-template-columns:repeat(5,1fr);gap:12px;margin-bottom:16px;">
+      <div>
+        <div style="height:64px;border-radius:10px;background:oklch(38% 0.07 195);"></div>
+        <div style="font-size:11px;margin-top:6px;color:oklch(48% 0.015 75);">primary (pine)</div>
+      </div>
+      <div>
+        <div style="height:64px;border-radius:10px;background:oklch(45% 0.1 325);"></div>
+        <div style="font-size:11px;margin-top:6px;color:oklch(48% 0.015 75);">accent (plum)</div>
+      </div>
+      <div>
+        <div style="height:64px;border-radius:10px;background:oklch(55% 0.14 75);"></div>
+        <div style="font-size:11px;margin-top:6px;color:oklch(48% 0.015 75);">status: active</div>
+      </div>
+      <div>
+        <div style="height:64px;border-radius:10px;background:oklch(48% 0.1 150);"></div>
+        <div style="font-size:11px;margin-top:6px;color:oklch(48% 0.015 75);">status: success</div>
+      </div>
+      <div>
+        <div style="height:64px;border-radius:10px;background:oklch(52% 0.15 25);"></div>
+        <div style="font-size:11px;margin-top:6px;color:oklch(48% 0.015 75);">status: danger</div>
+      </div>
+    </div>
+
+    <p style="font-size:12px;color:oklch(65% 0.01 75);margin:4px 0 0;">Compare to today's app: teal-600 on most screens, blue-600 in Admin, plus indigo/green/emerald/yellow scattered across statuses with no shared logic.</p>
+  </section>
+
+  <!-- Type -->
+  <section style="margin-bottom:56px;">
+    <h2 style="font-family:'Newsreader',serif;font-weight:600;font-size:22px;margin:0 0 6px;">Type</h2>
+    <p style="font-size:13px;color:oklch(48% 0.015 75);margin:0 0 24px;">Newsreader for display — gives the editorial, journal-like warmth the brand wants. Manrope for UI text — stays legible and dense at small sizes.</p>
+
+    <div style="display:flex;flex-direction:column;gap:18px;padding:28px;background:oklch(99% 0.002 80);border:1px solid oklch(89% 0.012 80);border-radius:14px;">
+      <div style="display:flex;align-items:baseline;gap:16px;"><span style="font-family:'Newsreader',serif;font-weight:500;font-size:40px;letter-spacing:-0.5px;">Kyoto, Autumn</span><span style="font-size:11px;color:oklch(65% 0.01 75);font-family:'Manrope';">Newsreader 500 / 40px — page titles</span></div>
+      <div style="display:flex;align-items:baseline;gap:16px;"><span style="font-family:'Newsreader',serif;font-weight:500;font-size:26px;">Arashiyama Bamboo Grove</span><span style="font-size:11px;color:oklch(65% 0.01 75);font-family:'Manrope';">Newsreader 500 / 26px — trip / place names</span></div>
+      <div style="display:flex;align-items:baseline;gap:16px;"><span style="font-family:'Manrope';font-weight:700;font-size:15px;">Section label</span><span style="font-size:11px;color:oklch(65% 0.01 75);">Manrope 700 / 15px — UI headers</span></div>
+      <div style="display:flex;align-items:baseline;gap:16px;"><span style="font-family:'Manrope';font-weight:500;font-size:14px;">Body / control text sits here at comfortable reading size.</span><span style="font-size:11px;color:oklch(65% 0.01 75);">Manrope 500 / 14px — body</span></div>
+      <div style="display:flex;align-items:baseline;gap:16px;"><span style="font-family:'Manrope';font-weight:600;font-size:12px;color:oklch(48% 0.015 75);">METADATA · DATES · TAGS</span><span style="font-size:11px;color:oklch(65% 0.01 75);">Manrope 600 / 12px — meta / labels</span></div>
+    </div>
+  </section>
+
+  <!-- Icons -->
+  <section style="margin-bottom:56px;">
+    <h2 style="font-family:'Newsreader',serif;font-weight:600;font-size:22px;margin:0 0 6px;">Icons</h2>
+    <p style="font-size:13px;color:oklch(48% 0.015 75);margin:0 0 24px;">One consistent filled-glyph set, replacing the emoji (🍽️🏨✈️🚗🎫📝🔒📷) used throughout today.</p>
+
+    <div style="display:grid;grid-template-columns:repeat(8,1fr);gap:8px;">
+      <div style="display:flex;flex-direction:column;align-items:center;gap:8px;padding:16px 8px;background:oklch(99% 0.002 80);border:1px solid oklch(89% 0.012 80);border-radius:10px;">
+        <svg width="22" height="22" viewBox="0 0 24 24"><path d="M4 20V9.5L12 4l8 5.5V20a1 1 0 0 1-1 1h-5v-6h-4v6H5a1 1 0 0 1-1-1Z" fill="oklch(38% 0.07 195)"/></svg>
+        <span style="font-size:10px;color:oklch(48% 0.015 75);">hotel</span>
+      </div>
+      <div style="display:flex;flex-direction:column;align-items:center;gap:8px;padding:16px 8px;background:oklch(99% 0.002 80);border:1px solid oklch(89% 0.012 80);border-radius:10px;">
+        <svg width="22" height="22" viewBox="0 0 24 24"><path d="M21 15.5v-2l-8-5V4.5a1.5 1.5 0 0 0-3 0V8.5l-8 5v2l8-2.5V17l-2.5 2v1.5l3.5-1 3.5 1V19L13 17v-4.5l8 2.5Z" fill="oklch(38% 0.07 195)"/></svg>
+        <span style="font-size:10px;color:oklch(48% 0.015 75);">flight</span>
+      </div>
+      <div style="display:flex;flex-direction:column;align-items:center;gap:8px;padding:16px 8px;background:oklch(99% 0.002 80);border:1px solid oklch(89% 0.012 80);border-radius:10px;">
+        <svg width="22" height="22" viewBox="0 0 24 24"><path d="M6 3v7a2 2 0 0 0 2 2v9h1.5v-9a2 2 0 0 0 2-2V3H10v6H9V3H8v6H7V3H6Zm9.5 0c-1.4 0-2.5 2.1-2.5 5s1 5 2 5.6V21H16.5V3.05c-.35-.03-.68-.05-1-.05Z" fill="oklch(38% 0.07 195)"/></svg>
+        <span style="font-size:10px;color:oklch(48% 0.015 75);">dining</span>
+      </div>
+      <div style="display:flex;flex-direction:column;align-items:center;gap:8px;padding:16px 8px;background:oklch(99% 0.002 80);border:1px solid oklch(89% 0.012 80);border-radius:10px;">
+        <svg width="22" height="22" viewBox="0 0 24 24"><path d="M5 16.5V11l1.8-4.5A2 2 0 0 1 8.7 5h6.6a2 2 0 0 1 1.9 1.5L19 11v5.5a1 1 0 0 1-1 1H17a1 1 0 0 1-1-1V16H8v.5a1 1 0 0 1-1 1H6a1 1 0 0 1-1-1ZM7.5 14a1.2 1.2 0 1 0 0-2.4 1.2 1.2 0 0 0 0 2.4Zm9 0a1.2 1.2 0 1 0 0-2.4 1.2 1.2 0 0 0 0 2.4ZM7 10.5h10L15.7 7H8.3L7 10.5Z" fill="oklch(38% 0.07 195)"/></svg>
+        <span style="font-size:10px;color:oklch(48% 0.015 75);">car</span>
+      </div>
+      <div style="display:flex;flex-direction:column;align-items:center;gap:8px;padding:16px 8px;background:oklch(99% 0.002 80);border:1px solid oklch(89% 0.012 80);border-radius:10px;">
+        <svg width="22" height="22" viewBox="0 0 24 24"><path d="M3 8a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2v1.5a1.5 1.5 0 0 0 0 3V14a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-1.5a1.5 1.5 0 0 0 0-3V8Zm9-1v2h1.5V7H12Zm0 4v2h1.5v-2H12Zm0 4v2h1.5v-2H12Z" fill="oklch(38% 0.07 195)"/></svg>
+        <span style="font-size:10px;color:oklch(48% 0.015 75);">experience</span>
+      </div>
+      <div style="display:flex;flex-direction:column;align-items:center;gap:8px;padding:16px 8px;background:oklch(99% 0.002 80);border:1px solid oklch(89% 0.012 80);border-radius:10px;">
+        <svg width="22" height="22" viewBox="0 0 24 24"><path d="M5 3.5h14a1 1 0 0 1 1 1V20a1 1 0 0 1-1.45.9L12 18.4l-6.55 2.5A1 1 0 0 1 4 20V4.5a1 1 0 0 1 1-1ZM7 8h10V6.5H7V8Zm0 3.5h10V10H7v1.5Z" fill="oklch(38% 0.07 195)"/></svg>
+        <span style="font-size:10px;color:oklch(48% 0.015 75);">note</span>
+      </div>
+      <div style="display:flex;flex-direction:column;align-items:center;gap:8px;padding:16px 8px;background:oklch(99% 0.002 80);border:1px solid oklch(89% 0.012 80);border-radius:10px;">
+        <svg width="22" height="22" viewBox="0 0 24 24"><path d="M7 10V7a5 5 0 0 1 10 0v3h.5A1.5 1.5 0 0 1 19 11.5v8A1.5 1.5 0 0 1 17.5 21h-11A1.5 1.5 0 0 1 5 19.5v-8A1.5 1.5 0 0 1 6.5 10H7Zm1.5 0h7V7a3.5 3.5 0 0 0-7 0v3Z" fill="oklch(38% 0.07 195)"/></svg>
+        <span style="font-size:10px;color:oklch(48% 0.015 75);">locked</span>
+      </div>
+      <div style="display:flex;flex-direction:column;align-items:center;gap:8px;padding:16px 8px;background:oklch(99% 0.002 80);border:1px solid oklch(89% 0.012 80);border-radius:10px;">
+        <svg width="22" height="22" viewBox="0 0 24 24"><path d="M9.5 5h5l.9 1.5H18a1.5 1.5 0 0 1 1.5 1.5v9A1.5 1.5 0 0 1 18 18.5H6A1.5 1.5 0 0 1 4.5 17V8A1.5 1.5 0 0 1 6 6.5h2.6L9.5 5Zm2.5 4.5a3.5 3.5 0 1 0 0 7 3.5 3.5 0 0 0 0-7Z" fill="oklch(38% 0.07 195)"/></svg>
+        <span style="font-size:10px;color:oklch(48% 0.015 75);">photos</span>
+      </div>
+    </div>
+  </section>
+
+  <!-- Status badges -->
+  <section style="margin-bottom:56px;">
+    <h2 style="font-family:'Newsreader',serif;font-weight:600;font-size:22px;margin:0 0 6px;">Status &amp; category badges</h2>
+    <p style="font-size:13px;color:oklch(48% 0.015 75);margin:0 0 20px;">Every hue is used once, at the same tint/weight, so a color always means the same status across trips and items.</p>
+
+    <div style="display:flex;flex-wrap:wrap;gap:10px;margin-bottom:14px;">
+      <span style="font-family:'Manrope';font-weight:700;font-size:11px;letter-spacing:0.3px;padding:5px 12px;border-radius:20px;background:oklch(94% 0.025 195);color:oklch(30% 0.07 195);">PLANNING</span>
+      <span style="font-family:'Manrope';font-weight:700;font-size:11px;letter-spacing:0.3px;padding:5px 12px;border-radius:20px;background:oklch(94% 0.03 75);color:oklch(40% 0.12 75);">ACTIVE</span>
+      <span style="font-family:'Manrope';font-weight:700;font-size:11px;letter-spacing:0.3px;padding:5px 12px;border-radius:20px;background:oklch(94% 0.025 325);color:oklch(38% 0.1 325);">REVIEW</span>
+      <span style="font-family:'Manrope';font-weight:700;font-size:11px;letter-spacing:0.3px;padding:5px 12px;border-radius:20px;background:oklch(93% 0.006 80);color:oklch(40% 0.01 80);">LOCKED</span>
+    </div>
+    <div style="display:flex;flex-wrap:wrap;gap:10px;">
+      <span style="font-family:'Manrope';font-weight:700;font-size:11px;letter-spacing:0.3px;padding:5px 12px;border-radius:20px;background:oklch(94% 0.025 150);color:oklch(38% 0.1 150);">CONFIRMED</span>
+      <span style="font-family:'Manrope';font-weight:700;font-size:11px;letter-spacing:0.3px;padding:5px 12px;border-radius:20px;background:oklch(95% 0.03 25);color:oklch(42% 0.13 25);">CANCELLED</span>
+      <span style="font-family:'Manrope';font-weight:700;font-size:11px;letter-spacing:0.3px;padding:5px 12px;border-radius:20px;background:oklch(93% 0.006 80);color:oklch(40% 0.01 80);">CONSIDER</span>
+    </div>
+  </section>
+
+  <!-- Buttons & inputs -->
+  <section>
+    <h2 style="font-family:'Newsreader',serif;font-weight:600;font-size:22px;margin:0 0 6px;">Buttons &amp; inputs</h2>
+    <p style="font-size:13px;color:oklch(48% 0.015 75);margin:0 0 20px;">10px radius throughout (vs. today's inconsistent md/lg/full mix).</p>
+    <div style="display:flex;align-items:center;gap:12px;flex-wrap:wrap;">
+      <button type="button" style="font-family:'Manrope';font-weight:600;font-size:14px;padding:10px 20px;border-radius:10px;border:none;background:oklch(38% 0.07 195);color:white;cursor:pointer;">New Trip</button>
+      <button type="button" style="font-family:'Manrope';font-weight:600;font-size:14px;padding:10px 20px;border-radius:10px;border:1px solid oklch(89% 0.012 80);background:oklch(99% 0.002 80);color:oklch(22% 0.02 75);cursor:pointer;">Edit</button>
+      <button type="button" style="font-family:'Manrope';font-weight:600;font-size:14px;padding:10px 20px;border-radius:10px;border:1px solid oklch(89% 0.03 25);background:oklch(97% 0.02 25);color:oklch(42% 0.13 25);cursor:pointer;">Delete</button>
+      <input type="search" placeholder="Search trips…" style="font-family:'Manrope';font-size:14px;padding:10px 14px;border-radius:10px;border:1px solid oklch(89% 0.012 80);background:oklch(99% 0.002 80);width:220px;" />
+    </div>
+  </section>
+
+</div>
+
+</x-dc>
+</body>
+</html>

--- a/jobs/ux/tech/waypoint-mockups/trips-desktop.dc.html
+++ b/jobs/ux/tech/waypoint-mockups/trips-desktop.dc.html
@@ -1,0 +1,391 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link href="https://fonts.googleapis.com/css2?family=Newsreader:opsz,wght@6..72,400;6..72,500;6..72,600&family=Manrope:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+  <style>
+    body { margin: 0; background: oklch(97.5% 0.006 80); font-family: 'Manrope', sans-serif; }
+    input:focus, select:focus { outline: 2px solid oklch(38% 0.07 195); outline-offset: 1px; }
+  </style>
+</helmet>
+
+<div style="display:flex;flex-direction:column;height:100vh;overflow:hidden;color:oklch(22% 0.02 75);">
+
+  <!-- Nav bar -->
+  <nav style="display:flex;align-items:center;gap:4px;padding:12px 24px;background:oklch(99% 0.002 80);border-bottom:1px solid oklch(89% 0.012 80);flex-shrink:0;">
+    <div style="display:flex;align-items:center;gap:8px;margin-right:20px;">
+      <svg width="22" height="22" viewBox="0 0 24 24" fill="none"><path d="M12 2C8.5 2 6 5 6 8.5C6 13 12 21 12 21C12 21 18 13 18 8.5C18 5 15.5 2 12 2Z" fill="oklch(38% 0.07 195)"/><circle cx="12" cy="8.5" r="2.6" fill="oklch(99% 0.002 80)"/></svg>
+      <span style="font-family:'Newsreader',serif;font-weight:600;font-size:17px;">Waypoint</span>
+    </div>
+    <a href="#" style-hover="background:oklch(96% 0.008 80);" style="text-decoration:none;padding:8px 14px;border-radius:8px;font-size:13px;font-weight:600;color:oklch(48% 0.015 75);transition:background 0.15s ease;">Map</a>
+    <a href="#" style="text-decoration:none;padding:8px 14px;border-radius:8px;font-size:13px;font-weight:700;color:oklch(30% 0.07 195);background:oklch(94% 0.025 195);">Trips</a>
+    <a href="#" style-hover="background:oklch(96% 0.008 80);" style="text-decoration:none;padding:8px 14px;border-radius:8px;font-size:13px;font-weight:600;color:oklch(48% 0.015 75);transition:background 0.15s ease;">Admin</a>
+  </nav>
+
+  <div style="display:flex;flex:1;overflow:hidden;">
+
+    <!-- Left panel -->
+    <div style="width:340px;flex-shrink:0;display:flex;flex-direction:column;border-right:1px solid oklch(89% 0.012 80);background:oklch(99% 0.002 80);overflow:hidden;">
+
+      <div style="padding:20px 20px 12px;flex-shrink:0;">
+        <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:14px;">
+          <h1 style="font-family:'Newsreader',serif;font-weight:600;font-size:22px;margin:0;display:flex;align-items:baseline;gap:8px;">
+            My Trips
+            <span style="font-family:'Manrope';font-weight:700;font-size:11px;background:oklch(93% 0.006 80);color:oklch(48% 0.015 75);padding:2px 8px;border-radius:20px;">{{ tripCount }}</span>
+          </h1>
+          <button type="button" onClick="{{ openNew }}" style-hover="background:oklch(33% 0.07 195);" style="font-family:'Manrope';font-weight:700;font-size:12.5px;padding:8px 14px;border-radius:9px;border:none;background:oklch(38% 0.07 195);color:white;cursor:pointer;white-space:nowrap;transition:background 0.15s ease;">+ New Trip</button>
+        </div>
+        <input type="search" placeholder="Search trips or places…" value="{{ searchText }}" onInput="{{ onSearch }}"
+          style="width:100%;box-sizing:border-box;font-family:'Manrope';font-size:13.5px;padding:9px 12px;border-radius:9px;border:1px solid oklch(89% 0.012 80);background:oklch(97.5% 0.006 80);" />
+      </div>
+
+      <div style="padding:0 20px 14px;flex-shrink:0;display:flex;flex-wrap:wrap;gap:6px;">
+        <sc-for list="{{ statusChips }}" as="chip" hint-placeholder-count="4">
+          <button type="button" onClick="{{ chip.onClick }}"
+            style-hover="filter:brightness(0.92);"
+            style="font-family:'Manrope';font-weight:700;font-size:11.5px;letter-spacing:0.2px;padding:6px 13px;border-radius:20px;cursor:pointer;transition:filter 0.15s ease;{{ chip.style }}">
+            {{ chip.label }}
+          </button>
+        </sc-for>
+      </div>
+
+      <div style="flex:1;overflow-y:auto;padding:0 16px 20px;display:flex;flex-direction:column;gap:10px;">
+        <sc-if value="{{ hasTrips }}" hint-placeholder-val="{{ true }}">
+          <sc-for list="{{ trips }}" as="trip" hint-placeholder-count="4">
+            <div onClick="{{ trip.onSelect }}" style-hover="box-shadow:0 4px 14px oklch(22% 0.02 75 / 0.14);border-color:oklch(78% 0.012 80);" style="cursor:pointer;padding:14px;border-radius:14px;background:oklch(99% 0.002 80);transition:box-shadow 0.15s ease,border-color 0.15s ease;{{ trip.cardStyle }}">
+              <div style="display:flex;justify-content:space-between;align-items:flex-start;gap:10px;">
+                <div style="min-width:0;">
+                  <div style="font-family:'Newsreader',serif;font-weight:600;font-size:16.5px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;">{{ trip.name }}</div>
+                  <div style="font-size:12px;color:oklch(48% 0.015 75);margin-top:2px;">{{ trip.dates }}</div>
+                </div>
+                <span style="flex-shrink:0;font-family:'Manrope';font-weight:700;font-size:10.5px;letter-spacing:0.3px;padding:4px 10px;border-radius:20px;white-space:nowrap;{{ trip.badgeStyle }}">{{ trip.statusLabel }}</span>
+              </div>
+              <div style="margin-top:9px;display:flex;flex-wrap:wrap;gap:5px;">
+                <sc-for list="{{ trip.places }}" as="place" hint-placeholder-count="2">
+                  <span style="font-size:11px;padding:3px 9px;border-radius:7px;background:oklch(96% 0.008 80);color:oklch(40% 0.015 75);">{{ place }}</span>
+                </sc-for>
+                <sc-for list="{{ trip.categories }}" as="cat" hint-placeholder-count="1">
+                  <span style="font-size:11px;padding:3px 9px;border-radius:7px;background:oklch(94% 0.03 255);color:oklch(42% 0.1 255);">{{ cat }}</span>
+                </sc-for>
+              </div>
+            </div>
+          </sc-for>
+        </sc-if>
+        <sc-if value="{{ hasTrips }}" hint-placeholder-val="{{ false }}">
+          <div style="padding:40px 12px;text-align:center;display:flex;flex-direction:column;align-items:center;gap:12px;">
+            <svg width="34" height="34" viewBox="0 0 24 24"><path d="M12 2C8.5 2 6 5 6 8.5C6 13 12 21 12 21C12 21 18 13 18 8.5C18 5 15.5 2 12 2Z" fill="oklch(89% 0.012 80)"/><circle cx="12" cy="8.5" r="2.6" fill="oklch(99% 0.002 80)"/></svg>
+            <p style="font-family:'Newsreader',serif;font-size:16px;color:oklch(40% 0.015 75);margin:0;">No trips match</p>
+            <p style="font-size:12.5px;color:oklch(60% 0.01 75);margin:0;line-height:1.5;">Try a different search term or filter.</p>
+          </div>
+        </sc-if>
+      </div>
+    </div>
+
+    <!-- Right panel -->
+    <div style="flex:1;overflow-y:auto;background:oklch(97.5% 0.006 80);">
+      <sc-if value="{{ selectedTrip }}" hint-placeholder-val="{{ true }}">
+        <div style="max-width:820px;margin:0 auto;padding:36px 40px 60px;">
+
+          <!-- Header -->
+          <div style="display:flex;justify-content:space-between;align-items:flex-start;gap:16px;margin-bottom:6px;">
+            <div style="min-width:0;">
+              <h1 style="font-family:'Newsreader',serif;font-weight:600;font-size:34px;margin:0 0 8px;letter-spacing:-0.3px;">{{ selectedTrip.name }}</h1>
+              <div style="display:flex;align-items:center;flex-wrap:wrap;gap:8px;font-size:13px;color:oklch(48% 0.015 75);margin-bottom:14px;">
+                <span>{{ selectedTrip.dates }}</span>
+                <sc-if value="{{ selectedTrip.companions }}" hint-placeholder-val="{{ false }}">
+                  <span style="color:oklch(80% 0.01 75);">·</span>
+                  <span>{{ selectedTrip.companions }}</span>
+                </sc-if>
+                <sc-for list="{{ selectedTrip.tags }}" as="tag" hint-placeholder-count="2">
+                  <span style="font-size:11px;font-weight:700;padding:4px 10px;border-radius:20px;background:oklch(94% 0.03 255);color:oklch(42% 0.1 255);">{{ tag }}</span>
+                </sc-for>
+              </div>
+            </div>
+            <div style="flex-shrink:0;display:flex;align-items:center;gap:8px;">
+              <span style="font-family:'Manrope';font-weight:700;font-size:11px;letter-spacing:0.3px;padding:5px 13px;border-radius:20px;{{ selectedTrip.badgeStyle }}">{{ selectedTrip.statusLabel }}</span>
+              <button type="button" style-hover="background:oklch(96% 0.008 80);" style="font-family:'Manrope';font-weight:600;font-size:13px;padding:9px 16px;border-radius:9px;border:1px solid oklch(89% 0.012 80);background:oklch(99% 0.002 80);cursor:pointer;transition:background 0.15s ease;">Edit</button>
+              <button type="button" style-hover="background:oklch(96% 0.008 80);" style="display:flex;align-items:center;gap:6px;font-family:'Manrope';font-weight:600;font-size:13px;padding:9px 14px;border-radius:9px;border:1px solid oklch(89% 0.012 80);background:oklch(99% 0.002 80);cursor:pointer;color:oklch(22% 0.02 75);transition:background 0.15s ease;">
+                <svg width="14" height="14" viewBox="0 0 24 24"><path d="M9.5 5h5l.9 1.5H18a1.5 1.5 0 0 1 1.5 1.5v9A1.5 1.5 0 0 1 18 18.5H6A1.5 1.5 0 0 1 4.5 17V8A1.5 1.5 0 0 1 6 6.5h2.6L9.5 5Zm2.5 4.5a3.5 3.5 0 1 0 0 7 3.5 3.5 0 0 0 0-7Z" fill="currentColor"/></svg>
+                Photos
+              </button>
+            </div>
+          </div>
+
+          <!-- Status stepper -->
+          <div style="display:flex;align-items:center;justify-content:space-between;gap:16px;flex-wrap:wrap;margin:22px 0;padding:18px 22px;background:oklch(99% 0.002 80);border:1px solid oklch(89% 0.012 80);border-radius:14px;">
+            <div style="display:flex;align-items:flex-start;flex-shrink:0;">
+              <sc-for list="{{ selectedTrip.steps }}" as="step" hint-placeholder-count="4">
+                <div style="display:flex;align-items:flex-start;">
+                  <div style="display:flex;flex-direction:column;align-items:center;gap:6px;width:64px;">
+                    <div style="width:22px;height:22px;border-radius:50%;display:flex;align-items:center;justify-content:center;font-family:'Manrope';font-size:11px;font-weight:700;flex-shrink:0;{{ step.dotStyle }}">{{ step.dotContent }}</div>
+                    <span style="font-family:'Manrope';font-size:10.5px;font-weight:700;letter-spacing:0.2px;text-align:center;{{ step.labelStyle }}">{{ step.label }}</span>
+                  </div>
+                  <sc-if value="{{ step.hasNext }}" hint-placeholder-val="{{ true }}">
+                    <div style="width:36px;height:2px;margin:10px -12px 0;{{ step.lineStyle }}"></div>
+                  </sc-if>
+                </div>
+              </sc-for>
+            </div>
+            <sc-if value="{{ selectedTrip.nextLabel }}" hint-placeholder-val="{{ false }}">
+              <div style="display:flex;align-items:center;gap:12px;flex-shrink:0;margin-left:auto;">
+                <span style="font-family:'Manrope';font-size:11.5px;color:oklch(48% 0.015 75);max-width:150px;text-align:right;line-height:1.4;">{{ selectedTrip.nextHint }}</span>
+                <button type="button" style-hover="background:oklch(33% 0.07 195);" style="font-family:'Manrope';font-weight:700;font-size:12.5px;padding:9px 18px;border-radius:9px;border:none;background:oklch(38% 0.07 195);color:white;cursor:pointer;white-space:nowrap;transition:background 0.15s ease;">{{ selectedTrip.nextLabel }}</button>
+              </div>
+            </sc-if>
+          </div>
+
+          <!-- Places -->
+          <sc-for list="{{ selectedTrip.placeSections }}" as="place" hint-placeholder-count="2">
+            <div style="border:1px solid oklch(89% 0.012 80);border-radius:14px;overflow:hidden;margin-bottom:18px;background:oklch(99% 0.002 80);">
+              <div style="display:flex;justify-content:space-between;align-items:flex-start;padding:16px 18px;background:oklch(96% 0.008 80);border-bottom:1px solid oklch(89% 0.012 80);">
+                <div>
+                  <div style="font-family:'Newsreader',serif;font-weight:600;font-size:17px;">{{ place.city }}</div>
+                  <div style="font-size:12px;color:oklch(48% 0.015 75);margin-top:2px;">{{ place.country }} · {{ place.dateRange }}</div>
+                </div>
+                <button type="button" style-hover="background:oklch(33% 0.07 195);" style="font-family:'Manrope';font-weight:700;font-size:11.5px;padding:7px 14px;border-radius:9px;border:none;background:oklch(38% 0.07 195);color:white;cursor:pointer;white-space:nowrap;transition:background 0.15s ease;">+ Add Item</button>
+              </div>
+              <div style="padding:14px 18px;display:flex;flex-direction:column;gap:10px;">
+                <sc-for list="{{ place.items }}" as="item" hint-placeholder-count="2">
+                  <div style="display:flex;align-items:flex-start;gap:12px;padding:12px 14px;background:oklch(97.5% 0.006 80);border-radius:11px;border:1px solid oklch(92% 0.008 80);">
+                    <div style="width:32px;height:32px;flex-shrink:0;border-radius:8px;background:oklch(94% 0.025 195);display:flex;align-items:center;justify-content:center;" dangerouslySetInnerHTML="{{ item.iconHtml }}"></div>
+                    <div style="flex:1;min-width:0;">
+                      <div style="display:flex;align-items:center;gap:8px;flex-wrap:wrap;">
+                        <span style="font-weight:700;font-size:13.5px;">{{ item.label }}</span>
+                        <span style="font-family:'Manrope';font-weight:700;font-size:10px;letter-spacing:0.2px;padding:3px 9px;border-radius:20px;{{ item.badgeStyle }}">{{ item.statusLabel }}</span>
+                      </div>
+                      <sc-if value="{{ item.sub }}" hint-placeholder-val="{{ false }}">
+                        <div style="font-size:12px;color:oklch(48% 0.015 75);margin-top:3px;">{{ item.sub }}</div>
+                      </sc-if>
+                    </div>
+                  </div>
+                </sc-for>
+              </div>
+            </div>
+          </sc-for>
+
+          <button type="button" style-hover="border-color:oklch(70% 0.012 80);color:oklch(38% 0.015 75);" style="width:100%;padding:16px;border-radius:14px;border:2px dashed oklch(85% 0.012 80);background:transparent;color:oklch(48% 0.015 75);font-family:'Manrope';font-weight:600;font-size:13.5px;cursor:pointer;transition:all 0.15s ease;">+ Add Place</button>
+        </div>
+      </sc-if>
+
+      <sc-if value="{{ selectedTrip }}" hint-placeholder-val="{{ false }}">
+        <div style="height:100%;display:flex;flex-direction:column;align-items:center;justify-content:center;color:oklch(65% 0.01 75);gap:14px;">
+          <svg width="48" height="48" viewBox="0 0 24 24"><path d="M12 2C8.5 2 6 5 6 8.5C6 13 12 21 12 21C12 21 18 13 18 8.5C18 5 15.5 2 12 2Z" fill="oklch(89% 0.012 80)"/><circle cx="12" cy="8.5" r="2.6" fill="oklch(97.5% 0.006 80)"/></svg>
+          <p style="font-family:'Newsreader',serif;font-size:18px;margin:0;color:oklch(40% 0.015 75);">Select a trip</p>
+          <p style="font-size:13px;max-width:240px;text-align:center;margin:0;line-height:1.5;">Choose a trip from the list to see its places and itinerary.</p>
+        </div>
+      </sc-if>
+    </div>
+  </div>
+</div>
+
+</x-dc>
+<script type="text/x-dc" data-dc-script>
+class Component extends DCLogic {
+  state = {
+    searchText: '',
+    activeStatus: '',
+    selectedId: 1,
+  };
+
+  trips = [
+    {
+      id: 1, name: 'Kyoto in Autumn', start: 'Nov 3', end: 'Nov 12, 2026', status: 'active',
+      companions: 'Mira, Dad', places: ['Kyoto', 'Osaka'], categories: ['Culture'],
+      tags: ['Culture'],
+      placeSections: [
+        { city: 'Kyoto', country: 'Japan', dateRange: 'Nov 3 – Nov 8', items: [
+          { type: 'hotel', label: 'Ryokan Sumiya', status: 'confirmed', sub: 'Nov 3 – Nov 8' },
+          { type: 'restaurant', label: 'Kikunoi', status: 'consider', sub: 'Kaiseki' },
+        ]},
+        { city: 'Osaka', country: 'Japan', dateRange: 'Nov 8 – Nov 12', items: [
+          { type: 'flight', label: 'KIX → NRT', status: 'confirmed', sub: 'JL 123 · Nov 12' },
+        ]},
+      ],
+    },
+    {
+      id: 2, name: 'Lisbon Long Weekend', start: 'Feb 14', end: 'Feb 18, 2026', status: 'planning',
+      companions: 'Sam', places: ['Lisbon'], categories: ['Food'],
+      tags: ['Food'],
+      placeSections: [
+        { city: 'Lisbon', country: 'Portugal', dateRange: 'Feb 14 – Feb 18', items: [
+          { type: 'hotel', label: 'Memmo Alfama', status: 'consider', sub: null },
+        ]},
+      ],
+    },
+    {
+      id: 3, name: 'Patagonia Trek', start: 'Jan 5', end: 'Jan 20, 2026', status: 'review_pending',
+      companions: '', places: ['El Chaltén', 'Puerto Natales'], categories: [],
+      tags: [],
+      placeSections: [
+        { city: 'El Chaltén', country: 'Argentina', dateRange: 'Jan 5 – Jan 12', items: [
+          { type: 'experience', label: 'Fitz Roy day hike', status: 'completed', sub: null },
+          { type: 'note', label: 'Pack layers — weather shifts fast', status: 'confirmed', sub: null },
+        ]},
+      ],
+    },
+    {
+      id: 4, name: 'Family Reunion — Cape Cod', start: 'Jul 1', end: 'Jul 8, 2025', status: 'locked',
+      companions: 'The whole family', places: ['Provincetown'], categories: [],
+      tags: [],
+      placeSections: [
+        { city: 'Provincetown', country: 'United States', dateRange: 'Jul 1 – Jul 8', items: [
+          { type: 'car_rental', label: 'Hertz — Boston Logan', status: 'completed', sub: null },
+        ]},
+      ],
+    },
+  ];
+
+  STATUS_META = {
+    planning: { label: 'PLANNING', bg: 'oklch(94% 0.025 195)', fg: 'oklch(30% 0.07 195)' },
+    active: { label: 'ACTIVE', bg: 'oklch(94% 0.03 75)', fg: 'oklch(40% 0.12 75)' },
+    review_pending: { label: 'REVIEW', bg: 'oklch(94% 0.025 325)', fg: 'oklch(38% 0.1 325)' },
+    locked: { label: 'LOCKED', bg: 'oklch(93% 0.006 80)', fg: 'oklch(40% 0.01 80)' },
+    confirmed: { label: 'CONFIRMED', bg: 'oklch(94% 0.025 150)', fg: 'oklch(38% 0.1 150)' },
+    completed: { label: 'DONE', bg: 'oklch(94% 0.025 150)', fg: 'oklch(38% 0.1 150)' },
+    consider: { label: 'CONSIDER', bg: 'oklch(93% 0.006 80)', fg: 'oklch(40% 0.01 80)' },
+    cancelled: { label: 'CANCELLED', bg: 'oklch(95% 0.03 25)', fg: 'oklch(42% 0.13 25)' },
+  };
+
+  NEXT_STEP = {
+    planning: { label: 'Mark as Active', hint: 'Next: active → review → lock' },
+    active: { label: 'Move to Review', hint: 'Next: post-trip review → lock' },
+    review_pending: { label: 'Lock Trip', hint: 'Final step' },
+  };
+
+  STEP_ORDER = [
+    { key: 'planning', label: 'Plan' },
+    { key: 'active', label: 'Active' },
+    { key: 'review_pending', label: 'Review' },
+    { key: 'locked', label: 'Locked' },
+  ];
+
+  buildSteps(status) {
+    const idx = this.STEP_ORDER.findIndex((s) => s.key === status);
+    return this.STEP_ORDER.map((s, i) => {
+      const state = i < idx ? 'done' : i === idx ? 'current' : 'upcoming';
+      const dotStyle = state === 'upcoming'
+        ? 'background:oklch(93% 0.006 80);color:oklch(58% 0.01 75);'
+        : 'background:oklch(38% 0.07 195);color:white;';
+      const labelStyle = state === 'upcoming' ? 'color:oklch(60% 0.01 75);' : 'color:oklch(30% 0.07 195);';
+      const lineStyle = i < idx ? 'background:oklch(38% 0.07 195);' : 'background:oklch(89% 0.012 80);';
+      return {
+        label: s.label,
+        dotContent: state === 'done' ? '✓' : String(i + 1),
+        dotStyle,
+        labelStyle,
+        lineStyle,
+        hasNext: i < this.STEP_ORDER.length - 1,
+      };
+    });
+  }
+
+  ICONS = {
+    hotel: '<svg width="16" height="16" viewBox="0 0 24 24"><path d="M4 20V9.5L12 4l8 5.5V20a1 1 0 0 1-1 1h-5v-6h-4v6H5a1 1 0 0 1-1-1Z" fill="oklch(38% 0.07 195)"/></svg>',
+    flight: '<svg width="16" height="16" viewBox="0 0 24 24"><path d="M21 15.5v-2l-8-5V4.5a1.5 1.5 0 0 0-3 0V8.5l-8 5v2l8-2.5V17l-2.5 2v1.5l3.5-1 3.5 1V19L13 17v-4.5l8 2.5Z" fill="oklch(38% 0.07 195)"/></svg>',
+    restaurant: '<svg width="16" height="16" viewBox="0 0 24 24"><path d="M6 3v7a2 2 0 0 0 2 2v9h1.5v-9a2 2 0 0 0 2-2V3H10v6H9V3H8v6H7V3H6Zm9.5 0c-1.4 0-2.5 2.1-2.5 5s1 5 2 5.6V21H16.5V3.05c-.35-.03-.68-.05-1-.05Z" fill="oklch(38% 0.07 195)"/></svg>',
+    car_rental: '<svg width="16" height="16" viewBox="0 0 24 24"><path d="M5 16.5V11l1.8-4.5A2 2 0 0 1 8.7 5h6.6a2 2 0 0 1 1.9 1.5L19 11v5.5a1 1 0 0 1-1 1H17a1 1 0 0 1-1-1V16H8v.5a1 1 0 0 1-1 1H6a1 1 0 0 1-1-1ZM7.5 14a1.2 1.2 0 1 0 0-2.4 1.2 1.2 0 0 0 0 2.4Zm9 0a1.2 1.2 0 1 0 0-2.4 1.2 1.2 0 0 0 0 2.4ZM7 10.5h10L15.7 7H8.3L7 10.5Z" fill="oklch(38% 0.07 195)"/></svg>',
+    experience: '<svg width="16" height="16" viewBox="0 0 24 24"><path d="M3 8a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2v1.5a1.5 1.5 0 0 0 0 3V14a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-1.5a1.5 1.5 0 0 0 0-3V8Zm9-1v2h1.5V7H12Zm0 4v2h1.5v-2H12Zm0 4v2h1.5v-2H12Z" fill="oklch(38% 0.07 195)"/></svg>',
+    note: '<svg width="16" height="16" viewBox="0 0 24 24"><path d="M5 3.5h14a1 1 0 0 1 1 1V20a1 1 0 0 1-1.45.9L12 18.4l-6.55 2.5A1 1 0 0 1 4 20V4.5a1 1 0 0 1 1-1ZM7 8h10V6.5H7V8Zm0 3.5h10V10H7v1.5Z" fill="oklch(38% 0.07 195)"/></svg>',
+  };
+
+  renderVals() {
+    const { searchText, activeStatus, selectedId } = this.state;
+
+    const q = searchText.trim().toLowerCase();
+    let filtered = this.trips.filter((t) => {
+      if (activeStatus && t.status !== activeStatus) return false;
+      if (q && !t.name.toLowerCase().includes(q) && !t.places.some((p) => p.toLowerCase().includes(q))) return false;
+      return true;
+    });
+
+    const chips = [
+      { value: '', label: 'All' },
+      { value: 'planning', label: 'Planning' },
+      { value: 'active', label: 'Active' },
+      { value: 'review_pending', label: 'Review' },
+      { value: 'locked', label: 'Locked' },
+    ].map((c) => {
+      const isActive = activeStatus === c.value;
+      return {
+        label: c.label,
+        onClick: () => this.setState({ activeStatus: c.value }),
+        style: isActive
+          ? 'background:oklch(38% 0.07 195);color:white;'
+          : 'background:oklch(96% 0.008 80);color:oklch(48% 0.015 75);',
+      };
+    });
+
+    const trips = filtered.map((t) => {
+      const meta = this.STATUS_META[t.status];
+      const isSelected = t.id === selectedId;
+      return {
+        id: t.id,
+        name: t.name,
+        dates: `${t.start} – ${t.end}`,
+        statusLabel: meta.label,
+        badgeStyle: `background:${meta.bg};color:${meta.fg};`,
+        places: t.places,
+        categories: t.categories,
+        onSelect: () => this.setState({ selectedId: t.id }),
+        cardStyle: isSelected
+          ? 'border:1.5px solid oklch(38% 0.07 195);box-shadow:0 2px 10px oklch(38% 0.07 195 / 0.12);'
+          : 'border:1px solid oklch(89% 0.012 80);',
+      };
+    });
+
+    const sel = this.trips.find((t) => t.id === selectedId) ?? null;
+    let selectedTrip = null;
+    if (sel) {
+      const meta = this.STATUS_META[sel.status];
+      const next = this.NEXT_STEP[sel.status];
+      selectedTrip = {
+        name: sel.name,
+        dates: `${sel.start} – ${sel.end}`,
+        companions: sel.companions,
+        tags: sel.tags,
+        statusLabel: meta.label,
+        badgeStyle: `background:${meta.bg};color:${meta.fg};`,
+        nextLabel: next ? next.label : null,
+        nextHint: next ? next.hint : null,
+        steps: this.buildSteps(sel.status),
+        placeSections: sel.placeSections.map((p) => ({
+          city: p.city,
+          country: p.country,
+          dateRange: p.dateRange,
+          items: p.items.map((it) => {
+            const im = this.STATUS_META[it.status] ?? this.STATUS_META.consider;
+            return {
+              label: it.label,
+              sub: it.sub,
+              statusLabel: im.label,
+              badgeStyle: `background:${im.bg};color:${im.fg};`,
+              iconHtml: { __html: this.ICONS[it.type] ?? '' },
+            };
+          }),
+        })),
+      };
+    }
+
+    return {
+      tripCount: filtered.length,
+      hasTrips: trips.length > 0,
+      searchText,
+      onSearch: (e) => this.setState({ searchText: e.target.value }),
+      openNew: () => {},
+      statusChips: chips,
+      trips,
+      selectedTrip,
+    };
+  }
+}
+
+</script>
+</body>
+</html>

--- a/jobs/ux/tech/waypoint-mockups/trips-mobile.dc.html
+++ b/jobs/ux/tech/waypoint-mockups/trips-mobile.dc.html
@@ -1,0 +1,365 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link href="https://fonts.googleapis.com/css2?family=Newsreader:opsz,wght@6..72,400;6..72,500;6..72,600&family=Manrope:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+  <style>
+    body { margin: 0; background: oklch(97.5% 0.006 80); font-family: 'Manrope', sans-serif; display:flex; justify-content:center; padding: 24px 0; }
+  </style>
+</helmet>
+
+<div style="width:390px;height:844px;background:oklch(97.5% 0.006 80);color:oklch(22% 0.02 75);position:relative;overflow:hidden;border-radius:36px;box-shadow:0 0 0 10px oklch(15% 0.01 75), 0 20px 60px rgba(0,0,0,0.35);">
+
+  <!-- LIST VIEW -->
+  <div style="{{ listViewStyle }}position:absolute;inset:0;display:flex;flex-direction:column;">
+    <div style="height:47px;flex-shrink:0;"></div>
+
+    <div style="padding:8px 20px 12px;flex-shrink:0;">
+      <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:14px;">
+        <h1 style="font-family:'Newsreader',serif;font-weight:600;font-size:28px;margin:0;display:flex;align-items:baseline;gap:8px;">My Trips <span style="font-family:'Manrope';font-weight:700;font-size:12px;background:oklch(93% 0.006 80);color:oklch(48% 0.015 75);padding:2px 9px;border-radius:20px;">{{ tripCount }}</span></h1>
+        <button type="button" onClick="{{ openNew }}" style="width:36px;height:36px;border-radius:11px;border:none;background:oklch(38% 0.07 195);color:white;font-size:20px;line-height:1;cursor:pointer;">+</button>
+      </div>
+      <input type="search" placeholder="Search trips…" value="{{ searchText }}" onInput="{{ onSearch }}"
+        style="width:100%;box-sizing:border-box;font-family:'Manrope';font-size:15px;padding:11px 14px;border-radius:11px;border:1px solid oklch(89% 0.012 80);background:oklch(99% 0.002 80);" />
+    </div>
+
+    <div style="padding:0 20px 12px;flex-shrink:0;display:flex;gap:7px;overflow-x:auto;">
+      <sc-for list="{{ statusChips }}" as="chip" hint-placeholder-count="4">
+<button type="button" onClick="{{ chip.onClick }}" style-active="filter:brightness(0.88);" style="flex-shrink:0;font-family:'Manrope';font-weight:700;font-size:12.5px;padding:7px 14px;border-radius:20px;border:none;cursor:pointer;transition:filter 0.1s ease;{{ chip.style }}">{{ chip.label }}</button>
+      </sc-for>
+    </div>
+
+    <div style="flex:1;overflow-y:auto;padding:4px 20px 20px;display:flex;flex-direction:column;gap:12px;">
+      <sc-if value="{{ hasTrips }}" hint-placeholder-val="{{ true }}">
+        <sc-for list="{{ trips }}" as="trip" hint-placeholder-count="4">
+          <div onClick="{{ trip.onSelect }}" style-active="background:oklch(95% 0.006 80);" style="cursor:pointer;padding:16px;border-radius:16px;background:oklch(99% 0.002 80);border:1px solid oklch(89% 0.012 80);transition:background 0.1s ease;">
+            <div style="display:flex;justify-content:space-between;align-items:flex-start;gap:10px;">
+              <div style="min-width:0;">
+                <div style="font-family:'Newsreader',serif;font-weight:600;font-size:18px;">{{ trip.name }}</div>
+                <div style="font-size:13px;color:oklch(48% 0.015 75);margin-top:3px;">{{ trip.dates }}</div>
+              </div>
+              <span style="flex-shrink:0;font-family:'Manrope';font-weight:700;font-size:10.5px;letter-spacing:0.3px;padding:5px 11px;border-radius:20px;white-space:nowrap;{{ trip.badgeStyle }}">{{ trip.statusLabel }}</span>
+            </div>
+            <div style="margin-top:10px;display:flex;flex-wrap:wrap;gap:6px;">
+              <sc-for list="{{ trip.places }}" as="place" hint-placeholder-count="2">
+                <span style="font-size:12px;padding:4px 10px;border-radius:8px;background:oklch(96% 0.008 80);color:oklch(40% 0.015 75);">{{ place }}</span>
+              </sc-for>
+              <sc-for list="{{ trip.categories }}" as="cat" hint-placeholder-count="1">
+                <span style="font-size:12px;padding:4px 10px;border-radius:8px;background:oklch(94% 0.03 255);color:oklch(42% 0.1 255);">{{ cat }}</span>
+              </sc-for>
+            </div>
+          </div>
+        </sc-for>
+      </sc-if>
+      <sc-if value="{{ hasTrips }}" hint-placeholder-val="{{ false }}">
+        <div style="padding:56px 12px;text-align:center;">
+          <p style="font-family:'Newsreader',serif;font-size:16px;color:oklch(40% 0.015 75);margin:0 0 6px;">No trips match</p>
+          <p style="font-size:12.5px;color:oklch(60% 0.01 75);margin:0;line-height:1.5;">Try a different search or filter.</p>
+        </div>
+      </sc-if>
+    </div>
+
+    <!-- Tab bar -->
+    <div style="flex-shrink:0;display:flex;align-items:center;justify-content:space-around;padding:10px 0 26px;border-top:1px solid oklch(89% 0.012 80);background:oklch(99% 0.002 80);">
+      <div style="display:flex;flex-direction:column;align-items:center;gap:3px;color:oklch(65% 0.01 75);">
+        <svg width="21" height="21" viewBox="0 0 24 24"><path d="M12 2C8.5 2 6 5 6 8.5C6 13 12 21 12 21C12 21 18 13 18 8.5C18 5 15.5 2 12 2Z" fill="currentColor"/></svg>
+        <span style="font-size:10.5px;font-weight:600;">Map</span>
+      </div>
+      <div style="display:flex;flex-direction:column;align-items:center;gap:3px;color:oklch(38% 0.07 195);">
+        <svg width="21" height="21" viewBox="0 0 24 24"><rect x="5" y="8" width="14" height="10.5" rx="2" fill="currentColor"/><rect x="9" y="5" width="6" height="3.5" rx="1.5" fill="none" stroke="currentColor" stroke-width="1.8"/></svg>
+        <span style="font-size:10.5px;font-weight:700;">Trips</span>
+      </div>
+      <div style="display:flex;flex-direction:column;align-items:center;gap:3px;color:oklch(65% 0.01 75);">
+        <svg width="21" height="21" viewBox="0 0 24 24"><rect x="4" y="5.2" width="16" height="2" rx="1" fill="currentColor" opacity="0.3"/><circle cx="15" cy="6.2" r="2.6" fill="currentColor"/><rect x="4" y="11" width="16" height="2" rx="1" fill="currentColor" opacity="0.3"/><circle cx="9" cy="12" r="2.6" fill="currentColor"/><rect x="4" y="16.8" width="16" height="2" rx="1" fill="currentColor" opacity="0.3"/><circle cx="17" cy="17.8" r="2.6" fill="currentColor"/></svg>
+        <span style="font-size:10.5px;font-weight:600;">Admin</span>
+      </div>
+    </div>
+  </div>
+
+  <!-- DETAIL VIEW -->
+  <div style="{{ detailViewStyle }}position:absolute;inset:0;display:flex;flex-direction:column;background:oklch(97.5% 0.006 80);">
+    <div style="height:47px;flex-shrink:0;"></div>
+
+    <sc-if value="{{ selectedTrip }}" hint-placeholder-val="{{ true }}">
+      <div style="flex:1;overflow-y:auto;">
+        <!-- Back bar -->
+        <div style="display:flex;align-items:center;gap:6px;padding:6px 16px 10px;">
+          <button type="button" onClick="{{ goBack }}" style-active="opacity:0.6;" style="display:flex;align-items:center;gap:4px;border:none;background:none;color:oklch(38% 0.07 195);font-family:'Manrope';font-weight:600;font-size:15px;cursor:pointer;padding:6px 4px;transition:opacity 0.1s ease;">
+            <svg width="18" height="18" viewBox="0 0 24 24"><path d="M15 5l-7 7 7 7" stroke="currentColor" stroke-width="2.2" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg>
+            Trips
+          </button>
+        </div>
+
+        <div style="padding:4px 20px 32px;">
+          <div style="display:flex;justify-content:space-between;align-items:flex-start;gap:12px;margin-bottom:10px;">
+            <h1 style="font-family:'Newsreader',serif;font-weight:600;font-size:26px;margin:0;letter-spacing:-0.3px;">{{ selectedTrip.name }}</h1>
+            <span style="flex-shrink:0;font-family:'Manrope';font-weight:700;font-size:10.5px;letter-spacing:0.3px;padding:5px 12px;border-radius:20px;white-space:nowrap;{{ selectedTrip.badgeStyle }}">{{ selectedTrip.statusLabel }}</span>
+          </div>
+          <div style="display:flex;align-items:center;flex-wrap:wrap;gap:8px;font-size:13px;color:oklch(48% 0.015 75);margin-bottom:16px;">
+            <span>{{ selectedTrip.dates }}</span>
+            <sc-if value="{{ selectedTrip.companions }}" hint-placeholder-val="{{ false }}">
+              <span style="color:oklch(80% 0.01 75);">·</span>
+              <span>{{ selectedTrip.companions }}</span>
+            </sc-if>
+            <sc-for list="{{ selectedTrip.tags }}" as="tag" hint-placeholder-count="2">
+              <span style="font-size:11px;font-weight:700;padding:4px 10px;border-radius:20px;background:oklch(94% 0.03 255);color:oklch(42% 0.1 255);">{{ tag }}</span>
+            </sc-for>
+          </div>
+
+          <div style="display:flex;align-items:center;padding:14px 16px;background:oklch(99% 0.002 80);border:1px solid oklch(89% 0.012 80);border-radius:14px;margin-bottom:20px;">
+            <sc-for list="{{ selectedTrip.steps }}" as="step" hint-placeholder-count="4">
+              <div style="display:flex;align-items:flex-start;">
+                <div style="display:flex;flex-direction:column;align-items:center;gap:4px;width:52px;">
+                  <div style="width:18px;height:18px;border-radius:50%;display:flex;align-items:center;justify-content:center;font-family:'Manrope';font-size:9.5px;font-weight:700;flex-shrink:0;{{ step.dotStyle }}">{{ step.dotContent }}</div>
+                  <span style="font-family:'Manrope';font-size:9px;font-weight:700;letter-spacing:0.2px;text-align:center;{{ step.labelStyle }}">{{ step.label }}</span>
+                </div>
+                <sc-if value="{{ step.hasNext }}" hint-placeholder-val="{{ true }}">
+                  <div style="width:20px;height:2px;margin:8px -8px 0;{{ step.lineStyle }}"></div>
+                </sc-if>
+              </div>
+            </sc-for>
+          </div>
+          <sc-if value="{{ selectedTrip.nextLabel }}" hint-placeholder-val="{{ false }}">
+            <div style="display:flex;align-items:center;justify-content:space-between;padding:14px 16px;background:oklch(94% 0.025 195);border-radius:14px;margin-bottom:20px;gap:10px;">
+              <span style="font-size:12.5px;color:oklch(30% 0.07 195);flex:1;">{{ selectedTrip.nextHint }}</span>
+              <button type="button" style="flex-shrink:0;font-family:'Manrope';font-weight:700;font-size:12.5px;padding:9px 14px;border-radius:10px;border:none;background:oklch(38% 0.07 195);color:white;cursor:pointer;white-space:nowrap;">{{ selectedTrip.nextLabel }}</button>
+            </div>
+          </sc-if>
+
+          <sc-for list="{{ selectedTrip.placeSections }}" as="place" hint-placeholder-count="2">
+            <div style="border:1px solid oklch(89% 0.012 80);border-radius:16px;overflow:hidden;margin-bottom:16px;background:oklch(99% 0.002 80);">
+              <div style="padding:14px 16px;background:oklch(96% 0.008 80);border-bottom:1px solid oklch(89% 0.012 80);">
+                <div style="font-family:'Newsreader',serif;font-weight:600;font-size:16px;">{{ place.city }}</div>
+                <div style="font-size:11.5px;color:oklch(48% 0.015 75);margin-top:2px;">{{ place.country }} · {{ place.dateRange }}</div>
+              </div>
+              <div style="padding:12px 16px;display:flex;flex-direction:column;gap:9px;">
+                <sc-for list="{{ place.items }}" as="item" hint-placeholder-count="2">
+                  <div style="display:flex;align-items:flex-start;gap:11px;padding:11px 12px;background:oklch(97.5% 0.006 80);border-radius:11px;border:1px solid oklch(92% 0.008 80);">
+                    <div style="width:30px;height:30px;flex-shrink:0;border-radius:8px;background:oklch(94% 0.025 195);display:flex;align-items:center;justify-content:center;" dangerouslySetInnerHTML="{{ item.iconHtml }}"></div>
+                    <div style="flex:1;min-width:0;">
+                      <div style="display:flex;align-items:center;gap:7px;flex-wrap:wrap;">
+                        <span style="font-weight:700;font-size:13.5px;">{{ item.label }}</span>
+                        <span style="font-family:'Manrope';font-weight:700;font-size:9.5px;letter-spacing:0.2px;padding:3px 8px;border-radius:20px;{{ item.badgeStyle }}">{{ item.statusLabel }}</span>
+                      </div>
+                      <sc-if value="{{ item.sub }}" hint-placeholder-val="{{ false }}">
+                        <div style="font-size:11.5px;color:oklch(48% 0.015 75);margin-top:2px;">{{ item.sub }}</div>
+                      </sc-if>
+                    </div>
+                  </div>
+                </sc-for>
+              </div>
+            </div>
+          </sc-for>
+        </div>
+      </div>
+    </sc-if>
+  </div>
+</div>
+
+</x-dc>
+<script type="text/x-dc" data-dc-script>
+class Component extends DCLogic {
+  state = {
+    searchText: '',
+    activeStatus: '',
+    selectedId: null,
+  };
+
+  trips = [
+    {
+      id: 1, name: 'Kyoto in Autumn', start: 'Nov 3', end: 'Nov 12, 2026', status: 'active',
+      companions: 'Mira, Dad', places: ['Kyoto', 'Osaka'], categories: ['Culture'], tags: ['Culture'],
+      placeSections: [
+        { city: 'Kyoto', country: 'Japan', dateRange: 'Nov 3 – Nov 8', items: [
+          { type: 'hotel', label: 'Ryokan Sumiya', status: 'confirmed', sub: 'Nov 3 – Nov 8' },
+          { type: 'restaurant', label: 'Kikunoi', status: 'consider', sub: 'Kaiseki' },
+        ]},
+        { city: 'Osaka', country: 'Japan', dateRange: 'Nov 8 – Nov 12', items: [
+          { type: 'flight', label: 'KIX → NRT', status: 'confirmed', sub: 'JL 123 · Nov 12' },
+        ]},
+      ],
+    },
+    {
+      id: 2, name: 'Lisbon Long Weekend', start: 'Feb 14', end: 'Feb 18, 2026', status: 'planning',
+      companions: 'Sam', places: ['Lisbon'], categories: ['Food'], tags: ['Food'],
+      placeSections: [
+        { city: 'Lisbon', country: 'Portugal', dateRange: 'Feb 14 – Feb 18', items: [
+          { type: 'hotel', label: 'Memmo Alfama', status: 'consider', sub: null },
+        ]},
+      ],
+    },
+    {
+      id: 3, name: 'Patagonia Trek', start: 'Jan 5', end: 'Jan 20, 2026', status: 'review_pending',
+      companions: '', places: ['El Chaltén', 'Puerto Natales'], categories: [], tags: [],
+      placeSections: [
+        { city: 'El Chaltén', country: 'Argentina', dateRange: 'Jan 5 – Jan 12', items: [
+          { type: 'experience', label: 'Fitz Roy day hike', status: 'completed', sub: null },
+          { type: 'note', label: 'Pack layers — weather shifts fast', status: 'confirmed', sub: null },
+        ]},
+      ],
+    },
+    {
+      id: 4, name: 'Family Reunion — Cape Cod', start: 'Jul 1', end: 'Jul 8, 2025', status: 'locked',
+      companions: 'The whole family', places: ['Provincetown'], categories: [], tags: [],
+      placeSections: [
+        { city: 'Provincetown', country: 'United States', dateRange: 'Jul 1 – Jul 8', items: [
+          { type: 'car_rental', label: 'Hertz — Boston Logan', status: 'completed', sub: null },
+        ]},
+      ],
+    },
+  ];
+
+  STATUS_META = {
+    planning: { label: 'PLANNING', bg: 'oklch(94% 0.025 195)', fg: 'oklch(30% 0.07 195)' },
+    active: { label: 'ACTIVE', bg: 'oklch(94% 0.03 75)', fg: 'oklch(40% 0.12 75)' },
+    review_pending: { label: 'REVIEW', bg: 'oklch(94% 0.025 325)', fg: 'oklch(38% 0.1 325)' },
+    locked: { label: 'LOCKED', bg: 'oklch(93% 0.006 80)', fg: 'oklch(40% 0.01 80)' },
+    confirmed: { label: 'CONFIRMED', bg: 'oklch(94% 0.025 150)', fg: 'oklch(38% 0.1 150)' },
+    completed: { label: 'DONE', bg: 'oklch(94% 0.025 150)', fg: 'oklch(38% 0.1 150)' },
+    consider: { label: 'CONSIDER', bg: 'oklch(93% 0.006 80)', fg: 'oklch(40% 0.01 80)' },
+    cancelled: { label: 'CANCELLED', bg: 'oklch(95% 0.03 25)', fg: 'oklch(42% 0.13 25)' },
+  };
+
+  NEXT_STEP = {
+    planning: { label: 'Mark Active', hint: 'Next: active → review → lock' },
+    active: { label: 'Move to Review', hint: 'Next: post-trip review → lock' },
+    review_pending: { label: 'Lock Trip', hint: 'Final step' },
+  };
+
+  STEP_ORDER = [
+    { key: 'planning', label: 'Plan' },
+    { key: 'active', label: 'Active' },
+    { key: 'review_pending', label: 'Review' },
+    { key: 'locked', label: 'Locked' },
+  ];
+
+  buildSteps(status) {
+    const idx = this.STEP_ORDER.findIndex((s) => s.key === status);
+    return this.STEP_ORDER.map((s, i) => {
+      const state = i < idx ? 'done' : i === idx ? 'current' : 'upcoming';
+      const dotStyle = state === 'upcoming'
+        ? 'background:oklch(93% 0.006 80);color:oklch(58% 0.01 75);'
+        : 'background:oklch(38% 0.07 195);color:white;';
+      const labelStyle = state === 'upcoming' ? 'color:oklch(60% 0.01 75);' : 'color:oklch(30% 0.07 195);';
+      const lineStyle = i < idx ? 'background:oklch(38% 0.07 195);' : 'background:oklch(89% 0.012 80);';
+      return {
+        label: s.label,
+        dotContent: state === 'done' ? '✓' : String(i + 1),
+        dotStyle,
+        labelStyle,
+        lineStyle,
+        hasNext: i < this.STEP_ORDER.length - 1,
+      };
+    });
+  }
+
+  ICONS = {
+    hotel: '<svg width="15" height="15" viewBox="0 0 24 24"><path d="M4 20V9.5L12 4l8 5.5V20a1 1 0 0 1-1 1h-5v-6h-4v6H5a1 1 0 0 1-1-1Z" fill="oklch(38% 0.07 195)"/></svg>',
+    flight: '<svg width="15" height="15" viewBox="0 0 24 24"><path d="M21 15.5v-2l-8-5V4.5a1.5 1.5 0 0 0-3 0V8.5l-8 5v2l8-2.5V17l-2.5 2v1.5l3.5-1 3.5 1V19L13 17v-4.5l8 2.5Z" fill="oklch(38% 0.07 195)"/></svg>',
+    restaurant: '<svg width="15" height="15" viewBox="0 0 24 24"><path d="M6 3v7a2 2 0 0 0 2 2v9h1.5v-9a2 2 0 0 0 2-2V3H10v6H9V3H8v6H7V3H6Zm9.5 0c-1.4 0-2.5 2.1-2.5 5s1 5 2 5.6V21H16.5V3.05c-.35-.03-.68-.05-1-.05Z" fill="oklch(38% 0.07 195)"/></svg>',
+    car_rental: '<svg width="15" height="15" viewBox="0 0 24 24"><path d="M5 16.5V11l1.8-4.5A2 2 0 0 1 8.7 5h6.6a2 2 0 0 1 1.9 1.5L19 11v5.5a1 1 0 0 1-1 1H17a1 1 0 0 1-1-1V16H8v.5a1 1 0 0 1-1 1H6a1 1 0 0 1-1-1ZM7.5 14a1.2 1.2 0 1 0 0-2.4 1.2 1.2 0 0 0 0 2.4Zm9 0a1.2 1.2 0 1 0 0-2.4 1.2 1.2 0 0 0 0 2.4ZM7 10.5h10L15.7 7H8.3L7 10.5Z" fill="oklch(38% 0.07 195)"/></svg>',
+    experience: '<svg width="15" height="15" viewBox="0 0 24 24"><path d="M3 8a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2v1.5a1.5 1.5 0 0 0 0 3V14a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-1.5a1.5 1.5 0 0 0 0-3V8Zm9-1v2h1.5V7H12Zm0 4v2h1.5v-2H12Zm0 4v2h1.5v-2H12Z" fill="oklch(38% 0.07 195)"/></svg>',
+    note: '<svg width="15" height="15" viewBox="0 0 24 24"><path d="M5 3.5h14a1 1 0 0 1 1 1V20a1 1 0 0 1-1.45.9L12 18.4l-6.55 2.5A1 1 0 0 1 4 20V4.5a1 1 0 0 1 1-1ZM7 8h10V6.5H7V8Zm0 3.5h10V10H7v1.5Z" fill="oklch(38% 0.07 195)"/></svg>',
+  };
+
+  renderVals() {
+    const { searchText, activeStatus, selectedId } = this.state;
+    const q = searchText.trim().toLowerCase();
+
+    let filtered = this.trips.filter((t) => {
+      if (activeStatus && t.status !== activeStatus) return false;
+      if (q && !t.name.toLowerCase().includes(q) && !t.places.some((p) => p.toLowerCase().includes(q))) return false;
+      return true;
+    });
+
+    const chips = [
+      { value: '', label: 'All' },
+      { value: 'planning', label: 'Planning' },
+      { value: 'active', label: 'Active' },
+      { value: 'review_pending', label: 'Review' },
+      { value: 'locked', label: 'Locked' },
+    ].map((c) => {
+      const isActive = activeStatus === c.value;
+      return {
+        label: c.label,
+        onClick: () => this.setState({ activeStatus: c.value }),
+        style: isActive
+          ? 'background:oklch(38% 0.07 195);color:white;'
+          : 'background:oklch(96% 0.008 80);color:oklch(48% 0.015 75);',
+      };
+    });
+
+    const trips = filtered.map((t) => {
+      const meta = this.STATUS_META[t.status];
+      return {
+        name: t.name,
+        dates: `${t.start} – ${t.end}`,
+        statusLabel: meta.label,
+        badgeStyle: `background:${meta.bg};color:${meta.fg};`,
+        places: t.places,
+        categories: t.categories,
+        onSelect: () => this.setState({ selectedId: t.id }),
+      };
+    });
+
+    const sel = this.trips.find((t) => t.id === selectedId) ?? null;
+    let selectedTrip = null;
+    if (sel) {
+      const meta = this.STATUS_META[sel.status];
+      const next = this.NEXT_STEP[sel.status];
+      selectedTrip = {
+        name: sel.name,
+        dates: `${sel.start} – ${sel.end}`,
+        companions: sel.companions,
+        tags: sel.tags,
+        statusLabel: meta.label,
+        badgeStyle: `background:${meta.bg};color:${meta.fg};`,
+        nextLabel: next ? next.label : null,
+        nextHint: next ? next.hint : null,
+        steps: this.buildSteps(sel.status),
+        placeSections: sel.placeSections.map((p) => ({
+          city: p.city,
+          country: p.country,
+          dateRange: p.dateRange,
+          items: p.items.map((it) => {
+            const im = this.STATUS_META[it.status] ?? this.STATUS_META.consider;
+            return {
+              label: it.label,
+              sub: it.sub,
+              statusLabel: im.label,
+              badgeStyle: `background:${im.bg};color:${im.fg};`,
+              iconHtml: { __html: this.ICONS[it.type] ?? '' },
+            };
+          }),
+        })),
+      };
+    }
+
+    const showDetail = selectedId !== null;
+
+    return {
+      tripCount: filtered.length,
+      hasTrips: trips.length > 0,
+      searchText,
+      onSearch: (e) => this.setState({ searchText: e.target.value }),
+      openNew: () => {},
+      statusChips: chips,
+      trips,
+      selectedTrip,
+      goBack: () => this.setState({ selectedId: null }),
+      listViewStyle: showDetail ? 'transform:translateX(-30%);opacity:0;pointer-events:none;transition:all 0.25s ease;' : 'transform:translateX(0);opacity:1;transition:all 0.25s ease;',
+      detailViewStyle: showDetail ? 'transform:translateX(0);opacity:1;transition:all 0.25s ease;' : 'transform:translateX(30%);opacity:0;pointer-events:none;transition:all 0.25s ease;',
+    };
+  }
+}
+
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Brief: formalize the "Waypoint" claude.ai Design mockups (project `8cc525c1-b678-4976-a207-57f7f489844b`) into a two-phase, briefable implementation spec.
- This PR started as a blocker record (the `DesignSync` tool named in the brief turned out to be main-session-only, unavailable to a dispatched agent — confirmed via ToolSearch, `claude mcp list`, and a 403 WebFetch). The coordinator then supplied verbatim copies of the three mockup files directly into this worktree, unblocking the thread; the real spec was written from those files in the same branch.
- Deliverable: `jobs/ux/tech/20260721-UX-waypoint-spec.md` — full Phase 1 (design-system foundation: exact oklch color tokens, Newsreader/Manrope type scale, 11 SVG icon glyphs with exact path data, badge/button/input styling) and Phase 2 (desktop + mobile Trips screen reskin, cross-referenced against DP-01..06, TR-09/11/12/13, BUG-31/32/34/36, IT-01, UX-02, FEAT-BD, NTH-01/03) spec.
- **13 flagged conflicts (C1-C13)** requiring explicit COO/Ryan decisions before Frontend dispatch — not silently resolved. Highlights: the mockup renames the product to "Waypoint" in the nav (C1); the new status-stepper component has no Unlock affordance where the current app has a working tested one (C2); BUG-36's trip-level items section is entirely absent from both mockups (C3); the mockup's own reference implementation uses `dangerouslySetInnerHTML` for icons, a blocking defect in this codebase (C8). Full list at the top of the spec doc.

## What's in this PR
- `jobs/ux/tech/20260721-UX-waypoint-spec.md` — the formal spec (Phase 1 + Phase 2, success criteria for each)
- `jobs/ux/tech/waypoint-mockups/*.dc.html` — verbatim mockup source files this spec was written from (committed as the reference record)
- `jobs/ux/tech/20260721-UX-waypoint-spec-blocked.md` — retained blocker history, stamped RESOLVED at the top
- `jobs/ux/park-docs/20260721-UX-park.txt`, `jobs/ux/context/current.txt` — updated to DONE status

No source code changed. No BRD section yet — per CLAUDE.md's BRD-gate-before-dispatch rule, COO adds any new requirement IDs to the BRD after reviewing this spec, before dispatching Frontend. This PR does not dispatch Frontend and does not touch the BRD.

## What COO needs to do next
1. Review the spec, especially the 13 flagged conflicts (C1-C13) at the top.
2. Resolve each with Ryan, recording decisions per the document-lifecycle/record-decision rules (BRD, ADL, or tracker as appropriate).
3. BRD gate: add any new requirement IDs, bump version.
4. Dispatch Frontend: Phase 1 first (verified/UAT'd before any reskin), then Phase 2 once C1-C13 are resolved.

## Test plan
- [x] `npm run check` — clean
- [x] `npm run type:check:all` — clean
- [x] `npm run test:backend` — 532 passed, 1 skipped
- [x] `npm run test:frontend` — 120 passed
- [x] `npm run status:check` — STATUS.md up to date
- [x] All 9 CI checks green on latest commit
- [x] No source files touched — docs/jobs-folder only

🤖 Generated with [Claude Code](https://claude.com/claude-code)