### PR TITLE
feat(WP-02): Waypoint design-system foundation — Phase 1 (#197)

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -24,6 +24,11 @@
       "arrowParentheses": "always"
     }
   },
+  "css": {
+    "parser": {
+      "tailwindDirectives": true
+    }
+  },
   "linter": {
     "enabled": true,
     "rules": {

--- a/jobs/COO/inbox/20260721_2310-FRONTEND-wp02-complete.txt
+++ b/jobs/COO/inbox/20260721_2310-FRONTEND-wp02-complete.txt
@@ -1,0 +1,41 @@
+Tracker ID: WP-02 · GitHub issue #197 / PR #198 · BRD §5.16 WP-02 (v3.3) · Branch: feat/wp02-waypoint-design-system
+
+WHAT WAS BUILT
+Waypoint design-system Phase 1 primitives (colors, typography, icons, badge-hue
+logic, button/input variants) as reusable, unused-by-default building blocks per
+jobs/ux/tech/20260721-UX-waypoint-spec.md §1-6. One deliberate exception applied
+immediately: all emoji item/status/photo/map icons replaced with inline SVG
+components everywhere they appear in src/frontend/.
+
+ACCEPTANCE CRITERIA
+1. All §1 color tokens as Tailwind v4 @theme properties, zero raw oklch elsewhere — PASS
+2. Newsreader + Manrope self-hosted, font-display/font-ui utilities, body font unchanged — PASS
+3. 11 icons as inline SVG, zero emoji/dangerouslySetInnerHTML — PASS, WITH A FLAG: brief/BRD/spec all say "11" but spec §3 enumerates 12 icons with real path data (8+4=12, not 11). Implemented all 12 — no principled basis to drop one. Flagged to COO/UX to correct the count.
+4. Badge hue table as reusable logic, not wired into StatusBadge.tsx — PASS
+5. Button/input variants as components, not swapped into existing call sites — PASS
+6. test:frontend / type:check:all / check all pass — PASS
+7. Trips screen pixel-identical except icon swap — SELF-VERIFIED via full diff review (no incidental className/color/spacing changes) + build output; PO UAT (mandatory gate) still required, not run by me.
+
+CI: gh pr checks 198 — all 9 green (Backend/Frontend/Contract/E2E Tests, Type
+Check, Biome, Secret Scanning, Semgrep, Dependency Vulnerability Scan). Confirmed
+via a blocking `gh pr checks 198 --watch`, not a one-shot poll. One follow-up
+commit was required: the first CI run was red because 2 E2E tests
+(trips-status.spec.ts) locator-matched the literal 🔒 emoji, which the icon swap
+correctly removed. Fixed the test locators (not the component); grepped all 9
+replaced emoji across src/e2e/ + src/frontend/ tests to confirm no other test
+needed the same fix.
+
+OPEN ISSUES / BLOCKERS
+- FLAG-WP02-1: "11 vs 12 icons" count error in the brief/BRD/spec (see above) — needs a BRD/spec correction, not app work.
+- FLAG-WP02-2 (process, needs COO action): a `cd /workspace &&`-prefixed npm install briefly ran against the SHARED checkout instead of this worktree early in the thread, before being caught and corrected. Left /workspace/package.json and package-lock.json with stray UNCOMMITTED changes (no commit, nothing pushed) that I cannot revert myself — the sandbox's worktree-isolation guard correctly refuses any further command targeting /workspace, which also blocks cleanup. COO: run `git checkout -- package.json package-lock.json` in /workspace.
+- FLAG-WP02-3 (informational, not blocking): badges.ts's itemStatusToBadgeHue returns null for ItemStatus 'next_time' — spec's hue table doesn't cover it. Phase 2's StatusBadge wiring will need a resolution.
+- npm audit: 5 pre-existing moderate/low vulnerabilities (body-parser, esbuild, drizzle-kit toolchain), unrelated to the two new @fontsource packages, present before this thread's install too.
+
+WHAT'S NOW UNBLOCKED
+WP-03 (Trips desktop reskin) depends on WP-02 shipping first per tracker.json —
+once this PR merges and PO UAT passes, WP-03 can be dispatched.
+
+Full detail: jobs/frontend/tech/20260721-WP02-design-system-primitives.md and
+jobs/frontend/park-docs/20260721-FRONTEND-wp02-park.txt. tracker.json's WP-02
+entry (currently "pending") was left for COO to update per this role's system
+prompt — PR # is #198.

--- a/jobs/frontend/context/current.txt
+++ b/jobs/frontend/context/current.txt
@@ -1,9 +1,11 @@
 FRONTEND CONTEXT — as of 2026-07-21 (WP-02 Waypoint design-system foundation, Phase 1)
 
-STATUS: WP-02 (#197) implemented on branch feat/wp02-waypoint-design-system, PR opened
-  and CI checked before filing completion report (see completion report / park doc for
-  exact PR # and CI status). Awaiting COO review + PO UAT sign-off (mandatory
-  phase-completion gate per CLAUDE.md) — do not treat as closed until PO PASS lands.
+STATUS: WP-02 (#197) implemented on branch feat/wp02-waypoint-design-system, PR #198
+  open, all 9 CI checks green (confirmed via `gh pr checks 198 --watch`, not just a
+  poll). Awaiting COO review + PO UAT sign-off (mandatory phase-completion gate per
+  CLAUDE.md) — do not treat as closed until PO PASS lands. One follow-up commit was
+  needed after the first CI run: the icon swap broke two E2E locators that matched on
+  the literal 🔒 emoji — see park doc's "CI FIX" section.
 
   This supersedes the prior (2026-07-20, BUG-32/#156) entry in this file as the "current"
   thread; that thread's own detail lives in jobs/frontend/park-docs/20260720-FRONTEND-

--- a/jobs/frontend/context/current.txt
+++ b/jobs/frontend/context/current.txt
@@ -1,117 +1,80 @@
-FRONTEND CONTEXT — as of 2026-07-20 (merge-conflict resolution pass)
+FRONTEND CONTEXT — as of 2026-07-21 (WP-02 Waypoint design-system foundation, Phase 1)
 
-STATUS: BUG-32 (#156) frontend done — Remove-place affordance wired up. PR #170 open on
-  fix/bug32-remove-place-ui, being rebased against main to pick up several other
-  2026-07-20 UAT-triage threads that merged in the meantime (BUG-10, BUG-30, BUG-31,
-  BUG-34, BUG-35, BUG-36 — see PRIOR THREAD below for the one that conflicted with this
-  file). A CRITICAL backend bug was found and flagged to COO during verification (see
-  OPEN FLAGS below) — it does not block this PR but blocks BUG-32 being fully closeable.
+STATUS: WP-02 (#197) implemented on branch feat/wp02-waypoint-design-system, PR opened
+  and CI checked before filing completion report (see completion report / park doc for
+  exact PR # and CI status). Awaiting COO review + PO UAT sign-off (mandatory
+  phase-completion gate per CLAUDE.md) — do not treat as closed until PO PASS lands.
 
-PRIOR THREAD (merged first, conflicted with this file on merge): BUG-10 frontend fix
-  (fix/bug10-name-limit-frontend, commit ed2821c, merged as 9e5b020 — trip-name field now
-  hard-restricts to 75 chars with an inline "75 character limit reached" error, replacing
-  the old 200-char maxLength + silent-truncation behavior). Fixed in TripForm.tsx. Its own
-  park doc has full detail; not duplicated here. Its "await COO merge" next-step is now
-  moot (merged) — dropped below. Its flaky-CarryForwardModal-test finding is folded into
-  OPEN FLAGS below (renumbered to avoid colliding with this thread's own FLAG-F3/F4).
+  This supersedes the prior (2026-07-20, BUG-32/#156) entry in this file as the "current"
+  thread; that thread's own detail lives in jobs/frontend/park-docs/20260720-FRONTEND-
+  bug32-park.txt and is not repeated here. Its carried-over open flags (item-status naming
+  mismatch, no GET /api/cities list, flaky CarryForwardModal.test.tsx assertion) were not
+  re-verified in this thread (out of scope for WP-02) — check that park doc / the tracker
+  for their current status rather than assuming this file's silence means resolved.
 
-  This resolves the "staleness" note that was in this file before either of these threads
-  ran (it dated from 2026-03-20 and predates BUG-10/26/30/31/34/35/36 — those have since
-  happened and merged; the note is retired rather than carried forward as if still true).
+WHAT WAS DONE (this thread — WP-02 / GitHub #197)
+  Full detail in jobs/frontend/tech/20260721-WP02-design-system-primitives.md and the
+  park doc (jobs/frontend/park-docs/20260721-FRONTEND-wp02-park.txt). Summary:
+  - Color: all spec §1 oklch tokens as Tailwind v4 @theme custom properties in new
+    src/frontend/theme-waypoint.css (imported from index.css). Zero raw oklch literals
+    elsewhere for these values.
+  - Typography: Newsreader + Manrope self-hosted via @fontsource/*, font-display/font-ui
+    utilities. Global body font in index.css's @layer base is UNCHANGED.
+  - Icons: 12 inline-SVG icon components under src/frontend/components/icons/ (spec/BRD
+    say "11" but enumerate 12 with real path data — flagged, all 12 implemented; see
+    tech doc). Wired immediately (the one Phase 1 exception) into ItemCard,
+    ReviewItemRow, CarryForwardModal, ItemForm, TripDetail, App — zero emoji remaining
+    in src/frontend/, zero new dangerouslySetInnerHTML.
+  - Badges: src/frontend/design/badges.ts — 7-hue lookup + unit tests. NOT wired into
+    StatusBadge.tsx yet (Phase 2). Documents a spec gap: no hue defined for ItemStatus
+    'next_time'.
+  - Buttons/inputs: src/frontend/design/{Button,Input}.tsx — 4 button variants + input
+    styling per spec §5. Not swapped into any existing call site yet.
+  - biome.json: added css.parser.tailwindDirectives: true (needed for @theme support;
+    nothing in the repo used Tailwind v4's @theme at-rule before this PR).
 
-WHAT WAS DONE (this thread — BUG-32 / GitHub #156)
-  - Confirmed the documented DELETE /api/trips/:tripId/places/:placeId route and the
-    useRemovePlace hook (src/frontend/hooks/usePlaces.ts) already existed — the gap was
-    UI-only (tracker note assumed the route might be missing; it wasn't).
-  - src/frontend/components/TripDetail/PlaceSection.tsx: added a "Remove" button next to
-    "+ Add Item" / "Set dates" (hidden when isLocked, same pattern as the others), opening
-    a ConfirmDialog. Confirmation copy mentions the item count when the place has items
-    ("...along with the N items logged under it...") since deletion is meant to cascade.
-    IMPORTANT (learned the hard way): this button intentionally has NO aria-label — an
-    earlier version added `aria-label={`Remove ${place.city.name} from trip`}` and it
-    broke two pre-existing E2E tests (places-items.spec.ts) whose fixture cities are named
-    "EditCity"/"DeleteCity", because Playwright's getByRole name match is substring-based
-    by default and "Remove EditCity from trip" contains "Edit". Caught by PR #170's first
-    CI run, fixed by dropping the aria-label (plain visible text "Remove" is the accessible
-    name, disambiguated from the dialog's own "Remove" button by the dialog being unmounted
-    until opened, not by name). Don't reintroduce a name-based aria-label on this button
-    without checking it against existing E2E fixture names first.
-  - src/frontend/components/shared/ConfirmDialog.tsx: added optional `error` and
-    `isConfirming`/`confirmingLabel` props (all default to no-op, so ItemCard/ReviewPanel/
-    TripDetail's existing usages are unaffected) so a failed mutation keeps the dialog open
-    and shows why, instead of silently closing on a rejected promise (ItemCard's existing
-    delete-item flow has this same silent-failure gap — not fixed here, out of scope, but
-    worth a follow-up since it's the same shared component).
-  - src/frontend/hooks/usePlaces.ts: useRemovePlace's onSuccess invalidated only
-    ['trips', tripId] — found via live verification that the trip-list sidebar card (DP-01
-    shows place names per card) kept a stale place chip after a successful removal.
-    Fixed to invalidate ['trips'] (bare), matching the convention already used in
-    useTrips.ts (['trips'] is a prefix of ['trips', id], so one call covers both the list
-    and the detail query). Classified MINOR per frameworks.txt severity scale, fixed
-    directly (in-scope: same hook this PR newly wires up for the first time).
-  - New test file: src/frontend/components/TripDetail/__tests__/PlaceSection.test.tsx —
-    7 tests (hidden when locked, visible + opens dialog when unlocked, item-count copy
-    with/without items, cancel doesn't call mutation, confirm calls mutation with right
-    args, failed mutation keeps dialog open + shows error).
+VERIFICATION
+  npm run test:frontend (153 passed), type:check:all (clean), check/biome (clean),
+  npm run build (fonts bundle correctly, wp-* utility classes compile), npm run
+  test:backend (532 passed, unaffected — sanity check only), npm audit (5 pre-existing
+  moderate/low vulns, unrelated to the two new @fontsource packages, not introduced by
+  this PR). Full diff of the 6 emoji-swap call sites self-reviewed — no incidental
+  visual/className changes beyond what's needed to lay icon+text side by side.
+  Did NOT run a live dev-server screenshot pass — self-verified via code diff + build
+  output instead; PO UAT (mandatory gate) is the authoritative visual check.
 
-VERIFICATION (ran the real app, not just tests)
-  Spun up backend + frontend dev servers with BYPASS_AUTH=true / VITE_BYPASS_AUTH=true on
-  scratch ports (3057/5188, to avoid colliding with any other session's 3001/5173) against
-  a scratch SQLite DB, then drove it with a throwaway Playwright script (not committed):
-    1. Place with 0 items: Remove → confirm → DELETE returns 204, place disappears from
-       trip detail AND (after the invalidation fix) the sidebar trip-list card.
-    2. Place with 1 item: Remove → confirm → DELETE returns 500 "Internal server error".
-       This is the CRITICAL bug below, confirmed live end-to-end (screenshots taken).
-       ConfirmDialog stayed open and showed "Internal server error" instead of silently
-       failing — this is exactly the failure mode the ConfirmDialog error-prop change
-       was built to handle gracefully.
-    3. Locked trip: Remove button correctly absent (locked-trip read-only banner shown,
-       same as every other write control).
-  Also reproduced the two E2E fixture-name-collision scenarios (EditCity/DeleteCity)
-  live, before and after the aria-label fix, since the official test:e2e harness's
-  hardcoded ports (3001/5173) collided with another concurrent session in this workspace.
-
-KEY FILE LOCATIONS
-  Entry point:        src/frontend/main.tsx
-  Router / layout:   src/frontend/App.tsx
-  Pages:             src/frontend/pages/{MapPage,TripsPage,TripDetailPage,AdminPage}.tsx
-  Hooks:             src/frontend/hooks/{useTrips,usePlaces,useItems,useCities,useMapShading,useAdmin,useMe,useGeocodeRetryQueue}.ts
-  Types:             src/frontend/types/api.ts
-  API client:        src/frontend/utils/apiClient.ts
-  URL sanitiser:     src/frontend/utils/urlSanitiser.ts (SEC-12)
-  Date formatter:    src/frontend/utils/formatDate.ts
-  Shared dialogs:    src/frontend/components/shared/{ConfirmDialog,ErrorMessage}.tsx
-  Trip form:         src/frontend/components/TripDetail/TripForm.tsx (BUG-10 fix here)
-  Field-level error pattern reference: AddPlaceFlow.tsx:316, PlaceDateForm.tsx:149
-  Config:            vite.config.ts, tsconfig.frontend.json, index.html
+KEY FILE LOCATIONS (new/changed this thread)
+  Theme tokens:       src/frontend/theme-waypoint.css (new), src/frontend/index.css (now imports it)
+  Icons:               src/frontend/components/icons/ (new directory, 12 icons + barrel + tests)
+  Badge/button/input:  src/frontend/design/ (new directory: badges.ts, Button.tsx, Input.tsx + tests)
+  Emoji swap sites:    ItemCard.tsx, ReviewItemRow.tsx, CarryForwardModal.tsx, ItemForm.tsx,
+                        TripDetail.tsx, App.tsx
+  Config:              biome.json (css.parser.tailwindDirectives added)
+  New deps:            @fontsource/newsreader, @fontsource/manrope
 
 OPEN FLAGS FOR COO
-  FLAG-F1 (carried over, unresolved): Item status names in API reference doc don't match
-    Zod schema (see original Phase 1 completion report for details).
-  FLAG-F2 (carried over, unresolved): No standalone GET /api/cities list endpoint exists
-    (not needed currently).
-  FLAG-F3 (CRITICAL, this thread): DELETE /api/trips/:tripId/places/:placeId fails with a
-    500 when the place has any items attached — items.tripPlaceId has no onDelete cascade
-    in src/backend/db/schema.ts (trip_place_activities.tripPlaceId does). Confirmed both
-    via an isolated @libsql/client script and live through the running app (screenshots).
-    Full bug report: jobs/COO/inbox/20260720_1746-FRONTEND-bug32-blocker-place-delete-fk-cascade.txt
-    Does not block this PR; blocks BUG-32 being fully closed. Recommend routing the schema
-    fix + migration into whichever backend brief is touching this route.
-  FLAG-F4 (MINOR, this thread, informational only — not fixed): ItemCard.tsx's delete-item
-    flow (ConfirmDialog usage) doesn't surface mutation errors — a failed item delete
-    silently closes/does nothing visible. Same class of gap as FLAG-F3's UX side, now that
-    ConfirmDialog supports an error prop it would be a small follow-up to wire it there too.
-  FLAG-F5 (carried over from the BUG-10 frontend thread, unresolved): CarryForwardModal
-    .test.tsx has a flaky assertion ("calls onClose immediately when Skip is clicked" —
-    onClose called 2-3x instead of 1x). Reproducible on a clean main checkout with no
-    BUG-10 or BUG-32 changes applied (verified independently by both threads via git
-    stash). Worth a QA/backend look; not blocking either PR.
+  FLAG-WP02-1: Icon count discrepancy — brief/BRD/spec-success-criteria all say "11
+    icons total (8 item/status + 4 nav/chrome)" but 8+4=12 and spec §3 enumerates 12
+    icons with real path data. Implemented all 12. COO/UX should correct the BRD's "11"
+    or clarify which icon is out of scope.
+  FLAG-WP02-2 (process, not app defect): early in this thread, `npm install
+    @fontsource/newsreader @fontsource/manrope` was accidentally run against the SHARED
+    checkout (/workspace) instead of this worktree (a `cd /workspace &&` prefix slipped
+    into the command). It modified /workspace/package.json and package-lock.json as
+    uncommitted changes before the sandbox's worktree-isolation guard started refusing
+    any further /workspace-targeting command (cd, -C, --git-dir all blocked). Redone
+    correctly in this worktree immediately after; rest of thread stayed properly
+    isolated. COO needs to run `git checkout -- package.json package-lock.json` in
+    /workspace to discard the two stray uncommitted files — no commit was made, nothing
+    pushed, so this is a clean revert with no data loss.
+  FLAG-WP02-3 (carried, informational): badges.ts's itemStatusToBadgeHue returns null
+    for ItemStatus 'next_time' — the spec's hue table doesn't define one. Not a blocker
+    now (unwired), but Phase 2's StatusBadge.tsx wiring will need a resolution.
 
 NEXT STEPS (when resumed)
-  - Once FLAG-F3 (backend schema fix) merges, re-verify place removal with items attached
-    actually succeeds and cascades — this PR's UI/copy already assumes that will be true.
-  - Consider FLAG-F4 (ItemCard error surfacing) as a small follow-up.
-  - Consider FLAG-F5 (flaky CarryForwardModal test) as a small follow-up — flagged twice
-    now by independent threads, worth fixing rather than re-flagging a third time.
-  - Coordinate wording with BUG-10's backend half if its 400 message text differs from
-    the frontend's "75 character limit reached" (per tracker guidance).
+  - COO: revert the two stray /workspace files (FLAG-WP02-2).
+  - COO/UX: resolve the "11 vs 12 icons" BRD/spec count discrepancy (FLAG-WP02-1).
+  - PO: UAT pass confirming Trips (and every other screen) is pixel-identical to
+    pre-Phase-1 except the icon swap, per spec's Phase 1 success criterion 7.
+  - Once WP-02 UAT-passes, WP-03 (Trips desktop reskin) can be dispatched — it depends
+    on WP-02 shipping first per tracker.json.

--- a/jobs/frontend/park-docs/20260721-FRONTEND-wp02-park.txt
+++ b/jobs/frontend/park-docs/20260721-FRONTEND-wp02-park.txt
@@ -1,0 +1,146 @@
+FRONTEND PARK DOCUMENT — 2026-07-21
+Thread: WP-02 (Waypoint design-system foundation, Phase 1) — GitHub #197
+Branch: feat/wp02-waypoint-design-system
+BRD: §5.16 WP-02 (v3.3)
+Spec: jobs/ux/tech/20260721-UX-waypoint-spec.md §1-6 (Phase 1 section)
+
+SCOPE
+  Implement the Phase 1 design-system primitives (colors, typography, icons,
+  badge-hue lookup, button/input variants) as reusable, unused-by-default building
+  blocks. No existing screen reskin, with one deliberate exception: emoji item/
+  status/photo/map icons replaced with inline SVG everywhere they currently appear.
+
+WHAT WAS BUILT
+  1. Color (spec §1) — src/frontend/theme-waypoint.css, a new file imported from
+     index.css. Every oklch value from the spec's neutrals/brand/status-hue tables
+     is a Tailwind v4 @theme custom property (--color-wp-*), copied verbatim, no
+     rounding. Tailwind v4 auto-generates bg-wp-*/text-wp-*/border-wp-* utilities
+     from these — no tailwind.config.js involved (CSS-first v4 setup, confirmed
+     via index.css before starting). Also added --radius-wp: 10px (spec §5) since
+     Button/Input needed a shared radius token.
+
+  2. Typography (spec §2) — self-hosted via @fontsource/newsreader and
+     @fontsource/manrope (npm deps), NOT a Google Fonts CDN link (explicit PO
+     decision per the BRD changelog entry). Only the weights the spec's type scale
+     actually names are imported (Newsreader 400/500/600, Manrope 400/500/600/700/
+     800) to keep bundle size down. Exposed as font-display/font-ui utilities.
+     Global body font-family in index.css's @layer base is untouched — verified by
+     diff (no change to that block).
+
+  3. Icons (spec §3) — src/frontend/components/icons/, 12 components (see COUNT
+     DISCREPANCY below), each a literal inline <svg> React component (never
+     dangerouslySetInnerHTML — this was the explicit blocking-defect callout in
+     the spec's C8 and frameworks.txt rule 22, and I did not use it anywhere).
+     Path data copied verbatim from the spec's tables. Applied immediately (the
+     one Phase 1 exception) to every emoji call site in src/frontend/: ItemCard.tsx,
+     ReviewItemRow.tsx, CarryForwardModal.tsx, ItemForm.tsx (item-type icons via a
+     new ITEM_TYPE_ICONS lookup shared across all four), TripDetail.tsx (Photos
+     button/toast, locked banner), App.tsx (empty-state map pin). Verified zero
+     remaining emoji via grep (including scrubbing emoji out of my own doc
+     comments, since the success-criterion grep is literal and would otherwise
+     false-positive there).
+
+  4. Badges (spec §4) — src/frontend/design/badges.ts. BADGE_HUE_CLASSES (7 hues →
+     Tailwind class pairs), tripStatusToBadgeHue/itemStatusToBadgeHue (status →
+     hue), BADGE_LABELS (uppercase display text, e.g. completed → "DONE" per the
+     spec's STATUS_META). Unit-tested in isolation. NOT wired into
+     StatusBadge.tsx's actual COLOR_CLASSES — confirmed by grep/diff that
+     StatusBadge.tsx is untouched.
+
+  5. Buttons/inputs (spec §5) — src/frontend/design/{Button,Input}.tsx. Button
+     supports primary/secondary/destructive/ghost variants; Input matches the
+     spec's focus-outline behavior (outline: 2px solid primary; outline-offset:
+     1px, replacing the pattern used elsewhere). Neither is imported by any
+     existing screen — confirmed by grep (only the new kitchen-sink tests import
+     them).
+
+VERIFICATION (what I actually ran, not just what I wrote)
+  - npm run test:frontend: 153 passed (18 test files, including 3 new files:
+    icons.test.tsx, Button.test.tsx, Input.test.tsx, badges.test.ts).
+  - npm run type:check:all: clean (frontend + backend).
+  - npm run check (biome ci): clean, after two fixups —
+      (a) biome format --write for a handful of formatting nits in new files,
+      (b) biome.json needed css.parser.tailwindDirectives: true, since nothing in
+          the repo previously used Tailwind v4's @theme at-rule and biome's CSS
+          parser rejected it as "Tailwind-specific syntax is disabled" — a
+          necessary, minimal, additive config change, not scope creep.
+  - npm run build: succeeded. Confirmed the compiled CSS output actually contains
+    the new utility classes (bg-wp-primary, font-display, font-ui, rounded-wp) and
+    that font woff2/woff assets for both families emit correctly.
+  - npm run test:backend: 532 passed / 1 skipped — unaffected, ran as a sanity
+    check since this PR touches no backend code.
+  - npm audit: 5 pre-existing vulnerabilities (1 low, 4 moderate) in body-parser/
+    esbuild/drizzle-kit's toolchain — present before my install too (I ran audit
+    right after the very first, pre-fix npm install and saw the same "5
+    vulnerabilities" count). NOT introduced by @fontsource/newsreader or
+    @fontsource/manrope. Per frameworks.txt rule 20, reporting moderate findings
+    to COO — none HIGH/CRITICAL, so not thread-blocking under that rule, but
+    flagging as required.
+  - Did NOT spin up a live dev server / take screenshots this thread — self-
+    verification consisted of the full diff review of all 6 emoji-swap call
+    sites (confirmed every className addition was the minimal accommodation
+    needed to lay an icon element next to text where an emoji character used to
+    sit inline — no color/spacing/radius/font changes anywhere) plus the build
+    output. The mandatory PO UAT gate (CLAUDE.md) is the authoritative visual
+    check for "pixel-identical except icon swap" and hasn't run yet.
+
+COUNT DISCREPANCY — ICONS (flagged, not silently resolved)
+  The WP-02 GitHub brief, the BRD (§5.16, WP-02 row), and the spec's own Phase 1
+  success criteria all say "11 icons total (8 item/status + 4 nav/chrome)." But
+  8 + 4 = 12, and the spec's §3 tables enumerate exactly 12 icons with real,
+  copyable SVG path data: 6 item-type icons (hotel/flight/dining/car/experience/
+  note) + locked + photos = 8, plus location pin + suitcase + admin + back
+  chevron = 4. I implemented all 12 rather than dropping one arbitrarily to match
+  the stated "11" — there's no principled way to pick which of 12 fully-specified
+  icons isn't "real." This is documented in code (components/icons/index.ts
+  header comment) and asserted by a test (icons.test.tsx). Recommend COO/UX
+  correct the "11" in the BRD/spec, or clarify if one of the 12 is genuinely
+  meant to be out of scope (in which case which one, and why it has full path
+  data in the spec anyway).
+
+PROCESS INCIDENT (flagged to COO, not an app defect)
+  Early in this thread, `npm install @fontsource/newsreader @fontsource/manrope`
+  was run with a `cd /workspace &&` prefix — the shared checkout, not my assigned
+  worktree (/workspace/.claude/worktrees/agent-a7173bb2c0dabb4a1). This actually
+  executed there: it added the two packages to /workspace/package.json and
+  /workspace/package-lock.json as uncommitted working-tree changes (no commit, not
+  pushed). I caught this on the very next tool call (a Write to a file under
+  /workspace/src/... — the sandbox's worktree-isolation guard refused it, correctly
+  identifying the path as outside my assigned worktree). From that point every
+  further attempt to even inspect the shared checkout's git state (`git -C
+  /workspace status`, `git --git-dir=/workspace/.git --work-tree=/workspace
+  status`) was also refused by the same guard — which is the correct behavior, but
+  it also means I have no way to revert the two files I accidentally touched
+  there. Redid the install correctly in my own worktree immediately, and the rest
+  of the thread's git/npm work stayed properly isolated (confirmed pwd/toplevel
+  before every subsequent operation).
+  ACTION NEEDED FROM COO: run `git checkout -- package.json package-lock.json`
+  in /workspace to discard those two files' stray uncommitted changes. This is a
+  clean, harmless revert (no commit exists to lose).
+
+BUGS DISCOVERED (frameworks.txt rule 30 format)
+  [TRIVIAL] Icon count "11" vs actual 12 documented icons in BRD/spec — disposition:
+    escalated to COO (see COUNT DISCREPANCY above). Re-evaluated per rule 26: does
+    not touch shared state/FK/query, doesn't produce silently-persisted bad data,
+    no load/production behavior impact, and isn't a symptom of a deeper root
+    cause beyond "two numbers in prose don't add up" — stays TRIVIAL, but still
+    escalated because it's a documentation-accuracy issue COO/UX should fix at
+    the source rather than have every future reader of the BRD re-discover it.
+  [MINOR→escalated as process, not severity-scaled] Accidental npm install
+    against the shared checkout — disposition: escalated to COO (see PROCESS
+    INCIDENT above). This doesn't fit the frameworks.txt bug-severity scale
+    cleanly (it's not an app defect), so I'm not forcing a TRIVIAL/MINOR/MAJOR/
+    CRITICAL label onto it — treating it as a process incident per CLAUDE.md's
+    dispatch-isolation guardrail history (OP-19/OP-20), which is the closer
+    precedent.
+
+NEXT STEPS
+  - COO: revert /workspace/package.json + package-lock.json (see PROCESS INCIDENT).
+  - COO/UX: resolve the icon count discrepancy in the BRD/spec.
+  - COO: update _project/tracker.json's WP-02 entry (this role's system prompt
+    doesn't call for me to own tracker.json — noting the PR # in the completion
+    report instead, per the brief's instructions).
+  - PO: UAT pass against spec's Phase 1 success criterion 7 before WP-02 can be
+    marked closed.
+  - Once WP-02 is UAT-approved, WP-03 (Trips desktop reskin) is unblocked per its
+    tracker.json dependency note.

--- a/jobs/frontend/park-docs/20260721-FRONTEND-wp02-park.txt
+++ b/jobs/frontend/park-docs/20260721-FRONTEND-wp02-park.txt
@@ -134,6 +134,24 @@ BUGS DISCOVERED (frameworks.txt rule 30 format)
     dispatch-isolation guardrail history (OP-19/OP-20), which is the closer
     precedent.
 
+CI FIX (post-PR-open)
+  First CI run on PR #198 was red: 2 E2E failures in src/e2e/trips-status.spec.ts
+  ("review → locked via PostTripReview panel" and "locked trip hides write
+  controls"), both timing out on `page.getByText('🔒 Read-only — trip is
+  locked.')` — the literal emoji locator no longer matched once TripDetail.tsx
+  started rendering LockedIcon (an <svg>) instead of the 🔒 character. This is
+  the icon swap working as intended, not a regression to undo. Grepped
+  src/e2e/ and src/frontend/ for all 9 replaced emoji individually
+  (🍽️🏨✈️🚗🎫📝🔒📷🗺) to check for other stale locators before assuming this was
+  the only instance — it was the only one. Fixed by dropping the emoji from the
+  three locator strings (getByText('Read-only — trip is locked.')), matching
+  this repo's existing e2e convention of plain getByText text matching (not
+  data-testid, which is used sparingly here — only on TripDetail's own root
+  container). Pushed as a follow-up commit; re-ran `gh pr checks 198 --watch`
+  to observe the full run directly rather than poll-and-hope — all 9 checks
+  (Backend/Frontend/Contract/E2E Tests, Type Check, Biome, Secret Scanning,
+  Semgrep, Dependency Vulnerability Scan) passed.
+
 NEXT STEPS
   - COO: revert /workspace/package.json + package-lock.json (see PROCESS INCIDENT).
   - COO/UX: resolve the icon count discrepancy in the BRD/spec.

--- a/jobs/frontend/tech/20260721-WP02-design-system-primitives.md
+++ b/jobs/frontend/tech/20260721-WP02-design-system-primitives.md
@@ -1,0 +1,129 @@
+# WP-02 — Waypoint Design-System Primitives (Phase 1)
+
+Date: 2026-07-21
+Branch: `feat/wp02-waypoint-design-system`
+Spec: `jobs/ux/tech/20260721-UX-waypoint-spec.md` §1-6 (Phase 1)
+BRD: §5.16 WP-02 (v3.3)
+
+## What this is
+
+Phase 1 primitives only — reusable, unused-by-default building blocks. Nothing in
+this PR reskins an existing screen except the one deliberate exception: emoji item
+icons replaced with SVG (see below). Colors, type, badge logic, and button/input
+variants are defined but not wired into `StatusBadge.tsx`, existing buttons/inputs,
+or the global body font — that's Phase 2 (WP-03/WP-04).
+
+## File map
+
+```
+src/frontend/
+├── theme-waypoint.css          ← @theme tokens: colors, fonts, radius (imported by index.css)
+├── index.css                    ← now imports theme-waypoint.css; global body font UNCHANGED
+├── components/icons/
+│   ├── IconProps.ts              ← shared { size?, className? } contract
+│   ├── HotelIcon.tsx / FlightIcon.tsx / RestaurantIcon.tsx / CarRentalIcon.tsx /
+│   │   ExperienceIcon.tsx / NoteIcon.tsx     ← 6 item-type icons
+│   ├── LockedIcon.tsx / PhotosIcon.tsx       ← 2 status icons (not item types)
+│   ├── LocationPinIcon.tsx                   ← nav brand / map tab / empty states (cutoutColor prop)
+│   ├── SuitcaseIcon.tsx / AdminIcon.tsx / BackChevronIcon.tsx  ← mobile tab-bar icons (unwired, no mobile UI exists yet)
+│   ├── itemTypeIcons.tsx        ← ITEM_TYPE_ICONS: Record<ItemType, IconComponent>
+│   ├── index.ts                 ← barrel export
+│   └── __tests__/icons.test.tsx
+├── design/
+│   ├── badges.ts                 ← BADGE_HUE_CLASSES, tripStatusToBadgeHue, itemStatusToBadgeHue, BADGE_LABELS
+│   ├── Button.tsx                 ← variant: primary | secondary | destructive | ghost
+│   ├── Input.tsx                  ← text input w/ wp-primary focus outline
+│   └── __tests__/{badges,Button,Input}.test.{ts,tsx}
+```
+
+## Color tokens
+
+All spec §1 oklch values live in `theme-waypoint.css`'s `@theme` block, prefixed
+`--color-wp-*` (e.g. `--color-wp-primary`, `--color-wp-status-planning-bg`). Tailwind
+v4 auto-generates `bg-wp-*` / `text-wp-*` / `border-wp-*` utilities from these — no
+`tailwind.config.js` involved (this repo is CSS-first Tailwind v4). Also added
+`--radius-wp: 10px` (spec §5) → `rounded-wp` utility.
+
+`biome.json` needed one addition to support this: `css.parser.tailwindDirectives:
+true`, since biome's CSS parser didn't previously recognize Tailwind v4's `@theme`
+at-rule (nothing in the repo used it before this PR). This is a one-line, additive
+config change — `@import`/`@layer` in the existing `index.css` were already fine
+without it; only `@theme` needed the flag.
+
+## Fonts
+
+Self-hosted via `@fontsource/newsreader` and `@fontsource/manrope` (npm deps added).
+Only the weights the spec's type scale actually names are imported, to keep bundle
+size down: Newsreader 400/500/600, Manrope 400/500/600/700/800. Verified via
+`npm run build` — woff2/woff assets emit correctly and the CSS output contains the
+`font-display`/`font-ui` utility classes. Global `body` font-family in `index.css`'s
+`@layer base` is untouched.
+
+## Icons — count discrepancy (flagged, not silently resolved)
+
+The WP-02 brief, the BRD (§5.16 line for WP-02), and the spec's own Phase 1 success
+criteria all say **"11 icons total (8 item/status + 4 nav/chrome)"** — but 8 + 4 = 12,
+and the spec's §3 tables enumerate **12** icons with real path data (6 item-type +
+locked + photos = 8; location pin + suitcase + admin + back chevron = 4). Implemented
+all 12 documented icons rather than arbitrarily omitting one to hit "11" — every one
+has exact SVG path data in the spec, so there's no principled way to pick which to
+drop. Documented in code comments (`components/icons/index.ts`) and the test suite
+(`components/icons/__tests__/icons.test.tsx`). **COO/UX should correct the "11" count
+in the BRD and spec**, or explain which of the 12 documented icons isn't actually
+in scope.
+
+All icons render `currentColor` fill/stroke (except `LocationPinIcon`, which takes an
+explicit `cutoutColor` prop for its hole — the spec says this must match "the
+surrounding background color," which is context-dependent and can't be hardcoded).
+This is what let the emoji→SVG swap stay visually equivalent without pre-committing
+to the `primary` (pine) brand color ahead of Phase 2 — callers control color via
+their existing `text-*` className, same as they controlled emoji color before (they
+didn't — but sizing/positioning context is preserved).
+
+## Emoji → SVG swap (the one Phase 1 exception, applied immediately)
+
+Replaced everywhere in `src/frontend/`:
+- `ItemCard.tsx`, `ReviewItemRow.tsx`, `CarryForwardModal.tsx`, `ItemForm.tsx`'s
+  `TYPE_ICONS`/`ITEM_TYPES` — now use `ITEM_TYPE_ICONS` from `components/icons`.
+- `TripDetail.tsx` — Photos button/toast (📷) → `PhotosIcon`; locked banner (🔒) →
+  `LockedIcon`.
+- `App.tsx` — "select a trip" empty-state map emoji (🗺) → `LocationPinIcon`.
+
+Verified via `grep -rn '🍽️\|🏨\|✈️\|🚗\|🎫\|📝\|🔒\|📷\|🗺' src/frontend/` returning
+zero hits (including doc comments — scrubbed those of literal emoji glyphs too, since
+the success-criterion grep is literal and would otherwise false-positive on comments
+describing what each icon replaces).
+
+## Badge hue logic (§4) — not wired into StatusBadge yet
+
+`design/badges.ts` exports `BADGE_HUE_CLASSES` (7 hues → Tailwind class pairs),
+`tripStatusToBadgeHue` / `itemStatusToBadgeHue` (status → hue), and `BADGE_LABELS`
+(uppercase display text, e.g. `completed` → `"DONE"` per spec's `STATUS_META`).
+
+**Spec gap documented in code:** the spec's hue table (§1) doesn't define a hue for
+`ItemStatus: 'next_time'` — `itemStatusToBadgeHue('next_time')` returns `null` and
+callers must handle it. Not a blocker for Phase 1 (nothing calls this yet), but Phase
+2's `StatusBadge.tsx` wiring will need a resolution before it can fully replace the
+current `COLOR_CLASSES`.
+
+## Buttons / inputs (§5) — not swapped into any call site yet
+
+`design/Button.tsx` (variants: primary/secondary/destructive/ghost) and
+`design/Input.tsx`, built from the `wp-*` tokens and `rounded-wp`. Kitchen-sink tests
+in `design/__tests__/` render every variant to prove the primitive works in
+isolation, per the spec's Phase 1 success criteria.
+
+## Process note (flagged to COO)
+
+Early in this thread, `npm install @fontsource/newsreader @fontsource/manrope` was
+run once against the **shared checkout** (`/workspace`) instead of this worktree, due
+to a `cd /workspace &&` prefix in the command. This modified `/workspace/package.json`
+and `/workspace/package-lock.json` as uncommitted working-tree changes before the
+sandbox's worktree-isolation guard correctly started refusing any further command
+targeting `/workspace` (via `cd`, `-C`, or `--git-dir`/`--work-tree`). The install was
+immediately redone correctly inside this worktree, and this thread proceeded entirely
+within its assigned worktree from that point on — but the shared checkout's two files
+were left modified and I have no way to revert them myself (the guard that stopped
+further damage also blocks cleanup). **COO action needed:** run
+`git checkout -- package.json package-lock.json` in `/workspace` to discard those two
+files' uncommitted changes (harmless — no commit was made, nothing was pushed).

--- a/jobs/ux/tech/20260721-UX-waypoint-spec.md
+++ b/jobs/ux/tech/20260721-UX-waypoint-spec.md
@@ -2,7 +2,9 @@
 
 **Date:** 2026-07-21
 **Author:** UX
-**Status:** Ready for COO review → BRD gate → Frontend dispatch (phased: Phase 1 first, verified, then Phase 2)
+**Status:** BRD-gated (v3.3) and dispatched. Phase 1 (WP-02, GitHub #197) implemented on
+`feat/wp02-waypoint-design-system` (PR TBD by COO on merge), pending PO UAT sign-off per
+CLAUDE.md's mandatory phase-completion gate. Phase 2 (WP-03/WP-04) not yet dispatched.
 **Source:** claude.ai Design project "Travel tracker design review"
 (`8cc525c1-b678-4976-a207-57f7f489844b`), read directly from verbatim copies at
 `jobs/ux/tech/waypoint-mockups/{design-system,trips-desktop,trips-mobile}.dc.html`

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,8 @@
       "hasInstallScript": true,
       "dependencies": {
         "@clerk/react": "^6.1.2",
+        "@fontsource/manrope": "^5.3.0",
+        "@fontsource/newsreader": "^5.3.0",
         "@libsql/client": "^0.14.0",
         "@tanstack/react-query": "^5.90.21",
         "cors": "^2.8.6",
@@ -1303,6 +1305,24 @@
         "@noble/hashes": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@fontsource/manrope": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@fontsource/manrope/-/manrope-5.3.0.tgz",
+      "integrity": "sha512-obJ1Dv3+uCA6HlHgW8u4BGYxJR9In2HW7gjJhlflEvkrj1X1iSEwu0fToL+JYGC/FEKFfIz1sBuPduvcL2gIAA==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource/newsreader": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@fontsource/newsreader/-/newsreader-5.3.0.tgz",
+      "integrity": "sha512-AFR6ZKY89GNL+9qBI2P2+66NhD5bhOj/v6fsLnFYLM4E0JnMB1yKb+Ro8cA64i1hwAWoBfTq5CHJGWH1toLDkw==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,8 @@
   },
   "dependencies": {
     "@clerk/react": "^6.1.2",
+    "@fontsource/manrope": "^5.3.0",
+    "@fontsource/newsreader": "^5.3.0",
     "@libsql/client": "^0.14.0",
     "@tanstack/react-query": "^5.90.21",
     "cors": "^2.8.6",

--- a/src/e2e/trips-status.spec.ts
+++ b/src/e2e/trips-status.spec.ts
@@ -48,7 +48,7 @@ test('review → locked via PostTripReview panel', async ({ page, request }) => 
 
   // After locking, PostTripReview navigates to the trips list — go to the trip detail to verify
   await page.goto(`http://localhost:5173/trips/${trip.id}`);
-  await expect(page.getByText('🔒 Read-only — trip is locked.')).toBeVisible({ timeout: 5_000 });
+  await expect(page.getByText('Read-only — trip is locked.')).toBeVisible({ timeout: 5_000 });
 });
 
 test('locked trip hides write controls', async ({ page, request }) => {
@@ -58,7 +58,7 @@ test('locked trip hides write controls', async ({ page, request }) => {
   await transitionTripStatus(request, trip.id, 'locked');
   await page.goto(`http://localhost:5173/trips/${trip.id}`);
 
-  await expect(page.getByText('🔒 Read-only — trip is locked.')).toBeVisible();
+  await expect(page.getByText('Read-only — trip is locked.')).toBeVisible();
   await expect(page.getByRole('button', { name: 'Edit' })).not.toBeVisible();
   await expect(page.getByRole('button', { name: /Add Place/ })).not.toBeVisible();
 });
@@ -79,5 +79,5 @@ test('unlock locked trip via confirmation', async ({ page, request }) => {
 
   // Lock Trip button reappears when back in review_pending; banner gone
   await expect(page.getByRole('button', { name: 'Lock Trip' })).toBeVisible({ timeout: 5_000 });
-  await expect(page.getByText('🔒 Read-only — trip is locked.')).not.toBeVisible();
+  await expect(page.getByText('Read-only — trip is locked.')).not.toBeVisible();
 });

--- a/src/frontend/App.tsx
+++ b/src/frontend/App.tsx
@@ -13,6 +13,7 @@
 import { UserButton } from '@clerk/react';
 import type { ReactNode } from 'react';
 import { Navigate, NavLink, Route, Routes } from 'react-router-dom';
+import { LocationPinIcon } from './components/icons';
 import { TripsLayout } from './components/TripList/TripsLayout';
 import { useGeocodeRetryQueue } from './hooks/useGeocodeRetryQueue';
 import { useMe } from './hooks/useMe';
@@ -156,7 +157,7 @@ export function App() {
               element={
                 <div className="flex flex-col items-center justify-center h-full text-gray-400 p-12 text-center">
                   <div className="w-14 h-14 rounded-full bg-gray-200 flex items-center justify-center mb-4">
-                    <span className="text-2xl text-gray-300">🗺</span>
+                    <LocationPinIcon size={28} className="text-gray-300" cutoutColor="#E5E7EB" />
                   </div>
                   <p className="text-base font-semibold text-gray-500 mb-1.5">Select a trip</p>
                   <p className="text-sm text-gray-400 max-w-[260px] leading-relaxed">

--- a/src/frontend/components/CarryForward/CarryForwardModal.tsx
+++ b/src/frontend/components/CarryForward/CarryForwardModal.tsx
@@ -11,6 +11,7 @@ import type React from 'react';
 import { useState } from 'react';
 import { useCarryForward } from '../../hooks/usePlaces';
 import type { CarryForwardCandidate } from '../../types/api';
+import { ITEM_TYPE_ICONS, NoteIcon } from '../icons';
 import { ErrorMessage } from '../shared/ErrorMessage';
 
 interface CarryForwardModalProps {
@@ -41,15 +42,6 @@ const modalStyle: React.CSSProperties = {
   maxHeight: '85vh',
   overflowY: 'auto',
   boxShadow: '0 20px 60px rgba(0,0,0,0.25)',
-};
-
-const TYPE_ICONS: Record<string, string> = {
-  restaurant: '🍽️',
-  hotel: '🏨',
-  flight: '✈️',
-  car_rental: '🚗',
-  experience: '🎫',
-  note: '📝',
 };
 
 /**
@@ -135,50 +127,55 @@ export function CarryForwardModal({
             <div
               style={{ display: 'flex', flexDirection: 'column', gap: '8px', marginBottom: '20px' }}
             >
-              {candidates.map((c) => (
-                <label
-                  key={c.id}
-                  style={{
-                    display: 'flex',
-                    alignItems: 'flex-start',
-                    gap: '10px',
-                    padding: '10px 12px',
-                    border: '1px solid #E5E7EB',
-                    borderRadius: '6px',
-                    cursor: 'pointer',
-                    background: selectedIds.has(c.id) ? '#EFF6FF' : '#fff',
-                    borderColor: selectedIds.has(c.id) ? '#93C5FD' : '#E5E7EB',
-                  }}
-                >
-                  <input
-                    type="checkbox"
-                    checked={selectedIds.has(c.id)}
-                    onChange={() => toggleId(c.id)}
-                    style={{ marginTop: '2px', flexShrink: 0 }}
-                  />
-                  <div>
-                    <div style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
-                      <span>{TYPE_ICONS[c.item_type] ?? '📌'}</span>
-                      <span style={{ fontWeight: 600, fontSize: '14px' }}>{candidateLabel(c)}</span>
-                    </div>
-                    <div style={{ fontSize: '12px', color: '#6B7280', marginTop: '2px' }}>
-                      From: {c.source_trip_name} ({c.source_trip_end_date.slice(0, 7)})
-                    </div>
-                    {c.notes && (
-                      <div
-                        style={{
-                          fontSize: '12px',
-                          color: '#6B7280',
-                          fontStyle: 'italic',
-                          marginTop: '2px',
-                        }}
-                      >
-                        {c.notes.slice(0, 80)}
+              {candidates.map((c) => {
+                const TypeIcon = ITEM_TYPE_ICONS[c.item_type] ?? NoteIcon;
+                return (
+                  <label
+                    key={c.id}
+                    style={{
+                      display: 'flex',
+                      alignItems: 'flex-start',
+                      gap: '10px',
+                      padding: '10px 12px',
+                      border: '1px solid #E5E7EB',
+                      borderRadius: '6px',
+                      cursor: 'pointer',
+                      background: selectedIds.has(c.id) ? '#EFF6FF' : '#fff',
+                      borderColor: selectedIds.has(c.id) ? '#93C5FD' : '#E5E7EB',
+                    }}
+                  >
+                    <input
+                      type="checkbox"
+                      checked={selectedIds.has(c.id)}
+                      onChange={() => toggleId(c.id)}
+                      style={{ marginTop: '2px', flexShrink: 0 }}
+                    />
+                    <div>
+                      <div style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
+                        <TypeIcon size={16} />
+                        <span style={{ fontWeight: 600, fontSize: '14px' }}>
+                          {candidateLabel(c)}
+                        </span>
                       </div>
-                    )}
-                  </div>
-                </label>
-              ))}
+                      <div style={{ fontSize: '12px', color: '#6B7280', marginTop: '2px' }}>
+                        From: {c.source_trip_name} ({c.source_trip_end_date.slice(0, 7)})
+                      </div>
+                      {c.notes && (
+                        <div
+                          style={{
+                            fontSize: '12px',
+                            color: '#6B7280',
+                            fontStyle: 'italic',
+                            marginTop: '2px',
+                          }}
+                        >
+                          {c.notes.slice(0, 80)}
+                        </div>
+                      )}
+                    </div>
+                  </label>
+                );
+              })}
             </div>
 
             {carryForward.error && <ErrorMessage error={carryForward.error} />}

--- a/src/frontend/components/PostTripReview/ReviewItemRow.tsx
+++ b/src/frontend/components/PostTripReview/ReviewItemRow.tsx
@@ -8,6 +8,7 @@
 import { useState } from 'react';
 import { useUpdateItem } from '../../hooks/useItems';
 import type { Item, ItemStatus, ItemType } from '../../types/api';
+import { ITEM_TYPE_ICONS } from '../icons';
 import { RatingStars } from '../shared/RatingStars';
 
 interface ReviewItemRowProps {
@@ -28,14 +29,6 @@ const STATUS_LABELS: Record<ItemStatus, string> = {
   completed: 'Completed',
   cancelled: 'Cancelled',
   next_time: 'Next Time',
-};
-const TYPE_ICONS: Record<ItemType, string> = {
-  restaurant: '🍽️',
-  hotel: '🏨',
-  flight: '✈️',
-  car_rental: '🚗',
-  experience: '🎫',
-  note: '📝',
 };
 const RATEABLE_TYPES: ItemType[] = ['restaurant', 'hotel', 'experience'];
 
@@ -60,6 +53,7 @@ export function ReviewItemRow({ item, tripId }: ReviewItemRowProps) {
 
   const isRateable = RATEABLE_TYPES.includes(item.item_type);
   const showRating = isRateable && status === 'completed';
+  const TypeIcon = ITEM_TYPE_ICONS[item.item_type];
 
   const handleStatusChange = async (newStatus: ItemStatus) => {
     setStatus(newStatus);
@@ -79,7 +73,9 @@ export function ReviewItemRow({ item, tripId }: ReviewItemRowProps) {
   return (
     <div style={{ padding: '12px 0', borderBottom: '1px solid #F3F4F6' }}>
       <div style={{ display: 'flex', alignItems: 'flex-start', gap: '10px', flexWrap: 'wrap' }}>
-        <span style={{ fontSize: '18px', flexShrink: 0 }}>{TYPE_ICONS[item.item_type]}</span>
+        <span style={{ flexShrink: 0, display: 'inline-flex', alignItems: 'center' }}>
+          <TypeIcon size={18} />
+        </span>
         <div style={{ flex: 1, minWidth: '160px' }}>
           <div style={{ fontWeight: 600, fontSize: '14px' }}>{getItemLabel(item)}</div>
           {item.notes && (

--- a/src/frontend/components/TripDetail/ItemCard.tsx
+++ b/src/frontend/components/TripDetail/ItemCard.tsx
@@ -8,6 +8,7 @@ import { useState } from 'react';
 import { useDeleteItem } from '../../hooks/useItems';
 import type { Item } from '../../types/api';
 import { formatDate } from '../../utils/formatDate';
+import { ITEM_TYPE_ICONS, NoteIcon } from '../icons';
 import { ConfirmDialog } from '../shared/ConfirmDialog';
 import { RatingStars } from '../shared/RatingStars';
 import { StatusBadge } from '../shared/StatusBadge';
@@ -22,16 +23,6 @@ interface ItemCardProps {
   /** Called when the user wants to edit this item. */
   onEdit: (item: Item) => void;
 }
-
-/** Maps item_type to a display emoji icon. */
-const TYPE_ICONS: Record<string, string> = {
-  restaurant: '🍽️',
-  hotel: '🏨',
-  flight: '✈️',
-  car_rental: '🚗',
-  experience: '🎫',
-  note: '📝',
-};
 
 /**
  * Derives a human-readable primary label for the item based on its type.
@@ -79,12 +70,16 @@ export function ItemCard({ item, tripId, isLocked, onEdit }: ItemCardProps) {
       item.item_type === 'experience') &&
     rating !== null;
 
+  // WP-02: icon lookup by item_type; falls back to the generic Note glyph for
+  // any (currently impossible) unrecognised type rather than leaving a gap.
+  const TypeIcon = ITEM_TYPE_ICONS[item.item_type] ?? NoteIcon;
+
   return (
     <>
       <div className="p-3 border border-gray-200 rounded-md bg-gray-50 flex justify-between items-start gap-2">
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-2 flex-wrap">
-            <span className="text-lg">{TYPE_ICONS[item.item_type] ?? '📌'}</span>
+            <TypeIcon size={18} className="text-gray-600 flex-shrink-0" />
             <span className="font-semibold text-sm text-gray-900">{getItemLabel(item)}</span>
             <StatusBadge status={item.status} />
             {item.is_carried_forward && (

--- a/src/frontend/components/TripDetail/ItemForm.tsx
+++ b/src/frontend/components/TripDetail/ItemForm.tsx
@@ -16,6 +16,7 @@ import {
   useUpdateItem,
 } from '../../hooks/useItems';
 import type { Item, ItemStatus, ItemType } from '../../types/api';
+import { ITEM_TYPE_ICONS } from '../icons';
 import { ErrorMessage } from '../shared/ErrorMessage';
 import { RatingStars } from '../shared/RatingStars';
 
@@ -37,13 +38,13 @@ interface ItemFormProps {
   onClose: () => void;
 }
 
-const ITEM_TYPES: { value: ItemType; label: string; icon: string }[] = [
-  { value: 'restaurant', label: 'Restaurant', icon: '🍽️' },
-  { value: 'hotel', label: 'Hotel', icon: '🏨' },
-  { value: 'flight', label: 'Flight', icon: '✈️' },
-  { value: 'car_rental', label: 'Car Rental', icon: '🚗' },
-  { value: 'experience', label: 'Experience', icon: '🎫' },
-  { value: 'note', label: 'Note', icon: '📝' },
+const ITEM_TYPES: { value: ItemType; label: string }[] = [
+  { value: 'restaurant', label: 'Restaurant' },
+  { value: 'hotel', label: 'Hotel' },
+  { value: 'flight', label: 'Flight' },
+  { value: 'car_rental', label: 'Car Rental' },
+  { value: 'experience', label: 'Experience' },
+  { value: 'note', label: 'Note' },
 ];
 
 const STATUS_OPTIONS: ItemStatus[] = [
@@ -282,17 +283,22 @@ export function ItemForm({
             <div>
               <p className="m-0 mb-3.5 text-sm text-gray-600">Select item type:</p>
               <div className="grid grid-cols-3 gap-2.5">
-                {selectableTypes.map((t) => (
-                  <button
-                    key={t.value}
-                    type="button"
-                    onClick={() => setItemType(t.value)}
-                    className="p-3.5 border border-gray-300 rounded-lg bg-white hover:bg-gray-50 cursor-pointer text-center"
-                  >
-                    <div className="text-2xl">{t.icon}</div>
-                    <div className="text-xs mt-1 text-gray-700">{t.label}</div>
-                  </button>
-                ))}
+                {selectableTypes.map((t) => {
+                  const TypeIcon = ITEM_TYPE_ICONS[t.value];
+                  return (
+                    <button
+                      key={t.value}
+                      type="button"
+                      onClick={() => setItemType(t.value)}
+                      className="p-3.5 border border-gray-300 rounded-lg bg-white hover:bg-gray-50 cursor-pointer text-center"
+                    >
+                      <div className="flex justify-center">
+                        <TypeIcon size={22} className="text-gray-700" />
+                      </div>
+                      <div className="text-xs mt-1 text-gray-700">{t.label}</div>
+                    </button>
+                  );
+                })}
               </div>
             </div>
           )}

--- a/src/frontend/components/TripDetail/TripDetail.tsx
+++ b/src/frontend/components/TripDetail/TripDetail.tsx
@@ -15,6 +15,7 @@ import { useCallback, useState } from 'react';
 import { useLockTrip, useUnlockTrip, useUpdateTripStatus } from '../../hooks/useTrips';
 import type { TripDetail as TripDetailType, TripStatus } from '../../types/api';
 import { formatDate } from '../../utils/formatDate';
+import { LockedIcon, PhotosIcon } from '../icons';
 import { ConfirmDialog } from '../shared/ConfirmDialog';
 import { ErrorMessage } from '../shared/ErrorMessage';
 import { StatusBadge } from '../shared/StatusBadge';
@@ -160,9 +161,10 @@ export function TripDetail({ trip }: TripDetailProps) {
             <button
               type="button"
               onClick={handlePhotos}
-              className="px-3 py-1.5 border border-gray-300 rounded-md bg-white text-sm text-gray-600 hover:bg-gray-50 cursor-pointer"
+              className="px-3 py-1.5 border border-gray-300 rounded-md bg-white text-sm text-gray-600 hover:bg-gray-50 cursor-pointer inline-flex items-center gap-1.5"
             >
-              📷 Photos
+              <PhotosIcon size={14} />
+              Photos
             </button>
           </div>
         </div>
@@ -213,15 +215,17 @@ export function TripDetail({ trip }: TripDetailProps) {
       <div className="flex-1 overflow-y-auto p-6">
         {/* "Coming soon" toast for Photos */}
         {photosToast && (
-          <div className="mb-4 px-4 py-2 bg-gray-100 border border-gray-200 rounded-md text-sm text-gray-600">
-            📷 Photos feature coming soon!
+          <div className="mb-4 px-4 py-2 bg-gray-100 border border-gray-200 rounded-md text-sm text-gray-600 flex items-center gap-1.5">
+            <PhotosIcon size={14} />
+            Photos feature coming soon!
           </div>
         )}
 
         {/* Locked banner */}
         {isLocked && (
-          <div className="mb-4 px-4 py-2.5 bg-gray-100 border border-gray-300 rounded-md text-sm text-gray-700">
-            🔒 Read-only — trip is locked.
+          <div className="mb-4 px-4 py-2.5 bg-gray-100 border border-gray-300 rounded-md text-sm text-gray-700 flex items-center gap-1.5">
+            <LockedIcon size={14} />
+            Read-only — trip is locked.
           </div>
         )}
 

--- a/src/frontend/components/icons/AdminIcon.tsx
+++ b/src/frontend/components/icons/AdminIcon.tsx
@@ -1,0 +1,30 @@
+import type { IconProps } from './IconProps';
+
+/**
+ * Admin icon (WP-02 spec §3) — a 3-row settings-slider glyph for the mobile
+ * Admin tab in the (not-yet-built, Phase 2) bottom tab bar. Defined now as a
+ * reusable primitive, not yet wired into any call site.
+ *
+ * @param size - Icon size in px (square). Defaults to 16.
+ * @param className - Extra class names; `currentColor` drives fill.
+ */
+export function AdminIcon({ size = 16, className }: IconProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      className={className}
+      aria-hidden="true"
+      role="img"
+    >
+      <rect x="4" y="5.2" width="16" height="2" rx="1" fill="currentColor" opacity="0.3" />
+      <circle cx="15" cy="6.2" r="2.6" fill="currentColor" />
+      <rect x="4" y="11" width="16" height="2" rx="1" fill="currentColor" opacity="0.3" />
+      <circle cx="9" cy="12" r="2.6" fill="currentColor" />
+      <rect x="4" y="16.8" width="16" height="2" rx="1" fill="currentColor" opacity="0.3" />
+      <circle cx="17" cy="17.8" r="2.6" fill="currentColor" />
+    </svg>
+  );
+}

--- a/src/frontend/components/icons/BackChevronIcon.tsx
+++ b/src/frontend/components/icons/BackChevronIcon.tsx
@@ -1,0 +1,31 @@
+import type { IconProps } from './IconProps';
+
+/**
+ * Back chevron icon (WP-02 spec §3) — mobile detail-view "‹ Trips" back
+ * navigation (Phase 2, no mobile detail view exists yet). Defined now as a
+ * reusable primitive, not yet wired into any call site.
+ *
+ * @param size - Icon size in px (square). Defaults to 16.
+ * @param className - Extra class names; `currentColor` drives the stroke.
+ */
+export function BackChevronIcon({ size = 16, className }: IconProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      className={className}
+      aria-hidden="true"
+      role="img"
+    >
+      <path
+        d="M15 5l-7 7 7 7"
+        stroke="currentColor"
+        strokeWidth="2.2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}

--- a/src/frontend/components/icons/CarRentalIcon.tsx
+++ b/src/frontend/components/icons/CarRentalIcon.tsx
@@ -1,0 +1,23 @@
+import type { IconProps } from './IconProps';
+
+/**
+ * Car icon (WP-02 spec §3) — replaces the old car emoji. Maps to `item_type: 'car_rental'`.
+ *
+ * @param size - Icon size in px (square). Defaults to 16.
+ * @param className - Extra class names; `currentColor` drives fill.
+ */
+export function CarRentalIcon({ size = 16, className }: IconProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      className={className}
+      aria-hidden="true"
+      role="img"
+    >
+      <path d="M5 16.5V11l1.8-4.5A2 2 0 0 1 8.7 5h6.6a2 2 0 0 1 1.9 1.5L19 11v5.5a1 1 0 0 1-1 1H17a1 1 0 0 1-1-1V16H8v.5a1 1 0 0 1-1 1H6a1 1 0 0 1-1-1ZM7.5 14a1.2 1.2 0 1 0 0-2.4 1.2 1.2 0 0 0 0 2.4Zm9 0a1.2 1.2 0 1 0 0-2.4 1.2 1.2 0 0 0 0 2.4ZM7 10.5h10L15.7 7H8.3L7 10.5Z" />
+    </svg>
+  );
+}

--- a/src/frontend/components/icons/ExperienceIcon.tsx
+++ b/src/frontend/components/icons/ExperienceIcon.tsx
@@ -1,0 +1,23 @@
+import type { IconProps } from './IconProps';
+
+/**
+ * Experience icon (WP-02 spec §3) — replaces the old ticket emoji. Maps to `item_type: 'experience'`.
+ *
+ * @param size - Icon size in px (square). Defaults to 16.
+ * @param className - Extra class names; `currentColor` drives fill.
+ */
+export function ExperienceIcon({ size = 16, className }: IconProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      className={className}
+      aria-hidden="true"
+      role="img"
+    >
+      <path d="M3 8a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2v1.5a1.5 1.5 0 0 0 0 3V14a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-1.5a1.5 1.5 0 0 0 0-3V8Zm9-1v2h1.5V7H12Zm0 4v2h1.5v-2H12Zm0 4v2h1.5v-2H12Z" />
+    </svg>
+  );
+}

--- a/src/frontend/components/icons/FlightIcon.tsx
+++ b/src/frontend/components/icons/FlightIcon.tsx
@@ -1,0 +1,23 @@
+import type { IconProps } from './IconProps';
+
+/**
+ * Flight icon (WP-02 spec §3) — replaces the old airplane emoji. Maps to `item_type: 'flight'`.
+ *
+ * @param size - Icon size in px (square). Defaults to 16.
+ * @param className - Extra class names; `currentColor` drives fill.
+ */
+export function FlightIcon({ size = 16, className }: IconProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      className={className}
+      aria-hidden="true"
+      role="img"
+    >
+      <path d="M21 15.5v-2l-8-5V4.5a1.5 1.5 0 0 0-3 0V8.5l-8 5v2l8-2.5V17l-2.5 2v1.5l3.5-1 3.5 1V19L13 17v-4.5l8 2.5Z" />
+    </svg>
+  );
+}

--- a/src/frontend/components/icons/HotelIcon.tsx
+++ b/src/frontend/components/icons/HotelIcon.tsx
@@ -1,0 +1,23 @@
+import type { IconProps } from './IconProps';
+
+/**
+ * Hotel icon (WP-02 spec §3) — replaces the old hotel-building emoji. Maps to `item_type: 'hotel'`.
+ *
+ * @param size - Icon size in px (square). Defaults to 16.
+ * @param className - Extra class names; `currentColor` drives fill.
+ */
+export function HotelIcon({ size = 16, className }: IconProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      className={className}
+      aria-hidden="true"
+      role="img"
+    >
+      <path d="M4 20V9.5L12 4l8 5.5V20a1 1 0 0 1-1 1h-5v-6h-4v6H5a1 1 0 0 1-1-1Z" />
+    </svg>
+  );
+}

--- a/src/frontend/components/icons/IconProps.ts
+++ b/src/frontend/components/icons/IconProps.ts
@@ -1,0 +1,22 @@
+/**
+ * Shared prop contract for the Waypoint icon set (WP-02, spec §3).
+ *
+ * All icons render as literal inline `<svg>` JSX — never `dangerouslySetInnerHTML`
+ * (blocking defect per _shared/frameworks.txt rule 22 / spec C8).
+ */
+export interface IconProps {
+  /**
+   * Icon size in pixels, applied to both width and height (icons are square,
+   * viewBox 0 0 24 24 per spec). Spec recommends 16px for inline-with-text/tile
+   * contexts and 20-22px for standalone/showcase contexts — callers choose per
+   * context rather than one fixed magic number. Defaults to 16.
+   */
+  size?: number;
+  /**
+   * Additional class names. Icons fill/stroke with `currentColor`, so the
+   * surrounding text color (e.g. a Tailwind `text-*` class) controls icon color —
+   * this is what keeps the emoji→SVG swap visually equivalent to the emoji it
+   * replaces without hardcoding the new `primary` (pine) token ahead of Phase 2.
+   */
+  className?: string;
+}

--- a/src/frontend/components/icons/LocationPinIcon.tsx
+++ b/src/frontend/components/icons/LocationPinIcon.tsx
@@ -1,0 +1,43 @@
+import type { IconProps } from './IconProps';
+
+export interface LocationPinIconProps extends IconProps {
+  /**
+   * Fill color for the small circle that "punches" the pin's hole. The spec
+   * (§3) describes this as using "the surrounding background color to punch a
+   * hole, not a stroke" — i.e. it must match whatever the pin sits on top of,
+   * which is context-dependent (nav bar surface, empty-state circle, etc.), so
+   * callers pass it explicitly rather than the component guessing. Defaults to
+   * white, a reasonable neutral default for most contexts.
+   */
+  cutoutColor?: string;
+}
+
+/**
+ * Location pin icon (WP-02 spec §3) — replaces the old world-map emoji. Used for
+ * the nav brand mark, the mobile Map tab, and both "select a trip"/"no trips"
+ * empty states.
+ *
+ * @param size - Icon size in px (square). Defaults to 16.
+ * @param className - Extra class names; `currentColor` drives the pin's fill.
+ * @param cutoutColor - Fill for the cutout circle (see prop doc above).
+ */
+export function LocationPinIcon({
+  size = 16,
+  className,
+  cutoutColor = '#ffffff',
+}: LocationPinIconProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      className={className}
+      aria-hidden="true"
+      role="img"
+    >
+      <path d="M12 2C8.5 2 6 5 6 8.5C6 13 12 21 12 21C12 21 18 13 18 8.5C18 5 15.5 2 12 2Z" />
+      <circle cx="12" cy="8.5" r="2.6" fill={cutoutColor} />
+    </svg>
+  );
+}

--- a/src/frontend/components/icons/LockedIcon.tsx
+++ b/src/frontend/components/icons/LockedIcon.tsx
@@ -1,0 +1,24 @@
+import type { IconProps } from './IconProps';
+
+/**
+ * Locked icon (WP-02 spec §3) — replaces the old padlock emoji. Trip status only,
+ * not an `item_type`.
+ *
+ * @param size - Icon size in px (square). Defaults to 16.
+ * @param className - Extra class names; `currentColor` drives fill.
+ */
+export function LockedIcon({ size = 16, className }: IconProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      className={className}
+      aria-hidden="true"
+      role="img"
+    >
+      <path d="M7 10V7a5 5 0 0 1 10 0v3h.5A1.5 1.5 0 0 1 19 11.5v8A1.5 1.5 0 0 1 17.5 21h-11A1.5 1.5 0 0 1 5 19.5v-8A1.5 1.5 0 0 1 6.5 10H7Zm1.5 0h7V7a3.5 3.5 0 0 0-7 0v3Z" />
+    </svg>
+  );
+}

--- a/src/frontend/components/icons/NoteIcon.tsx
+++ b/src/frontend/components/icons/NoteIcon.tsx
@@ -1,0 +1,23 @@
+import type { IconProps } from './IconProps';
+
+/**
+ * Note icon (WP-02 spec §3) — replaces the old memo emoji. Maps to `item_type: 'note'`.
+ *
+ * @param size - Icon size in px (square). Defaults to 16.
+ * @param className - Extra class names; `currentColor` drives fill.
+ */
+export function NoteIcon({ size = 16, className }: IconProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      className={className}
+      aria-hidden="true"
+      role="img"
+    >
+      <path d="M5 3.5h14a1 1 0 0 1 1 1V20a1 1 0 0 1-1.45.9L12 18.4l-6.55 2.5A1 1 0 0 1 4 20V4.5a1 1 0 0 1 1-1ZM7 8h10V6.5H7V8Zm0 3.5h10V10H7v1.5Z" />
+    </svg>
+  );
+}

--- a/src/frontend/components/icons/PhotosIcon.tsx
+++ b/src/frontend/components/icons/PhotosIcon.tsx
@@ -1,0 +1,24 @@
+import type { IconProps } from './IconProps';
+
+/**
+ * Photos icon (WP-02 spec §3) — replaces the old camera emoji. Used for the
+ * Photos button/toast, not an `item_type`.
+ *
+ * @param size - Icon size in px (square). Defaults to 16.
+ * @param className - Extra class names; `currentColor` drives fill.
+ */
+export function PhotosIcon({ size = 16, className }: IconProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      className={className}
+      aria-hidden="true"
+      role="img"
+    >
+      <path d="M9.5 5h5l.9 1.5H18a1.5 1.5 0 0 1 1.5 1.5v9A1.5 1.5 0 0 1 18 18.5H6A1.5 1.5 0 0 1 4.5 17V8A1.5 1.5 0 0 1 6 6.5h2.6L9.5 5Zm2.5 4.5a3.5 3.5 0 1 0 0 7 3.5 3.5 0 0 0 0-7Z" />
+    </svg>
+  );
+}

--- a/src/frontend/components/icons/RestaurantIcon.tsx
+++ b/src/frontend/components/icons/RestaurantIcon.tsx
@@ -1,0 +1,24 @@
+import type { IconProps } from './IconProps';
+
+/**
+ * Dining icon (WP-02 spec §3, system-doc label "dining") — replaces the old
+ * fork-and-plate emoji. Maps to `item_type: 'restaurant'`.
+ *
+ * @param size - Icon size in px (square). Defaults to 16.
+ * @param className - Extra class names; `currentColor` drives fill.
+ */
+export function RestaurantIcon({ size = 16, className }: IconProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      className={className}
+      aria-hidden="true"
+      role="img"
+    >
+      <path d="M6 3v7a2 2 0 0 0 2 2v9h1.5v-9a2 2 0 0 0 2-2V3H10v6H9V3H8v6H7V3H6Zm9.5 0c-1.4 0-2.5 2.1-2.5 5s1 5 2 5.6V21H16.5V3.05c-.35-.03-.68-.05-1-.05Z" />
+    </svg>
+  );
+}

--- a/src/frontend/components/icons/SuitcaseIcon.tsx
+++ b/src/frontend/components/icons/SuitcaseIcon.tsx
@@ -1,0 +1,35 @@
+import type { IconProps } from './IconProps';
+
+/**
+ * Suitcase icon (WP-02 spec §3) — mobile Trips tab in the (not-yet-built, Phase 2)
+ * bottom tab bar. Defined now as a reusable primitive, not yet wired into any
+ * call site (no mobile tab bar exists in the app today).
+ *
+ * @param size - Icon size in px (square). Defaults to 16.
+ * @param className - Extra class names; `currentColor` drives fill.
+ */
+export function SuitcaseIcon({ size = 16, className }: IconProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      className={className}
+      aria-hidden="true"
+      role="img"
+    >
+      <rect x="5" y="8" width="14" height="10.5" rx="2" fill="currentColor" />
+      <rect
+        x="9"
+        y="5"
+        width="6"
+        height="3.5"
+        rx="1.5"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.8"
+      />
+    </svg>
+  );
+}

--- a/src/frontend/components/icons/__tests__/icons.test.tsx
+++ b/src/frontend/components/icons/__tests__/icons.test.tsx
@@ -1,0 +1,78 @@
+/**
+ * Tests for the WP-02 icon set (spec §3) — proves all 11 icons render as literal
+ * inline SVG (never dangerouslySetInnerHTML) and that ITEM_TYPE_ICONS covers every
+ * ItemType.
+ */
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import type { ItemType } from '../../../types/api';
+import {
+  AdminIcon,
+  BackChevronIcon,
+  CarRentalIcon,
+  ExperienceIcon,
+  FlightIcon,
+  HotelIcon,
+  ITEM_TYPE_ICONS,
+  LocationPinIcon,
+  LockedIcon,
+  NoteIcon,
+  PhotosIcon,
+  RestaurantIcon,
+  SuitcaseIcon,
+} from '..';
+
+const ALL_ICONS = [
+  HotelIcon,
+  FlightIcon,
+  RestaurantIcon,
+  CarRentalIcon,
+  ExperienceIcon,
+  NoteIcon,
+  LockedIcon,
+  PhotosIcon,
+  LocationPinIcon,
+  SuitcaseIcon,
+  AdminIcon,
+  BackChevronIcon,
+];
+
+describe('Waypoint icon set', () => {
+  // NOTE (spec/brief count discrepancy, flagged to COO): both the WP-02 brief
+  // and the spec's own Phase 1 success criteria say "11 icons total (8
+  // item/status + 4 nav/chrome)" — but 8 + 4 = 12, and spec §3's two tables
+  // enumerate 12 icons with real path data: hotel/flight/dining/car/experience/
+  // note/locked/photos (8) + location pin/suitcase/admin/back chevron (4).
+  // Implemented all 12 documented icons rather than dropping one arbitrarily to
+  // match the stated "11" — every one of them has exact path data in the spec,
+  // so there's no principled way to pick which one to omit.
+  it('has all 12 icon components documented in spec §3 (see count-discrepancy note above)', () => {
+    expect(ALL_ICONS).toHaveLength(12);
+  });
+
+  it.each(ALL_ICONS)('renders a literal <svg> element, sized via props', (Icon) => {
+    const { container } = render(<Icon size={20} className="text-red-500" />);
+    const svg = container.querySelector('svg');
+    expect(svg).not.toBeNull();
+    expect(svg).toHaveAttribute('width', '20');
+    expect(svg).toHaveAttribute('height', '20');
+    expect(svg?.getAttribute('class')).toContain('text-red-500');
+    // Blocking defect per _shared/frameworks.txt rule 22 / spec C8 — never inject
+    // icon markup via dangerouslySetInnerHTML.
+    expect(container.innerHTML).not.toContain('dangerouslySetInnerHTML');
+  });
+
+  it('defaults every icon to a 16px size when no size prop is passed', () => {
+    for (const Icon of ALL_ICONS) {
+      const { container } = render(<Icon />);
+      expect(container.querySelector('svg')).toHaveAttribute('width', '16');
+    }
+  });
+
+  it('ITEM_TYPE_ICONS covers every ItemType with no gaps', () => {
+    const types: ItemType[] = ['restaurant', 'hotel', 'flight', 'car_rental', 'experience', 'note'];
+    for (const type of types) {
+      expect(ITEM_TYPE_ICONS[type]).toBeDefined();
+    }
+  });
+});

--- a/src/frontend/components/icons/index.ts
+++ b/src/frontend/components/icons/index.ts
@@ -1,0 +1,31 @@
+/**
+ * Waypoint icon set (WP-02, spec §3) — barrel export.
+ *
+ * 8 item/status icons + 4 nav/chrome icons = 12 total, all literal inline `<svg>`
+ * JSX components (never `dangerouslySetInnerHTML` — frameworks.txt rule 22 / C8).
+ *
+ * NOTE: the WP-02 brief and the spec's own Phase 1 success criteria say "11
+ * icons total" but enumerate 8 + 4 = 12 — a count error in the spec text itself,
+ * not in this implementation. All 12 icons documented with real path data in
+ * spec §3 are implemented here; flagged to COO (see icons/__tests__/icons.test.tsx).
+ */
+
+export { AdminIcon } from './AdminIcon';
+export { BackChevronIcon } from './BackChevronIcon';
+export { CarRentalIcon } from './CarRentalIcon';
+export { ExperienceIcon } from './ExperienceIcon';
+export { FlightIcon } from './FlightIcon';
+// Item-type icons
+export { HotelIcon } from './HotelIcon';
+export type { IconProps } from './IconProps';
+export { ITEM_TYPE_ICONS } from './itemTypeIcons';
+export type { LocationPinIconProps } from './LocationPinIcon';
+
+// Nav/chrome icons
+export { LocationPinIcon } from './LocationPinIcon';
+// Status icons (not item types)
+export { LockedIcon } from './LockedIcon';
+export { NoteIcon } from './NoteIcon';
+export { PhotosIcon } from './PhotosIcon';
+export { RestaurantIcon } from './RestaurantIcon';
+export { SuitcaseIcon } from './SuitcaseIcon';

--- a/src/frontend/components/icons/itemTypeIcons.tsx
+++ b/src/frontend/components/icons/itemTypeIcons.tsx
@@ -1,0 +1,23 @@
+import type { ItemType } from '../../types/api';
+import { CarRentalIcon } from './CarRentalIcon';
+import { ExperienceIcon } from './ExperienceIcon';
+import { FlightIcon } from './FlightIcon';
+import { HotelIcon } from './HotelIcon';
+import type { IconProps } from './IconProps';
+import { NoteIcon } from './NoteIcon';
+import { RestaurantIcon } from './RestaurantIcon';
+
+/**
+ * Maps `item_type` to its Waypoint icon component (WP-02 spec §3). Single source
+ * of truth so ItemCard, ReviewItemRow, CarryForwardModal, and ItemForm's type
+ * picker all render the same glyph for the same type instead of each keeping its
+ * own emoji-keyed lookup (the pre-WP-02 pattern this replaces).
+ */
+export const ITEM_TYPE_ICONS: Record<ItemType, (props: IconProps) => React.JSX.Element> = {
+  restaurant: RestaurantIcon,
+  hotel: HotelIcon,
+  flight: FlightIcon,
+  car_rental: CarRentalIcon,
+  experience: ExperienceIcon,
+  note: NoteIcon,
+};

--- a/src/frontend/design/Button.tsx
+++ b/src/frontend/design/Button.tsx
@@ -1,0 +1,55 @@
+import type { ButtonHTMLAttributes, ReactNode } from 'react';
+
+/**
+ * Waypoint button variants (WP-02 spec §5).
+ *
+ * PHASE 1 ONLY — this component exists as a reusable primitive and is not yet
+ * swapped into any existing call site (Edit/Photos/Delete/etc. buttons across the
+ * app keep their current teal/gray Tailwind classes until Phase 2's Trips reskin).
+ */
+export type ButtonVariant = 'primary' | 'secondary' | 'destructive' | 'ghost';
+
+interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  /** Visual variant, per spec §5's table. Defaults to 'primary'. */
+  variant?: ButtonVariant;
+  children: ReactNode;
+}
+
+/** Per-variant background/text/border classes, built from the wp-* theme tokens. */
+const VARIANT_CLASSES: Record<ButtonVariant, string> = {
+  primary: 'bg-wp-primary text-white border border-transparent hover:bg-wp-primary-hover',
+  secondary: 'bg-wp-bg-surface text-wp-ink border border-wp-border hover:bg-wp-bg-subtle',
+  destructive:
+    'bg-wp-btn-destructive-bg text-wp-btn-destructive-text border border-wp-btn-destructive-border hover:brightness-95',
+  ghost:
+    'bg-transparent text-wp-ink-muted border-2 border-dashed border-wp-btn-ghost-border hover:border-wp-btn-ghost-border-hover hover:text-wp-btn-ghost-text-hover',
+};
+
+/** Shared shape/typography classes common to every variant (spec §5). */
+const BASE_CLASSES =
+  'font-ui font-semibold text-sm rounded-wp px-3.5 py-2 transition-colors cursor-pointer disabled:opacity-60 disabled:cursor-not-allowed';
+
+/**
+ * Renders a Waypoint-styled button. Not yet used by any existing screen (Phase 1
+ * primitive) — see module doc comment.
+ *
+ * @param variant - primary | secondary | destructive | ghost (spec §5).
+ * @param className - Additional classes, appended after the variant/base classes.
+ */
+export function Button({
+  variant = 'primary',
+  className,
+  children,
+  type = 'button',
+  ...rest
+}: ButtonProps) {
+  return (
+    <button
+      type={type}
+      className={`${BASE_CLASSES} ${VARIANT_CLASSES[variant]}${className ? ` ${className}` : ''}`}
+      {...rest}
+    >
+      {children}
+    </button>
+  );
+}

--- a/src/frontend/design/Input.tsx
+++ b/src/frontend/design/Input.tsx
@@ -1,0 +1,18 @@
+import type { InputHTMLAttributes } from 'react';
+
+/**
+ * Waypoint text input (WP-02 spec §5).
+ *
+ * PHASE 1 ONLY — reusable primitive, not yet swapped into any existing form
+ * field (those keep their current `focus:ring-2 focus:ring-teal-500` Tailwind
+ * pattern until Phase 2). Focus style here matches spec §5's explicit
+ * `outline: 2px solid primary; outline-offset: 1px`, which replaces that pattern.
+ */
+export function Input({ className, ...rest }: InputHTMLAttributes<HTMLInputElement>) {
+  return (
+    <input
+      className={`font-ui text-sm rounded-wp px-2.5 py-1.5 bg-wp-bg-surface text-wp-ink border border-wp-border focus:outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-wp-primary focus-visible:outline-offset-1${className ? ` ${className}` : ''}`}
+      {...rest}
+    />
+  );
+}

--- a/src/frontend/design/__tests__/Button.test.tsx
+++ b/src/frontend/design/__tests__/Button.test.tsx
@@ -1,0 +1,33 @@
+/**
+ * Kitchen-sink test for the WP-02 Button primitive (spec §5) — proves all four
+ * variants render correctly in isolation. Not wired into any existing screen.
+ */
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { Button, type ButtonVariant } from '../Button';
+
+const VARIANTS: ButtonVariant[] = ['primary', 'secondary', 'destructive', 'ghost'];
+
+describe('Button', () => {
+  it.each(VARIANTS)('renders the %s variant with its label', (variant) => {
+    render(<Button variant={variant}>Click me</Button>);
+    expect(screen.getByRole('button', { name: 'Click me' })).toBeInTheDocument();
+  });
+
+  it('defaults to the primary variant', () => {
+    render(<Button>Default</Button>);
+    expect(screen.getByRole('button', { name: 'Default' }).className).toContain('bg-wp-primary');
+  });
+
+  it('defaults to type="button" (no accidental form submits)', () => {
+    render(<Button>Submit-safe</Button>);
+    expect(screen.getByRole('button', { name: 'Submit-safe' })).toHaveAttribute('type', 'button');
+  });
+
+  it('forwards onClick and other native button props', () => {
+    const onClick = vi.fn();
+    render(<Button onClick={onClick}>Go</Button>);
+    screen.getByRole('button', { name: 'Go' }).click();
+    expect(onClick).toHaveBeenCalledOnce();
+  });
+});

--- a/src/frontend/design/__tests__/Input.test.tsx
+++ b/src/frontend/design/__tests__/Input.test.tsx
@@ -1,0 +1,25 @@
+/**
+ * Test for the WP-02 Input primitive (spec §5) — not wired into any existing form.
+ */
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { Input } from '../Input';
+
+describe('Input', () => {
+  it('renders and accepts a value via onChange like a native input', () => {
+    render(<Input placeholder="Search trips…" defaultValue="" />);
+    const input = screen.getByPlaceholderText('Search trips…');
+    expect(input).toBeInTheDocument();
+    expect(input.tagName).toBe('INPUT');
+  });
+
+  it('applies the wp-* token classes', () => {
+    render(<Input placeholder="x" />);
+    expect(screen.getByPlaceholderText('x').className).toContain('bg-wp-bg-surface');
+  });
+
+  it('merges a caller-supplied className', () => {
+    render(<Input placeholder="y" className="w-full" />);
+    expect(screen.getByPlaceholderText('y').className).toContain('w-full');
+  });
+});

--- a/src/frontend/design/__tests__/badges.test.ts
+++ b/src/frontend/design/__tests__/badges.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Unit tests for the WP-02 badge hue lookup (spec §4).
+ *
+ * These prove the primitive works in isolation (success criterion 4 — "a unit
+ * test asserting the color map"). They do not touch StatusBadge.tsx; that wiring
+ * is Phase 2.
+ */
+import { describe, expect, it } from 'vitest';
+import {
+  BADGE_HUE_CLASSES,
+  BADGE_LABELS,
+  itemStatusToBadgeHue,
+  tripStatusToBadgeHue,
+} from '../badges';
+
+describe('BADGE_HUE_CLASSES', () => {
+  it('defines all 7 hues from spec §1 with a bg + text class pair', () => {
+    const hues = [
+      'planning',
+      'active',
+      'review',
+      'locked',
+      'confirmed',
+      'cancelled',
+      'category',
+    ] as const;
+    expect(Object.keys(BADGE_HUE_CLASSES).sort()).toEqual([...hues].sort());
+    for (const hue of hues) {
+      expect(BADGE_HUE_CLASSES[hue].bg).toMatch(/^bg-wp-/);
+      expect(BADGE_HUE_CLASSES[hue].text).toMatch(/^text-wp-/);
+    }
+  });
+});
+
+describe('tripStatusToBadgeHue', () => {
+  it('maps every trip status to its spec §1 hue', () => {
+    expect(tripStatusToBadgeHue('planning')).toBe('planning');
+    expect(tripStatusToBadgeHue('active')).toBe('active');
+    expect(tripStatusToBadgeHue('review_pending')).toBe('review');
+    expect(tripStatusToBadgeHue('locked')).toBe('locked');
+  });
+});
+
+describe('itemStatusToBadgeHue', () => {
+  it('maps consider to the shared "locked" hue (hue 80)', () => {
+    expect(itemStatusToBadgeHue('consider')).toBe('locked');
+  });
+
+  it('maps confirmed and completed to the same hue (hue 150), per spec note', () => {
+    expect(itemStatusToBadgeHue('confirmed')).toBe('confirmed');
+    expect(itemStatusToBadgeHue('completed')).toBe('confirmed');
+  });
+
+  it('maps cancelled to its own hue (hue 25)', () => {
+    expect(itemStatusToBadgeHue('cancelled')).toBe('cancelled');
+  });
+
+  it('returns null for next_time — the spec table does not define a hue for it', () => {
+    expect(itemStatusToBadgeHue('next_time')).toBeNull();
+  });
+});
+
+describe('BADGE_LABELS', () => {
+  it('renders every label as upper-case content, per spec §4', () => {
+    for (const label of Object.values(BADGE_LABELS)) {
+      expect(label).toBe(label.toUpperCase());
+    }
+  });
+
+  it('labels completed as DONE, not COMPLETED, per the spec STATUS_META table', () => {
+    expect(BADGE_LABELS.completed).toBe('DONE');
+  });
+});

--- a/src/frontend/design/badges.ts
+++ b/src/frontend/design/badges.ts
@@ -1,0 +1,126 @@
+/**
+ * Waypoint badge hue lookup (WP-02 spec §4, BRD §5.16).
+ *
+ * PHASE 1 ONLY — this is reusable badge-variant logic, defined but not yet wired
+ * into `StatusBadge.tsx`'s actual `COLOR_CLASSES`/rendering. Wiring it in is Phase 2
+ * (spec "Scope and non-goals" — applying the new hue system to only some badges
+ * while StatusBadge keeps its old teal/amber/violet classes would be a worse,
+ * half-migrated state than either system alone).
+ *
+ * Source: spec §1 "Status / category hues" table + §4 "Status & category badges —
+ * component spec". Seven hues total, keyed here by a semantic variant name (not by
+ * the raw TripStatus/ItemStatus string) because two different status enums share a
+ * hue in the spec (Trip "Locked" and item "Consider" both use hue 80; item
+ * "Confirmed" and "Completed" both use hue 150, differing only in label text).
+ */
+import type { ItemStatus, TripStatus } from '../types/api';
+
+/** One of the 7 hue families defined in spec §1. */
+export type BadgeHue =
+  | 'planning'
+  | 'active'
+  | 'review'
+  | 'locked'
+  | 'confirmed'
+  | 'cancelled'
+  | 'category';
+
+/**
+ * Tailwind v4 utility class pair (bg + text) for a given hue, generated from the
+ * `--color-wp-status-*` / `--color-wp-category-*` tokens declared in
+ * `src/frontend/theme-waypoint.css`. Consumers apply both classes together.
+ */
+export interface BadgeHueClasses {
+  bg: string;
+  text: string;
+}
+
+/** Hue → Tailwind utility class pair, per spec §1's exact bg/text oklch pairs. */
+export const BADGE_HUE_CLASSES: Record<BadgeHue, BadgeHueClasses> = {
+  planning: { bg: 'bg-wp-status-planning-bg', text: 'text-wp-status-planning-text' },
+  active: { bg: 'bg-wp-status-active-bg', text: 'text-wp-status-active-text' },
+  review: { bg: 'bg-wp-status-review-bg', text: 'text-wp-status-review-text' },
+  locked: { bg: 'bg-wp-status-locked-bg', text: 'text-wp-status-locked-text' },
+  confirmed: { bg: 'bg-wp-status-confirmed-bg', text: 'text-wp-status-confirmed-text' },
+  cancelled: { bg: 'bg-wp-status-cancelled-bg', text: 'text-wp-status-cancelled-text' },
+  category: { bg: 'bg-wp-category-bg', text: 'text-wp-category-text' },
+};
+
+/**
+ * Badge shape recipe (spec §1 "Badge shape note" + §4). Pill = trip-detail header
+ * meta row / most status badges. Chip = trip-list-card category/place chips
+ * (rounded-rect, not a pill — same hue can render as either shape by context).
+ */
+export const BADGE_SHAPE_CLASSES = {
+  pill: 'rounded-full px-3 py-[5px]', // ~20px radius, 5px/12-13px padding
+  chip: 'rounded-[7px] px-2.5 py-1', // 7-8px radius, 3-4px/9-10px padding
+} as const;
+
+/** Badge text styling (spec §4): Manrope 700, 11-11.5px, uppercase, letter-spaced. */
+export const BADGE_TEXT_CLASSES =
+  'font-ui font-bold text-[11.5px] uppercase tracking-[0.25px] whitespace-nowrap';
+
+/**
+ * Maps a `TripStatus` to its badge hue per spec §1. Every TripStatus value has a
+ * defined hue — no gaps.
+ *
+ * @param status - Trip status value.
+ * @returns The badge hue for this status.
+ */
+export function tripStatusToBadgeHue(status: TripStatus): BadgeHue {
+  switch (status) {
+    case 'planning':
+      return 'planning';
+    case 'active':
+      return 'active';
+    case 'review_pending':
+      return 'review';
+    case 'locked':
+      return 'locked';
+  }
+}
+
+/**
+ * Maps an `ItemStatus` to its badge hue per spec §1.
+ *
+ * SPEC GAP: the spec's hue table (§1) does not define a hue for `'next_time'` —
+ * only consider/confirmed/completed/cancelled are covered (consider shares
+ * trip-status Locked's neutral hue 80; confirmed and completed share hue 150).
+ * Returns `null` for `'next_time'` until COO/UX resolves this gap; callers must
+ * handle the null case (e.g. by falling back to the current, pre-Waypoint
+ * class in `StatusBadge.tsx` — not this module's concern in Phase 1, since this
+ * module isn't wired into StatusBadge yet).
+ *
+ * @param status - Item status value.
+ * @returns The badge hue for this status, or `null` if the spec doesn't define one.
+ */
+export function itemStatusToBadgeHue(status: ItemStatus): BadgeHue | null {
+  switch (status) {
+    case 'consider':
+      return 'locked'; // hue 80, shared with trip status "Locked" per spec §1
+    case 'confirmed':
+    case 'completed':
+      return 'confirmed'; // hue 150, shared per spec §1's explicit note
+    case 'cancelled':
+      return 'cancelled';
+    case 'next_time':
+      return null; // SPEC GAP — see doc comment above
+  }
+}
+
+/**
+ * Uppercase label text for a badge, per spec §4 ("label text is always upper-case
+ * content"). `completed` renders as "DONE" per the spec's `STATUS_META` table, not
+ * "COMPLETED" — an explicit, deliberate label choice, not a truncation.
+ */
+export const BADGE_LABELS: Record<TripStatus | ItemStatus, string> = {
+  planning: 'PLANNING',
+  active: 'ACTIVE',
+  review_pending: 'REVIEW',
+  locked: 'LOCKED',
+  consider: 'CONSIDER',
+  confirmed: 'CONFIRMED',
+  completed: 'DONE',
+  cancelled: 'CANCELLED',
+  next_time: 'NEXT TIME', // SPEC GAP — see itemStatusToBadgeHue doc comment
+};

--- a/src/frontend/index.css
+++ b/src/frontend/index.css
@@ -1,5 +1,9 @@
 @import "tailwindcss";
 
+/* WP-02 Phase 1 — Waypoint design-system tokens (colors, fonts). Defined-but-unused
+   until Phase 2 wires them into existing screens; see theme-waypoint.css header. */
+@import "./theme-waypoint.css";
+
 @layer base {
   *,
   *::before,

--- a/src/frontend/theme-waypoint.css
+++ b/src/frontend/theme-waypoint.css
@@ -1,0 +1,93 @@
+/**
+ * Waypoint design-system tokens (WP-02, BRD §5.16, jobs/ux/tech/20260721-UX-waypoint-spec.md §1-2).
+ *
+ * PHASE 1 ONLY — these tokens are defined-but-unused. Nothing in the current app
+ * references them yet (except the icon-swap exception, which lives in
+ * src/frontend/components/icons/ and does not depend on this file). Wiring them into
+ * existing screens (StatusBadge, buttons, inputs, global body font) is Phase 2 work —
+ * see the spec's "Scope and non-goals" section for why partial application is worse
+ * than no application.
+ *
+ * Values are copied verbatim from the spec's §1 (color) and §2 (typography) tables —
+ * do not round or approximate. If a value here ever needs to change, change the spec
+ * first, then this file, so they never drift apart silently.
+ */
+
+/* Self-hosted font faces (Newsreader + Manrope) — NOT a Google Fonts CDN link, per
+   explicit PO decision (spec §2 "Font-loading call for Frontend/COO"). Only the
+   weights actually named in the spec's type scale (§2) are loaded, to keep bundle
+   size down: Newsreader 400/500/600, Manrope 400/500/600/700/800. */
+@import "@fontsource/newsreader/400.css";
+@import "@fontsource/newsreader/500.css";
+@import "@fontsource/newsreader/600.css";
+@import "@fontsource/manrope/400.css";
+@import "@fontsource/manrope/500.css";
+@import "@fontsource/manrope/600.css";
+@import "@fontsource/manrope/700.css";
+@import "@fontsource/manrope/800.css";
+
+@theme {
+  /* ---- Radius (spec §5: "10px radius throughout" for buttons/inputs) ---- */
+  --radius-wp: 10px;
+
+  /* ---- Typography ---- */
+  /* Newsreader: serif/display. Manrope: sans/UI. Named so Tailwind v4 generates
+     `font-display` / `font-ui` utilities automatically — opt-in only, the global
+     `body` font-family in index.css's @layer base is untouched by this file. */
+  --font-display: "Newsreader", serif;
+  --font-ui: "Manrope", sans-serif;
+
+  /* ---- Neutrals (warm paper) ---- */
+  --color-wp-bg-page: oklch(97.5% 0.006 80);
+  --color-wp-bg-surface: oklch(99% 0.002 80);
+  --color-wp-border: oklch(89% 0.012 80);
+  --color-wp-ink-muted: oklch(48% 0.015 75);
+  --color-wp-ink: oklch(22% 0.02 75);
+
+  /* Additional neutrals observed in application (spec §1) */
+  --color-wp-bg-subtle: oklch(96% 0.008 80);
+  --color-wp-bg-chip: oklch(93% 0.006 80);
+  --color-wp-ink-faint: oklch(65% 0.01 75);
+  --color-wp-ink-soft: oklch(40% 0.015 75);
+  --color-wp-border-soft: oklch(92% 0.008 80);
+
+  /* ---- Brand ---- */
+  --color-wp-primary: oklch(38% 0.07 195);
+  --color-wp-primary-hover: oklch(33% 0.07 195);
+  --color-wp-primary-subtle: oklch(94% 0.025 195);
+  --color-wp-primary-subtle-text: oklch(30% 0.07 195);
+  --color-wp-accent: oklch(45% 0.1 325);
+
+  /* ---- Status / category hues (spec §1 table + badge shape note) ----
+     Same hue used for trip-status, item-status, and category chips depending on
+     context — see src/frontend/design/badges.ts for the lookup that maps a
+     status/category value to one of these bg/text pairs. */
+  --color-wp-status-planning-bg: oklch(94% 0.025 195);
+  --color-wp-status-planning-text: oklch(30% 0.07 195);
+
+  --color-wp-status-active-bg: oklch(94% 0.03 75);
+  --color-wp-status-active-text: oklch(40% 0.12 75);
+
+  --color-wp-status-review-bg: oklch(94% 0.025 325);
+  --color-wp-status-review-text: oklch(38% 0.1 325);
+
+  --color-wp-status-locked-bg: oklch(93% 0.006 80);
+  --color-wp-status-locked-text: oklch(40% 0.01 80);
+
+  --color-wp-status-confirmed-bg: oklch(94% 0.025 150);
+  --color-wp-status-confirmed-text: oklch(38% 0.1 150);
+
+  --color-wp-status-cancelled-bg: oklch(95% 0.03 25);
+  --color-wp-status-cancelled-text: oklch(42% 0.13 25);
+
+  --color-wp-category-bg: oklch(94% 0.03 255);
+  --color-wp-category-text: oklch(42% 0.1 255);
+
+  /* ---- Button / input tokens (spec §5) ---- */
+  --color-wp-btn-destructive-bg: oklch(97% 0.02 25);
+  --color-wp-btn-destructive-text: oklch(42% 0.13 25);
+  --color-wp-btn-destructive-border: oklch(89% 0.03 25);
+  --color-wp-btn-ghost-border: oklch(85% 0.012 80);
+  --color-wp-btn-ghost-border-hover: oklch(70% 0.012 80);
+  --color-wp-btn-ghost-text-hover: oklch(38% 0.015 75);
+}


### PR DESCRIPTION
Closes #197
BRD §5.16 WP-02

## Summary

Implements Phase 1 of the "Waypoint" redesign per `jobs/ux/tech/20260721-UX-waypoint-spec.md` §1-6 — design-system primitives only, no existing-screen reskin, with one deliberate exception (emoji → SVG icon swap, applied immediately).

- **Color** (§1): all spec oklch tokens as Tailwind v4 `@theme` custom properties in new `src/frontend/theme-waypoint.css` (imported from `index.css`). Zero raw oklch literals introduced elsewhere.
- **Typography** (§2): Newsreader + Manrope self-hosted via `@fontsource/*` (not a Google Fonts CDN link, per the BRD's explicit PO decision). Exposed as `font-display`/`font-ui` utilities. Global `body` font unchanged.
- **Icons** (§3): 12 inline-SVG icon components under `src/frontend/components/icons/` — never `dangerouslySetInnerHTML`. Wired immediately into every current emoji call site (`ItemCard`, `ReviewItemRow`, `CarryForwardModal`, `ItemForm`, `TripDetail`, `App`). Zero emoji remain in `src/frontend/`.
- **Badges** (§4): `src/frontend/design/badges.ts` — 7-hue lookup + unit tests. **Not** wired into `StatusBadge.tsx` (Phase 2).
- **Buttons/Inputs** (§5): `src/frontend/design/{Button,Input}.tsx` — 4 button variants + input styling. **Not** swapped into any existing call site (Phase 2).

## Flagged for COO (see park doc / completion report for full detail)

1. **Icon count discrepancy**: the brief/BRD/spec success-criteria all say "11 icons total (8 + 4)" but 8+4=12, and spec §3 documents 12 icons with real path data. Implemented all 12 rather than dropping one arbitrarily.
2. **Process incident**: an early `npm install` in this thread briefly ran against the shared checkout instead of my worktree before being corrected — left two files (`/workspace/package.json`, `/workspace/package-lock.json`) with stray uncommitted changes that I have no ability to revert myself (worktree-isolation guard blocks it). COO needs to run `git checkout -- package.json package-lock.json` in `/workspace`.
3. **Spec gap**: `badges.ts`'s `itemStatusToBadgeHue` returns `null` for `ItemStatus: 'next_time'` — not covered by the spec's hue table. Not a blocker now (unwired), but Phase 2 will need a resolution.

## Test plan

- [x] `npm run test:frontend` — 153 passed (18 files, 4 new)
- [x] `npm run type:check:all` — clean
- [x] `npm run check` (biome ci) — clean (required a one-line `biome.json` addition: `css.parser.tailwindDirectives: true`, needed for Tailwind v4's `@theme` at-rule)
- [x] `npm run build` — succeeds; fonts bundle correctly, `wp-*` utility classes compile into output CSS
- [x] `npm run test:backend` — 532 passed / 1 skipped (unaffected, sanity check)
- [x] `npm audit` — 5 pre-existing moderate/low vulnerabilities, unrelated to the two new `@fontsource` packages
- [x] Full diff self-review of all 6 emoji-swap call sites — no incidental visual/className changes beyond laying icon+text side by side
- [ ] PO UAT (mandatory phase-completion gate, not run by Frontend) — confirms Trips (and every other screen) is pixel-identical to pre-Phase-1 except the icon swap

🤖 Generated with [Claude Code](https://claude.com/claude-code)