### PR TITLE
docs(WP-03/WP-04): stamp Waypoint Phase 2 conflict resolutions — closes C1-C13 gate

### DIFF
--- a/jobs/ux/context/current.txt
+++ b/jobs/ux/context/current.txt
@@ -1,8 +1,10 @@
-UX CONTEXT — 2026-07-21 (updated, unblocked + completed)
+UX CONTEXT — 2026-07-21 (updated — C1-C13 gate closed, Phase 2 ready for dispatch)
 PROJECT: Travel Tracker
-CURRENT STATUS: Waypoint redesign spec DELIVERED. Phase 1 (design-system foundation) +
-Phase 2 (Trips screen reskin, desktop + mobile) spec complete, with 13 flagged
-conflicts/open questions for COO/Ryan to resolve before Frontend dispatch.
+CURRENT STATUS: Waypoint redesign spec fully resolved. Phase 1 (WP-02) shipped, merged,
+UAT PASS. Phase 2 (WP-03/WP-04) spec is stamped with all 13 conflict resolutions plus
+three adjacent flagged items plus one new UX-made call (mobile Edit/Photos) plus one new
+constraint (mobile no-horizontal-scroll) — ready for Frontend dispatch, no open UX-owned
+questions remain on this spec.
 
 ================================================================================
 ROLE SUMMARY
@@ -21,90 +23,74 @@ PROJECT CONTEXT (verified 2026-07-21)
   Styling:      Tailwind CSS v4, CSS-first config (@import "tailwindcss" in
                 src/frontend/index.css — no tailwind.config.js/.ts exists)
   Component lib: NONE adopted. No shadcn/ui, no Radix, no icon library
-                (no lucide-react, no clsx/cva) in package.json as of 2026-07-21,
-                despite the March 2026 UX audit assuming a Tailwind+shadcn
-                migration. Only the Tailwind half of that plan landed.
+                (no lucide-react, no clsx/cva) in package.json as of 2026-07-21.
   Mapping:      MapLibre GL JS + react-map-gl + MapTiler tiles
-  Current palette: Teal primary / amber (active/review) / violet (category
-                badges) / emerald (positive CTA) — being replaced by the
-                Waypoint palette (warm paper neutrals + deep pine primary,
-                oklch-based) per the new spec.
+  Current palette: being replaced by the Waypoint palette (warm paper neutrals +
+                deep pine primary, oklch-based); Phase 1 tokens already shipped.
 
 ================================================================================
-COMPLETED THREAD — Waypoint redesign spec (2026-07-21)
+COMPLETED THREAD — Waypoint Phase 2 conflict-resolution stamp (2026-07-21, PM session)
 ================================================================================
 
-  Brief: formalize claude.ai Design project "Travel tracker design review"
-  (projectId 8cc525c1-b678-4976-a207-57f7f489844b — Design System.dc.html,
-  Trips Desktop.dc.html, Trips Mobile.dc.html) into a two-phase briefable spec.
+  Brief: jobs/ux/tech/20260721-UX-waypoint-spec.md (authored earlier the same day) left
+  13 conflicts (C1-C13) plus several adjacent flagged items explicitly open — "COO
+  adjudicates those; I have not." A COO/PO session the same day (two rounds) resolved all
+  of them, some already landed in BRD v3.3/v3.4 §5.16, others decided fresh in the second
+  round. Task: stamp every resolution into the spec so it stops asserting things are open,
+  and make one remaining judgment call myself.
 
-  Initially BLOCKED: the `DesignSync` tool named in the brief is specific to the
-  main interactive session and unavailable to a dispatched agent (confirmed via
-  ToolSearch, `claude mcp list`, and a direct WebFetch 403 — see
-  jobs/ux/tech/20260721-UX-waypoint-spec-blocked.md for the full trail). Did NOT
-  fabricate mockup content to paper over this.
+  What changed in the spec (same file, no new file):
+  - Status line: no longer "gated on 13 conflicts" — states resolved, ready for dispatch,
+    points to both this doc (design-detail record) and BRD v3.4 §5.16 (requirement-level
+    record).
+  - C1-C13 table: added a Resolution column, every row stamped "Confirmed 2026-07-21
+    (COO/PO)" with the verbatim decision (all matched my original recommendations, no
+    re-litigation needed).
+  - Confirmed/Completed status-badge hue: resolved as TWO distinct hues, not one (mockup's
+    STATUS_META collapsed them — rejected). I picked concrete replacement tokens myself:
+    Confirmed stays hue 150 (green), Completed moves to hue 220 (blue) — same L/C recipe
+    as the rest of the palette, chosen for open hue-space separation from all 7 existing
+    hues and a sensible green="on track"/blue="done" semantic pairing. Flagged that shipped
+    Phase 1 code (src/frontend/design/badges.ts) still collapses both to hue 150 — bug
+    relative to this decision, fix is part of the Phase 2 Frontend brief, not mine to touch.
+  - Font loading: confirmed final as self-hosted @fontsource (already implemented Phase 1).
+  - TR-12/stepper: confirmed by PO as acceptable fulfillment, not scope creep.
+  - MY OWN CALL: mobile trip-detail Edit/Photos entry point. Two conflicting COO/PO answers
+    existed (overflow "⋯" menu per BRD v3.3/v3.4 WP-04 as first recorded, vs. compact icon
+    pair as PO's answer in a later round, who then explicitly punted the final call to UX).
+    I chose the COMPACT ICON PAIR — reasoning: overflow menus earn their keep at 3+ actions,
+    not 2; hiding two frequent primary actions behind an extra tap actively works against
+    affordance/discoverability; icon-only pair keeps mobile behavior-consistent with desktop
+    (Edit/Photos always visible there too) as a density change, not a new interaction
+    pattern; extensibility isn't foreclosed since converting to an overflow menu later, if a
+    3rd action appears, is a small change. Added a new pencil/edit SVG icon spec to §3 (not
+    in either source mockup — authored to match the existing icon set's style) since the
+    mockup had no Edit icon at all. This supersedes the overflow-menu wording currently
+    sitting in BRD WP-04 — flagged explicitly for COO to reconcile in its own BRD pass; not
+    something I touched myself (BRD/tracker updates were COO's parallel work this session).
+  - New constraint added: no horizontal scrolling anywhere on mobile Trips except the
+    status filter chip row (already-documented overflow-x:auto exception) — trip cards,
+    place/category chip rows, item rows must all wrap/truncate. Added to the Mobile layout
+    section and as new Phase 2 success criterion #6 (verified against real/varied data, not
+    just the mockup's fixed example strings, since the mockup can't exercise this itself).
+  - Cross-reference summary table: all "Flag" verdicts converted to "Resolved" with the
+    concrete outcome; two new rows added (mobile Edit/Photos, mobile no-horizontal-scroll).
+  - Phase 2 success criteria: renumbered to 8 items, criterion 2 reworded from "needs
+    resolution" to "resolution must be honored in implementation," new criterion 6 added
+    for the no-horizontal-scroll constraint.
 
-  UNBLOCKED same thread: coordinator supplied verbatim copies of all three
-  mockup files into this worktree at jobs/ux/tech/waypoint-mockups/*.dc.html.
-  Read all three in full and produced the real spec:
-  jobs/ux/tech/20260721-UX-waypoint-spec.md
-
-  Deliverable contents:
-  - Phase 1: full oklch color token table (neutrals, brand, 7 status/category
-    hues), Newsreader/Manrope type scale, 11 SVG icon glyphs (8 item-type/status
-    + 4 nav/chrome) with exact path data — confirmed NO new icon-library
-    dependency needed (mockup icons are hand-authored SVG paths, not from a
-    named library), badge/button/input styling, and where these tokens should
-    live given this repo's Tailwind v4 CSS-first config. Recommended icon
-    replacement (emoji -> SVG) as the one immediate-apply exception; everything
-    else stays defined-but-unused until Phase 2 to avoid a half-migrated,
-    inconsistent state.
-  - Phase 2: full desktop + mobile Trips layout breakdown (nav, left panel,
-    trip cards, detail header, NEW status-stepper component replacing the flat
-    status bar, place sections, item cards, empty states, mobile slide
-    transition + bottom tab bar), cross-referenced line-by-line against
-    DP-01..06, TR-09/11/12/13, BUG-31/32/34/36, IT-01, UX-02, FEAT-BD, NTH-01/03.
-  - 13 flagged conflicts/open questions (C1-C13) requiring explicit COO/Ryan
-    decisions before Frontend dispatch — NOT silently resolved. Highlights:
-    * C1: mockup renames the product to "Waypoint" in the nav — real decision,
-      not styling.
-    * C2: mockup's status stepper has no Unlock affordance at all (current app
-      has a working, tested Unlock flow) — must be preserved, added to the new
-      stepper as chrome the mockup doesn't show.
-    * C3: BUG-36's trip-level items section (shipped 2026-07-20, IT-01) is
-      absent from both mockups entirely — must be preserved, not silently
-      dropped.
-    * C4: place-section Edit-dates/Remove buttons (UX-02, BUG-32) absent from
-      mockup place-header — must be preserved.
-    * C5: item card in mockup drops rating stars, carried-forward tag, and
-      full per-type subtext down to one generic line — must preserve full
-      richness inside the new visual shell.
-    * C6: mockup only shows the filtered-empty state, not the true first-run
-      zero-trips state current app already distinguishes — must preserve both.
-    * C7: FEAT-BD bulk delete, NTH-01 undo, NTH-03 filter counts, TR-09 sort,
-      map-filter badge all absent from mockup — must preserve all.
-    * C8: mockup's own reference implementation uses dangerouslySetInnerHTML
-      to render icons — blocking defect per _shared/frameworks.txt rule 22;
-      Frontend must use literal inline SVG JSX instead (same visual output).
-    * C9: mobile bottom tab bar only appears in list view, not detail view —
-      likely intentional (my read), needs Ryan confirmation since it's a nav
-      model decision.
-    * C10-C13: smaller precision flags (panel width 340 vs 320px, category
-      badge color undocumented in the system file itself, Newsreader weight
-      600 vs system doc's stated 500, button radius 10px vs mockups' applied
-      9px).
+  Did NOT touch: BRD, tracker.json (explicitly COO's parallel work this session, per
+  brief). Did NOT implement any code — spec only.
 
 ================================================================================
 NEXT ACTIONS
 ================================================================================
 
-  COO reviews jobs/ux/tech/20260721-UX-waypoint-spec.md, resolves C1-C13 with
-  Ryan (recording decisions per the document-lifecycle/record-decision rules —
-  BRD entries, ADL, or tracker notes as appropriate), adds any new requirement
-  IDs to the BRD (BRD-gate-before-dispatch rule), then dispatches Frontend:
-  Phase 1 first (verified/UAT'd before any reskin), then Phase 2.
+  Phase 2 (WP-03/WP-04) is unblocked for Frontend dispatch — no outstanding UX-owned
+  question remains on jobs/ux/tech/20260721-UX-waypoint-spec.md. COO's remaining work
+  (separate from this thread): reconcile BRD WP-04's overflow-menu wording against this
+  spec's compact-icon-pair resolution, then dispatch the Frontend brief for Phase 2.
 
-  Prior completed work (BRIEF-UX-01, DELTA docs) is now formally superseded in
-  intent by this spec for the Trips screen specifically — not yet stamped with
-  a formal supersession banner since that's the record-decision skill's job at
-  BRD-gate time, not mine to do unilaterally in this thread.
+  When Frontend's Phase 2 implementation lands, UX's next thread is the standard review-
+  against-spec pass (desktop + mobile, all cross-reference table rows, all 8 success
+  criteria above) before PO UAT.

--- a/jobs/ux/park-docs/20260721-UX-park.txt
+++ b/jobs/ux/park-docs/20260721-UX-park.txt
@@ -68,7 +68,76 @@ commit — coordinator's instruction was to update this branch, not open a new o
 PR #194 picks up the new commits automatically. No source code touched — spec/docs
 only. Pre-push checklist re-run and green before this final push.
 
-NEXT ACTIONS: See "CONFLICTS & OPEN QUESTIONS" at the top of
-jobs/ux/tech/20260721-UX-waypoint-spec.md and "NEXT ACTIONS" in
-jobs/ux/context/current.txt.
+NEXT ACTIONS (superseded — see second thread below): See "CONFLICTS & OPEN QUESTIONS" at
+the top of jobs/ux/tech/20260721-UX-waypoint-spec.md and "NEXT ACTIONS" in
+jobs/ux/context/current.txt as they stood at the end of this first thread.
+================================================================================
+
+UX PARK DOCUMENT — 2026-07-21 (SECOND THREAD, same day, PM session)
+================================================================================
+THREAD: Waypoint Phase 2 conflict-resolution stamp — closing the C1-C13 gate opened above
+================================================================================
+
+OUTCOME: DELIVERED. All 13 conflicts (C1-C13) from the thread above, plus three adjacent
+flagged items (Confirmed/Completed badge hue, font loading, TR-12), plus one new
+constraint (mobile no-horizontal-scroll), were resolved by a COO/PO session earlier the
+same day (two rounds). This thread's job: stamp every resolution into
+jobs/ux/tech/20260721-UX-waypoint-spec.md so it stops asserting them as open, and make one
+remaining judgment call explicitly punted to UX (mobile Edit/Photos entry point). Did NOT
+re-litigate any of the 13 — all matched my original recommendations verbatim, per
+instruction. Did NOT touch the BRD or tracker.json — COO's parallel work this session.
+
+WHAT CHANGED (single file, jobs/ux/tech/20260721-UX-waypoint-spec.md):
+- Status line: no longer "gated," states Phase 2 resolved and ready for Frontend
+  dispatch; points to this doc (design-detail record) + BRD v3.4 §5.16 WP-01/03/04/05
+  (requirement-level record).
+- C1-C13 table: added a Resolution column, every row stamped "Confirmed 2026-07-21
+  (COO/PO)."
+- Confirmed/Completed hue: resolved as two distinct hues (not the mockup's shared one). I
+  picked concrete tokens — Confirmed stays hue 150 (green), Completed moves to hue 220
+  (blue), same L/C recipe as the rest of the palette. Flagged that shipped Phase 1 code
+  (src/frontend/design/badges.ts) still collapses both to 150 — a bug relative to this
+  decision, fix belongs to the Phase 2 Frontend brief.
+- Font loading (self-hosted @fontsource) and TR-12 (stepper accepted as TR-12 fulfillment)
+  stamped confirmed.
+- MY OWN CALL: mobile Edit/Photos entry point. Two conflicting COO/PO answers existed
+  (overflow "⋯" menu, already in BRD WP-04, vs. compact icon pair, PO's later answer with
+  the final call explicitly deferred to UX). I chose the compact icon pair — reasoning:
+  overflow menus earn their keep at 3+ actions not 2; hiding two frequent primary actions
+  behind an extra tap works against affordance for no benefit at today's scope; keeps
+  mobile behavior-consistent with desktop (density change, not a new interaction pattern);
+  extensibility isn't foreclosed (converting to overflow later if a 3rd action appears is
+  a small change). This supersedes BRD WP-04's overflow-menu wording — flagged explicitly
+  for COO to reconcile in its own BRD pass. Added a new pencil/edit SVG icon to §3 (Icons)
+  since neither mockup has an Edit affordance on mobile at all.
+- New constraint: no horizontal scrolling anywhere on mobile Trips except the status
+  filter chip row (already-documented overflow-x:auto exception) — trip cards,
+  place/category chip rows, item rows must wrap/truncate. Added to the Mobile layout
+  section and as new Phase 2 success criterion #6, explicitly requiring verification
+  against real/varied data since the static mockup can't exercise scroll behavior itself.
+- Cross-reference summary table: all "Flag" verdicts converted to "Resolved" with the
+  concrete outcome; two new rows added (mobile Edit/Photos, mobile no-horizontal-scroll).
+- Phase 2 success criteria renumbered 1-8, criterion 2 reworded to reflect the closed
+  gate, new criterion 6 added for no-horizontal-scroll.
+
+BUGS DISCOVERED: None (docs-only thread).
+
+OPEN ISSUES / BLOCKERS: None. No outstanding UX-owned question remains on the Phase 2
+spec. One outstanding cross-team item, not a blocker to my own work: BRD WP-04's
+overflow-menu wording needs reconciling against this spec's compact-icon-pair resolution
+— flagged for COO, not mine to fix (BRD is COO's document this session).
+
+WHAT'S UNBLOCKED FOR OTHER JOBS: Frontend can now be dispatched for Phase 2 (WP-03
+desktop + WP-04 mobile) against a fully-stamped spec — no remaining gate.
+
+GIT: New branch docs/ux-waypoint-phase2-resolutions off main (this thread's own branch,
+per the standard branch-per-thread workflow — separate from the earlier thread's
+chore/waypoint-redesign-spec branch, which is already merged). Docs-only commit + a
+housekeeping commit for jobs/ux/context + this park doc + the completion report. See
+completion report in jobs/COO/inbox/ for the PR number and CI status.
+
+NEXT ACTIONS: COO reconciles BRD WP-04's overflow-menu wording against this spec's
+compact-icon-pair resolution, then dispatches the Frontend brief for Phase 2. My next
+thread (once Frontend's implementation lands): standard review-against-spec pass before
+PO UAT.
 ================================================================================

--- a/jobs/ux/tech/20260721-UX-waypoint-spec.md
+++ b/jobs/ux/tech/20260721-UX-waypoint-spec.md
@@ -2,10 +2,19 @@
 
 **Date:** 2026-07-21
 **Author:** UX
-**Status:** BRD-gated (v3.3). Phase 1 (WP-02, GitHub #197) implemented and merged (PR
+**Status:** BRD-gated (v3.4). Phase 1 (WP-02, GitHub #197) implemented and merged (PR
 #198), PO UAT PASS 2026-07-21 (`jobs/PO/uat-log.md`) — **WP-02 CLOSED**. Phase 2
-(WP-03/WP-04) BRD-gated and ready, not yet dispatched — gated on the 13 conflict
-resolutions (C1–C13 above) still needing COO/PO calls.
+(WP-03/WP-04) — **all 13 conflicts (C1–C13) plus the adjacent flagged items (Confirmed/
+Completed hue, font loading, TR-12) resolved by COO/PO 2026-07-21. This spec is stamped
+and Phase 2 is ready for Frontend dispatch.** Resolutions are recorded in two places: this
+document (inline stamps on each row/section below — the design-detail record) and BRD
+v3.4 §5.16 WP-01/WP-03/WP-04/WP-05 plus the TR-12 annotation (the requirement-level
+record COO maintains — see the BRD changelog v3.3/v3.4 entries). One item — the mobile
+detail-view Edit/Photos entry point — was explicitly punted to UX for a final call after
+two rounds of COO/PO discussion produced conflicting answers; resolved below (see the
+Mobile "Detail view" section) as a **compact icon pair**, which supersedes the
+overflow-menu wording currently sitting in BRD WP-04 — COO to reconcile that wording in
+its own pass, not this document's job.
 **Source:** claude.ai Design project "Travel tracker design review"
 (`8cc525c1-b678-4976-a207-57f7f489844b`), read directly from verbatim copies at
 `jobs/ux/tech/waypoint-mockups/{design-system,trips-desktop,trips-mobile}.dc.html`
@@ -19,34 +28,41 @@ design-system foundation (Phase 1) and the Trips screen, desktop + mobile (Phase
 
 **How to read this document:** Every color/size value below is copied verbatim from the
 `.dc.html` source (oklch values, px sizes, font weights) — I did not round or approximate
-anything. Where the mockup is ambiguous, silent, or in conflict with a real BRD requirement
-or shipped bug fix, I've said so explicitly in a **CONFLICT** or **GAP** callout rather than
-picking a resolution myself. COO adjudicates those; I have not.
+anything. Where the mockup was ambiguous, silent, or in conflict with a real BRD requirement
+or shipped bug fix, I said so explicitly in a **CONFLICT** or **GAP** callout rather than
+picking a resolution myself at the time of first authoring (2026-07-21, morning pass). Those
+callouts have since been adjudicated by COO/PO the same day (2026-07-21, afternoon session)
+and are now stamped inline throughout — see the CONFLICTS & OPEN QUESTIONS table below for
+the resolution record. One item (mobile Edit/Photos entry point) was explicitly punted back
+to UX for the final call; that call is made and recorded in the Mobile "Detail view"
+section.
 
 ---
 
 ## CONFLICTS & OPEN QUESTIONS — read this section first
 
-These need a decision before or during Frontend dispatch. Full detail on each is in the
-relevant Phase 2 subsection below; this is the index.
+**All 13 resolved by COO/PO 2026-07-21.** This index is retained as the design-detail
+record of each call (the requirement-level record lives in BRD v3.4 §5.16). Full detail on
+each is in the relevant Phase 2 subsection below; this is the index.
 
-| # | Issue | Why it matters | My recommendation |
-|---|---|---|---|
-| C1 | **Product name.** Both mockups render the nav brand as "Waypoint" (Newsreader wordmark + pin icon), not "Travel Tracker." | Renaming the product is a real decision, not a visual reskin detail — it touches the nav, page `<title>`, possibly docs/README/support materials. | Confirm with Ryan explicitly: is "Waypoint" the new product name, or just this design file's working title? Don't let Frontend infer a rename from a mockup file name. |
-| C2 | **Status stepper has no "Unlock" state.** The mockup's 4-step stepper (Plan→Active→Review→Locked) only defines a forward-progress CTA (`NEXT_STEP` has no `locked` entry) — no unlock affordance is shown anywhere in either mockup. | The current app has a real, tested Unlock button + confirm dialog (`TripDetail.tsx` lines 196-204) that returns a locked trip to `review_pending`. Dropping it would be a functional regression, not a skin change. | Preserve the existing Unlock button/flow; add it to the stepper card as new chrome the mockup doesn't show (e.g. an outlined "Unlock" button where the CTA slot would otherwise be empty). Flag to Frontend explicitly — don't let "the mockup doesn't show it" become "so we removed it." |
-| C3 | **BUG-36 trip-level items section is absent from both mockups.** Neither `trips-desktop.dc.html` nor `trips-mobile.dc.html` render anything resembling `TripItemsSection` (the "Trip Items" / "+ Add Trip Item" block for flights/car rentals not tied to a place). | This is a tested, BRD-linked (IT-01) feature that shipped 2026-07-20 (PR #171). The mockup may simply predate it, or Ryan may not have thought to include it in the design pass — either way it can't silently vanish. | Preserve `TripItemsSection` as its own reskinned block, positioned above Places exactly as today. Not a mockup omission Frontend should read as "remove this." |
-| C4 | **Place section's Edit-dates / Set-dates and Remove buttons are absent from both mockups.** Only "+ Add Item" appears in the place-header actions. | `UX-02` (per-place date editing) and `BUG-32` (remove-place, with cascade-reassign-to-trip-level and confirm dialog) are both shipped, tested features. | Preserve both buttons in the reskinned place header, alongside "+ Add Item." Recommend: `[Set/Edit dates] [+ Add Item] [Remove]` reading left-to-right by frequency of use, but this ordering is a minor call Frontend can make — the presence of both is not optional. |
-| C5 | **Item card in the mockup drops rating stars, the "carried forward" tag, and per-type subtext richness** (hotel check-in/out, flight number, cuisine type, notes excerpt) down to one generic `sub` line. | Ratings and the carried-forward indicator are real, shipped features (`RatingStars`, BUG-03 carry-forward). | Preserve today's full per-type subtext + rating stars + carried-forward tag inside the restyled item card shell (new icon tile, new badge colors) — the mockup's single-`sub`-string model is a demo simplification, not a spec to copy literally for this part. |
-| C6 | **Neither mockup shows the "no trips at all yet" first-run empty state** — only a "no trips match the filter" state (`hasTrips` toggles on the same filtered-list length in both cases). Current app already distinguishes the two ("No trips yet. Create one with '+ New'." vs "No trips match the current filters."). | Losing the first-run message would be a real UX regression for new users (a core "feedback" principle — don't let a blank list read as broken). | Preserve today's two-message distinction; apply the new icon/typography treatment to both. |
-| C7 | **FEAT-BD (bulk multi-select delete), NTH-01 (undo bar), NTH-03 (per-status filter counts), TR-09 sort control, and the map-filter badge have no mockup equivalent.** | All are real, shipped, tested functionality with no visual counterpart in either mockup — the mockups are demo-scoped to core browsing/detail viewing, not every toolbar feature. | Preserve all of them, reskinned with the new tokens (chip/button/badge styling from Phase 1). Do not remove on the theory that "the mockup doesn't have it." |
-| C8 | **Item icon rendering technique.** The mockup's own reference implementation uses `dangerouslySetInnerHTML` to inject icon SVG strings (`trips-desktop.dc.html` line 157, `trips-mobile.dc.html` line 145). | `_shared/frameworks.txt` rule 22 (binding project framework rule, restated in `CLAUDE.md`'s security spec references) makes `dangerouslySetInnerHTML` a **blocking defect** in this codebase, no exceptions without COO sign-off. | Frontend must implement icons as literal inline SVG JSX (`<svg>...</svg>` written directly in the component, or small dedicated icon components) using the exact path data below — same pixel output, zero banned API. This is not optional; flagging so it isn't missed as "just copy the mockup's approach." |
-| C9 | **Mobile bottom tab bar only appears in the list view, not the detail view** — the mockup's tab-bar markup lives inside the "LIST VIEW" wrapper only; the "DETAIL VIEW" wrapper has no tab bar, using the back-button bar instead. | Could be deliberate (more vertical space for content on a small screen once you've drilled in) or an oversight in the demo file. | My read: deliberate and good mobile practice — recommend keeping the tab bar hidden in detail view, back-button as primary nav there. Confirm with Ryan since it's a real navigation-model decision, not styling. |
-| C10 | **Left panel width mismatch.** Mockup desktop left panel is `340px`; current app is `320px` (already reduced once from an original `360px` per the March DELTA-11 fix). | Small but exact — my role doesn't treat pixel drift as "character." | Match the mockup: `340px`. Flagging since it's a second width change to the same panel in under a year — worth a beat of "is this the value we're keeping" before Frontend implements it a third time. |
-| C11 | **Category-badge color (hue 255, indigo-violet) is used in both Trips mockups but is not declared anywhere in `design-system.dc.html`'s own "Status & category badges" section** (which only shows PLANNING/ACTIVE/REVIEW/LOCKED/CONFIRMED/CANCELLED/CONSIDER). | The system doc is the nominal source of truth for tokens, but it's incomplete relative to what the Trips mockups actually use. | Treat the category-chip color as a real token anyway (documented below, sourced from application, not the system doc) — Frontend needs it regardless of which file "should" have declared it. Flag to whoever owns the Design System file that it's missing this swatch. |
-| C12 | **Newsreader heading weight: system doc says 500, both Trips mockups apply 600 everywhere a heading actually renders.** | Minor but exact per my role's standard — I don't let a font-weight drift pass as "close enough." | Use **600** — it's what's consistently applied in every real instance across both Trips mockups; the system doc's swatch appears to be the one that's slightly stale, not the applied files. |
-| C13 | **Button/input radius: system doc says "10px radius throughout," both Trips mockups apply 9px on nearly every button/input** (a couple of mobile-only elements use 10-11px). | Same category as C12 — a declared token that doesn't quite match its own application. | Use **10px** as the canonical Phase 1 token (per the system doc's explicit statement) and treat the mockups' 9px as sub-pixel drift from hand-authored inline styles, not an intentional second value. Frontend should standardize on one number; flagging so nobody "matches the mockup exactly" into a 9px/10px inconsistency across components. |
+| # | Issue | Why it matters | My recommendation | Resolution |
+|---|---|---|---|---|
+| C1 | **Product name.** Both mockups render the nav brand as "Waypoint" (Newsreader wordmark + pin icon), not "Travel Tracker." | Renaming the product is a real decision, not a visual reskin detail — it touches the nav, page `<title>`, possibly docs/README/support materials. | Confirm with Ryan explicitly: is "Waypoint" the new product name, or just this design file's working title? Don't let Frontend infer a rename from a mockup file name. | **Confirmed 2026-07-21 (COO/PO).** Real rename to "Waypoint" — nav brand, page `<title>`, in-app copy. Repo name/README/other project-identity artifacts outside the running app are explicitly out of scope. Recorded in BRD v3.4 §5.16 WP-01. |
+| C2 | **Status stepper has no "Unlock" state.** The mockup's 4-step stepper (Plan→Active→Review→Locked) only defines a forward-progress CTA (`NEXT_STEP` has no `locked` entry) — no unlock affordance is shown anywhere in either mockup. | The current app has a real, tested Unlock button + confirm dialog (`TripDetail.tsx` lines 196-204) that returns a locked trip to `review_pending`. Dropping it would be a functional regression, not a skin change. | Preserve the existing Unlock button/flow; add it to the stepper card as new chrome the mockup doesn't show (e.g. an outlined "Unlock" button where the CTA slot would otherwise be empty). Flag to Frontend explicitly — don't let "the mockup doesn't show it" become "so we removed it." | **Confirmed 2026-07-21 (COO/PO).** Preserve the existing Unlock button/flow as new stepper-card chrome, per recommendation. BRD v3.4 §5.16 WP-03. |
+| C3 | **BUG-36 trip-level items section is absent from both mockups.** Neither `trips-desktop.dc.html` nor `trips-mobile.dc.html` render anything resembling `TripItemsSection` (the "Trip Items" / "+ Add Trip Item" block for flights/car rentals not tied to a place). | This is a tested, BRD-linked (IT-01) feature that shipped 2026-07-20 (PR #171). The mockup may simply predate it, or Ryan may not have thought to include it in the design pass — either way it can't silently vanish. | Preserve `TripItemsSection` as its own reskinned block, positioned above Places exactly as today. Not a mockup omission Frontend should read as "remove this." | **Confirmed 2026-07-21 (COO/PO).** Preserve `TripItemsSection` exactly, reskinned with place-section card styling, per recommendation. BRD v3.4 §5.16 WP-03. |
+| C4 | **Place section's Edit-dates / Set-dates and Remove buttons are absent from both mockups.** Only "+ Add Item" appears in the place-header actions. | `UX-02` (per-place date editing) and `BUG-32` (remove-place, with cascade-reassign-to-trip-level and confirm dialog) are both shipped, tested features. | Preserve both buttons in the reskinned place header, alongside "+ Add Item." Recommend: `[Set/Edit dates] [+ Add Item] [Remove]` reading left-to-right by frequency of use, but this ordering is a minor call Frontend can make — the presence of both is not optional. | **Confirmed 2026-07-21 (COO/PO).** Preserve both buttons alongside "+ Add Item," per recommendation; exact ordering left to Frontend's judgment. BRD v3.4 §5.16 WP-03. |
+| C5 | **Item card in the mockup drops rating stars, the "carried forward" tag, and per-type subtext richness** (hotel check-in/out, flight number, cuisine type, notes excerpt) down to one generic `sub` line. | Ratings and the carried-forward indicator are real, shipped features (`RatingStars`, BUG-03 carry-forward). | Preserve today's full per-type subtext + rating stars + carried-forward tag inside the restyled item card shell (new icon tile, new badge colors) — the mockup's single-`sub`-string model is a demo simplification, not a spec to copy literally for this part. | **Confirmed 2026-07-21 (COO/PO).** Preserve all of it inside the restyled item card shell, per recommendation. BRD v3.4 §5.16 WP-03. |
+| C6 | **Neither mockup shows the "no trips at all yet" first-run empty state** — only a "no trips match the filter" state (`hasTrips` toggles on the same filtered-list length in both cases). Current app already distinguishes the two ("No trips yet. Create one with '+ New'." vs "No trips match the current filters."). | Losing the first-run message would be a real UX regression for new users (a core "feedback" principle — don't let a blank list read as broken). | Preserve today's two-message distinction; apply the new icon/typography treatment to both. | **Confirmed 2026-07-21 (COO/PO).** Preserve today's two-message distinction under the new visual treatment, per recommendation. BRD v3.4 §5.16 WP-03. |
+| C7 | **FEAT-BD (bulk multi-select delete), NTH-01 (undo bar), NTH-03 (per-status filter counts), TR-09 sort control, and the map-filter badge have no mockup equivalent.** | All are real, shipped, tested functionality with no visual counterpart in either mockup — the mockups are demo-scoped to core browsing/detail viewing, not every toolbar feature. | Preserve all of them, reskinned with the new tokens (chip/button/badge styling from Phase 1). Do not remove on the theory that "the mockup doesn't have it." | **Confirmed 2026-07-21 (COO/PO).** Preserve all of it, reskinned with new tokens, per recommendation. BRD v3.4 §5.16 WP-03. |
+| C8 | **Item icon rendering technique.** The mockup's own reference implementation uses `dangerouslySetInnerHTML` to inject icon SVG strings (`trips-desktop.dc.html` line 157, `trips-mobile.dc.html` line 145). | `_shared/frameworks.txt` rule 22 (binding project framework rule, restated in `CLAUDE.md`'s security spec references) makes `dangerouslySetInnerHTML` a **blocking defect** in this codebase, no exceptions without COO sign-off. | Frontend must implement icons as literal inline SVG JSX (`<svg>...</svg>` written directly in the component, or small dedicated icon components) using the exact path data below — same pixel output, zero banned API. This is not optional; flagging so it isn't missed as "just copy the mockup's approach." | **Confirmed 2026-07-21 (COO/PO).** Hard rule stands, no exception — inline SVG JSX only. |
+| C9 | **Mobile bottom tab bar only appears in the list view, not the detail view** — the mockup's tab-bar markup lives inside the "LIST VIEW" wrapper only; the "DETAIL VIEW" wrapper has no tab bar, using the back-button bar instead. | Could be deliberate (more vertical space for content on a small screen once you've drilled in) or an oversight in the demo file. | My read: deliberate and good mobile practice — recommend keeping the tab bar hidden in detail view, back-button as primary nav there. Confirm with Ryan since it's a real navigation-model decision, not styling. | **Confirmed 2026-07-21 (COO/PO).** Deliberate — tab bar stays list-view-only, back button is primary nav in detail view, per recommendation. BRD v3.4 §5.16 WP-04. |
+| C10 | **Left panel width mismatch.** Mockup desktop left panel is `340px`; current app is `320px` (already reduced once from an original `360px` per the March DELTA-11 fix). | Small but exact — my role doesn't treat pixel drift as "character." | Match the mockup: `340px`. Flagging since it's a second width change to the same panel in under a year — worth a beat of "is this the value we're keeping" before Frontend implements it a third time. | **Confirmed 2026-07-21 (COO/PO).** Match the mockup at **340px** — current shipped code is still 320px; this is a real value change to apply during Phase 2, not yet applied anywhere. |
+| C11 | **Category-badge color (hue 255, indigo-violet) is used in both Trips mockups but is not declared anywhere in `design-system.dc.html`'s own "Status & category badges" section** (which only shows PLANNING/ACTIVE/REVIEW/LOCKED/CONFIRMED/CANCELLED/CONSIDER). | The system doc is the nominal source of truth for tokens, but it's incomplete relative to what the Trips mockups actually use. | Treat the category-chip color as a real token anyway (documented below, sourced from application, not the system doc) — Frontend needs it regardless of which file "should" have declared it. Flag to whoever owns the Design System file that it's missing this swatch. | **Confirmed 2026-07-21 (COO/PO).** Real token despite the system doc's incomplete swatch set, per recommendation. Already correctly implemented in `src/frontend/design/badges.ts` from Phase 1. |
+| C12 | **Newsreader heading weight: system doc says 500, both Trips mockups apply 600 everywhere a heading actually renders.** | Minor but exact per my role's standard — I don't let a font-weight drift pass as "close enough." | Use **600** — it's what's consistently applied in every real instance across both Trips mockups; the system doc's swatch appears to be the one that's slightly stale, not the applied files. | **Confirmed 2026-07-21 (COO/PO).** **600**, per recommendation. Already correctly implemented in Phase 1's `theme-waypoint.css`. |
+| C13 | **Button/input radius: system doc says "10px radius throughout," both Trips mockups apply 9px on nearly every button/input** (a couple of mobile-only elements use 10-11px). | Same category as C12 — a declared token that doesn't quite match its own application. | Use **10px** as the canonical Phase 1 token (per the system doc's explicit statement) and treat the mockups' 9px as sub-pixel drift from hand-authored inline styles, not an intentional second value. Frontend should standardize on one number; flagging so nobody "matches the mockup exactly" into a 9px/10px inconsistency across components. | **Confirmed 2026-07-21 (COO/PO).** **10px**, per recommendation. Already correctly implemented in Phase 1's `theme-waypoint.css` as `--radius-wp: 10px`. |
 
-None of the above blocks Phase 1 (tokens only). C1–C10 must be resolved (or explicitly accepted as "preserve current behavior," per my recommendations) before Phase 2 is briefed to Frontend, since they're all real functional/behavioral questions, not styling choices.
+All 13 resolutions above are COO/PO-confirmed 2026-07-21 and require no further adjudication.
+Phase 2 is unblocked for Frontend dispatch on this basis.
 
 ---
 
@@ -125,17 +141,31 @@ confirmed against both the system doc's palette and every application in the Tri
 | 75 (amber/gold) | `oklch(94% 0.03 75)` | `oklch(40% 0.12 75)` | Trip status: **Active** |
 | 325 (magenta/plum) | `oklch(94% 0.025 325)` | `oklch(38% 0.1 325)` | Trip status: **Review** |
 | 80 (neutral, ~0 chroma) | `oklch(93% 0.006 80)` | `oklch(40% 0.01 80)` | Trip status: **Locked**; item status: **Consider** |
-| 150 (green) | `oklch(94% 0.025 150)` | `oklch(38% 0.1 150)` | Item status: **Confirmed** *and* **Completed** (label "DONE") — see note below |
+| 150 (green) | `oklch(94% 0.025 150)` | `oklch(38% 0.1 150)` | Item status: **Confirmed** — see note below (Completed now a separate hue, not shared) |
+| 220 (blue) | `oklch(94% 0.025 220)` | `oklch(36% 0.1 220)` | Item status: **Completed** (label "DONE") — new hue, resolved 2026-07-21, see note below |
 | 25 (red) | `oklch(95% 0.03 25)` | `oklch(42% 0.13 25)` | Item status: **Cancelled** |
 | 255 (indigo-violet) | `oklch(94% 0.03 255)` | `oklch(42% 0.1 255)` | Category / activity chips (see C11 — not in the system doc's own swatch set, sourced from application in both Trips mockups) |
 
-**Note on Confirmed vs Completed sharing a hue:** the mockup's `STATUS_META` gives `confirmed`
-and `completed` the *identical* bg/fg pair (hue 150), differing only in label text
-("CONFIRMED" vs "DONE"). The current app visually distinguishes them (`green-100/green-800`
-vs `emerald-100/emerald-800` — two different hues). Collapsing them to one hue is a real,
-if minor, semantic change (you lose an at-a-glance visual distinction between "confirmed,
-not yet done" and "actually completed") — flagging so it's a decision, not a side effect of
-copying the mockup's `STATUS_META` table.
+**Resolution — Confirmed vs Completed, two hues, not one (Confirmed 2026-07-21, COO/PO):**
+the mockup's `STATUS_META` gives `confirmed` and `completed` the *identical* bg/fg pair
+(hue 150), differing only in label text ("CONFIRMED" vs "DONE"). Do **not** collapse them —
+keep two visually distinct hues, overriding the mockup's literal table. Reason given: the
+mockup didn't know about "completed" as a distinct state when it was authored, so its
+single-hue table under-specifies the real status model. Concrete tokens: **Confirmed stays
+at hue 150 (green)** — `oklch(94% 0.025 150)` / `oklch(38% 0.1 150)`, unchanged from the
+table above. **Completed moves to hue 220 (blue)** — `oklch(94% 0.025 220)` /
+`oklch(36% 0.1 220)`, following the same background/text lightness-chroma recipe as every
+other status hue in this table. I picked blue deliberately: it reads as "informational/
+done" against green's "on track," it sits in open hue space between pine (195) and
+indigo-violet (255) with reasonable separation from both (25°/35°), and it doesn't collide
+with any hue already in use (25/75/80/150/195/255/325). This is my concrete pick, not a
+placeholder — Frontend/Architect can substitute a different hue only if there's a specific
+reason to; the requirement that binds is "two distinct hues," not this exact one. Note the
+shipped Phase 1 code (`src/frontend/design/badges.ts`) currently still collapses both to
+hue 150 per the mockup's literal content — that's a bug relative to this decision, to be
+fixed as part of the Phase 2 Frontend brief. BRD v3.4 §5.16 WP-02 already records "two
+hues preserved" at the requirement level; this is the concrete token-level fulfillment of
+that call.
 
 **Badge shape note:** status pills use `border-radius: 20px` (full pill) at
 `padding: 5px 12px` (system doc) / `5px 13px` (desktop trip-detail) / `4-5px 10-12px`
@@ -164,12 +194,9 @@ Font families: **Newsreader** (serif, display/editorial) and **Manrope** (sans, 
 Loaded in the mockup via a Google Fonts `<link>`:
 `family=Newsreader:opsz,wght@6..72,400;6..72,500;6..72,600&family=Manrope:wght@400;500;600;700;800`.
 
-**Font-loading call for Frontend/COO:** the mockup pulls both fonts from Google's CDN at
-runtime. Given this app's hosted-web direction (NF-09) an external font CDN is viable, but
-I'd recommend self-hosting via `@fontsource/newsreader` + `@fontsource/manrope` (or local
-woff2 files) instead of a live Google Fonts `<link>`, consistent with this app otherwise
-having no external runtime dependencies. This is an implementation-cost tradeoff, not a
-pure design call — flagging for a decision, not deciding it myself.
+**Font-loading — Confirmed 2026-07-21 (COO/PO):** self-host via `@fontsource/newsreader` +
+`@fontsource/manrope`, not a live Google Fonts CDN `<link>`, per my original recommendation.
+Final. Already implemented this way in Phase 1.
 
 ### Type scale
 
@@ -238,6 +265,7 @@ icon section — same "system doc is incomplete" situation as the category-badge
 | trips/suitcase (mobile Trips tab) | Mobile bottom tab bar | `<rect x="5" y="8" width="14" height="10.5" rx="2" fill="currentColor"/><rect x="9" y="5" width="6" height="3.5" rx="1.5" fill="none" stroke="currentColor" stroke-width="1.8"/>` |
 | admin (mobile Admin tab) | Mobile bottom tab bar | `<rect x="4" y="5.2" width="16" height="2" rx="1" fill="currentColor" opacity="0.3"/><circle cx="15" cy="6.2" r="2.6" fill="currentColor"/><rect x="4" y="11" width="16" height="2" rx="1" fill="currentColor" opacity="0.3"/><circle cx="9" cy="12" r="2.6" fill="currentColor"/><rect x="4" y="16.8" width="16" height="2" rx="1" fill="currentColor" opacity="0.3"/><circle cx="17" cy="17.8" r="2.6" fill="currentColor"/>` (a 3-row settings-slider glyph) |
 | back chevron (mobile detail-view back button) | "‹ Trips" back navigation | `<path d="M15 5l-7 7 7 7" stroke="currentColor" stroke-width="2.2" fill="none" stroke-linecap="round" stroke-linejoin="round"/>` |
+| edit/pencil (mobile detail-view compact icon pair) | Mobile trip-detail header, next to Photos icon — see "Mobile Edit/Photos entry point" resolution in the Detail view section below | `<path d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25ZM20.71 7.04c.39-.39.39-1.02 0-1.41l-2.34-2.34a1 1 0 0 0-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83Z" fill="currentColor"/>` — a new glyph, not present in either source mockup (neither shows a mobile Edit affordance at all); a standard filled pencil, authored to match this set's single-fill-color, geometric-path convention. Color: `ink` `oklch(22% 0.02 75)` to match the existing secondary-button text color used for "Edit" on desktop |
 
 ## 4. Status & category badges — component spec
 
@@ -432,12 +460,13 @@ the new tokens (chip/button styles per §4/§5) — none of them are being remov
     right-aligned, `max-width:150px`) + primary CTA button (per §5) with the next-step
     label. Both only render when a next step exists (`NEXT_STEP` has no `locked` entry —
     see **C2**, must add an Unlock affordance here since the mockup provides none).
-  - **BRD cross-check (TR-12):** "persistent status bar showing current status + primary
-    next action, always visible regardless of scroll" — the stepper still satisfies this
-    structurally (same position between header and scrollable content, still shows current
-    status and next action) but is a materially richer widget than a "bar." Flagging so
-    COO/Ryan explicitly confirms the stepper is an acceptable (better, arguably) fulfillment
-    of TR-12, not an unreviewed scope creep past what TR-12 originally asked for.
+  - **BRD cross-check (TR-12) — Confirmed 2026-07-21 (PO):** "persistent status bar showing
+    current status + primary next action, always visible regardless of scroll" — the
+    stepper satisfies this structurally (same position between header and scrollable
+    content, still shows current status and next action) but is a materially richer widget
+    than a "bar." PO confirmed this is an acceptable, arguably better, fulfillment of TR-12's
+    original intent, not unreviewed scope creep. Recorded in BRD v3.4 §5.16, TR-12 row
+    annotation (v3.3).
 
 - **Trip-level items section (BUG-36/IT-01):** **not in either mockup at all** (C3) —
   preserve `TripItemsSection` exactly as today, reskinned with the new place-section card
@@ -484,6 +513,27 @@ panels that cross-fade/slide between each other; nothing about this in the curre
 exists yet (there's no mobile-specific Trips layout today at all — this is genuinely new
 responsive work, not a reskin of an existing mobile view).
 
+**New constraint (2026-07-21, COO/PO): no horizontal scrolling anywhere on the mobile Trips
+screen, with exactly one documented exception.** The status filter chip row is the only
+element permitted `overflow-x: auto` — already specified below, because 5 status chips
+genuinely can't fit one mobile-width line. Everything else must wrap or truncate, never
+require a horizontal swipe/scroll:
+- **Trip cards** — name truncates with ellipsis (already specified above in the desktop
+  section and inherited here); date range, status badge, and the place-name/category chip
+  row all wrap onto additional lines as needed, they do not scroll.
+- **Place-name and category chip rows** (trip cards, place-section headers) — wrap to
+  multiple lines when they exceed the card width; do not lay out as a horizontally
+  scrolling strip.
+- **Item rows** (item cards inside place sections and `TripItemsSection`) — label and sub
+  text wrap or truncate within the row's fixed width; the row itself never becomes wider
+  than the viewport or scrolls sideways.
+- **Any other row/list content** introduced by this reskin (meta row tags, stepper labels,
+  etc.) follows the same rule by default unless a future spec update adds another named
+  exception the way the status-chip row is named here.
+
+This is a real, verifiable constraint, not a style preference — see Phase 2 success
+criteria below for its Definition-of-Done form.
+
 ### List view
 
 - Header: "My Trips (N)" (Newsreader 600/28px) + a small circular **"+"** FAB-style button
@@ -508,8 +558,8 @@ responsive work, not a reskin of an existing mobile view).
   `ink-faint oklch(65% 0.01 75)`.
 
   **This tab bar exists only in the list view** (C9) — the detail view has no bottom tab
-  bar in the mockup, using a top back-button instead. See C9 for the flag on whether that's
-  intentional.
+  bar in the mockup, using a top back-button instead. **Confirmed 2026-07-21 (COO/PO):**
+  deliberate, keep as-is — see C9 resolution in the index above.
 
 ### Detail view
 
@@ -518,11 +568,30 @@ responsive work, not a reskin of an existing mobile view).
   desktop's Edit/Photos-button-adjacent navigation model entirely on mobile (there's no
   visible Edit/Photos button in the mobile detail mockup at all — **only the back button,
   title, status badge, and stepper are shown**; Edit and Photos are conspicuously absent).
-  **This is a real gap to flag, not decide silently:** does mobile drop Edit/Photos
-  entirely, move them behind an overflow menu, or was this just cut from the demo for
-  space? My recommendation: don't drop functionality — add an overflow ("⋯") menu or a
-  compact icon-only Edit/Photos pair in the header row, but this needs Ryan's call since
-  the mockup gives zero guidance either way.
+
+  **Resolved 2026-07-21 — Mobile Edit/Photos entry point: compact icon pair, not an
+  overflow menu (my call, as UX).** Two options were on the table: (a) an overflow ("⋯")
+  menu exposing both actions — the COO/PO's initial call, recorded in BRD v3.3/v3.4 §5.16
+  WP-04 — or (b) a compact icon-only Edit/Photos pair directly in the header, next to the
+  back button — the PO's answer in a later round of the same conversation, who then
+  explicitly deferred the final call to UX, flagging extensibility (room for more actions
+  later) as the one thing worth weighing. My decision: **compact icon pair.** Reasoning —
+  overflow menus earn their keep at 3+ actions; hiding just two frequent, primary actions
+  behind an extra tap works against affordance and discoverability for no real benefit at
+  today's scope. It also keeps mobile behavior-consistent with desktop, where Edit and
+  Photos are already always visible, not tucked away — this is a density change (icon-only
+  vs. icon+label), not a new interaction pattern. Extensibility isn't foreclosed: if a
+  third action is added later, converting this pair to an overflow menu at that point is a
+  small, well-justified change, not a redesign. This supersedes the overflow-menu wording
+  in BRD WP-04 — COO to reconcile in a separate BRD pass, not this document's job.
+
+  **Spec:** two icon-only buttons in the header row, right of the title/status-badge row,
+  left of or level with the back bar per Frontend's layout judgment — Edit (new pencil
+  glyph, §3) and Photos (existing camera glyph, §3), each a `36×36px` tap target, `10px`
+  radius (§5), secondary-button chrome (`bg-surface`, 1px `border`, hover `bg-subtle`), icon
+  centered at `18-20px`, color `ink`. Preserve the existing `isLocked` conditional hiding of
+  Edit, same rule as the desktop header (see the Right panel "Header" cross-reference above)
+  — Photos stays visible regardless of lock state, matching desktop.
 - Title + status badge: same content as desktop, smaller type (26px vs 34px), badge to the
   right of the title on the same row (not below it).
 - Meta row: same `·`-separated dates/companions/tags pattern as desktop.
@@ -555,21 +624,23 @@ values and duration, not a generic "slide" guess.
 | Item | BRD/tracker ref | Mockup shows it? | Verdict |
 |---|---|---|---|
 | Two-panel desktop layout | TR-11 | Yes, matches | Reskin only |
-| Persistent status bar → stepper | TR-12 | Yes, richer widget | **Flag (see stepper note above)** — confirm stepper satisfies TR-12's intent |
+| Persistent status bar → stepper | TR-12 | Yes, richer widget | **Resolved** — PO confirmed 2026-07-21 the stepper is an acceptable, arguably better, fulfillment of TR-12's intent. BRD v3.4 §5.16 TR-12 note. |
 | Search matches trip + place names | TR-13 | Yes, matches (`filterAndSortTrips` already implements this) | Already aligned — copy-only change (placeholder text) |
 | Trip count badge | DP-02 | Yes, matches | Reskin only |
 | Place section: city/country/date-range | DP-04 | Yes, matches | Reskin only |
 | Place chronological ordering | DP-05 | Not visually distinguishable from insertion order in a static mockup (all example data is pre-sorted) | No conflict — behavior unaffected by reskin |
-| First place inherits trip dates | DP-06 | Not shown (all example places have explicit dates) — **and this requirement is tracker-status "pending," not yet built** | **Flag** — Phase 2 reskins the display of dates that exist; it does not (and per BRD-DP06's own tracker entry, currently cannot) address the underlying "first place inherits trip dates" gap. Don't let this PR accidentally get treated as closing that gap. |
-| Photos entry point | PH-03 | Yes (desktop); **absent in mobile detail view** | **Flag** — see mobile detail-view note above |
-| Trip-level items (flights/cars) | IT-01 / BUG-36 | **No** | **Flag (C3)** — preserve |
-| Remove place | BUG-32 | **No** | **Flag (C4)** — preserve |
-| Per-place date editing | UX-02 | **No** | **Flag (C4)** — preserve |
+| First place inherits trip dates | DP-06 | Not shown (all example places have explicit dates) — **and this requirement is tracker-status "pending," not yet built** | **Resolved (WP-05)** — Phase 2 reskins the display of dates that exist; it does not (and per BRD-DP06's own tracker entry, currently cannot) address the underlying "first place inherits trip dates" gap. This PR must not be treated as closing that gap. BRD v3.4 §5.16 WP-05. |
+| Photos entry point | PH-03 | Yes (desktop); **absent in mobile detail view** | **Resolved** — compact icon-only Edit/Photos pair added to mobile detail header (UX call, 2026-07-21 — see the Mobile "Detail view" section). |
+| Trip-level items (flights/cars) | IT-01 / BUG-36 | **No** | **Resolved (C3)** — preserve |
+| Remove place | BUG-32 | **No** | **Resolved (C4)** — preserve |
+| Per-place date editing | UX-02 | **No** | **Resolved (C4)** — preserve |
 | Map standout icon | BUG-34 | N/A — that fix lives in the Map screen, out of scope here | No action needed |
-| Ratings, carried-forward tag | (shipped features, `ItemCard.tsx`) | **No** (mockup's item card is simplified) | **Flag (C5)** — preserve |
-| Bulk delete, undo, sort, map-filter badge | FEAT-BD, NTH-01, NTH-03, TR-09, map filters | **No** | **Flag (C7)** — preserve |
-| First-run empty state (vs filtered-empty) | (existing UX, no formal BRD ID) | **No** — mockup only shows filtered-empty | **Flag (C6)** — preserve |
-| Unlock affordance | (existing UX, no formal BRD ID — inverse of TR-12's forward progression) | **No** | **Flag (C2)** — preserve |
+| Ratings, carried-forward tag | (shipped features, `ItemCard.tsx`) | **No** (mockup's item card is simplified) | **Resolved (C5)** — preserve |
+| Bulk delete, undo, sort, map-filter badge | FEAT-BD, NTH-01, NTH-03, TR-09, map filters | **No** | **Resolved (C7)** — preserve |
+| First-run empty state (vs filtered-empty) | (existing UX, no formal BRD ID) | **No** — mockup only shows filtered-empty | **Resolved (C6)** — preserve |
+| Unlock affordance | (existing UX, no formal BRD ID — inverse of TR-12's forward progression) | **No** | **Resolved (C2)** — preserve |
+| Mobile detail Edit/Photos entry point | (new — no prior BRD ID; now BRD v3.4 §5.16 WP-04) | **No** — mobile mockup shows no Edit/Photos affordance at all | **Resolved** — compact icon pair (UX call, 2026-07-21). See Mobile "Detail view" section. |
+| Mobile no-horizontal-scroll | (new — no prior BRD ID) | N/A — static mockup, scroll behavior not testable from a `.dc.html` snapshot | **Resolved** — new constraint, COO/PO 2026-07-21. Status filter chip row is the sole `overflow-x:auto` exception; everything else wraps/truncates. See Mobile layout section. |
 
 ## Phase 2 success criteria
 
@@ -579,10 +650,12 @@ Phase 2 is done when:
    descriptions, verified by side-by-side comparison against the two `.dc.html` mockups for
    every state enumerated above (empty list, filtered-empty, selected/unselected card,
    locked/unlocked detail, each of the 4 stepper states, search, each status filter chip).
-2. Every item in the "Cross-reference summary" table above marked **Flag** has an explicit,
-   recorded resolution (not a silent drop) before this phase is considered closed — i.e. the
-   COO/Ryan decision for each of C1-C13 is captured (in the BRD, an ADL, or the tracker,
-   whichever is the right home per `CLAUDE.md`'s document-lifecycle rule) prior to sign-off.
+2. Every item in the "Cross-reference summary" table above has its recorded resolution
+   honored in the implementation (not a silent drop) — all C1-C13 decisions plus the
+   adjacent flagged items (Confirmed/Completed hue, font loading, TR-12, mobile Edit/Photos,
+   mobile no-horizontal-scroll) are captured in this document and in the BRD (v3.4 §5.16)
+   per `CLAUDE.md`'s document-lifecycle rule. This gate is now satisfied at the spec level —
+   what remains is implementation fidelity, verified by side-by-side comparison and UAT.
 3. All currently-shipped Trips-screen functionality with no mockup counterpart (bulk delete,
    undo, sort, map-filter badge, trip-level items, remove-place, per-place date editing,
    ratings, carried-forward tag, Unlock) is present and working in the reskinned UI — a
@@ -596,7 +669,14 @@ Phase 2 is done when:
    per project memory notes this as known scoping debt) is required, not assumed free from
    the desktop pass.
 5. No `dangerouslySetInnerHTML` was introduced anywhere in the implementation (C8).
-6. `npm run test:frontend`, `npm run test:backend` (unaffected, but must still pass),
+6. **No horizontal scrolling exists anywhere on the mobile Trips screen except the status
+   filter chip row.** Verified at the 390px reference viewport (and at minimum one narrower
+   real-device width, e.g. 360px) across every mobile state in criterion 1: trip cards,
+   place-name/category chip rows, and item rows all wrap or truncate under real data
+   (long trip names, many categories, long item labels) rather than forcing a sideways
+   scroll — a data condition the static mockup's fixed example strings don't exercise, so
+   this must be checked against real/varied data, not just the mockup's own content.
+7. `npm run test:frontend`, `npm run test:backend` (unaffected, but must still pass),
    `npm run type:check:all`, and `npm run check` all pass; CI green on the implementing PR(s).
-7. UAT sign-off (mandatory per `CLAUDE.md`) against both desktop and mobile, at minimum
+8. UAT sign-off (mandatory per `CLAUDE.md`) against both desktop and mobile, at minimum
    covering every row of the cross-reference table above.


### PR DESCRIPTION
## Summary
- Stamps the 2026-07-21 COO/PO resolutions for all 13 flagged conflicts (C1-C13) plus the adjacent flagged items (Confirmed/Completed badge hue, font loading, TR-12) into `jobs/ux/tech/20260721-UX-waypoint-spec.md`, replacing "open, needs COO/PO call" language with inline stamps referencing BRD v3.4 §5.16 WP-01/WP-03/WP-04/WP-05.
- Makes the one remaining UX-owned judgment call: the mobile trip-detail Edit/Photos entry point is resolved as a **compact icon pair** (not the overflow "⋯" menu currently recorded in BRD WP-04) — reasoning recorded inline in the spec's Mobile "Detail view" section. This supersedes BRD WP-04's overflow-menu wording; flagged explicitly for COO to reconcile in a separate BRD pass, not done here.
- Adds a new pencil/edit SVG icon spec (§3) to support the compact icon pair, since neither source mockup has a mobile Edit affordance at all.
- Adds a new constraint — no horizontal scrolling anywhere on the mobile Trips screen except the status filter chip row — to the Mobile layout section and as a new, explicitly measurable Phase 2 success criterion.
- Updates the cross-reference summary table (all "Flag" verdicts → "Resolved" with concrete outcomes) and renumbers Phase 2 success criteria (1-8).
- Updates `jobs/ux/context/current.txt` and appends a second-thread section to `jobs/ux/park-docs/20260721-UX-park.txt` per the standard UX end-of-thread workflow.

Docs/spec only — no source code or BRD/tracker.json changes (COO is handling BRD/tracker updates separately, in parallel, per the dispatching brief).

Closes the C1-C13 gate — Phase 2 (WP-03 desktop reskin / WP-04 mobile responsive layout) is now unblocked for Frontend dispatch.

BRD §5.16 WP-01/WP-03/WP-04/WP-05

## Test plan
- [x] `npm run check` (Biome) — pass
- [x] `npm run type:check:all` — pass
- [x] `npm run test:backend` — 532 passed, 1 skipped
- [x] `npm run test:frontend` — 153 passed
- [x] `npm run status:check` — STATUS.md up to date
- [x] Docs-only diff verified via `git diff --stat` — only the three `jobs/ux/*` files touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)