### PR TITLE
fix(BUG-39): items.carriedFromItemId FK gets onDelete: set null (#209)

### DIFF
--- a/jobs/COO/inbox/20260721_2140-DATABASE-bug39-carry-forward-fk-ondelete-complete.txt
+++ b/jobs/COO/inbox/20260721_2140-DATABASE-bug39-carry-forward-fk-ondelete-complete.txt
@@ -1,4 +1,5 @@
-BUG-39 · ADL-36 · GitHub #209 · Branch fix/bug39-carry-forward-fk-ondelete
+BUG-39 · ADL-36 · GitHub #209 · PR #214 · Branch fix/bug39-carry-forward-fk-ondelete
+https://github.com/ryanv11/travel-tracker/pull/214
 
 Implemented ADL-36's ruling: items.carriedFromItemId FK changed to
 onDelete: 'set null' (schema.ts), migration 0011_majestic_nehzno.sql
@@ -31,10 +32,12 @@ Migration verified: db:generate + db:migrate ran clean against a fresh
 local DB (all 12 migrations 0000-0011); re-run of db:generate afterward
 reports "No schema changes" — no drift. Never used db:push (ADL-15).
 
-CI: pushed and PR opened; `gh pr checks` green — see below for run confirmation
-once available. Full local pre-push suite green before push: check,
-type:check:all, test:backend (533 pass/1 skip), test:frontend (154 pass),
-status:check.
+CI: PR #214 — `gh pr checks 214` confirmed all 9 checks green (Backend Tests,
+Frontend Tests, Contract Tests, E2E Tests, Type Check, Biome, Dependency
+Vulnerability Scan, Secret Scanning, Static Analysis) across both commits
+(implementation + park/context). Full local pre-push suite also green before
+push: check, type:check:all, test:backend (533 pass/1 skip), test:frontend
+(154 pass), status:check.
 
 Housekeeping done in this thread (flagging for your awareness, not asking
 for action beyond tracker.json):
@@ -50,10 +53,10 @@ for action beyond tracker.json):
 
 Open issues or blockers: none.
 
-What is now unblocked: BUG-39/#209 ready for your PR review/merge. Once
-merged and main's CI is green, tracker.json BUG-39 can flip to resolved
-(left untouched here — COO-maintained). QA can independently verify
-post-merge. No follow-up Database thread anticipated — ADL-36's FK audit
-already confirmed BUG-39 is an isolated instance, not a pattern.
+What is now unblocked: PR #214 ready for your review/merge (not merged by
+me). Once merged and main's CI is green, tracker.json BUG-39 can flip to
+resolved (left untouched here — COO-maintained). QA can independently
+verify post-merge. No follow-up Database thread anticipated — ADL-36's FK
+audit already confirmed BUG-39 is an isolated instance, not a pattern.
 
 Full detail: jobs/database/park-docs/20260721-DATABASE-park-bug39.txt

--- a/jobs/COO/inbox/20260721_2140-DATABASE-bug39-carry-forward-fk-ondelete-complete.txt
+++ b/jobs/COO/inbox/20260721_2140-DATABASE-bug39-carry-forward-fk-ondelete-complete.txt
@@ -1,0 +1,59 @@
+BUG-39 · ADL-36 · GitHub #209 · Branch fix/bug39-carry-forward-fk-ondelete
+
+Implemented ADL-36's ruling: items.carriedFromItemId FK changed to
+onDelete: 'set null' (schema.ts), migration 0011_majestic_nehzno.sql
+generated/applied, schema.ts doc comment updated, regression test added.
+Implementation only — Architect already reviewed and decided (ADL-36).
+
+Acceptance criteria (per ADL-36's "Implications for Database"):
+  FK clause changed to onDelete: 'set null'                          PASS
+  Generated via db:generate + applied via db:migrate (never db:push)  PASS
+  Generated SQL eyeballed — self-FK re-declared ON DELETE SET NULL    PASS
+  Generated SQL eyeballed — partial index idx_items_carried intact    PASS
+  Generated SQL eyeballed — all 3 chk_items_* CHECK constraints
+    intact, untruncated (no bug-2-style paren truncation)             PASS
+  Generated SQL eyeballed — INSERT...SELECT preserves all columns,
+    existing carry-forward row data survives the table recreation     PASS
+  schema.ts doc comment: is_carried_forward=1 + carried_from_item_id
+    IS NULL documented as legitimate post-deletion state, not
+    corruption to "fix" later                                         PASS
+  Regression test (BUG-39 close criterion): DELETE /api/trips/:id
+    returns 204 (was 500) when a trip's item is a carry-forward
+    source elsewhere; derived item survives with carried_from_item_id
+    NULL and is_carried_forward unchanged (1)                         PASS
+    (self-verified: test fails with the pre-fix 500 when the FK
+    clause is temporarily reverted — confirmed it's a real regression
+    guard, not a tautology)
+  No backend/frontend code change required                            PASS
+    (confirmed per ADL-36's analysis; none made)
+
+Migration verified: db:generate + db:migrate ran clean against a fresh
+local DB (all 12 migrations 0000-0011); re-run of db:generate afterward
+reports "No schema changes" — no drift. Never used db:push (ADL-15).
+
+CI: pushed and PR opened; `gh pr checks` green — see below for run confirmation
+once available. Full local pre-push suite green before push: check,
+type:check:all, test:backend (533 pass/1 skip), test:frontend (154 pass),
+status:check.
+
+Housekeeping done in this thread (flagging for your awareness, not asking
+for action beyond tracker.json):
+  - ADL-36's status line flipped PENDING -> Implemented in
+    jobs/architect/tech/20260307-architecture-decisions-log.md (Document
+    Lifecycle same-PR-update rule) — decision/rationale text untouched.
+  - Found the trips.delete.test.ts in-memory test DDL had its own
+    hand-rolled items table with no onDelete on carried_from_item_id
+    (separate from schema.ts/migrations) — updated to match, otherwise
+    the new regression test wouldn't have exercised the real fix.
+    Flagging as a general risk in that file's approach (hand-rolled DDL
+    can silently drift from schema.ts) for whoever next touches it.
+
+Open issues or blockers: none.
+
+What is now unblocked: BUG-39/#209 ready for your PR review/merge. Once
+merged and main's CI is green, tracker.json BUG-39 can flip to resolved
+(left untouched here — COO-maintained). QA can independently verify
+post-merge. No follow-up Database thread anticipated — ADL-36's FK audit
+already confirmed BUG-39 is an isolated instance, not a pattern.
+
+Full detail: jobs/database/park-docs/20260721-DATABASE-park-bug39.txt

--- a/jobs/architect/tech/20260307-architecture-decisions-log.md
+++ b/jobs/architect/tech/20260307-architecture-decisions-log.md
@@ -2167,7 +2167,14 @@ ADL only changes *which branch the Production environment watches* and *what tri
 ## ADL-36 — `items.carriedFromItemId` FK gets `onDelete: 'set null'` (BUG-39)
 
 **Date:** 2026-07-21
-**Status:** Decided — implementation PENDING (Database owns the migration; this ADL is the spec)
+**Status:** Decided — **Implemented** (Database, 2026-07-21, branch
+`fix/bug39-carry-forward-fk-ondelete`, refs #209). `items.carriedFromItemId` FK now
+`onDelete: 'set null'`; migration `0011_majestic_nehzno.sql` applied (items table
+recreation — self-FK, partial index `idx_items_carried`, and all three
+`chk_items_*` CHECK constraints verified intact through the generated SQL).
+Regression test added to `trips.delete.test.ts` per this ADL's success criterion.
+No backend/frontend change required, confirmed. See
+`jobs/database/park-docs/20260721-DATABASE-park-bug39.txt` for full detail.
 
 **Trigger:** BUG-39 / GitHub #209, discovered 2026-07-21 by the WP-03/WP-04 Frontend brief
 (PR #208) while writing E2E coverage for the carried-forward tag. `items.carriedFromItemId`

--- a/jobs/database/context/current.txt
+++ b/jobs/database/context/current.txt
@@ -1,10 +1,12 @@
 DATABASE CONTEXT — 2026-07-21
 PROJECT: Travel Tracker
-CURRENT STATUS: BRD-NF09 (ADL-32 hosted deployment) Database implication delivered
-on chore/nf09-staging-seed-strategy — staging Turso seed/reset strategy. See
-"THREAD — BRD-NF09 staging seed/reset strategy" at the end of this file for the
-active/most-recent thread. Everything below this point (2026-07-20 and earlier)
-is prior-thread history, preserved as-is.
+CURRENT STATUS: BUG-39 (ADL-36) fix implemented on
+fix/bug39-carry-forward-fk-ondelete — items.carriedFromItemId FK now
+onDelete: 'set null', migration 0011 applied, regression test added. See
+"THREAD — BUG-39 / ADL-36 carry-forward FK onDelete fix" at the end of this
+file for the active/most-recent thread. Everything above that section
+(including the BRD-NF09 thread, 2026-07-20 and earlier) is prior-thread
+history, preserved as-is.
 
 ================================================================================
 PRIOR STATUS LINE (2026-07-20, preserved for history)
@@ -242,3 +244,97 @@ NEXT DATABASE THREAD:
   If that surfaces anything the file:-URL simulation in this thread couldn't
   catch (should be nothing, given the shared @libsql/client code path, but
   flagging honestly), it comes back to Database.
+
+================================================================================
+THREAD — BUG-39 / ADL-36 carry-forward FK onDelete fix (2026-07-21) — branch
+fix/bug39-carry-forward-fk-ondelete
+================================================================================
+
+Bug (GitHub #209): items.carriedFromItemId, a self-referencing FK
+(`.references((): AnySQLiteColumn => items.id)`), had no onDelete clause.
+@libsql/client enforces FKs by default (BUG-38), so the omission defaulted
+to RESTRICT: DELETE /api/trips/:id (and direct item delete) 500'd whenever
+one of the trip's items had ever been used as a carry-forward source for an
+item on ANY other trip. Found by the WP-03/WP-04 Frontend brief (PR #208)
+writing E2E coverage for the carried-forward tag; dispatched to Architect
+for review before implementation per the schema-change-review rule.
+
+Architect ruling: ADL-36 (jobs/architect/tech/20260307-architecture-
+decisions-log.md) — onDelete: 'set null', not cascade (would destroy an
+independent item on a different trip) or explicit restrict (the bug
+itself). Full FK audit in the ADL confirmed BUG-39 is an isolated instance,
+not a pattern — no other schema FK has the same "hard-deletable parent +
+no onDelete + no app-level handling" shape.
+
+Delivered (this thread, implementation only — Architect already decided):
+  1. src/backend/db/schema.ts (~L432) — carriedFromItemId FK:
+     .references((): AnySQLiteColumn => items.id, { onDelete: 'set null' }).
+  2. src/backend/migrations/0011_majestic_nehzno.sql — generated via
+     db:generate (never db:push, ADL-15). SQLite can't alter a constraint
+     in place, so drizzle-kit emitted the items table-recreation path
+     (new table + copy + drop + rename + index rebuild) — exactly the path
+     the committed drizzle-kit@0.31.9 patch guards. Eyeballed the SQL
+     before applying:
+       - self-referencing FK re-declared `ON DELETE set null`     PASS
+       - partial index idx_items_carried (WHERE carried_from_item_id
+         IS NOT NULL) present as a single, untruncated statement    PASS
+       - all three chk_items_* CHECK constraints present, full
+         IN (...) lists intact (no bug-2-style truncation)          PASS
+       - INSERT...SELECT carries all 11 columns incl. is_carried_forward
+         and carried_from_item_id through the copy                  PASS
+     Applied via db:migrate against a fresh local file: DB (this worktree
+     had no dev.db or .env.local of its own — both are gitignored and not
+     worktree-shared; recreated .env.local locally from the values in the
+     main checkout's, pointing at file:./dev.db). Re-ran db:generate
+     afterward — "No schema changes, nothing to migrate" confirms no drift
+     between schema.ts and the applied DB state. Journal/snapshot chain
+     confirmed correct (idx 11, prevId chains from idx 10).
+  3. schema.ts doc comments (~L412-415 table-level, ~L430-432 column-level)
+     updated to record that carried_from_item_id is a
+     nullable-after-source-deletion provenance pointer, and that
+     is_carried_forward = 1 AND carried_from_item_id IS NULL is a
+     LEGITIMATE, INTENTIONAL post-deletion state (ADL-13's coupling is a
+     create-time invariant only) — explicit warning against a future
+     runtime consistency check or backfill "fixing" this.
+  4. Regression test added to
+     src/backend/routes/__tests__/trips.delete.test.ts (new describe
+     block 2f): seeds a source trip+item and an unrelated destination
+     trip+derived-item (carried_from_item_id -> source item,
+     is_carried_forward=1), deletes the source trip via the route,
+     asserts 204 (not 500), and asserts the derived item survives with
+     carried_from_item_id NULL and is_carried_forward still 1. This test
+     file's in-memory DDL is hand-rolled (not generated from schema.ts) —
+     had no onDelete on its own copy of the items FK, so it was updated
+     to match (`ON DELETE SET NULL`) as part of this change; otherwise the
+     new test wouldn't exercise the fix at all. Verified the test fails
+     with a 500 (matching the original bug) when temporarily reverted to
+     no onDelete clause, then restored — confirms the test is a genuine
+     regression guard, not a tautology.
+  5. No backend/frontend code change — confirmed per ADL-36's analysis
+     (UpdateItemSchema doesn't expose these fields, frontend tag reads
+     the boolean not the FK, no read path assumes non-null). Full
+     pre-push suite run clean: check, type:check:all, test:backend (533
+     pass/1 skip, +1 vs prior thread), test:frontend (154 pass),
+     status:check.
+  6. jobs/architect/tech/20260307-architecture-decisions-log.md — ADL-36's
+     status line flipped from "implementation PENDING" to "Implemented"
+     (branch, migration, verification pointer), per the Document Lifecycle
+     same-PR-update rule; decision/rationale text untouched.
+  7. jobs/database/tech/ mirror updated: schema.ts (full copy, current)
+     and 0011_majestic_nehzno.sql added. Did NOT backfill the rest of the
+     mirror's pre-existing 4-month drift (0001-0008 missing) — out of this
+     thread's scope, same judgment call as prior threads.
+
+NOT touched: tracker.json (BUG-39 status is COO's call — flagged for COO
+in the completion report), any backend route or frontend component.
+
+VERIFICATION: db:generate + db:migrate clean (fresh DB, all 12 migrations
+0000-0011), re-generate confirms no drift, type:check:all clean, test:backend
+533 pass/1 skip, test:frontend 154 pass, npm run check clean, status:check
+clean. Full pre-push suite green before push.
+
+NEXT DATABASE THREAD:
+  None pending from this thread. COO to flip BUG-39 to resolved/closed in
+  tracker.json once PR merges and CI on main is green (tracker.json is
+  COO-maintained, not touched here). No follow-up bug tracker entry per
+  ADL-36's FK audit conclusion (BUG-39 confirmed isolated).

--- a/jobs/database/park-docs/20260721-DATABASE-park-bug39.txt
+++ b/jobs/database/park-docs/20260721-DATABASE-park-bug39.txt
@@ -199,13 +199,22 @@ frontend file, .env.local / dev.db (gitignored, worktree-local only,
 recreated here for local verification but never committed).
 
 ================================================================================
+CI
+================================================================================
+PR #214 (https://github.com/ryanv11/travel-tracker/pull/214). All 9 checks
+green via `gh pr checks 214`: Backend Tests, Frontend Tests, Contract Tests,
+E2E Tests, Type Check, Biome (lint + format), Dependency Vulnerability Scan,
+Secret Scanning (Gitleaks), Static Analysis (Semgrep). Confirmed across both
+commits (implementation + park/context housekeeping).
+
+================================================================================
 WHAT'S NOW UNBLOCKED
 ================================================================================
-  - BUG-39 / GitHub #209 is implementation-complete pending PR review/merge
-    and CI. QA can independently verify against the merged PR once it
-    lands (a 500 on DELETE /api/trips/:id for a trip with a carried-forward-
-    sourced item is directly reproducible pre-fix and should no longer
-    occur post-fix).
+  - BUG-39 / GitHub #209 is implementation-complete, PR #214 open with CI
+    green, pending COO review/merge. QA can independently verify against
+    the merged PR once it lands (a 500 on DELETE /api/trips/:id for a trip
+    with a carried-forward-sourced item is directly reproducible pre-fix
+    and should no longer occur post-fix).
   - COO can flip tracker.json BUG-39 to resolved and close the WP-03/WP-04
     discovery loop (BUG-39 was raised out of that Frontend brief, PR #208)
     once this PR merges and main's CI is green.

--- a/jobs/database/park-docs/20260721-DATABASE-park-bug39.txt
+++ b/jobs/database/park-docs/20260721-DATABASE-park-bug39.txt
@@ -1,0 +1,213 @@
+DATABASE PARK DOCUMENT — 2026-07-21 (BUG-39)
+PROJECT: Travel Tracker
+THREAD: BUG-39 / ADL-36 — items.carriedFromItemId FK onDelete fix
+BRANCH: fix/bug39-carry-forward-fk-ondelete
+
+NOTE ON FILENAME: a same-day park doc already exists for the BRD-NF09
+staging seed/reset thread (20260721-DATABASE-park.txt, dispatched separately
+in its own worktree). This file is suffixed -bug39 to avoid overwriting it —
+both are 2026-07-21 Database threads, run in isolated worktrees.
+
+================================================================================
+BRIEF
+================================================================================
+GitHub #209 / BUG-39: items.carriedFromItemId is a self-referencing FK
+(`.references((): AnySQLiteColumn => items.id)`, schema.ts ~L432) with no
+onDelete clause. @libsql/client enforces FKs by default (BUG-38), so the
+omitted clause defaults to RESTRICT — DELETE /api/trips/:id (and a direct
+item delete) 500'd whenever one of the trip's items had ever been used as a
+carry-forward source for an item on ANY other trip, independent of that
+trip's status.
+
+Architect already reviewed and ruled on this (ADL-36,
+jobs/architect/tech/20260307-architecture-decisions-log.md) before this
+thread started — my job was implementation only, per the brief and per the
+no-schema-change-without-Architect-review rule this role enforces.
+
+Decision (ADL-36): onDelete: 'set null'. Deleting the source item clears
+the derived item's provenance pointer; does NOT cascade-delete the derived
+item (a first-class item on another trip with its own user-edited
+status/notes/rating). cascade rejected (destroys unrelated user data);
+explicit restrict rejected (that's the bug itself).
+
+================================================================================
+IMPLEMENTATION
+================================================================================
+
+1. SCHEMA CHANGE — src/backend/db/schema.ts
+   carriedFromItemId FK changed from:
+     .references((): AnySQLiteColumn => items.id)
+   to:
+     .references((): AnySQLiteColumn => items.id, { onDelete: 'set null' })
+   Doc comments updated at both the table level (~L412-415) and column
+   level (~L430-432) to record that carried_from_item_id is a
+   nullable-after-source-deletion provenance pointer, and that
+   is_carried_forward = 1 AND carried_from_item_id IS NULL is a LEGITIMATE,
+   INTENTIONAL post-deletion state (ADL-13's create-time coupling does not
+   hold permanently) — explicit instruction against a future runtime
+   consistency check or backfill treating it as corruption.
+
+2. MIGRATION — src/backend/migrations/0011_majestic_nehzno.sql
+   Generated via `npm run db:generate` (never db:push, ADL-15). SQLite
+   cannot alter a constraint in place, so drizzle-kit emitted the items
+   table-recreation path (new table + copy + drop + rename + index
+   rebuild) — exactly the path the committed drizzle-kit@0.31.9 patch
+   guards against (duplicate CREATE INDEX, CHECK-constraint truncation,
+   partial-index WHERE clause loss).
+
+   Eyeballed the generated SQL before applying — all four survival checks:
+     a. Self-referencing FK re-declared with ON DELETE SET NULL:
+        `FOREIGN KEY ("carried_from_item_id") REFERENCES "items"("id")
+         ON UPDATE no action ON DELETE set null`                    PASS
+     b. Partial index idx_items_carried survives intact, single
+        statement, WHERE clause present:
+        `CREATE INDEX "idx_items_carried" ON "items"
+         ("carried_from_item_id") WHERE "items"."carried_from_item_id"
+         IS NOT NULL;`                                               PASS
+     c. All three chk_items_* CHECK constraints present, full IN (...)
+        lists untruncated (chk_items_item_type's 6-value list,
+        chk_items_status's 5-value list, chk_items_is_carried_forward's
+        IN (0, 1) — none clipped at the first closing paren, which is
+        exactly bug 2 in the drizzle-kit patch)                      PASS
+     d. INSERT INTO __new_items ... SELECT carries all 11 columns,
+        including is_carried_forward and carried_from_item_id, through
+        the copy — existing carry-forward rows keep their data         PASS
+   Total CREATE INDEX count in the migration: 6 (matches schema's 6
+   indexes on items) — no duplicate-CREATE-INDEX artifact (patch bug 1).
+
+   Applied via `npm run db:migrate` against a fresh local SQLite DB (this
+   worktree had neither dev.db nor .env.local of its own — both are
+   gitignored and not shared/symlinked across worktrees in this repo's
+   setup; recreated .env.local locally, values copied from the main
+   checkout's, SQLITE_PATH=file:./dev.db). All 12 migrations (0000-0011)
+   applied clean on a from-scratch database. Re-ran `db:generate`
+   afterward: "No schema changes, nothing to migrate" — confirms schema.ts
+   and the applied DB state match exactly, no drift. Inspected the
+   resulting on-disk `items` CREATE TABLE and index SQL directly via
+   @libsql/client — byte-for-byte matches what the migration file
+   declared. Journal/snapshot chain confirmed correct: idx 11, tag
+   0011_majestic_nehzno, chains from idx 10 (0010_bug33_add_unique_index)
+   with no renumbering needed (no concurrent migration collision this
+   time, unlike the BUG-30/BUG-33 renumbering thread on 2026-07-20).
+
+3. REGRESSION TEST — src/backend/routes/__tests__/trips.delete.test.ts
+   New test in a new "2f. BUG-39 / ADL-36 regression" section:
+     - Seeds a source trip + source item (to be deleted).
+     - Seeds an unrelated destination trip + derived item with
+       carriedFromItemId = source item's id, isCarriedForward = 1.
+     - DELETE /api/trips/:sourceTripId -> asserts 204 (was 500 pre-fix).
+     - Asserts the source item is gone (cascade-deleted with its trip).
+     - Asserts the derived item survives on the destination trip, with
+       carriedFromItemId === null and isCarriedForward === 1 unchanged.
+
+   IMPORTANT FINDING: this test file's in-memory test DDL (used to build
+   an isolated :memory: SQLite instance per test, NOT generated from
+   schema.ts or the real migrations) had its OWN hand-rolled copy of the
+   items table with no onDelete on carried_from_item_id. Had to update
+   that DDL to `ON DELETE SET NULL` too, or the new test would exercise
+   the pre-fix behavior regardless of the real schema.ts change. Flagging
+   this because it's a general risk with this test file's approach
+   (hand-rolled DDL duplicating schema.ts by hand) — any future FK/column
+   change to items needs a matching manual update here, and nothing
+   currently guards against the two drifting apart silently. Not fixing
+   that structural issue in this thread (out of BUG-39's scope) — noting
+   it for whoever next touches this file or reviews test infra.
+
+   SELF-VERIFICATION: before finalizing, temporarily reverted the test
+   DDL's onDelete clause back to none (RESTRICT default) and re-ran the
+   suite — the new test failed with the expected 500
+   ("Failed query: delete from trips ... " surfaced through
+   repositories/trips.ts:196 -> routes/trips.ts:442), proving the test
+   actually catches the bug and isn't a tautology. Restored the fix
+   afterward; full suite green again (15/15 in this file).
+
+4. NO BACKEND/FRONTEND CHANGE — confirmed per ADL-36's own analysis
+   (UpdateItemSchema doesn't expose is_carried_forward/carried_from_item_id
+   so PATCH can't re-trigger the create-time coupling check against a
+   nulled row; frontend tag reads the boolean not the FK; no read path
+   assumes the FK non-null). Did not independently re-audit every backend
+   read path beyond what ADL-36 already covered — Architect's audit was
+   thorough and this thread's brief said to flag rather than silently
+   patch if anything broke. Nothing broke in test runs.
+
+5. ADL-36 STATUS LINE — jobs/architect/tech/20260307-architecture-
+   decisions-log.md: flipped "Status: Decided — implementation PENDING"
+   to "Status: Decided — Implemented" with branch/migration/verification
+   pointer, per the Document Lifecycle same-PR-update rule (this PR is
+   exactly what that PENDING marker was waiting on). Decision, options-
+   considered, and FK-audit sections left untouched — only the status
+   line and a pointer to this park doc were added.
+
+6. jobs/database/tech/ MIRROR — updated schema.ts (full current copy) and
+   added 0011_majestic_nehzno.sql. Did not backfill the mirror's
+   pre-existing gap (migrations 0001-0008 still missing from the mirror,
+   flagged by the prior BUG-30/33 thread as 4-month drift) — out of this
+   thread's scope, same judgment call as before.
+
+================================================================================
+ACCEPTANCE CRITERIA (per ADL-36's "Implications for Database")
+================================================================================
+  Schema FK changed to onDelete: 'set null'                          PASS
+  Migration generated via db:generate/db:migrate (never db:push)     PASS
+  Generated SQL eyeballed — FK clause survives                       PASS
+  Generated SQL eyeballed — partial index idx_items_carried survives PASS
+  Generated SQL eyeballed — all 3 chk_items_* CHECK constraints
+    survive, untruncated                                             PASS
+  Generated SQL eyeballed — existing row data preserved through copy PASS
+  schema.ts doc comment updated (legitimate post-deletion state)     PASS
+  Regression test: DELETE /api/trips/:id returns 204 (was 500)       PASS
+  Regression test: derived item survives, carried_from_item_id NULL,
+    is_carried_forward unchanged (1)                                 PASS
+  No backend/frontend code change required (confirmed, none made)    PASS
+  Full pre-push suite (check, type:check:all, test:backend,
+    test:frontend, status:check)                                     PASS
+
+================================================================================
+VERIFICATION
+================================================================================
+  npm run db:generate  -> 0011_majestic_nehzno.sql generated; re-run after
+                          applying -> "No schema changes, nothing to migrate"
+  npm run db:migrate   -> all 12 migrations (0000-0011) applied clean on a
+                          fresh database
+  npm run test:backend -> 533 pass / 1 skip (was 532/1 before this thread's
+                          new test)
+  npm run test:frontend -> 154 pass
+  npm run type:check:all -> clean
+  npm run check          -> clean (Biome)
+  npm run status:check   -> STATUS.md up to date, no change needed
+  Full pre-push suite run before push, all green.
+
+================================================================================
+FILES TOUCHED
+================================================================================
+  src/backend/db/schema.ts                          FK clause + doc comments
+  src/backend/migrations/0011_majestic_nehzno.sql   new migration
+  src/backend/migrations/meta/_journal.json         idx 11 entry
+  src/backend/migrations/meta/0011_snapshot.json    new snapshot
+  src/backend/routes/__tests__/trips.delete.test.ts regression test +
+                                                     matching DDL fix
+  jobs/architect/tech/20260307-architecture-decisions-log.md  ADL-36
+                                                     status line flip
+  jobs/database/tech/schema.ts                      mirror updated
+  jobs/database/tech/0011_majestic_nehzno.sql       mirror added
+  jobs/database/context/current.txt                 this thread appended
+  jobs/database/park-docs/20260721-DATABASE-park-bug39.txt  this file
+
+NOT touched: tracker.json (BUG-39 status is COO's call, per COO-maintained
+convention — flagged in the completion report), any route file, any
+frontend file, .env.local / dev.db (gitignored, worktree-local only,
+recreated here for local verification but never committed).
+
+================================================================================
+WHAT'S NOW UNBLOCKED
+================================================================================
+  - BUG-39 / GitHub #209 is implementation-complete pending PR review/merge
+    and CI. QA can independently verify against the merged PR once it
+    lands (a 500 on DELETE /api/trips/:id for a trip with a carried-forward-
+    sourced item is directly reproducible pre-fix and should no longer
+    occur post-fix).
+  - COO can flip tracker.json BUG-39 to resolved and close the WP-03/WP-04
+    discovery loop (BUG-39 was raised out of that Frontend brief, PR #208)
+    once this PR merges and main's CI is green.
+  - No follow-up Database thread anticipated — ADL-36's FK audit already
+    confirmed BUG-39 is an isolated instance, not a pattern.

--- a/jobs/database/tech/0011_majestic_nehzno.sql
+++ b/jobs/database/tech/0011_majestic_nehzno.sql
@@ -1,0 +1,32 @@
+PRAGMA foreign_keys=OFF;--> statement-breakpoint
+CREATE TABLE `__new_items` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`trip_id` integer NOT NULL,
+	`trip_place_id` integer,
+	`item_type` text NOT NULL,
+	`status` text DEFAULT 'consider' NOT NULL,
+	`notes` text,
+	`is_carried_forward` integer DEFAULT 0 NOT NULL,
+	`carried_from_item_id` integer,
+	`user_id` text NOT NULL,
+	`created_at` text DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')) NOT NULL,
+	`updated_at` text DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')) NOT NULL,
+	FOREIGN KEY (`trip_id`) REFERENCES `trips`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`trip_place_id`) REFERENCES `trip_places`(`id`) ON UPDATE no action ON DELETE no action,
+	FOREIGN KEY (`carried_from_item_id`) REFERENCES `items`(`id`) ON UPDATE no action ON DELETE set null,
+	FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE no action,
+	CONSTRAINT "chk_items_item_type" CHECK("__new_items"."item_type" IN ('restaurant', 'hotel', 'flight', 'car_rental', 'experience', 'note')),
+	CONSTRAINT "chk_items_status" CHECK("__new_items"."status" IN ('consider', 'confirmed', 'completed', 'cancelled', 'next_time')),
+	CONSTRAINT "chk_items_is_carried_forward" CHECK("__new_items"."is_carried_forward" IN (0, 1))
+);
+--> statement-breakpoint
+INSERT INTO `__new_items`("id", "trip_id", "trip_place_id", "item_type", "status", "notes", "is_carried_forward", "carried_from_item_id", "user_id", "created_at", "updated_at") SELECT "id", "trip_id", "trip_place_id", "item_type", "status", "notes", "is_carried_forward", "carried_from_item_id", "user_id", "created_at", "updated_at" FROM `items`;--> statement-breakpoint
+DROP TABLE `items`;--> statement-breakpoint
+ALTER TABLE `__new_items` RENAME TO `items`;--> statement-breakpoint
+PRAGMA foreign_keys=ON;--> statement-breakpoint
+CREATE INDEX `idx_items_trip` ON `items` (`trip_id`);--> statement-breakpoint
+CREATE INDEX `idx_items_trip_place` ON `items` (`trip_place_id`);--> statement-breakpoint
+CREATE INDEX `idx_items_type` ON `items` (`item_type`);--> statement-breakpoint
+CREATE INDEX `idx_items_status` ON `items` (`status`);--> statement-breakpoint
+CREATE INDEX `idx_items_carried` ON `items` (`carried_from_item_id`) WHERE "items"."carried_from_item_id" IS NOT NULL;--> statement-breakpoint
+CREATE INDEX `items_user_id_idx` ON `items` (`user_id`);

--- a/jobs/database/tech/schema.ts
+++ b/jobs/database/tech/schema.ts
@@ -12,21 +12,24 @@
  * column names and relationships are identical; only the table builder
  * and column type imports change.
  *
- * @see jobs/architect/tech/20260307-ER-schema.md (v1.1 — authoritative)
+ * @see jobs/architect/tech/20260307-ER-schema.md (v1.1 — original design, historical).
+ *      Schema evolution since v1.1 (users, trip_countries, is_owner, place dates,
+ *      user_id FKs) is recorded in the architecture-decisions-log (ADL-16/19/20/23/24/27).
+ *      This file — not the ER doc — is the authoritative current schema.
  */
 
+import { sql } from 'drizzle-orm';
 import {
+  type AnySQLiteColumn,
+  check,
+  index,
+  integer,
+  primaryKey,
+  real,
   sqliteTable,
   text,
-  integer,
-  real,
-  index,
   uniqueIndex,
-  primaryKey,
-  check,
-  AnySQLiteColumn,
 } from 'drizzle-orm/sqlite-core';
-import { sql } from 'drizzle-orm';
 
 // ============================================================
 // 1. GEOGRAPHIC HIERARCHY
@@ -50,19 +53,12 @@ export const countries = sqliteTable(
     regionTierEnabled: integer('region_tier_enabled').notNull().default(0),
     // Human-readable label for the region tier: 'State' | 'Province' | 'Territory' | NULL
     regionTierLabel: text('region_tier_label'),
-    createdAt: text('created_at')
-      .notNull()
-      .default(sql`(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))`),
-    updatedAt: text('updated_at')
-      .notNull()
-      .default(sql`(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))`),
+    createdAt: text('created_at').notNull().default(sql`(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))`),
+    updatedAt: text('updated_at').notNull().default(sql`(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))`),
   },
   (t) => [
     // region_tier_label must be NULL when region_tier_enabled = 0 — enforced by BACKEND
-    check(
-      'chk_countries_region_tier_enabled',
-      sql`${t.regionTierEnabled} IN (0, 1)`,
-    ),
+    check('chk_countries_region_tier_enabled', sql`${t.regionTierEnabled} IN (0, 1)`),
   ],
 );
 
@@ -78,14 +74,14 @@ export const regions = sqliteTable(
       .notNull()
       .references(() => countries.countryCode),
     name: text('name').notNull(), // e.g. 'California', 'New South Wales'
-    createdAt: text('created_at')
-      .notNull()
-      .default(sql`(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))`),
-    updatedAt: text('updated_at')
-      .notNull()
-      .default(sql`(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))`),
+    iso3166_2: text('iso_3166_2').notNull(),
+    createdAt: text('created_at').notNull().default(sql`(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))`),
+    updatedAt: text('updated_at').notNull().default(sql`(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))`),
   },
-  (t) => [index('idx_regions_country').on(t.countryCode)],
+  (t) => [
+    index('idx_regions_country').on(t.countryCode),
+    uniqueIndex('uniq_regions_iso_3166_2').on(t.iso3166_2),
+  ],
 );
 
 /**
@@ -104,29 +100,30 @@ export const cities = sqliteTable(
     // NULL for cities in countries where region_tier_enabled = 0
     regionId: integer('region_id').references(() => regions.id),
     name: text('name').notNull(),
-    latitude: real('latitude'),  // NULL while geocode_status = 'pending'
+    latitude: real('latitude'), // NULL while geocode_status = 'pending'
     longitude: real('longitude'), // NULL while geocode_status = 'pending'
     // 'pending' = awaiting Nominatim resolution; 'resolved' = coordinates confirmed
     geocodeStatus: text('geocode_status').notNull().default('pending'),
     geocodeAttemptedAt: text('geocode_attempted_at'), // ISO 8601 timestamp of last attempt
-    createdAt: text('created_at')
-      .notNull()
-      .default(sql`(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))`),
-    updatedAt: text('updated_at')
-      .notNull()
-      .default(sql`(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))`),
+    createdAt: text('created_at').notNull().default(sql`(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))`),
+    updatedAt: text('updated_at').notNull().default(sql`(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))`),
   },
   (t) => [
     index('idx_cities_country').on(t.countryCode),
     index('idx_cities_region').on(t.regionId),
     // Partial index — only indexes pending cities, making the geocoding queue scan efficient
-    index('idx_cities_geocode')
-      .on(t.geocodeStatus)
-      .where(sql`${t.geocodeStatus} = 'pending'`),
-    check(
-      'chk_cities_geocode_status',
-      sql`${t.geocodeStatus} IN ('pending', 'resolved')`,
-    ),
+    index('idx_cities_geocode').on(t.geocodeStatus).where(sql`${t.geocodeStatus} = 'pending'`),
+    check('chk_cities_geocode_status', sql`${t.geocodeStatus} IN ('pending', 'resolved')`),
+    // BUG-33 (#157): prevents duplicate city rows for the same (name, country_code) —
+    // find-or-create logic was creating a new row instead of reusing the existing one
+    // (e.g. "Glasgow" appeared twice in the place autocomplete). COLLATE NOCASE is
+    // SQLite's built-in ASCII-only case fold (A-Z/a-z) — it resolves the real-world
+    // "Glasgow"/"glasgow" case but does not fold non-ASCII/diacritic variants; that
+    // is an accepted, documented limitation, not a silent gap (Architect-reviewed
+    // 2026-07-20). Backend's find-or-create lookup must match this collation (its own
+    // WHERE clause needs to be case-insensitive too) or it will fail to find the
+    // canonical row and attempt an insert that now throws instead of reusing it.
+    uniqueIndex('uniq_cities_name_country_ci').on(sql`${t.name} COLLATE NOCASE`, t.countryCode),
   ],
 );
 
@@ -147,16 +144,10 @@ export const tripCategories = sqliteTable(
     id: integer('id').primaryKey({ autoIncrement: true }),
     name: text('name').notNull().unique(),
     isActive: integer('is_active').notNull().default(1),
-    createdAt: text('created_at')
-      .notNull()
-      .default(sql`(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))`),
-    updatedAt: text('updated_at')
-      .notNull()
-      .default(sql`(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))`),
+    createdAt: text('created_at').notNull().default(sql`(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))`),
+    updatedAt: text('updated_at').notNull().default(sql`(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))`),
   },
-  (t) => [
-    check('chk_trip_categories_is_active', sql`${t.isActive} IN (0, 1)`),
-  ],
+  (t) => [check('chk_trip_categories_is_active', sql`${t.isActive} IN (0, 1)`)],
 );
 
 /**
@@ -169,12 +160,8 @@ export const activities = sqliteTable(
     id: integer('id').primaryKey({ autoIncrement: true }),
     name: text('name').notNull().unique(),
     isActive: integer('is_active').notNull().default(1),
-    createdAt: text('created_at')
-      .notNull()
-      .default(sql`(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))`),
-    updatedAt: text('updated_at')
-      .notNull()
-      .default(sql`(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))`),
+    createdAt: text('created_at').notNull().default(sql`(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))`),
+    updatedAt: text('updated_at').notNull().default(sql`(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))`),
   },
   (t) => [check('chk_activities_is_active', sql`${t.isActive} IN (0, 1)`)],
 );
@@ -188,12 +175,8 @@ export const companions = sqliteTable(
     id: integer('id').primaryKey({ autoIncrement: true }),
     name: text('name').notNull().unique(),
     isActive: integer('is_active').notNull().default(1),
-    createdAt: text('created_at')
-      .notNull()
-      .default(sql`(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))`),
-    updatedAt: text('updated_at')
-      .notNull()
-      .default(sql`(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))`),
+    createdAt: text('created_at').notNull().default(sql`(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))`),
+    updatedAt: text('updated_at').notNull().default(sql`(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))`),
   },
   (t) => [check('chk_companions_is_active', sql`${t.isActive} IN (0, 1)`)],
 );
@@ -212,9 +195,7 @@ export const mapShadingConfig = sqliteTable(
     stateKey: text('state_key').primaryKey(),
     displayName: text('display_name').notNull(),
     colorHex: text('color_hex').notNull(), // e.g. '#2196F3' — validated by FRONTEND
-    updatedAt: text('updated_at')
-      .notNull()
-      .default(sql`(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))`),
+    updatedAt: text('updated_at').notNull().default(sql`(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))`),
   },
   (t) => [
     check(
@@ -241,21 +222,21 @@ export const trips = sqliteTable(
     id: integer('id').primaryKey({ autoIncrement: true }),
     name: text('name').notNull(),
     startDate: text('start_date').notNull(), // ISO 8601 date: 'YYYY-MM-DD'
-    endDate: text('end_date').notNull(),     // ISO 8601 date: 'YYYY-MM-DD'
+    endDate: text('end_date').notNull(), // ISO 8601 date: 'YYYY-MM-DD'
     // Status progression: planning → active → review_pending → locked
     status: text('status').notNull().default('planning'),
     photoAlbumRef: text('photo_album_ref'), // URL or folder path — no file stored (PH-01)
-    createdAt: text('created_at')
+    userId: text('user_id')
       .notNull()
-      .default(sql`(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))`),
-    updatedAt: text('updated_at')
-      .notNull()
-      .default(sql`(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))`),
+      .references(() => users.id), // HC-07c: NOT NULL enforced at DB level
+    createdAt: text('created_at').notNull().default(sql`(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))`),
+    updatedAt: text('updated_at').notNull().default(sql`(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))`),
   },
   (t) => [
     index('idx_trips_status').on(t.status),
     index('idx_trips_start_date').on(t.startDate),
     index('idx_trips_end_date').on(t.endDate),
+    index('trips_user_id_idx').on(t.userId),
     check(
       'chk_trips_status',
       sql`${t.status} IN ('planning', 'active', 'review_pending', 'locked')`,
@@ -346,12 +327,13 @@ export const tripPlaces = sqliteTable(
     cityId: integer('city_id')
       .notNull()
       .references(() => cities.id),
-    createdAt: text('created_at')
+    userId: text('user_id')
       .notNull()
-      .default(sql`(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))`),
-    updatedAt: text('updated_at')
-      .notNull()
-      .default(sql`(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))`),
+      .references(() => users.id), // HC-07c: NOT NULL enforced at DB level
+    arrivedOn: text('arrived_on'), // nullable, no default (ADL-24)
+    departedOn: text('departed_on'), // nullable, no default (ADL-24)
+    createdAt: text('created_at').notNull().default(sql`(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))`),
+    updatedAt: text('updated_at').notNull().default(sql`(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))`),
   },
   (t) => [
     // A trip visits each city at most once
@@ -359,6 +341,7 @@ export const tripPlaces = sqliteTable(
     index('idx_trip_places_trip').on(t.tripId),
     // Critical for cross-trip queries joining on city_id (IT-07, IT-09)
     index('idx_trip_places_city').on(t.cityId),
+    index('trip_places_user_id_idx').on(t.userId),
   ],
 );
 
@@ -381,6 +364,30 @@ export const tripPlaceActivitiesMap = sqliteTable(
   (t) => [primaryKey({ columns: [t.tripPlaceId, t.activityId] })],
 );
 
+/**
+ * Trip ↔ Country junction — tracks which countries a trip visits (ADL-23).
+ * Derived from trip_places via city → country_code, but stored explicitly for
+ * efficient map shading queries without repeated aggregation joins.
+ * Cascade delete: removing a trip removes its country associations.
+ * RESTRICT on country: a country record must exist before it can be linked.
+ */
+export const tripCountries = sqliteTable(
+  'trip_countries',
+  {
+    tripId: integer('trip_id')
+      .notNull()
+      .references(() => trips.id, { onDelete: 'cascade' }),
+    countryCode: text('country_code')
+      .notNull()
+      .references(() => countries.countryCode, { onDelete: 'restrict' }),
+    createdAt: text('created_at').notNull().default(sql`(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))`),
+  },
+  (t) => ({
+    pk: primaryKey({ columns: [t.tripId, t.countryCode] }),
+    countryIdx: index('idx_trip_countries_country').on(t.countryCode),
+  }),
+);
+
 // ============================================================
 // 5. ITEMS (BASE TABLE + EXTENSION TABLES)
 // ============================================================
@@ -397,11 +404,29 @@ export const tripPlaceActivitiesMap = sqliteTable(
  *
  * item_type determines which extension table (if any) holds additional fields.
  * trip_place_id is NULL for trip-level items (e.g. a flight attached to the trip,
- * not a specific city).
+ * not a specific city). This is also the target state when a place is deleted —
+ * BUG-32: placeRepository.delete reassigns trip_place_id to NULL for any items
+ * under the deleted place rather than cascade-deleting them (no onDelete is set
+ * on this FK deliberately — application code owns this reassignment).
  *
  * Carry-forward pattern (ADL-13, IT-07):
  *   is_carried_forward = 1 AND carried_from_item_id IS NOT NULL → carried item
- *   BACKEND must enforce these two fields are always set together.
+ *   BACKEND must enforce these two fields are always set together AT CREATE TIME.
+ *
+ *   This coupling is a CREATE-TIME invariant only, not a permanent one (ADL-36,
+ *   BUG-39). carried_from_item_id is a nullable-after-source-deletion provenance
+ *   pointer ("...from this specific source, while it still exists") — its FK has
+ *   onDelete: 'set null', so deleting the source item clears the pointer without
+ *   cascade-deleting the derived item (which is a first-class item on another
+ *   trip with its own user-edited status/notes/rating). is_carried_forward is a
+ *   permanent historical fact ("this item originated as a carry-forward") and is
+ *   NOT cleared when the source is deleted. Therefore
+ *   is_carried_forward = 1 AND carried_from_item_id IS NULL is a LEGITIMATE,
+ *   INTENTIONAL post-deletion state — it means "this item was carried forward,
+ *   but its source has since been deleted" — NOT data corruption. Do not add a
+ *   runtime consistency check or backfill that treats it as a bug; the redundant
+ *   boolean flag exists precisely so the historical fact survives loss of the
+ *   pointer.
  */
 export const items = sqliteTable(
   'items',
@@ -419,15 +444,19 @@ export const items = sqliteTable(
     isCarriedForward: integer('is_carried_forward').notNull().default(0),
     // Self-referential FK — preserves lineage to the source item (ADL-13)
     // Uses a lazy reference function to avoid circular dependency at module load time
-    carriedFromItemId: integer('carried_from_item_id').references(
-      (): AnySQLiteColumn => items.id,
-    ),
-    createdAt: text('created_at')
+    // onDelete: 'set null' (ADL-36, BUG-39) — deleting the source item must not
+    // RESTRICT-block a normal trip/item delete; it clears this pointer only, and
+    // never cascade-deletes the derived item on the other trip. See the table
+    // doc comment above for why is_carried_forward can legitimately survive as 1
+    // with this column NULL afterward.
+    carriedFromItemId: integer('carried_from_item_id').references((): AnySQLiteColumn => items.id, {
+      onDelete: 'set null',
+    }),
+    userId: text('user_id')
       .notNull()
-      .default(sql`(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))`),
-    updatedAt: text('updated_at')
-      .notNull()
-      .default(sql`(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))`),
+      .references(() => users.id), // HC-07c: NOT NULL enforced at DB level
+    createdAt: text('created_at').notNull().default(sql`(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))`),
+    updatedAt: text('updated_at').notNull().default(sql`(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))`),
   },
   (t) => [
     index('idx_items_trip').on(t.tripId),
@@ -438,6 +467,7 @@ export const items = sqliteTable(
     index('idx_items_carried')
       .on(t.carriedFromItemId)
       .where(sql`${t.carriedFromItemId} IS NOT NULL`),
+    index('items_user_id_idx').on(t.userId),
     check(
       'chk_items_item_type',
       sql`${t.itemType} IN ('restaurant', 'hotel', 'flight', 'car_rental', 'experience', 'note')`,
@@ -446,10 +476,7 @@ export const items = sqliteTable(
       'chk_items_status',
       sql`${t.status} IN ('consider', 'confirmed', 'completed', 'cancelled', 'next_time')`,
     ),
-    check(
-      'chk_items_is_carried_forward',
-      sql`${t.isCarriedForward} IN (0, 1)`,
-    ),
+    check('chk_items_is_carried_forward', sql`${t.isCarriedForward} IN (0, 1)`),
   ],
 );
 
@@ -466,9 +493,9 @@ export const itemFlights = sqliteTable('item_flights', {
   airline: text('airline'),
   flightNumber: text('flight_number'),
   departureAirport: text('departure_airport'), // IATA code preferred but not enforced
-  arrivalAirport: text('arrival_airport'),     // IATA code preferred but not enforced
+  arrivalAirport: text('arrival_airport'), // IATA code preferred but not enforced
   departureDatetime: text('departure_datetime'), // ISO 8601 datetime
-  arrivalDatetime: text('arrival_datetime'),     // ISO 8601 datetime
+  arrivalDatetime: text('arrival_datetime'), // ISO 8601 datetime
   bookingReference: text('booking_reference'),
   seat: text('seat'),
 });
@@ -487,20 +514,17 @@ export const itemHotels = sqliteTable(
       .references(() => items.id, { onDelete: 'cascade' }),
     propertyName: text('property_name'),
     address: text('address'),
-    checkInDate: text('check_in_date'),   // ISO 8601 date
+    checkInDate: text('check_in_date'), // ISO 8601 date
     checkOutDate: text('check_out_date'), // ISO 8601 date
     bookingReference: text('booking_reference'),
     confirmationNumber: text('confirmation_number'),
-    rating: integer('rating'),            // NULL = unrated (HT-04)
+    rating: integer('rating'), // NULL = unrated (HT-04)
     postVisitNotes: text('post_visit_notes'), // NULL until reviewed (HT-04)
   },
   (t) => [
     // Index on rating for sort/filter queries (IT-08, IT-09)
     index('idx_item_hotels_rating').on(t.rating),
-    check(
-      'chk_item_hotels_rating',
-      sql`${t.rating} IS NULL OR (${t.rating} BETWEEN 1 AND 5)`,
-    ),
+    check('chk_item_hotels_rating', sql`${t.rating} IS NULL OR (${t.rating} BETWEEN 1 AND 5)`),
   ],
 );
 
@@ -515,7 +539,7 @@ export const itemCarRentals = sqliteTable('item_car_rentals', {
   provider: text('provider'),
   pickupLocation: text('pickup_location'),
   dropoffLocation: text('dropoff_location'),
-  pickupDatetime: text('pickup_datetime'),   // ISO 8601 datetime
+  pickupDatetime: text('pickup_datetime'), // ISO 8601 datetime
   dropoffDatetime: text('dropoff_datetime'), // ISO 8601 datetime
   bookingReference: text('booking_reference'),
   vehicleClass: text('vehicle_class'),
@@ -536,16 +560,13 @@ export const itemRestaurants = sqliteTable(
     name: text('name'),
     neighbourhoodArea: text('neighbourhood_area'),
     cuisineType: text('cuisine_type'),
-    source: text('source'),                  // How the user heard about it (RS-01)
-    rating: integer('rating'),               // NULL = unrated (RS-03)
+    source: text('source'), // How the user heard about it (RS-01)
+    rating: integer('rating'), // NULL = unrated (RS-03)
     postVisitNotes: text('post_visit_notes'), // NULL until reviewed (RS-03)
   },
   (t) => [
     index('idx_item_restaurants_rating').on(t.rating),
-    check(
-      'chk_item_restaurants_rating',
-      sql`${t.rating} IS NULL OR (${t.rating} BETWEEN 1 AND 5)`,
-    ),
+    check('chk_item_restaurants_rating', sql`${t.rating} IS NULL OR (${t.rating} BETWEEN 1 AND 5)`),
   ],
 );
 
@@ -565,17 +586,35 @@ export const itemExperiences = sqliteTable(
     itemId: integer('item_id')
       .primaryKey()
       .references(() => items.id, { onDelete: 'cascade' }),
-    rating: integer('rating'),               // NULL = unrated (EX-01)
+    rating: integer('rating'), // NULL = unrated (EX-01)
     postVisitNotes: text('post_visit_notes'), // NULL until reviewed (EX-01)
   },
   (t) => [
     index('idx_item_experiences_rating').on(t.rating),
-    check(
-      'chk_item_experiences_rating',
-      sql`${t.rating} IS NULL OR (${t.rating} BETWEEN 1 AND 5)`,
-    ),
+    check('chk_item_experiences_rating', sql`${t.rating} IS NULL OR (${t.rating} BETWEEN 1 AND 5)`),
   ],
 );
+
+// ============================================================
+// 6. AUTH / USERS
+// ============================================================
+
+/**
+ * Users — one record per authenticated user (ADL-20).
+ * Internal `id` is a UUID v4 string (ADL-16, prevents enumeration).
+ * `clerk_id` is the external Clerk identifier; all FK relationships use `id`.
+ * No password_hash, oauth_provider, or refresh_token — Clerk handles auth.
+ * `email` is stored for display/admin purposes; Clerk is authoritative for identity.
+ */
+export const users = sqliteTable('users', {
+  id: text('id').primaryKey(), // UUID v4 — generated by backend on first sign-in
+  clerkId: text('clerk_id').notNull().unique(), // Clerk user ID (e.g. user_2abc...)
+  email: text('email').notNull(),
+  // ADL-27: 1 = owner (has access to admin routes), 0 = non-owner. Set from OWNER_CLERK_ID env var.
+  isOwner: integer('is_owner').notNull().default(0),
+  createdAt: integer('created_at', { mode: 'timestamp' }).notNull(),
+  updatedAt: integer('updated_at', { mode: 'timestamp' }).notNull(),
+});
 
 // ============================================================
 // TYPE EXPORTS
@@ -623,6 +662,9 @@ export type NewTripPlace = typeof tripPlaces.$inferInsert;
 export type TripPlaceActivitiesMap = typeof tripPlaceActivitiesMap.$inferSelect;
 export type NewTripPlaceActivitiesMap = typeof tripPlaceActivitiesMap.$inferInsert;
 
+export type TripCountry = typeof tripCountries.$inferSelect;
+export type NewTripCountry = typeof tripCountries.$inferInsert;
+
 export type Item = typeof items.$inferSelect;
 export type NewItem = typeof items.$inferInsert;
 
@@ -640,3 +682,6 @@ export type NewItemRestaurant = typeof itemRestaurants.$inferInsert;
 
 export type ItemExperience = typeof itemExperiences.$inferSelect;
 export type NewItemExperience = typeof itemExperiences.$inferInsert;
+
+export type User = typeof users.$inferSelect;
+export type NewUser = typeof users.$inferInsert;

--- a/src/backend/db/schema.ts
+++ b/src/backend/db/schema.ts
@@ -411,7 +411,22 @@ export const tripCountries = sqliteTable(
  *
  * Carry-forward pattern (ADL-13, IT-07):
  *   is_carried_forward = 1 AND carried_from_item_id IS NOT NULL → carried item
- *   BACKEND must enforce these two fields are always set together.
+ *   BACKEND must enforce these two fields are always set together AT CREATE TIME.
+ *
+ *   This coupling is a CREATE-TIME invariant only, not a permanent one (ADL-36,
+ *   BUG-39). carried_from_item_id is a nullable-after-source-deletion provenance
+ *   pointer ("...from this specific source, while it still exists") — its FK has
+ *   onDelete: 'set null', so deleting the source item clears the pointer without
+ *   cascade-deleting the derived item (which is a first-class item on another
+ *   trip with its own user-edited status/notes/rating). is_carried_forward is a
+ *   permanent historical fact ("this item originated as a carry-forward") and is
+ *   NOT cleared when the source is deleted. Therefore
+ *   is_carried_forward = 1 AND carried_from_item_id IS NULL is a LEGITIMATE,
+ *   INTENTIONAL post-deletion state — it means "this item was carried forward,
+ *   but its source has since been deleted" — NOT data corruption. Do not add a
+ *   runtime consistency check or backfill that treats it as a bug; the redundant
+ *   boolean flag exists precisely so the historical fact survives loss of the
+ *   pointer.
  */
 export const items = sqliteTable(
   'items',
@@ -429,7 +444,14 @@ export const items = sqliteTable(
     isCarriedForward: integer('is_carried_forward').notNull().default(0),
     // Self-referential FK — preserves lineage to the source item (ADL-13)
     // Uses a lazy reference function to avoid circular dependency at module load time
-    carriedFromItemId: integer('carried_from_item_id').references((): AnySQLiteColumn => items.id),
+    // onDelete: 'set null' (ADL-36, BUG-39) — deleting the source item must not
+    // RESTRICT-block a normal trip/item delete; it clears this pointer only, and
+    // never cascade-deletes the derived item on the other trip. See the table
+    // doc comment above for why is_carried_forward can legitimately survive as 1
+    // with this column NULL afterward.
+    carriedFromItemId: integer('carried_from_item_id').references((): AnySQLiteColumn => items.id, {
+      onDelete: 'set null',
+    }),
     userId: text('user_id')
       .notNull()
       .references(() => users.id), // HC-07c: NOT NULL enforced at DB level

--- a/src/backend/migrations/0011_majestic_nehzno.sql
+++ b/src/backend/migrations/0011_majestic_nehzno.sql
@@ -1,0 +1,32 @@
+PRAGMA foreign_keys=OFF;--> statement-breakpoint
+CREATE TABLE `__new_items` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`trip_id` integer NOT NULL,
+	`trip_place_id` integer,
+	`item_type` text NOT NULL,
+	`status` text DEFAULT 'consider' NOT NULL,
+	`notes` text,
+	`is_carried_forward` integer DEFAULT 0 NOT NULL,
+	`carried_from_item_id` integer,
+	`user_id` text NOT NULL,
+	`created_at` text DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')) NOT NULL,
+	`updated_at` text DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')) NOT NULL,
+	FOREIGN KEY (`trip_id`) REFERENCES `trips`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`trip_place_id`) REFERENCES `trip_places`(`id`) ON UPDATE no action ON DELETE no action,
+	FOREIGN KEY (`carried_from_item_id`) REFERENCES `items`(`id`) ON UPDATE no action ON DELETE set null,
+	FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE no action,
+	CONSTRAINT "chk_items_item_type" CHECK("__new_items"."item_type" IN ('restaurant', 'hotel', 'flight', 'car_rental', 'experience', 'note')),
+	CONSTRAINT "chk_items_status" CHECK("__new_items"."status" IN ('consider', 'confirmed', 'completed', 'cancelled', 'next_time')),
+	CONSTRAINT "chk_items_is_carried_forward" CHECK("__new_items"."is_carried_forward" IN (0, 1))
+);
+--> statement-breakpoint
+INSERT INTO `__new_items`("id", "trip_id", "trip_place_id", "item_type", "status", "notes", "is_carried_forward", "carried_from_item_id", "user_id", "created_at", "updated_at") SELECT "id", "trip_id", "trip_place_id", "item_type", "status", "notes", "is_carried_forward", "carried_from_item_id", "user_id", "created_at", "updated_at" FROM `items`;--> statement-breakpoint
+DROP TABLE `items`;--> statement-breakpoint
+ALTER TABLE `__new_items` RENAME TO `items`;--> statement-breakpoint
+PRAGMA foreign_keys=ON;--> statement-breakpoint
+CREATE INDEX `idx_items_trip` ON `items` (`trip_id`);--> statement-breakpoint
+CREATE INDEX `idx_items_trip_place` ON `items` (`trip_place_id`);--> statement-breakpoint
+CREATE INDEX `idx_items_type` ON `items` (`item_type`);--> statement-breakpoint
+CREATE INDEX `idx_items_status` ON `items` (`status`);--> statement-breakpoint
+CREATE INDEX `idx_items_carried` ON `items` (`carried_from_item_id`) WHERE "items"."carried_from_item_id" IS NOT NULL;--> statement-breakpoint
+CREATE INDEX `items_user_id_idx` ON `items` (`user_id`);

--- a/src/backend/migrations/meta/0011_snapshot.json
+++ b/src/backend/migrations/meta/0011_snapshot.json
@@ -1,0 +1,1804 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "e3cf242b-4cd2-4ea6-84af-fee589a32015",
+  "prevId": "fa51bb92-b286-4dba-b2b5-26828a0899bb",
+  "tables": {
+    "activities": {
+      "name": "activities",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "activities_name_unique": {
+          "name": "activities_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "chk_activities_is_active": {
+          "name": "chk_activities_is_active",
+          "value": "\"activities\".\"is_active\" IN (0, 1)"
+        }
+      }
+    },
+    "cities": {
+      "name": "cities",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "country_code": {
+          "name": "country_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "region_id": {
+          "name": "region_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "geocode_status": {
+          "name": "geocode_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "geocode_attempted_at": {
+          "name": "geocode_attempted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "idx_cities_country": {
+          "name": "idx_cities_country",
+          "columns": [
+            "country_code"
+          ],
+          "isUnique": false
+        },
+        "idx_cities_region": {
+          "name": "idx_cities_region",
+          "columns": [
+            "region_id"
+          ],
+          "isUnique": false
+        },
+        "idx_cities_geocode": {
+          "name": "idx_cities_geocode",
+          "columns": [
+            "geocode_status"
+          ],
+          "isUnique": false,
+          "where": "\"cities\".\"geocode_status\" = 'pending'"
+        },
+        "uniq_cities_name_country_ci": {
+          "name": "uniq_cities_name_country_ci",
+          "columns": [
+            "\"name\" COLLATE NOCASE",
+            "country_code"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "cities_country_code_countries_country_code_fk": {
+          "name": "cities_country_code_countries_country_code_fk",
+          "tableFrom": "cities",
+          "tableTo": "countries",
+          "columnsFrom": [
+            "country_code"
+          ],
+          "columnsTo": [
+            "country_code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "cities_region_id_regions_id_fk": {
+          "name": "cities_region_id_regions_id_fk",
+          "tableFrom": "cities",
+          "tableTo": "regions",
+          "columnsFrom": [
+            "region_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "chk_cities_geocode_status": {
+          "name": "chk_cities_geocode_status",
+          "value": "\"cities\".\"geocode_status\" IN ('pending', 'resolved')"
+        }
+      }
+    },
+    "companions": {
+      "name": "companions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "companions_name_unique": {
+          "name": "companions_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "chk_companions_is_active": {
+          "name": "chk_companions_is_active",
+          "value": "\"companions\".\"is_active\" IN (0, 1)"
+        }
+      }
+    },
+    "countries": {
+      "name": "countries",
+      "columns": {
+        "country_code": {
+          "name": "country_code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "region_tier_enabled": {
+          "name": "region_tier_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "region_tier_label": {
+          "name": "region_tier_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "chk_countries_region_tier_enabled": {
+          "name": "chk_countries_region_tier_enabled",
+          "value": "\"countries\".\"region_tier_enabled\" IN (0, 1)"
+        }
+      }
+    },
+    "item_car_rentals": {
+      "name": "item_car_rentals",
+      "columns": {
+        "item_id": {
+          "name": "item_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pickup_location": {
+          "name": "pickup_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dropoff_location": {
+          "name": "dropoff_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pickup_datetime": {
+          "name": "pickup_datetime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dropoff_datetime": {
+          "name": "dropoff_datetime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "booking_reference": {
+          "name": "booking_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vehicle_class": {
+          "name": "vehicle_class",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "item_car_rentals_item_id_items_id_fk": {
+          "name": "item_car_rentals_item_id_items_id_fk",
+          "tableFrom": "item_car_rentals",
+          "tableTo": "items",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "item_experiences": {
+      "name": "item_experiences",
+      "columns": {
+        "item_id": {
+          "name": "item_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "post_visit_notes": {
+          "name": "post_visit_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_item_experiences_rating": {
+          "name": "idx_item_experiences_rating",
+          "columns": [
+            "rating"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "item_experiences_item_id_items_id_fk": {
+          "name": "item_experiences_item_id_items_id_fk",
+          "tableFrom": "item_experiences",
+          "tableTo": "items",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "chk_item_experiences_rating": {
+          "name": "chk_item_experiences_rating",
+          "value": "\"item_experiences\".\"rating\" IS NULL OR (\"item_experiences\".\"rating\" BETWEEN 1 AND 5)"
+        }
+      }
+    },
+    "item_flights": {
+      "name": "item_flights",
+      "columns": {
+        "item_id": {
+          "name": "item_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "airline": {
+          "name": "airline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "flight_number": {
+          "name": "flight_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "departure_airport": {
+          "name": "departure_airport",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "arrival_airport": {
+          "name": "arrival_airport",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "departure_datetime": {
+          "name": "departure_datetime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "arrival_datetime": {
+          "name": "arrival_datetime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "booking_reference": {
+          "name": "booking_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "seat": {
+          "name": "seat",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "item_flights_item_id_items_id_fk": {
+          "name": "item_flights_item_id_items_id_fk",
+          "tableFrom": "item_flights",
+          "tableTo": "items",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "item_hotels": {
+      "name": "item_hotels",
+      "columns": {
+        "item_id": {
+          "name": "item_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "property_name": {
+          "name": "property_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "check_in_date": {
+          "name": "check_in_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "check_out_date": {
+          "name": "check_out_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "booking_reference": {
+          "name": "booking_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "confirmation_number": {
+          "name": "confirmation_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "post_visit_notes": {
+          "name": "post_visit_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_item_hotels_rating": {
+          "name": "idx_item_hotels_rating",
+          "columns": [
+            "rating"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "item_hotels_item_id_items_id_fk": {
+          "name": "item_hotels_item_id_items_id_fk",
+          "tableFrom": "item_hotels",
+          "tableTo": "items",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "chk_item_hotels_rating": {
+          "name": "chk_item_hotels_rating",
+          "value": "\"item_hotels\".\"rating\" IS NULL OR (\"item_hotels\".\"rating\" BETWEEN 1 AND 5)"
+        }
+      }
+    },
+    "item_restaurants": {
+      "name": "item_restaurants",
+      "columns": {
+        "item_id": {
+          "name": "item_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "neighbourhood_area": {
+          "name": "neighbourhood_area",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cuisine_type": {
+          "name": "cuisine_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "post_visit_notes": {
+          "name": "post_visit_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_item_restaurants_rating": {
+          "name": "idx_item_restaurants_rating",
+          "columns": [
+            "rating"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "item_restaurants_item_id_items_id_fk": {
+          "name": "item_restaurants_item_id_items_id_fk",
+          "tableFrom": "item_restaurants",
+          "tableTo": "items",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "chk_item_restaurants_rating": {
+          "name": "chk_item_restaurants_rating",
+          "value": "\"item_restaurants\".\"rating\" IS NULL OR (\"item_restaurants\".\"rating\" BETWEEN 1 AND 5)"
+        }
+      }
+    },
+    "items": {
+      "name": "items",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "trip_id": {
+          "name": "trip_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "trip_place_id": {
+          "name": "trip_place_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "item_type": {
+          "name": "item_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'consider'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_carried_forward": {
+          "name": "is_carried_forward",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "carried_from_item_id": {
+          "name": "carried_from_item_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "idx_items_trip": {
+          "name": "idx_items_trip",
+          "columns": [
+            "trip_id"
+          ],
+          "isUnique": false
+        },
+        "idx_items_trip_place": {
+          "name": "idx_items_trip_place",
+          "columns": [
+            "trip_place_id"
+          ],
+          "isUnique": false
+        },
+        "idx_items_type": {
+          "name": "idx_items_type",
+          "columns": [
+            "item_type"
+          ],
+          "isUnique": false
+        },
+        "idx_items_status": {
+          "name": "idx_items_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "idx_items_carried": {
+          "name": "idx_items_carried",
+          "columns": [
+            "carried_from_item_id"
+          ],
+          "isUnique": false,
+          "where": "\"items\".\"carried_from_item_id\" IS NOT NULL"
+        },
+        "items_user_id_idx": {
+          "name": "items_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "items_trip_id_trips_id_fk": {
+          "name": "items_trip_id_trips_id_fk",
+          "tableFrom": "items",
+          "tableTo": "trips",
+          "columnsFrom": [
+            "trip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "items_trip_place_id_trip_places_id_fk": {
+          "name": "items_trip_place_id_trip_places_id_fk",
+          "tableFrom": "items",
+          "tableTo": "trip_places",
+          "columnsFrom": [
+            "trip_place_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "items_carried_from_item_id_items_id_fk": {
+          "name": "items_carried_from_item_id_items_id_fk",
+          "tableFrom": "items",
+          "tableTo": "items",
+          "columnsFrom": [
+            "carried_from_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "items_user_id_users_id_fk": {
+          "name": "items_user_id_users_id_fk",
+          "tableFrom": "items",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "chk_items_item_type": {
+          "name": "chk_items_item_type",
+          "value": "\"items\".\"item_type\" IN ('restaurant', 'hotel', 'flight', 'car_rental', 'experience', 'note')"
+        },
+        "chk_items_status": {
+          "name": "chk_items_status",
+          "value": "\"items\".\"status\" IN ('consider', 'confirmed', 'completed', 'cancelled', 'next_time')"
+        },
+        "chk_items_is_carried_forward": {
+          "name": "chk_items_is_carried_forward",
+          "value": "\"items\".\"is_carried_forward\" IN (0, 1)"
+        }
+      }
+    },
+    "map_shading_config": {
+      "name": "map_shading_config",
+      "columns": {
+        "state_key": {
+          "name": "state_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "color_hex": {
+          "name": "color_hex",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "chk_map_shading_state_key": {
+          "name": "chk_map_shading_state_key",
+          "value": "\"map_shading_config\".\"state_key\" IN ('active', 'planned', 'visited_once', 'visited_once_planning', 'visited_multiple', 'visited_multiple_planning')"
+        }
+      }
+    },
+    "regions": {
+      "name": "regions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "country_code": {
+          "name": "country_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "iso_3166_2": {
+          "name": "iso_3166_2",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "idx_regions_country": {
+          "name": "idx_regions_country",
+          "columns": [
+            "country_code"
+          ],
+          "isUnique": false
+        },
+        "uniq_regions_iso_3166_2": {
+          "name": "uniq_regions_iso_3166_2",
+          "columns": [
+            "iso_3166_2"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "regions_country_code_countries_country_code_fk": {
+          "name": "regions_country_code_countries_country_code_fk",
+          "tableFrom": "regions",
+          "tableTo": "countries",
+          "columnsFrom": [
+            "country_code"
+          ],
+          "columnsTo": [
+            "country_code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "trip_activities_map": {
+      "name": "trip_activities_map",
+      "columns": {
+        "trip_id": {
+          "name": "trip_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "activity_id": {
+          "name": "activity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "trip_activities_map_trip_id_trips_id_fk": {
+          "name": "trip_activities_map_trip_id_trips_id_fk",
+          "tableFrom": "trip_activities_map",
+          "tableTo": "trips",
+          "columnsFrom": [
+            "trip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "trip_activities_map_activity_id_activities_id_fk": {
+          "name": "trip_activities_map_activity_id_activities_id_fk",
+          "tableFrom": "trip_activities_map",
+          "tableTo": "activities",
+          "columnsFrom": [
+            "activity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "trip_activities_map_trip_id_activity_id_pk": {
+          "columns": [
+            "trip_id",
+            "activity_id"
+          ],
+          "name": "trip_activities_map_trip_id_activity_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "trip_categories": {
+      "name": "trip_categories",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "trip_categories_name_unique": {
+          "name": "trip_categories_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "chk_trip_categories_is_active": {
+          "name": "chk_trip_categories_is_active",
+          "value": "\"trip_categories\".\"is_active\" IN (0, 1)"
+        }
+      }
+    },
+    "trip_categories_map": {
+      "name": "trip_categories_map",
+      "columns": {
+        "trip_id": {
+          "name": "trip_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_tcm_category": {
+          "name": "idx_tcm_category",
+          "columns": [
+            "category_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "trip_categories_map_trip_id_trips_id_fk": {
+          "name": "trip_categories_map_trip_id_trips_id_fk",
+          "tableFrom": "trip_categories_map",
+          "tableTo": "trips",
+          "columnsFrom": [
+            "trip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "trip_categories_map_category_id_trip_categories_id_fk": {
+          "name": "trip_categories_map_category_id_trip_categories_id_fk",
+          "tableFrom": "trip_categories_map",
+          "tableTo": "trip_categories",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "trip_categories_map_trip_id_category_id_pk": {
+          "columns": [
+            "trip_id",
+            "category_id"
+          ],
+          "name": "trip_categories_map_trip_id_category_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "trip_companions_map": {
+      "name": "trip_companions_map",
+      "columns": {
+        "trip_id": {
+          "name": "trip_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "companion_id": {
+          "name": "companion_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_tcpm_companion": {
+          "name": "idx_tcpm_companion",
+          "columns": [
+            "companion_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "trip_companions_map_trip_id_trips_id_fk": {
+          "name": "trip_companions_map_trip_id_trips_id_fk",
+          "tableFrom": "trip_companions_map",
+          "tableTo": "trips",
+          "columnsFrom": [
+            "trip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "trip_companions_map_companion_id_companions_id_fk": {
+          "name": "trip_companions_map_companion_id_companions_id_fk",
+          "tableFrom": "trip_companions_map",
+          "tableTo": "companions",
+          "columnsFrom": [
+            "companion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "trip_companions_map_trip_id_companion_id_pk": {
+          "columns": [
+            "trip_id",
+            "companion_id"
+          ],
+          "name": "trip_companions_map_trip_id_companion_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "trip_countries": {
+      "name": "trip_countries",
+      "columns": {
+        "trip_id": {
+          "name": "trip_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "country_code": {
+          "name": "country_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "idx_trip_countries_country": {
+          "name": "idx_trip_countries_country",
+          "columns": [
+            "country_code"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "trip_countries_trip_id_trips_id_fk": {
+          "name": "trip_countries_trip_id_trips_id_fk",
+          "tableFrom": "trip_countries",
+          "tableTo": "trips",
+          "columnsFrom": [
+            "trip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "trip_countries_country_code_countries_country_code_fk": {
+          "name": "trip_countries_country_code_countries_country_code_fk",
+          "tableFrom": "trip_countries",
+          "tableTo": "countries",
+          "columnsFrom": [
+            "country_code"
+          ],
+          "columnsTo": [
+            "country_code"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "trip_countries_trip_id_country_code_pk": {
+          "columns": [
+            "trip_id",
+            "country_code"
+          ],
+          "name": "trip_countries_trip_id_country_code_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "trip_place_activities_map": {
+      "name": "trip_place_activities_map",
+      "columns": {
+        "trip_place_id": {
+          "name": "trip_place_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "activity_id": {
+          "name": "activity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "trip_place_activities_map_trip_place_id_trip_places_id_fk": {
+          "name": "trip_place_activities_map_trip_place_id_trip_places_id_fk",
+          "tableFrom": "trip_place_activities_map",
+          "tableTo": "trip_places",
+          "columnsFrom": [
+            "trip_place_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "trip_place_activities_map_activity_id_activities_id_fk": {
+          "name": "trip_place_activities_map_activity_id_activities_id_fk",
+          "tableFrom": "trip_place_activities_map",
+          "tableTo": "activities",
+          "columnsFrom": [
+            "activity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "trip_place_activities_map_trip_place_id_activity_id_pk": {
+          "columns": [
+            "trip_place_id",
+            "activity_id"
+          ],
+          "name": "trip_place_activities_map_trip_place_id_activity_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "trip_places": {
+      "name": "trip_places",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "trip_id": {
+          "name": "trip_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "city_id": {
+          "name": "city_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "arrived_on": {
+          "name": "arrived_on",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "departed_on": {
+          "name": "departed_on",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "uniq_trip_places_trip_city": {
+          "name": "uniq_trip_places_trip_city",
+          "columns": [
+            "trip_id",
+            "city_id"
+          ],
+          "isUnique": true
+        },
+        "idx_trip_places_trip": {
+          "name": "idx_trip_places_trip",
+          "columns": [
+            "trip_id"
+          ],
+          "isUnique": false
+        },
+        "idx_trip_places_city": {
+          "name": "idx_trip_places_city",
+          "columns": [
+            "city_id"
+          ],
+          "isUnique": false
+        },
+        "trip_places_user_id_idx": {
+          "name": "trip_places_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "trip_places_trip_id_trips_id_fk": {
+          "name": "trip_places_trip_id_trips_id_fk",
+          "tableFrom": "trip_places",
+          "tableTo": "trips",
+          "columnsFrom": [
+            "trip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "trip_places_city_id_cities_id_fk": {
+          "name": "trip_places_city_id_cities_id_fk",
+          "tableFrom": "trip_places",
+          "tableTo": "cities",
+          "columnsFrom": [
+            "city_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "trip_places_user_id_users_id_fk": {
+          "name": "trip_places_user_id_users_id_fk",
+          "tableFrom": "trip_places",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "trips": {
+      "name": "trips",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'planning'"
+        },
+        "photo_album_ref": {
+          "name": "photo_album_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "idx_trips_status": {
+          "name": "idx_trips_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "idx_trips_start_date": {
+          "name": "idx_trips_start_date",
+          "columns": [
+            "start_date"
+          ],
+          "isUnique": false
+        },
+        "idx_trips_end_date": {
+          "name": "idx_trips_end_date",
+          "columns": [
+            "end_date"
+          ],
+          "isUnique": false
+        },
+        "trips_user_id_idx": {
+          "name": "trips_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "trips_user_id_users_id_fk": {
+          "name": "trips_user_id_users_id_fk",
+          "tableFrom": "trips",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "chk_trips_status": {
+          "name": "chk_trips_status",
+          "value": "\"trips\".\"status\" IN ('planning', 'active', 'review_pending', 'locked')"
+        }
+      }
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "clerk_id": {
+          "name": "clerk_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_owner": {
+          "name": "is_owner",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_clerk_id_unique": {
+          "name": "users_clerk_id_unique",
+          "columns": [
+            "clerk_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {
+      "uniq_cities_name_country_ci": {
+        "columns": {
+          "\"name\" COLLATE NOCASE": {
+            "isExpression": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/backend/migrations/meta/_journal.json
+++ b/src/backend/migrations/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1784593112729,
       "tag": "0010_bug33_add_unique_index",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "6",
+      "when": 1784694605260,
+      "tag": "0011_majestic_nehzno",
+      "breakpoints": true
     }
   ]
 }

--- a/src/backend/routes/__tests__/trips.delete.test.ts
+++ b/src/backend/routes/__tests__/trips.delete.test.ts
@@ -169,6 +169,7 @@ async function createTestDb() {
       updated_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')) NOT NULL,
       FOREIGN KEY (trip_id) REFERENCES trips(id) ON DELETE CASCADE,
       FOREIGN KEY (trip_place_id) REFERENCES trip_places(id),
+      FOREIGN KEY (carried_from_item_id) REFERENCES items(id) ON DELETE SET NULL,
       FOREIGN KEY (user_id) REFERENCES users(id)
     )`,
     `CREATE TABLE IF NOT EXISTS item_flights (
@@ -492,5 +493,94 @@ describe('DELETE /api/trips/:id', () => {
     const response = await supertest(app).delete(`/api/trips/${trip.id}`).expect(404);
 
     expect(response.body).toEqual({ error: 'Trip not found' });
+  });
+
+  // ----------------------------------------------------------------
+  // 2f. BUG-39 / ADL-36 regression — deleting a carry-forward SOURCE trip
+  //
+  // items.carried_from_item_id is a self-referencing FK with
+  // onDelete: 'set null' (ADL-36). Before the fix it had no onDelete
+  // clause, which @libsql/client defaults to RESTRICT — deleting a trip
+  // 500'd whenever one of its items had ever been used as a carry-forward
+  // source for an item on ANY OTHER trip. This asserts the delete now
+  // succeeds (204) and that the derived item survives on its own trip
+  // with carried_from_item_id cleared to NULL while is_carried_forward
+  // stays 1 — the legitimate post-deletion state documented in schema.ts.
+  // ----------------------------------------------------------------
+
+  it('returns 204 deleting a trip whose item is a carry-forward source for an item on another trip, and the derived item survives with carried_from_item_id nulled', async () => {
+    const db = testDb!;
+    const { eq } = await import('drizzle-orm');
+
+    // Source trip — will be deleted
+    const [sourceTrip] = await db
+      .insert(schema.trips)
+      .values({
+        name: 'Source Trip (to be deleted)',
+        startDate: '2025-01-01',
+        endDate: '2025-01-07',
+        status: 'completed',
+        userId: TEST_USER_ID,
+      })
+      .returning();
+
+    // Destination trip — unrelated, must NOT be affected
+    const [destTrip] = await db
+      .insert(schema.trips)
+      .values({
+        name: 'Destination Trip',
+        startDate: '2026-01-01',
+        endDate: '2026-01-07',
+        status: 'planning',
+        userId: TEST_USER_ID,
+      })
+      .returning();
+
+    // Source item on the source trip
+    const [sourceItem] = await db
+      .insert(schema.items)
+      .values({
+        tripId: sourceTrip.id,
+        itemType: 'note',
+        status: 'completed',
+        userId: TEST_USER_ID,
+      })
+      .returning();
+
+    // Derived item on the destination trip, carried forward from the source item
+    const [derivedItem] = await db
+      .insert(schema.items)
+      .values({
+        tripId: destTrip.id,
+        itemType: 'note',
+        status: 'consider',
+        isCarriedForward: 1,
+        carriedFromItemId: sourceItem.id,
+        userId: TEST_USER_ID,
+      })
+      .returning();
+
+    // Deleting the source trip must succeed, not 500 with FK RESTRICT
+    const response = await supertest(app).delete(`/api/trips/${sourceTrip.id}`).expect(204);
+    expect(response.body).toEqual({});
+
+    // Source item is gone (cascade-deleted with its trip)
+    const sourceItemsAfter = await db
+      .select()
+      .from(schema.items)
+      .where(eq(schema.items.id, sourceItem.id));
+    expect(sourceItemsAfter).toHaveLength(0);
+
+    // Derived item survives on the destination trip — not deleted, not reverted
+    const derivedAfter = await db
+      .select()
+      .from(schema.items)
+      .where(eq(schema.items.id, derivedItem.id));
+    expect(derivedAfter).toHaveLength(1);
+    expect(derivedAfter[0].tripId).toBe(destTrip.id);
+    // Provenance pointer cleared by ON DELETE SET NULL...
+    expect(derivedAfter[0].carriedFromItemId).toBeNull();
+    // ...but the permanent historical fact is untouched (ADL-36).
+    expect(derivedAfter[0].isCarriedForward).toBe(1);
   });
 });


### PR DESCRIPTION
Refs #209, ADL-36, BUG-39

## Summary

`items.carriedFromItemId` was a self-referencing FK with no `onDelete`
clause. `@libsql/client` enforces FKs by default (BUG-38), so the omitted
clause defaulted to RESTRICT: `DELETE /api/trips/:id` (and a direct item
delete) 500'd whenever one of a trip's items had ever been used as a
carry-forward source for an item on any *other* trip.

Implements Architect's ADL-36 ruling
(`jobs/architect/tech/20260307-architecture-decisions-log.md`) —
implementation only, decision already made:

- `src/backend/db/schema.ts`: `carriedFromItemId` FK now
  `onDelete: 'set null'`. Deleting the source item clears the derived
  item's provenance pointer without cascade-deleting the derived item
  itself (a first-class item on another trip with its own user-edited
  status/notes/rating).
- `src/backend/migrations/0011_majestic_nehzno.sql` — generated via
  `db:generate` + applied via `db:migrate` (never `db:push`, ADL-15).
  SQLite can't alter a constraint in place, so drizzle-kit emitted the
  `items` table-recreation path the committed `drizzle-kit@0.31.9` patch
  guards against. Eyeballed the generated SQL before applying:
  self-referencing FK re-declared `ON DELETE SET NULL`, partial index
  `idx_items_carried` intact, all three `chk_items_*` CHECK constraints
  intact and untruncated, `INSERT...SELECT` preserves all columns
  through the copy.
- Doc comment updated to record that `is_carried_forward = 1` with
  `carried_from_item_id IS NULL` is a legitimate, intentional
  post-deletion state (ADL-13's coupling is a create-time invariant
  only) — not corruption to "fix" later.
- Regression test added to `trips.delete.test.ts` (BUG-39's close
  criterion): asserts `DELETE /api/trips/:id` returns 204 (was 500) when
  one of its items is a carry-forward source for an item on another
  trip, and that the derived item survives with `carried_from_item_id`
  nulled and `is_carried_forward` unchanged. Verified the test fails
  with the pre-fix 500 when temporarily reverted, confirming it's a real
  regression guard.
- No backend/frontend code change required (confirmed per ADL-36's
  analysis — `UpdateItemSchema` doesn't expose these fields, frontend
  tag reads the boolean not the FK, no read path assumes non-null).
- `jobs/architect/tech/20260307-architecture-decisions-log.md`: ADL-36's
  status line flipped from "implementation PENDING" to "Implemented"
  (Document Lifecycle same-PR-update rule) — decision/rationale text
  untouched.

## Test plan

- [x] `npm run db:generate` + `npm run db:migrate` — clean, all 12
      migrations (0000-0011) apply on a fresh DB; re-run confirms no drift
- [x] `npm run test:backend` — 533 pass / 1 skip (new regression test included)
- [x] `npm run test:frontend` — 154 pass
- [x] `npm run type:check:all` — clean
- [x] `npm run check` (Biome) — clean
- [x] `npm run status:check` — clean
- [x] Manually confirmed the new regression test fails (500) against the
      pre-fix FK clause, then passes (204) with the fix restored

🤖 Generated with [Claude Code](https://claude.com/claude-code)