### PR TITLE
chore: add railway-query.sh logs subcommand + runbook doc

### DIFF
--- a/.planning/drift-ledger.jsonl
+++ b/.planning/drift-ledger.jsonl
@@ -1302,3 +1302,4 @@
 {"ts":"2026-07-22T06:12:09Z","action":"edit","file":"/workspace/scripts/agent-diagnostics/railway-query.sh"}
 {"ts":"2026-07-22T06:12:20Z","action":"edit","file":"/workspace/scripts/agent-diagnostics/railway-query.sh"}
 {"ts":"2026-07-22T06:12:30Z","action":"edit","file":"/workspace/jobs/architect/tech/20260721-agent-diagnostics-runbook.md"}
+{"ts":"2026-07-22T06:14:06Z","action":"edit","file":"/workspace/jobs/COO/open-dialogues.md"}

--- a/.planning/drift-ledger.jsonl
+++ b/.planning/drift-ledger.jsonl
@@ -1298,3 +1298,7 @@
 {"ts":"2026-07-22T06:03:20Z","action":"edit","file":"/workspace/_project/tracker.json"}
 {"ts":"2026-07-22T06:07:14Z","action":"edit","file":"/workspace/_project/tracker.json"}
 {"ts":"2026-07-22T06:07:31Z","action":"edit","file":"/workspace/_project/tracker.json"}
+{"ts":"2026-07-22T06:11:16Z","action":"reviewed"}
+{"ts":"2026-07-22T06:12:09Z","action":"edit","file":"/workspace/scripts/agent-diagnostics/railway-query.sh"}
+{"ts":"2026-07-22T06:12:20Z","action":"edit","file":"/workspace/scripts/agent-diagnostics/railway-query.sh"}
+{"ts":"2026-07-22T06:12:30Z","action":"edit","file":"/workspace/jobs/architect/tech/20260721-agent-diagnostics-runbook.md"}

--- a/jobs/COO/open-dialogues.md
+++ b/jobs/COO/open-dialogues.md
@@ -86,6 +86,14 @@ Adding the domain would let COO fetch the actual served HTML/JS directly next ti
 credentialed access ADL-33 already granted). Not yet decided — raised, not confirmed
 either way by Ryan.
 
+**Update 2026-07-21 (later same day):** hit the same limitation again diagnosing BUG-59
+(staging white screen) — worked around it via `railway-query.sh`'s new `logs` subcommand
+(deployment console output) plus `turso-query.mjs` instead of hitting the site directly,
+and it was sufficient to find the exact root cause without needing the domain allowlisted.
+Doesn't resolve the open question, but is a second data point: the Turso/Railway-metadata
+diagnostic path has now twice been enough on its own, which may be relevant to how much
+this is actually worth adding.
+
 ### D-07: `gh` CLI has no persistent auth in this container
 **Raised:** 2026-07-21
 

--- a/jobs/architect/tech/20260721-agent-diagnostics-runbook.md
+++ b/jobs/architect/tech/20260721-agent-diagnostics-runbook.md
@@ -50,7 +50,15 @@ environment within a project, narrower than just "the project"):
 scripts/agent-diagnostics/railway-query.sh prod status                        # 5 most recent deployments
 scripts/agent-diagnostics/railway-query.sh staging status
 scripts/agent-diagnostics/railway-query.sh prod deployment <deployment-id>    # full detail on one deployment
+scripts/agent-diagnostics/railway-query.sh staging logs <deployment-id> [limit]  # runtime log lines (default 150)
 ```
+
+`logs` is the one that actually shows the application's own console output (startup sequence,
+thrown errors with stack traces) — `status`/`deployment` only give Railway's own metadata
+(build info, commit, deploy status), not what the running process printed. Added 2026-07-21
+after diagnosing BUG-59 (staging CORS misconfiguration) required reading the actual server
+error, not just confirming the deploy succeeded — the query existed as an ad-hoc curl call
+during that session and is now a proper subcommand instead of something to be rediscovered.
 
 The script resolves `projectId`/`environmentId` from the token itself at runtime (via the
 `projectToken { projectId environmentId }` query) — nothing is hardcoded, so it keeps working if

--- a/scripts/agent-diagnostics/railway-query.sh
+++ b/scripts/agent-diagnostics/railway-query.sh
@@ -15,6 +15,7 @@
 # Usage:
 #   scripts/agent-diagnostics/railway-query.sh <prod|staging> status
 #   scripts/agent-diagnostics/railway-query.sh <prod|staging> deployment <deployment-id>
+#   scripts/agent-diagnostics/railway-query.sh <prod|staging> logs <deployment-id> [limit]
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -80,10 +81,21 @@ case "$COMMAND" in
         gql "$(printf '{"query":"query { deployment(id: \\"%s\\") { id status statusUpdatedAt canRedeploy meta } }"}' "$DEPLOYMENT_ID")" \
             | jq '.data.deployment'
         ;;
+    logs)
+        DEPLOYMENT_ID="${3:-}"
+        LIMIT="${4:-150}"
+        if [ -z "$DEPLOYMENT_ID" ]; then
+            echo "Usage: $0 <prod|staging> logs <deployment-id> [limit]" >&2
+            exit 1
+        fi
+        gql "$(printf '{"query":"query { deploymentLogs(deploymentId: \\"%s\\", limit: %s) { message timestamp severity } }"}' "$DEPLOYMENT_ID" "$LIMIT")" \
+            | jq '.data.deploymentLogs[]'
+        ;;
     *)
-        echo "Usage: $0 <prod|staging> <status|deployment> [deployment-id]" >&2
+        echo "Usage: $0 <prod|staging> <status|deployment|logs> [deployment-id] [limit]" >&2
         echo "  status                    -- 5 most recent deployments for this environment" >&2
         echo "  deployment <id>           -- full detail (status, meta, commit) for one deployment" >&2
+        echo "  logs <id> [limit]         -- runtime log lines for one deployment (default limit 150)" >&2
         exit 1
         ;;
 esac


### PR DESCRIPTION
## Summary
- Adds a `logs` subcommand to `scripts/agent-diagnostics/railway-query.sh`, wrapping Railway's `deploymentLogs` GraphQL query — same read-only discipline as the existing `status`/`deployment` subcommands (ADL-33), no new credentials.
- Documents it in `jobs/architect/tech/20260721-agent-diagnostics-runbook.md`.
- This formalizes a query I ran ad-hoc via curl while diagnosing BUG-59 today (staging CORS misconfiguration) — the existing subcommands only surface Railway's deploy metadata, not the application's own console output, which is what actually revealed the root cause. Session close-out gap-fill rather than leaving it to be rediscovered.

## Test plan
- [x] `npm run check` — clean
- [x] `npm run type:check:all` — clean
- [x] `npm run test:backend` — 533 passed, 1 skipped
- [x] `npm run test:frontend` — 154 passed
- [x] `npm run status:check` — STATUS.md in sync
- [x] Smoke-tested `railway-query.sh staging logs <id> 5` against a real deployment — returns valid JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)