### PR TITLE
fix(BUG-60): configure Express trust proxy for Railway's edge (#221)

### DIFF
--- a/jobs/COO/inbox/20260722_2010-ARCHITECT-adl37-bug60-trust-proxy.txt
+++ b/jobs/COO/inbox/20260722_2010-ARCHITECT-adl37-bug60-trust-proxy.txt
@@ -1,0 +1,42 @@
+COMPLETION REPORT — ARCHITECT
+Tracker: BUG-60 · ADL-37 · GitHub issue #221 · PR #<pending> · BRD: none (bug/infra) · Branch fix/bug60-trust-proxy
+
+DECIDED + IMPLEMENTED
+Express `trust proxy` was unset, so behind Railway's edge proxy express-rate-limit (SEC-07)
+threw ERR_ERL_UNEXPECTED_X_FORWARDED_FOR at boot in BOTH prod and staging. Fixed with
+`app.set('trust proxy', 1)` — trust exactly Railway's single edge hop.
+
+PER-DECISION VERDICT
+- trust proxy value = integer `1` — ADOPTED (High confidence). `1` strips exactly Railway's
+  one edge hop and takes the real (last-appended) client IP as req.ip.
+- trust proxy = `true` — REJECTED. Trusts the whole X-Forwarded-For chain => client-forgeable
+  req.ip => rate-limit bypass. express-rate-limit rejects it (ERR_ERL_PERMISSIVE_TRUST_PROXY).
+  This is the "trust too much" security hole the brief flagged.
+- CIDR/IP allowlist — REJECTED. Railway publishes no committed edge CIDR; pinned IPs rotate and
+  silently break. Hop-count fails LOUD instead (error resurfaces if Railway ever adds a hop).
+- Prod vs staging — IDENTICAL topology, one hardcoded value, no env gating; inert in dev/CI.
+
+FILES
+- src/backend/server.ts (setting added before the rate-limiter)
+- src/backend/server-test-app.ts (mirrored — two app builders kept in sync by design)
+- src/backend/__tests__/trust-proxy.test.ts (NEW regression test — see below)
+- jobs/architect/tech/20260307-architecture-decisions-log.md (ADL-37, full reasoning)
+
+TEST (brief step 4 — judgment call): YES, added. Asserts the setting is `1` AND that Express's
+compiled trust predicate trusts hop 0 but not hop 1 — the security property (a forged deeper-hop
+entry is not trusted) encoded directly, without an intrusive req.ip-echoing probe route.
+
+VERIFICATION
+- type:check:backend clean; test:backend 535 passed | 1 skipped (incl. new test).
+- CI: <fill after gh pr checks green — report not final until then>.
+
+OPEN / ACTION FOR COO
+1. Cross-reference rule: add GitHub issue #221 to the BUG-60 tracker `notes` field. I did NOT
+   edit tracker.json (COO-maintained). Issue title already carries the BUG-60 ID.
+2. Flip BUG-60 status on merge.
+3. Real close-out (next Architect thread, noted in park doc): after merge + Railway redeploy of
+   BOTH envs, confirm the boot error is gone from both deployment logs — that's the true DoD.
+
+UNBLOCKED: nothing was blocked on this; it removes a startup error and makes SEC-07 rate-limiting
+correct and non-spoofable behind Railway. Detail in park doc 20260722-ARCHITECT-park-adl37.txt
+and ADL-37.

--- a/jobs/architect/context/current.txt
+++ b/jobs/architect/context/current.txt
@@ -1,88 +1,59 @@
-ARCHITECT CONTEXT — 2026-07-21
+ARCHITECT CONTEXT — 2026-07-22
 PROJECT: Travel Tracker
-CURRENT STATUS: ADL-36 decided — BUG-39 (#209) FK review. items.carriedFromItemId gets
+CURRENT STATUS: ADL-37 decided AND implemented — BUG-60 (#221) trust-proxy fix.
+`app.set('trust proxy', 1)` added to src/backend/server.ts (before the SEC-07 rate limiter)
+and mirrored into src/backend/server-test-app.ts to keep the two app builders' pipelines in
+sync. Railway sits a single TLS-terminating edge hop in front of the container and sets
+X-Forwarded-For; Express defaulted to `false` (untrusted), so express-rate-limit threw
+ERR_ERL_UNEXPECTED_X_FORWARDED_FOR on boot in BOTH prod (f60d623b) and staging (12e1e764).
+Value is the integer hop count `1`, NOT `true`: `true` trusts the whole XFF chain and is
+client-spoofable (express-rate-limit rejects it with ERR_ERL_PERMISSIVE_TRUST_PROXY) — a
+rate-limit-bypass hole. `1` strips exactly Railway's one edge hop and takes the last-appended
+address as req.ip; a forged prefix is ignored. Identical prod/staging (same topology);
+hardcoded (property of the platform, not env config); inert in local dev/CI (no XFF present).
+Regression test: src/backend/__tests__/trust-proxy.test.ts (asserts setting==1 and the
+compiled trust predicate trusts hop 0 but not hop 1). This was an implement-directly thread
+(single-file infra config), not a hand-off. Branch fix/bug60-trust-proxy, PR pending CI.
+See 20260722-ARCHITECT-park-adl37.txt.
+
+PRIOR STATUS: ADL-36 decided — BUG-39 (#209) FK review. items.carriedFromItemId gets
 onDelete: 'set null' (confirmed Frontend's proposal; cascade/restrict rejected). Verified NO
-backend/frontend change needed — UpdateItemSchema doesn't expose the carry-forward fields, the
-frontend tag reads the is_carried_forward boolean not the FK, so the resulting
-is_carried_forward=1 / carried_from_item_id=NULL post-deletion state is intentional (ADL-13
-coupling is create-time only). FK audit: BUG-39 is ISOLATED — other no-onDelete FKs reference
-soft-delete-only admin lists or non-deletable seed/geo tables. Database owns the migration next
-(ADL-36 "Implications for Database"). Review-only thread; committed change is the ADL-36 entry +
-BUG-39 tracker note. Branch chore/bug39-adl-fk-ondelete. See 20260721-ARCHITECT-park-adl36.txt.
+backend/frontend change needed. Database owned the migration (implemented 2026-07-21,
+migration 0011_majestic_nehzno.sql). Branch chore/bug39-adl-fk-ondelete.
 
 PRIOR STATUS: ADL-35 decided — environment promotion model. Staging keeps watching `main`
 (continuous soak); Production is repointed to watch a long-lived `production` branch, promoted
-by explicit `git merge --ff-only origin/main` + push. Design only; the only committed change is
-the ADL-35 entry + a supersession stamp on ADL-32 §5. Railway repoint, CLAUDE.md workflow
-addition, and an OP-22 tracker entry are COO/PO follow-ups (ADL-35 §8). Branch-per-brief is
-UNCHANGED (§7). D-05 Clerk app split noted as out of scope. Prior thread: ADL-33 (read-only
-agent diagnostic access) — see 20260721-ARCHITECT-park.txt.
-
-================================================================================
-WORK COMPLETED THIS THREAD (ADL-33)
-================================================================================
-
-PO ask (2026-07-21): give the COO/Claude Code agent direct READ-ONLY diagnostic access to
-Railway, Turso, Clerk so live-deploy debugging stops depending on Ryan pasting logs by hand.
-Scope pre-negotiated + binding: Railway read-only (logs/status/var names), Turso read-only
-SELECT, Clerk read-only config.
-
-Research (WebSearch/WebFetch — current API surfaces, not assumed):
-- Turso: `turso db tokens create <db> --read-only` is a GENUINE DB-scoped read-only token.
-  DB hosts: libsql://<db>-<org>.turso.io (+ regional <db>-<org>.<region>.turso.io).
-  Platform API api.turso.tech is account-level, NOT read-only — deliberately excluded.
-  => GRANT (clean). Allowlist DB hosts only; invoke via @libsql/client (existing dep).
-- Railway: API + CLI log host = backboard.railway.com (/graphql/v2). NO read-only token
-  scope — Account/Workspace/Project tokens all carry full perms of scope; Project token can
-  still deploy/delete. => GRANT WITH CAVEAT. Project-scoped token = narrowest blast radius;
-  read-only is behavioural only; treat as write-capable secret.
-- Clerk: Backend API api.clerk.com; only credential is Secret Key sk_* = full write to auth
-  config + full user CRUD (PII). NO read-only credential. => DO NOT GRANT (recommend). Keep
-  manual dashboard/paste for rare config lookups. Highest stakes (identity provider).
-- Storage: separate gitignored .env.agent-diagnostics, NOT .env.local (operator vs app
-  secrets; don't load into app process).
-- No BRD ID (operational tooling; ADL-33 §8). Suggested OP-21 tracker entry (COO to create).
-
-ADL-33 logged in jobs/architect/tech/20260307-architecture-decisions-log.md. Completion
-report: jobs/COO/inbox/20260721_2100-ARCHITECT-adl33-agent-service-access.txt.
-Branch: chore/adl-agent-service-access (not yet merged — awaiting PO review/merge).
+by explicit `git merge --ff-only origin/main` + push. Branch-per-brief is UNCHANGED.
 
 ================================================================================
 OPEN / HANDOFF
 ================================================================================
 
-  1. PO/Ryan to provision (blocks implementation):
-     - Turso: `turso db tokens create <prod-db> --read-only` AND `<staging-db> --read-only`;
-       supply both tokens + both libsql:// URLs.
-     - Railway: create a PROJECT token (not Account/Workspace); supply it.
-     - Clerk: nothing — recommended decline. Overriding = conscious sk_* acceptance, own decision.
-  2. COO: create OP-21 tracker entry; after provisioning, dispatch firewall+credential brief
-     (add backboard.railway.com + two Turso DB hosts to init-firewall.sh; create
-     .env.agent-diagnostics + .gitignore entry; short invocation runbook). Firewall change
-     only takes effect on NEXT container start (postStartCommand) — not hot-appliable.
-     Validate reachability after restart; CDN A-record pinning caveat (Cloudflare edge IPs).
-     Do NOT allowlist api.turso.tech or api.clerk.com.
-
-  3. Carried over from ADL-32 (unrelated to this thread, still live):
-     - Clerk preview-origin question (ADL-32 §6) + §10 success criteria pending an actual
-       Railway deploy — see BRD-NF09 tracker.
-  4. Still open, unrelated: OQ-03 (shell trip approximate dates), OQ-05 (trip_places
-     one-row-per-city constraint vs realistic same-city revisits).
+  1. COO: cross-reference rule — write GitHub issue #221 into the BUG-60 tracker `notes`
+     field (tracker is COO-maintained; I did not edit it). Issue title already carries the
+     BUG-60 ID. Flip BUG-60 status when PR merges.
+  2. No new BRD requirement IDs — BUG-60 is a bug fix / infra config, brdRefs empty, no BRD
+     bump needed.
+  3. Carried over, still open, unrelated to this thread:
+     - Clerk preview-origin question (ADL-32 §6) + §10 success criteria pending a real deploy.
+     - D-05 Clerk staging/prod user-pool split (shared pool today — jobs/COO/open-dialogues.md).
+     - OQ-03 (shell trip approximate dates), OQ-05 (trip_places one-row-per-city constraint).
+     - ADL-33 agent read-only diagnostic access — provisioning/firewall brief (PO/COO).
 
 ================================================================================
 TECH FILES
 ================================================================================
 
-  jobs/architect/tech/20260307-architecture-decisions-log.md  ADL-01 through ADL-35
+  jobs/architect/tech/20260307-architecture-decisions-log.md  ADL-01 through ADL-37
   jobs/architect/tech/OP-06-hardening-checklist.md            unchanged, 13/13 PASS
 
 ================================================================================
 NEXT ARCHITECT THREAD — RECOMMENDED STARTING POINT
 ================================================================================
 
-  1. Check whether chore/adl-agent-service-access (ADL-33) and chore/adl-32-hosted-deployment
-     have merged.
-  2. If Ryan chose to override the Clerk decline, capture that as its own tracked decision.
-  3. If Backend's ADL-32 implementing brief resolves the Clerk dynamic-preview-origin
-     question, record it as an ADL-32 addendum or a short new ADL.
-  4. OQ-03 and OQ-05 remain open — pick up independently.
+  1. Confirm fix/bug60-trust-proxy (ADL-37 / #221) merged and BUG-60 closed; verify main CI
+     green post-merge and that the ERR_ERL_UNEXPECTED_X_FORWARDED_FOR boot error is gone from
+     the next Railway deployment logs of BOTH environments (that is the real-world close-out).
+  2. If Railway ever shows the error return, the hop count no longer matches topology (Railway
+     added a hop) — revisit the count per ADL-37's fail-loud note.
+  3. OQ-03 and OQ-05 remain open — pick up independently.

--- a/jobs/architect/park-docs/20260722-ARCHITECT-park-adl37.txt
+++ b/jobs/architect/park-docs/20260722-ARCHITECT-park-adl37.txt
@@ -1,0 +1,84 @@
+PARK DOCUMENT — ARCHITECT — ADL-37 (BUG-60 trust-proxy config)
+Date: 2026-07-22
+Tracker: BUG-60 · ADL-37 · GitHub #221 · Branch fix/bug60-trust-proxy
+
+SCOPE
+Implement-directly dispatch (decision + single-file infra config, no hand-off). BUG-60:
+the app runs on Railway, whose TLS-terminating edge proxy sets X-Forwarded-For on every
+request. src/backend/server.ts never called app.set('trust proxy', ...), so Express
+defaulted to `false` (do not trust the header). express-rate-limit (SEC-07, server.ts
+L147-153 + the secondary cities limiter L158-163) detects the mismatch and throws
+ERR_ERL_UNEXPECTED_X_FORWARDED_FOR at boot in BOTH prod (deployment f60d623b) and staging
+(12e1e764) — confirmed from deployment logs, pre-dates the session that found it.
+
+RULING (ADL-37) — High confidence
+app.set('trust proxy', 1) — trust exactly Railway's ONE edge hop. The value is the crux;
+the two failure modes are the two errors express-rate-limit guards:
+  - false (current default): X-Forwarded-For present but untrusted => req.ip = socket peer
+    (Railway edge) for EVERY request => all clients share one bucket. Throws
+    ERR_ERL_UNEXPECTED_X_FORWARDED_FOR. This is the bug.
+  - true: trusts the WHOLE chain => Express returns the leftmost (forgeable) XFF entry as
+    req.ip => client spoofs its IP and rotates it to bypass rate limits. express-rate-limit
+    rejects it with ERR_ERL_PERMISSIVE_TRUST_PROXY. This is the "trust too much" hole.
+  - 1 (selected): strips exactly one hop (Railway edge = immediate socket peer), takes the
+    last-appended address (the real client IP Railway itself wrote) as req.ip. A forged
+    prefix sits deeper in the chain and is ignored. Correct + not spoofable, given Railway's
+    edge APPENDS the connecting IP (standard XFF reverse-proxy behaviour — same assumption
+    every "trust proxy: 1 behind one reverse proxy" deployment relies on).
+
+WHY NOT A HIGHER COUNT OR A CIDR ALLOWLIST
+  - Railway is a single edge tier from the app's XFF perspective — count must match topology
+    exactly; 2+ would hand an attacker back a spoofable position.
+  - CIDR allowlist (pin Railway edge IPs) is theoretically tightest but Railway publishes no
+    committed edge CIDR; pinned IPs rotate and would silently start throwing again. Hop-count
+    needs no list and FAILS LOUD: if Railway ever added a hop, the boot error resurfaces
+    (visible) rather than opening a silent trust gap. That fail-loud property is the reason
+    Medium-confidence residual risk ("could Railway be >1 hop") is acceptable.
+  - Firewall blocked fetching Railway's own edge docs from the devcontainer (allowlist is
+    GitHub/npm/Anthropic only). Hop count reasoned from the standard single-reverse-proxy
+    model Railway's TLS-terminating edge fits + the observed error signature (UNEXPECTED =
+    header-present-but-untrusted, consistent with exactly one untrusted hop).
+
+PROD vs STAGING: identical. Same image, same platform, same single-edge topology; error
+present in both deployments' logs. One hardcoded value covers both — no env-var gating
+(the value is a property of the Railway platform, not of an environment's config, so it must
+not be something an env var can silently get wrong). Inert in local dev/CI (no XFF present =>
+req.ip = socket peer, limiter never trips).
+
+FILES CHANGED
+  - src/backend/server.ts        — app.set('trust proxy', 1) added immediately after
+                                    express(), BEFORE the rate-limiter middleware (limiter
+                                    reads resolved req.ip; ordering must be settled first).
+  - src/backend/server-test-app.ts — same setting mirrored. The two app builders duplicate
+                                    the middleware chain BY DESIGN (test export documents
+                                    "same request pipeline as production"); both must move
+                                    together or the test pipeline silently diverges. Mirroring
+                                    is also what makes the setting assertable under supertest.
+  - src/backend/__tests__/trust-proxy.test.ts — NEW. Asserts (1) app.get('trust proxy') === 1
+                                    (not true = spoofable, not false = default bug), and (2)
+                                    the compiled trust predicate (app.get('trust proxy fn'))
+                                    trusts hop 0 but NOT hop 1 — i.e. exactly one hop. That
+                                    second assertion is the security property in code: a
+                                    forged deeper-hop entry is not trusted.
+  - jobs/architect/tech/20260307-architecture-decisions-log.md — ADL-37 entry.
+
+TEST NOTE (judgment call, per brief step 4)
+There IS a clean way to assert this and I took it — but note WHAT is asserted. Express does
+not expose a live-request hook to prove "a forged X-Forwarded-For was rejected" without
+adding a req.ip-echoing probe route (intrusive, auth-gated). The compiled-trust-fn assertion
+(trust hop 0, reject hop 1) is the precise, non-intrusive encoding of the same property and
+is what Express itself uses at request time, so it is a faithful guard, not a proxy for one.
+
+VERIFICATION
+  - npm run type:check:backend — clean.
+  - npm run test:backend — 535 passed | 1 skipped (24 files), includes the new test.
+  - /pre-push — run before push (see completion report for result).
+  - CI — see completion report; do not close until gh pr checks green.
+
+HAND-OFFS / OPEN
+  - COO: write issue #221 into BUG-60 tracker `notes` (COO-maintained; I did not touch
+    tracker.json). Flip BUG-60 status on merge.
+  - Real-world close-out (next thread): after merge + Railway redeploy of BOTH environments,
+    confirm the ERR_ERL_UNEXPECTED_X_FORWARDED_FOR boot error is GONE from both deployment
+    logs. That is the actual definition-of-done, beyond CI green.
+  - No BRD change (bug fix, brdRefs empty).

--- a/jobs/architect/tech/20260307-architecture-decisions-log.md
+++ b/jobs/architect/tech/20260307-architecture-decisions-log.md
@@ -2279,3 +2279,100 @@ revisited under this same rule. This is guidance, not a defect — no tracker en
 **Supersession:** none. Refines ADL-13's carry-forward model (clarifies the two-field coupling is a
 create-time invariant, not a permanent one) without overturning it — no stamp required; ADL-13's
 create-time enforcement stands unchanged.
+
+---
+
+## ADL-37 — Express `trust proxy` = `1` (single Railway edge hop) (BUG-60)
+
+**Date:** 2026-07-22
+**Status:** Decided — **Implemented** (Architect, 2026-07-22, branch `fix/bug60-trust-proxy`,
+refs #221). `app.set('trust proxy', 1)` added to `src/backend/server.ts` (before the
+SEC-07 rate-limiter middleware) and mirrored into `src/backend/server-test-app.ts` to keep the
+two app builders' pipelines identical. Regression test:
+`src/backend/__tests__/trust-proxy.test.ts` (asserts the setting is the integer `1` and that the
+compiled trust predicate trusts exactly hop 0, not hop 1). Single-file infra config change, no
+backend hand-off.
+
+**Trigger:** BUG-60, found 2026-07-21 while verifying BUG-59's fix by reviewing Railway
+deployment logs. Both environments' logs show `express-rate-limit` throwing
+`ERR_ERL_UNEXPECTED_X_FORWARDED_FOR` once shortly after boot — staging deployment `12e1e764`
+and prod `f60d623b` (i.e. already present in prod before that session's changes). Railway sits a
+TLS-terminating edge proxy in front of the container and sets `X-Forwarded-For` on every request;
+`server.ts` never called `app.set('trust proxy', ...)`, so Express defaulted to `false` (do not
+trust the header). Not a hard block on traffic (fires at startup, not per-request; both
+environments otherwise functional), but SEC-07's IP attribution is unreliable in that state — the
+reason this was routed to Architect for an ADL rather than fixed unilaterally, per the standing
+"runtime/infra config needs an Architect decision first" rule.
+
+**Decision:** Set `trust proxy` to the **integer hop count `1`** — trust exactly one proxy hop
+(Railway's edge), no more. Not `true`, not `false`, not a CIDR allowlist.
+
+**Why the value matters in both directions (this is the whole reason it's an ADL, not a
+one-liner):** the two ways to get this wrong are the two errors `express-rate-limit` guards, and
+they map exactly onto the two directions of misconfiguration:
+- **`false` (the current default) — the bug.** With a proxy present but untrusted, `req.ip`
+  resolves to the *socket peer* (Railway's edge) for **every** request, so all clients look like
+  one IP. `express-rate-limit` detects the mismatch (X-Forwarded-For present + `trust proxy`
+  off) and throws `ERR_ERL_UNEXPECTED_X_FORWARDED_FOR`. Effect if it didn't throw: the whole
+  internet shares one rate-limit bucket — the limiter is simultaneously useless (one attacker
+  exhausts everyone's quota) and hostile (legitimate users collide).
+- **`true` — the security hole in the other direction.** `true` trusts the *entire*
+  X-Forwarded-For chain, so Express walks it fully left and returns the **leftmost** value as
+  `req.ip`. A client can forge `X-Forwarded-For: <anything>`; Railway's edge appends the real
+  peer to the right, but with `true` Express still honours the forged leftmost entry — so the
+  client picks its own apparent IP and rotates it to **bypass rate limiting entirely**.
+  `express-rate-limit` rejects this configuration outright with
+  `ERR_ERL_PERMISSIVE_TRUST_PROXY` precisely because it is spoofable.
+- **`1` — correct.** Express strips exactly one trusted hop from the right (Railway's edge, the
+  immediate socket peer) and takes the *last-appended* address as `req.ip` — that is the real
+  client IP that Railway's edge itself wrote. A forged prefix from the client sits deeper in the
+  chain (to the left of Railway's appended value) and is **ignored**, because Express only trusts
+  one hop. This satisfies the limiter, attributes IPs correctly, and is not spoofable — assuming
+  Railway's edge *appends* the connecting IP (standard, XFF-conformant reverse-proxy behaviour),
+  which is the same assumption every "`trust proxy: 1` behind one reverse proxy" deployment
+  (Heroku, nginx, Cloudflare-to-single-origin) relies on.
+
+**Why `1` and not a higher count or a CIDR allowlist:**
+- Railway's public networking is a **single** edge tier in front of the app container from the
+  app's `X-Forwarded-For` perspective — one hop to trust. A hop count of `2+` would strip a hop
+  Railway doesn't add, handing the attacker back a spoofable position; the count must match the
+  real topology exactly, and that count is `1`.
+- A CIDR/IP allowlist (trusting Railway's edge subnet) is the theoretically tightest option but
+  requires a **stable, documented** set of Railway edge IPs to pin; Railway does not publish a
+  committed egress/edge CIDR, and pinning to observed IPs would silently break (start throwing
+  again) whenever they rotate. The hop-count form needs no such list and degrades safely: if
+  Railway ever inserted a second hop, the symptom would resurface as a *visible* boot error, not
+  a *silent* trust gap — the fail-loud direction. `1` is the correct, maintainable choice.
+- Firewall note: Railway's own edge-topology docs were not fetchable from inside the devcontainer
+  (allowlist is GitHub/npm/Anthropic only), so the hop count is reasoned from the standard
+  single-reverse-proxy model that Railway's TLS-terminating edge fits, plus the observed error
+  signature (`UNEXPECTED`, i.e. header-present-but-untrusted — consistent with exactly one
+  untrusted hop). Confidence: **High** on the direction and the `1`-vs-`true` security argument;
+  **Medium** only on the residual "could Railway ever be >1 hop" — mitigated by the fail-loud
+  property above.
+
+**Prod vs staging:** identical. Both run the same image on the same Railway platform with the
+same single-edge topology (confirmed: the error appears in both deployments' logs with the same
+signature). One value, hardcoded, covers both — no env-var gating. It is also safe in **local dev
+and CI**: with no `X-Forwarded-For` present, `req.ip` simply falls back to the socket peer and the
+limiter never trips, so the setting is inert outside a proxied deployment. Hardcoding (not
+env-driven) is deliberate — the value is a property of the Railway platform, not of a particular
+environment's config, so it should not be something an env var can silently get wrong.
+
+**Placement:** `app.set('trust proxy', 1)` is registered immediately after `express()` and
+before the rate-limiter (and all other) middleware in `server.ts`. `express-rate-limit` reads the
+resolved `req.ip`, so the app-level setting must be in effect before the limiter runs; setting it
+first removes any ordering ambiguity.
+
+**Implications for other jobs:**
+- **Backend:** none — no route or repository change. Any *future* code that reads `req.ip` (audit
+  logging, per-IP throttles, geo) now gets the real client IP behind Railway, correctly; code
+  should continue to use `req.ip` rather than parsing `X-Forwarded-For` by hand.
+- **The two app builders must stay in sync.** `server.ts` and `server-test-app.ts` duplicate the
+  middleware chain by design (the test export documents this). Any future change to proxy/trust
+  handling must touch both, or the test pipeline silently diverges from production. The added test
+  guards the test-app side of that.
+
+**Supersession:** none. Additive server configuration; no prior ADL addressed `trust proxy`.
+Complements SEC-07 (rate limiting) by making its client-IP resolution correct and non-spoofable
+behind the ADL-32 Railway deployment.

--- a/src/backend/__tests__/trust-proxy.test.ts
+++ b/src/backend/__tests__/trust-proxy.test.ts
@@ -1,0 +1,35 @@
+/**
+ * BUG-60 / ADL-37 — Express `trust proxy` configured for Railway's single edge hop.
+ *
+ * Railway sits a TLS-terminating edge proxy in front of this container and appends the
+ * real client IP to X-Forwarded-For. Without `trust proxy`, Express won't read that
+ * header and express-rate-limit (SEC-07) throws ERR_ERL_UNEXPECTED_X_FORWARDED_FOR on
+ * boot; with `trust proxy: true` a client could forge the chain and spoof its IP
+ * (ERR_ERL_PERMISSIVE_TRUST_PROXY). The correct value is the integer hop count `1`.
+ *
+ * These assertions run against the test-export app (server-test-app.ts), which mirrors
+ * server.ts's middleware pipeline, so they lock in the setting for the exact app tests
+ * exercise. See ADL-37.
+ */
+
+import { describe, expect, it } from 'vitest';
+import app from '../server-test-app.js';
+
+describe('BUG-60 — trust proxy configuration', () => {
+  it('trusts exactly one hop (integer 1), not the whole chain', () => {
+    // The literal setting value must be the integer 1 — never `true` (spoofable) and
+    // never left at the `false` default (rate limiter can't resolve client IPs).
+    expect(app.get('trust proxy')).toBe(1);
+  });
+
+  it('compiled trust function trusts only the first (nearest) hop', () => {
+    // Express compiles `trust proxy` into a predicate (addr, hopIndex) => boolean.
+    // For hop count 1 it must trust hop 0 (Railway's edge, the immediate peer) and
+    // NOT hop 1 — this is the security property: a forged X-Forwarded-For prefix from
+    // the client sits at a deeper hop and is therefore ignored when resolving req.ip.
+    const trust = app.get('trust proxy fn') as (addr: string, i: number) => boolean;
+    expect(typeof trust).toBe('function');
+    expect(trust('10.0.0.1', 0)).toBe(true);
+    expect(trust('10.0.0.1', 1)).toBe(false);
+  });
+});

--- a/src/backend/server-test-app.ts
+++ b/src/backend/server-test-app.ts
@@ -42,6 +42,12 @@ const ALLOWED_ORIGINS = (
 
 const app = express();
 
+// Trust proxy — mirrors server.ts (BUG-60 / ADL-37). Kept in sync so tests exercise
+// the same request pipeline as production. Railway is a single trusted edge hop, hence
+// the integer `1` (not `true`, which would be spoofable — see ADL-37). Harmless under
+// supertest's loopback transport (no X-Forwarded-For present).
+app.set('trust proxy', 1);
+
 // Helmet — HTTP security headers (SEC-01)
 app.use(
   helmet({

--- a/src/backend/server.ts
+++ b/src/backend/server.ts
@@ -80,6 +80,23 @@ const SERVE_STATIC = process.env.NODE_ENV === 'production' && fs.existsSync(DIST
 
 const app = express();
 
+// 0. Trust proxy — Railway edge proxy (BUG-60 / ADL-37)
+//
+// Railway terminates TLS at its edge and forwards to this container, appending the
+// real client IP to X-Forwarded-For (exactly one trusted hop). Express defaults to
+// NOT trusting that header, so express-rate-limit (SEC-07, below) can't resolve the
+// client IP and throws ERR_ERL_UNEXPECTED_X_FORWARDED_FOR on boot.
+//
+// The value is the integer hop count `1`, NOT `true`. `true` would trust the entire
+// X-Forwarded-For chain, so a client could forge a leftmost entry and spoof its IP to
+// evade rate limits (express-rate-limit rejects that with ERR_ERL_PERMISSIVE_TRUST_PROXY).
+// `1` strips exactly one hop (Railway's edge) and takes the last-appended address as
+// req.ip — a forged prefix is ignored because Railway appends the real peer to the right.
+// Identical topology in prod and staging; safe in local dev/CI too (no X-Forwarded-For
+// present → req.ip falls back to the socket peer, and the limiter never trips).
+// MUST be set before the rate-limiter middleware registers. See ADL-37.
+app.set('trust proxy', 1);
+
 // 1. Helmet — HTTP security headers (SEC-01)
 app.use(
   helmet({


### PR DESCRIPTION
Closes #221
Tracker: BUG-60 (P2) · ADL: ADL-37 · BRD: none (bug fix / infra config)

## Problem
Railway's TLS-terminating edge proxy sets `X-Forwarded-For` on every request, but `src/backend/server.ts` never called `app.set('trust proxy', ...)`, so Express defaulted to **not** trusting the header. `express-rate-limit` (SEC-07) detects this and throws `ERR_ERL_UNEXPECTED_X_FORWARDED_FOR` at boot in **both** prod (`f60d623b`) and staging (`12e1e764`), confirmed from Railway deployment logs. Not a hard traffic block (startup, not per-request), but SEC-07's client-IP attribution is unreliable in that state.

## Fix
`app.set('trust proxy', 1)` — trust exactly Railway's single edge hop.

The value is the crux (full reasoning in **ADL-37**):
- **`false`** (current default) → all clients bucket under one apparent IP; the error we see.
- **`true`** → trusts the whole `X-Forwarded-For` chain → client can forge `req.ip` and rotate it to **bypass rate limits** (`express-rate-limit` rejects it as `ERR_ERL_PERMISSIVE_TRUST_PROXY`). The "trust too much" hole.
- **`1`** → strips exactly Railway's one edge hop, takes the real last-appended client IP as `req.ip`; a forged prefix is ignored. Correct and non-spoofable.

Prod and staging are identical Railway topology, so one hardcoded value covers both; inert in local dev/CI (no `X-Forwarded-For` present).

## Changes
- `src/backend/server.ts` — setting added immediately after `express()`, before the rate limiter.
- `src/backend/server-test-app.ts` — mirrored (the two app builders are kept in sync by design).
- `src/backend/__tests__/trust-proxy.test.ts` — regression test: asserts the setting is `1` and that Express's compiled trust predicate trusts hop 0 but **not** hop 1 (the security property in code).
- ADL-37 logged.

## Verification
- `type:check:all` clean; `test:backend` 535 pass; `test:frontend` 154 pass; `check` (biome) clean; `status:check` in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)