### PR TITLE
fix(BUG-61): countries/regions reads require auth not owner (#225)

### DIFF
--- a/jobs/COO/inbox/20260722_2148-ARCHITECT-BUG61-country-picker-auth-complete.txt
+++ b/jobs/COO/inbox/20260722_2148-ARCHITECT-BUG61-country-picker-auth-complete.txt
@@ -1,0 +1,50 @@
+TO: COO
+FROM: Architect
+DATE: 2026-07-22
+RE: BUG-61 — non-owner country-picker auth fix — COMPLETE (implemented)
+
+IDs: BUG-61 · GitHub #225 (issue) / PR #227 · BRD §GE-04 / §GE-05 · ADL-38
+Branch: fix/bug61-country-picker-auth
+
+WHAT: Split countries/regions READ from WRITE in the admin router. The two GET
+routes (countries list + regions list) now require only requireAuth; the three
+write routes stay requireOwner. Fixes non-owner accounts getting 403 on the trip-
+create country picker, which blocked non-owner trip creation entirely. Root cause:
+both GET routes were under the router-level requireOwner guard; per GE-04/GE-05
+countries are global pre-seeded defaults, not owner-only data.
+
+PER-DECISION:
+- Read/write split (ADL-38): ADOPTED. Reads=requireAuth, writes=requireOwner.
+- Implementation shape: ADOPTED fail-closed — GET routes moved ABOVE the blanket
+  requireOwner guard (not per-route requireOwner), so new admin routes stay
+  owner-gated by default. Only global-reference-data reads may sit above the guard.
+- Scope boundary: explicitly NOT ADL-28 (per-user shading/companions userId FK).
+  No scope creep into that work; this is countries/regions read-access only.
+
+AUDITABLE ACCESS MATRIX (self-applied Backend security checklist):
+  requireAuth only : GET /api/admin/countries
+                     GET /api/admin/countries/:code/regions
+  requireOwner     : PATCH /api/admin/countries/:code
+                     POST  /api/admin/countries/:code/regions
+                     PATCH /api/admin/countries/:code/regions/:regionId
+                     + all categories/activities/companions CRUD (unchanged)
+  All six still 401 when unauthenticated (requireAuth global in server.ts).
+
+CI: PR #227 opened; checks running at report time. Local pre-push all green:
+biome, type:check:all, test:backend (538), test:frontend (154), status:check.
+Will not consider done until gh CI green — see my push note below.
+
+MANUAL VERIFICATION: non-owner bypass user (isOwner:0) — GET countries 200 (250
+rows), GET regions 200, PATCH/POST writes 403, GET categories 403 (fail-closed OK).
+
+DOCS: ADL-38 in main log (full matrix); ADL-27 file stamped SUPERSEDED IN PART.
+
+BLOCKERS: none.
+
+UNBLOCKED: Non-owner trip creation works end-to-end on merge — the "share the app
+with a friend to test" path is no longer capped at country selection. No frontend
+change required.
+
+COO ACTIONS: merge PR #227 after CI green (do not self-merge per workflow); flip
+BUG-61 tracker status on merge (tracker is COO-maintained — I did not edit it). No
+BRD bump (bug fix against existing GE-04/GE-05).

--- a/jobs/architect/context/current.txt
+++ b/jobs/architect/context/current.txt
@@ -1,59 +1,62 @@
 ARCHITECT CONTEXT — 2026-07-22
 PROJECT: Travel Tracker
-CURRENT STATUS: ADL-37 decided AND implemented — BUG-60 (#221) trust-proxy fix.
-`app.set('trust proxy', 1)` added to src/backend/server.ts (before the SEC-07 rate limiter)
-and mirrored into src/backend/server-test-app.ts to keep the two app builders' pipelines in
-sync. Railway sits a single TLS-terminating edge hop in front of the container and sets
-X-Forwarded-For; Express defaulted to `false` (untrusted), so express-rate-limit threw
-ERR_ERL_UNEXPECTED_X_FORWARDED_FOR on boot in BOTH prod (f60d623b) and staging (12e1e764).
-Value is the integer hop count `1`, NOT `true`: `true` trusts the whole XFF chain and is
-client-spoofable (express-rate-limit rejects it with ERR_ERL_PERMISSIVE_TRUST_PROXY) — a
-rate-limit-bypass hole. `1` strips exactly Railway's one edge hop and takes the last-appended
-address as req.ip; a forged prefix is ignored. Identical prod/staging (same topology);
-hardcoded (property of the platform, not env config); inert in local dev/CI (no XFF present).
-Regression test: src/backend/__tests__/trust-proxy.test.ts (asserts setting==1 and the
-compiled trust predicate trusts hop 0 but not hop 1). This was an implement-directly thread
-(single-file infra config), not a hand-off. Branch fix/bug60-trust-proxy, PR pending CI.
-See 20260722-ARCHITECT-park-adl37.txt.
+CURRENT STATUS: ADL-38 decided AND implemented — BUG-61 (#225) non-owner country-picker fix.
+Root cause: src/backend/routes/admin.ts registered GET /countries and
+GET /countries/:countryCode/regions directly on adminRouter, and adminRouter.use(requireOwner)
+(admin.ts) gated the WHOLE router — reads included. So a non-owner account (Ryan's staging test
+sign-in) got 403 on GET /api/admin/countries; TripForm's country picker (useCountries) rendered
+empty and no non-owner could create a trip at all. Per GE-04/GE-05 every country ships as a
+global, pre-seeded default available to all users out of the box (same tier as AD-09
+categories/activities), so gating the READ behind owner status was wrong.
+
+DECISION (read/write split): the two country/region GET routes now require only requireAuth
+(already applied globally to /api/* in server.ts); the three WRITE routes (PATCH country config,
+POST region, PATCH region) stay owner-gated exactly as before. Implementation kept the router
+FAIL-CLOSED by default: I moved the two GET handlers ABOVE the router-level requireOwner guard
+rather than removing the blanket guard + adding per-route requireOwner. That means a future
+admin route is owner-gated unless deliberately moved into the small, labelled reads block —
+avoids the fail-open BUG-22 class (requireOwner forgotten on a write route). The guard block in
+admin.ts carries an explicit FAIL-CLOSED comment; only global-reference-data reads may sit above it.
+
+DISTINCT FROM ADL-28 (BRD-AD07/AD08): ADL-28 = make genuinely owner-only data (map shading,
+companions) work PER-USER via a userId FK (still awaiting Backend brief). BUG-61 = global,
+already-shared data wrongly gated as owner-only. No userId scoping here; countries/regions have
+no per-user dimension. Did NOT expand into ADL-28's scope.
+
+Change confined to admin.ts. Regression: security.access-matrix.test.ts Part E added (non-owner
+GET countries/regions -> 200; non-owner writes -> 403); the two old GET-403 cases removed from
+Part B. Full backend suite 538 passed / 1 skip; type:check:backend clean. Manual live check with
+a non-owner bypass user (BYPASS_AUTH=true, OWNER_CLERK_ID mismatch -> isOwner:0): GET countries
+200 (250 rows), GET regions 200, PATCH/POST writes 403, GET /api/admin/categories still 403
+(fail-closed intact). ADL-27 standalone file stamped SUPERSEDED IN PART for the two GET routes.
+Branch fix/bug61-country-picker-auth, PR pending CI. See 20260722-ARCHITECT-park-adl38.txt.
+
+PRIOR STATUS: ADL-37 decided AND implemented — BUG-60 (#221) trust-proxy fix.
+app.set('trust proxy', 1) in server.ts + server-test-app.ts. Integer hop count 1 (NOT true,
+which is client-spoofable). Regression test src/backend/__tests__/trust-proxy.test.ts.
+Branch fix/bug60-trust-proxy. See 20260722-ARCHITECT-park-adl37.txt.
 
 PRIOR STATUS: ADL-36 decided — BUG-39 (#209) FK review. items.carriedFromItemId gets
-onDelete: 'set null' (confirmed Frontend's proposal; cascade/restrict rejected). Verified NO
-backend/frontend change needed. Database owned the migration (implemented 2026-07-21,
-migration 0011_majestic_nehzno.sql). Branch chore/bug39-adl-fk-ondelete.
+onDelete: 'set null'. Database owned the migration (0011_majestic_nehzno.sql).
 
-PRIOR STATUS: ADL-35 decided — environment promotion model. Staging keeps watching `main`
-(continuous soak); Production is repointed to watch a long-lived `production` branch, promoted
-by explicit `git merge --ff-only origin/main` + push. Branch-per-brief is UNCHANGED.
+PRIOR STATUS: ADL-35 decided — environment promotion model. Staging watches `main`
+(continuous soak); Production watches a long-lived `production` branch, promoted by explicit
+`git merge --ff-only origin/main` + push. Branch-per-brief UNCHANGED.
 
 ================================================================================
 OPEN / HANDOFF
 ================================================================================
 
-  1. COO: cross-reference rule — write GitHub issue #221 into the BUG-60 tracker `notes`
-     field (tracker is COO-maintained; I did not edit it). Issue title already carries the
-     BUG-60 ID. Flip BUG-60 status when PR merges.
-  2. No new BRD requirement IDs — BUG-60 is a bug fix / infra config, brdRefs empty, no BRD
-     bump needed.
-  3. Carried over, still open, unrelated to this thread:
+  1. COO: merge PR #225 (fix/bug61-country-picker-auth) after CI green — do not self-merge.
+     Then flip BUG-61 tracker status (tracker is COO-maintained; I did not edit it). Issue
+     title / tracker notes already carry BUG-61 <-> #225 cross-reference.
+  2. No new BRD requirement IDs — BUG-61 is a bug fix against existing GE-04/GE-05, brdRefs
+     already set; no BRD bump needed.
+  3. Frontend: no change required — the reported symptom (empty country picker for non-owners)
+     resolves end-to-end once this merges. Non-owner "share the app with a friend" path is
+     unblocked through trip creation.
+  4. Carried over, still open, unrelated to this thread:
+     - ADL-28 (BRD-AD07/AD08) per-user map-shading + companions still awaiting Backend brief.
      - Clerk preview-origin question (ADL-32 §6) + §10 success criteria pending a real deploy.
      - D-05 Clerk staging/prod user-pool split (shared pool today — jobs/COO/open-dialogues.md).
      - OQ-03 (shell trip approximate dates), OQ-05 (trip_places one-row-per-city constraint).
-     - ADL-33 agent read-only diagnostic access — provisioning/firewall brief (PO/COO).
-
-================================================================================
-TECH FILES
-================================================================================
-
-  jobs/architect/tech/20260307-architecture-decisions-log.md  ADL-01 through ADL-37
-  jobs/architect/tech/OP-06-hardening-checklist.md            unchanged, 13/13 PASS
-
-================================================================================
-NEXT ARCHITECT THREAD — RECOMMENDED STARTING POINT
-================================================================================
-
-  1. Confirm fix/bug60-trust-proxy (ADL-37 / #221) merged and BUG-60 closed; verify main CI
-     green post-merge and that the ERR_ERL_UNEXPECTED_X_FORWARDED_FOR boot error is gone from
-     the next Railway deployment logs of BOTH environments (that is the real-world close-out).
-  2. If Railway ever shows the error return, the hop count no longer matches topology (Railway
-     added a hop) — revisit the count per ADL-37's fail-loud note.
-  3. OQ-03 and OQ-05 remain open — pick up independently.

--- a/jobs/architect/park-docs/20260722-ARCHITECT-park-adl38.txt
+++ b/jobs/architect/park-docs/20260722-ARCHITECT-park-adl38.txt
@@ -1,0 +1,102 @@
+ARCHITECT PARK DOCUMENT — 2026-07-22 (ADL-38 / BUG-61)
+================================================================================
+
+THREAD: BUG-61 — non-owner accounts cannot create a trip (country picker empty).
+GitHub issue #225. Branch fix/bug61-country-picker-auth. ADL-38.
+
+--------------------------------------------------------------------------------
+WHAT THE BUG WAS
+--------------------------------------------------------------------------------
+Ryan signed into staging as a non-owner test account and could not create a trip.
+TripForm.tsx's country picker (useCountries in src/frontend/hooks/useAdmin.ts ->
+GET /api/admin/countries) rendered empty because the route 403'd.
+
+Root cause in src/backend/routes/admin.ts: GET /countries and
+GET /countries/:countryCode/regions were registered directly on adminRouter, and
+adminRouter.use(requireOwner) gated the ENTIRE router — reads included. Countries had
+no read/write split, so global reference data every user needs to create a trip was
+visible only to the owner. This was the practical ceiling on "share the app with a
+friend to test": a non-owner could not get past country selection at all.
+
+--------------------------------------------------------------------------------
+THE DECISION (ADL-38)
+--------------------------------------------------------------------------------
+Read/write split for the countries/regions resources:
+  READS  (GET /countries, GET /countries/:code/regions) -> requireAuth only.
+  WRITES (PATCH /countries/:code, POST /countries/:code/regions,
+          PATCH /countries/:code/regions/:regionId)     -> requireOwner (unchanged).
+
+Justification: GE-04/GE-05 — every country ships as a global, pre-seeded default with
+region-tier config applied automatically on first launch (seedCountries/seedRegions at
+startup), same tier as AD-09 categories/activities. It is NOT owner-configured per-user
+data, so gating its READ behind owner status was simply wrong. The write operations are
+a genuine owner-admin function (editing the shared region-tier config / region set), so
+they stay owner-gated.
+
+--------------------------------------------------------------------------------
+IMPLEMENTATION SHAPE — WHY IT MATTERS (the load-bearing design call)
+--------------------------------------------------------------------------------
+Two ways to carve the reads out:
+  (a) register the two GET routes ABOVE the blanket requireOwner guard; guard still
+      covers everything else. -> FAIL-CLOSED default.
+  (b) remove the blanket guard, apply requireOwner per write route. -> FAIL-OPEN:
+      a future author who forgets requireOwner on a new write route leaves it open.
+
+Chose (a). The reads are the small, enumerable exception; writes are protected by
+default. A newly added admin route is owner-gated unless a future author DELIBERATELY
+moves it into the labelled reads block above the guard. This avoids the exact
+BUG-22 failure class (requireOwner missing on PATCH /api/cities/:id). The guard block in
+admin.ts carries an explicit FAIL-CLOSED comment stating only global-reference-data
+reads may live above it.
+
+Change is confined to admin.ts (route ordering + comments). No schema, no migration, no
+server.ts change (requireAuth is already applied globally to /api/* before /api/admin is
+mounted, so all six routes still 401 unauthenticated).
+
+--------------------------------------------------------------------------------
+NOT ADL-28 — kept the scopes separate (per the brief's explicit instruction)
+--------------------------------------------------------------------------------
+ADL-28 (BRD-AD07/AD08) = make genuinely owner-only data (map-shading config, companions)
+work PER-USER via a userId FK; still "awaiting Backend implementation brief."
+BUG-61/ADL-38 = the opposite shape — global, already-shared data wrongly gated as
+owner-only. No userId scoping is involved; countries/regions have no per-user dimension.
+Did not touch ADL-28's territory.
+
+--------------------------------------------------------------------------------
+VERIFICATION
+--------------------------------------------------------------------------------
+- security.access-matrix.test.ts: added Part E (non-owner GET countries/regions -> 200;
+  non-owner writes -> 403). Removed the two now-invalid GET-403 cases from Part B;
+  updated the file + Part B header comments to list the two GET routes as requireAuth-only
+  (like /api/map/shading/{countries,regions}/:code and /api/me). Suite: 67 passed, 1 skip.
+- Full backend suite: 538 passed / 1 skip. type:check:backend: clean.
+- Manual live check (this is what confirms the reported symptom is gone): started the
+  backend with a scratch sqlite DB, BYPASS_AUTH=true and OWNER_CLERK_ID set to a value that
+  does NOT match the bypass user's clerkId, so the bypass user resolves to isOwner:0.
+  GET /api/me -> {"isOwner":0}. Then:
+    GET  /api/admin/countries            -> 200 (250-country list)
+    GET  /api/admin/countries/US/regions -> 200
+    PATCH /api/admin/countries/US        -> 403
+    POST  /api/admin/countries/US/regions-> 403
+    GET  /api/admin/categories           -> 403  (fail-closed default intact)
+
+--------------------------------------------------------------------------------
+DOC LIFECYCLE
+--------------------------------------------------------------------------------
+- ADL-38 added to the main log (jobs/architect/tech/20260307-architecture-decisions-log.md)
+  with a full access matrix + implemented status.
+- ADL-27 standalone file (jobs/architect/tech/ADL-27-admin-role-model.md) stamped
+  "SUPERSEDED IN PART (2026-07-22) by ADL-38" on the "Routes to protect" section for the two
+  GET routes only. ADL-27 itself had anticipated this: it said opening a read route to
+  non-owners requires an explicit security assessment — ADL-38 is that assessment.
+- admin.ts header docstring + guard-block comment document the auth model and fail-closed
+  invariant inline.
+
+--------------------------------------------------------------------------------
+HANDOFF
+--------------------------------------------------------------------------------
+1. COO: merge PR #225 after CI green (do not self-merge); flip BUG-61 tracker status.
+2. No BRD bump — bug fix against existing GE-04/GE-05.
+3. Frontend: no change needed; symptom resolves on merge.
+4. Carried-over open items unchanged (ADL-28 backend brief; Clerk preview origins;
+   D-05 user-pool split; OQ-03; OQ-05).

--- a/jobs/architect/tech/20260307-architecture-decisions-log.md
+++ b/jobs/architect/tech/20260307-architecture-decisions-log.md
@@ -2376,3 +2376,88 @@ first removes any ordering ambiguity.
 **Supersession:** none. Additive server configuration; no prior ADL addressed `trust proxy`.
 Complements SEC-07 (rate limiting) by making its client-IP resolution correct and non-spoofable
 behind the ADL-32 Railway deployment.
+
+---
+
+## ADL-38 — Countries/regions are global reference data: READ = requireAuth, WRITE = requireOwner (BUG-61)
+
+**Date:** 2026-07-22
+**Status:** Decided — **Implemented** (Architect, 2026-07-22, branch `fix/bug61-country-picker-auth`,
+refs #225). Change confined to `src/backend/routes/admin.ts`: the two country/region GET routes
+are moved above the router-level `requireOwner` guard; all writes stay below it. Regression
+coverage added to `src/backend/routes/__tests__/security.access-matrix.test.ts` (Part E). No
+schema, migration, or backend hand-off.
+
+**Trigger:** BUG-61 (GitHub #225), found 2026-07-22 live in staging — Ryan signed in as a
+non-owner test account and could not create a trip: the TripForm country picker
+(`src/frontend/components/TripDetail/TripForm.tsx` → `useCountries` in
+`src/frontend/hooks/useAdmin.ts`, `GET /api/admin/countries`) rendered empty because the route
+403'd. Root cause: `admin.ts` registered `GET /countries` and `GET /countries/:countryCode/regions`
+directly on `adminRouter`, and `adminRouter.use(requireOwner)` gated the **whole router** — reads
+included. A non-owner therefore hit the practical ceiling on "share the app with a friend to test":
+they could not get past country selection at all.
+
+**Decision:** Split read from write for the countries/regions resources.
+- **Reads** (`GET /api/admin/countries`, `GET /api/admin/countries/:countryCode/regions`) require
+  only authentication — `requireAuth`, already applied globally to all of `/api/*` in `server.ts`.
+- **Writes** (`PATCH /countries/:countryCode`, `POST /countries/:countryCode/regions`,
+  `PATCH /countries/:countryCode/regions/:regionId`) stay owner-only, unchanged.
+
+**Why this is correct (GE-04 / GE-05):** every country ships as a global, pre-seeded default with
+its region-tier config applied automatically on first launch — the same data tier as AD-09's
+categories/activities, seeded by `seedCountries()`/`seedRegions()` at startup, not owner-configured
+per-user data. Gating the *read* of global defaults behind owner status was simply wrong: it made a
+resource every user needs to create a trip visible only to the owner. The write operations are
+genuinely an owner-admin function (editing the shared region-tier config, adding regions), so they
+correctly stay owner-gated.
+
+**Distinct from ADL-28 (BRD-AD07 / BRD-AD08) — do not conflate.** ADL-28 is about making
+genuinely owner-only data (map-shading config, companions) work *per-user* via a `userId` FK — that
+work is still "awaiting Backend implementation brief." BUG-61 is the opposite shape: global,
+already-shared data that was *incorrectly* gated as owner-only. No `userId` scoping is involved
+here; countries/regions have no per-user dimension. This brief touched countries/regions
+read-access only and did not enter ADL-28's territory.
+
+**Implementation shape — why carve-out-above-the-guard, not per-route `requireOwner`:** I kept the
+router **fail-closed by default**. The two options were (a) register the read routes above the
+blanket `requireOwner` guard and leave the guard covering everything else, or (b) remove the blanket
+guard and apply `requireOwner` per write route. Option (b) is fail-*open*: a future author who adds a
+new write route and forgets `requireOwner` leaves it unprotected — exactly the class of mistake this
+project's security checklist and OP-06/ADL-27 exist to prevent (cf. BUG-22, where `requireOwner` was
+missing on `PATCH /api/cities/:id`). Option (a) keeps the invariant "a newly added admin route is
+owner-gated unless deliberately moved into the small, clearly-labelled reads block above the guard,"
+so the reads are the enumerable exception and writes are protected by default. Chosen (a). The guard
+block carries an explicit FAIL-CLOSED comment stating only global-reference-data reads may live
+above it.
+
+**Access matrix after this change (audit record):**
+
+| Route | Middleware | Rationale |
+| --- | --- | --- |
+| `GET /api/admin/countries` | `requireAuth` | global reference data (GE-04/05) — every user reads it to create a trip |
+| `GET /api/admin/countries/:countryCode/regions` | `requireAuth` | same — region list for the picker |
+| `PATCH /api/admin/countries/:countryCode` | `requireAuth` + `requireOwner` | edits shared region-tier config — owner admin |
+| `POST /api/admin/countries/:countryCode/regions` | `requireAuth` + `requireOwner` | adds to shared region set — owner admin |
+| `PATCH /api/admin/countries/:countryCode/regions/:regionId` | `requireAuth` + `requireOwner` | edits shared region — owner admin |
+| `GET/POST/PATCH/DELETE /api/admin/{categories,activities,companions}` | `requireAuth` + `requireOwner` | unchanged — owner-only list admin |
+
+`requireAuth` remains globally applied in `server.ts` before `/api/admin` is mounted, so all six
+routes still return 401 when unauthenticated (Part A of the access-matrix suite is unchanged).
+
+**Verification:** access-matrix suite green (67 passed, 1 pre-existing skip); Part E added asserting
+non-owner `GET` → 200 and non-owner writes → 403. Manual live check with a non-owner bypass user
+(`BYPASS_AUTH=true`, `OWNER_CLERK_ID` set to a non-matching value → `isOwner:0`) against a seeded DB:
+`GET /api/admin/countries` → 200 with the 250-country list, `GET .../US/regions` → 200,
+`PATCH .../US` → 403, `POST .../US/regions` → 403, and `GET /api/admin/categories` → 403 (fail-closed
+default intact).
+
+**Supersession:** partially supersedes ADL-27's "all admin routes require owner status" for the two
+country/region GET routes only — the ADL-27 standalone file's blanket statement is stamped in this
+PR. The router-level guard and the owner-only status of every write route are unchanged.
+
+**Implications for other jobs:**
+- **Frontend:** the trip-create country picker now populates for any authenticated user — the
+  reported BUG-61 symptom is resolved end to end. No frontend change was required.
+- **Backend:** the fail-closed invariant is now load-bearing and documented in `admin.ts`. Any new
+  admin route must stay below the `requireOwner` guard unless it is a read of global reference data;
+  writes never move above the guard.

--- a/jobs/architect/tech/ADL-27-admin-role-model.md
+++ b/jobs/architect/tech/ADL-27-admin-role-model.md
@@ -157,6 +157,14 @@ the user DB row).
 
 ### Routes to protect with requireOwner
 
+> SUPERSEDED IN PART (2026-07-22) by ADL-38 — the two country/region READ routes
+> (`GET /api/admin/countries` and `GET /api/admin/countries/:code/regions`) are no longer
+> owner-gated; they require only `requireAuth` because countries/regions are global,
+> pre-seeded reference data (GE-04/GE-05), not owner-configured per-user data. This is the
+> "explicit security assessment" the last paragraph of this section required for opening a
+> read route. All WRITE routes below (and every other admin route) remain owner-only, and
+> the router stays fail-closed by default. Original text retained for history.
+
 `requireOwner` must be applied at the **`adminRouter` level** — one `router.use(requireOwner)`
 call at the top of the admin router, not per-handler. This ensures every current and future
 route on that router is automatically protected without requiring per-handler discipline.

--- a/src/backend/routes/__tests__/security.access-matrix.test.ts
+++ b/src/backend/routes/__tests__/security.access-matrix.test.ts
@@ -12,6 +12,10 @@
  *   are requireAuth only (not owner-restricted) — intentional per OP-06 §2 access matrix.
  *   GET /api/me is also requireAuth only (BUG-26) — every authenticated user may ask
  *   who they are; see Part D for its shape/isOwner coverage.
+ *   GET /api/admin/countries and GET /api/admin/countries/:code/regions are requireAuth
+ *   only too (BUG-61 / ADL-38) — global pre-seeded reference data (GE-04/GE-05) that every
+ *   user reads to create a trip; only the country/region WRITES stay owner-only. Positive
+ *   read coverage is in Part E; the writes remain in Part B.
  */
 
 import { createClient } from '@libsql/client';
@@ -512,7 +516,7 @@ describe('Part A — Unauthenticated rejection: all API routes return 401', () =
 });
 
 // ================================================================
-// Part B — Owner-only routes: non-owner gets 403 (27 cases)
+// Part B — Owner-only routes: non-owner gets 403 (25 cases)
 //
 // Authenticated as USER_B (isOwner=0). All owner-gated routes must
 // return 403 { error: 'Forbidden' }.
@@ -520,6 +524,8 @@ describe('Part A — Unauthenticated rejection: all API routes return 401', () =
 // NOT included here (requireAuth only, not requireOwner):
 //   GET /api/map/shading/countries/:code
 //   GET /api/map/shading/regions/:code
+//   GET /api/admin/countries                   (BUG-61 / ADL-38 — see Part E)
+//   GET /api/admin/countries/:code/regions     (BUG-61 / ADL-38 — see Part E)
 // ================================================================
 
 describe('Part B — Non-owner authenticated user receives 403 on owner-only routes', () => {
@@ -623,21 +629,9 @@ describe('Part B — Non-owner authenticated user receives 403 on owner-only rou
     expect(res.body).toMatchObject({ error: 'Forbidden' });
   });
 
-  // Admin — countries
-  it('GET /api/admin/countries → 403', async () => {
-    const res = await supertest(app).get('/api/admin/countries');
-    expect(res.status).toBe(403);
-    expect(res.body).toMatchObject({ error: 'Forbidden' });
-  });
-
+  // Admin — countries (WRITES only; the GET reads moved to Part E per BUG-61)
   it('PATCH /api/admin/countries/US → 403', async () => {
     const res = await supertest(app).patch('/api/admin/countries/US').send({});
-    expect(res.status).toBe(403);
-    expect(res.body).toMatchObject({ error: 'Forbidden' });
-  });
-
-  it('GET /api/admin/countries/US/regions → 403', async () => {
-    const res = await supertest(app).get('/api/admin/countries/US/regions');
     expect(res.status).toBe(403);
     expect(res.body).toMatchObject({ error: 'Forbidden' });
   });
@@ -810,5 +804,70 @@ describe('Part D — GET /api/me returns the caller identity with isOwner flag',
     const res = await supertest(app).get('/api/me');
     expect(res.status).toBe(200);
     expect(Object.keys(res.body).sort()).toEqual(['email', 'id', 'isOwner']);
+  });
+});
+
+// ================================================================
+// Part E — Global reference-data READS: countries/regions readable by
+//          any authenticated user (BUG-61 / ADL-38 / GE-04 / GE-05)
+//
+// Regression for BUG-61: GET /api/admin/countries (and .../regions) were
+// wrongly gated by the router-level requireOwner, so a non-owner's trip-create
+// country picker 403'd and rendered empty — no non-owner could create a trip.
+// These are global, pre-seeded defaults (GE-04/GE-05), so their READS require
+// only auth. The matching WRITES stay owner-only (asserted here + in Part B).
+//
+// Run as USER_B (isOwner=0).
+// ================================================================
+
+describe('Part E — Non-owner can READ global countries/regions; WRITES stay owner-only', () => {
+  beforeEach(async () => {
+    mockAuthEnabled = true;
+    mockIsOwner = 0;
+    mockUserId = USER_B_ID;
+    await seedUser(testDb!, USER_B_ID, 'clerk_user_b', 'userb@example.com', 0);
+    await seedCountry(testDb!, 'US', 'United States');
+  });
+
+  it('GET /api/admin/countries → 200 with the country list (was 403 pre-BUG-61)', async () => {
+    const res = await supertest(app).get('/api/admin/countries');
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+    expect(res.body).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ country_code: 'US', name: 'United States' }),
+      ]),
+    );
+  });
+
+  it('GET /api/admin/countries/US/regions → 200 (empty list ok, was 403 pre-BUG-61)', async () => {
+    const res = await supertest(app).get('/api/admin/countries/US/regions');
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+  });
+
+  // Read/write split — the same resources' WRITES remain owner-gated.
+  it('PATCH /api/admin/countries/US → 403 (write still owner-only)', async () => {
+    const res = await supertest(app)
+      .patch('/api/admin/countries/US')
+      .send({ region_tier_enabled: true });
+    expect(res.status).toBe(403);
+    expect(res.body).toMatchObject({ error: 'Forbidden' });
+  });
+
+  it('POST /api/admin/countries/US/regions → 403 (write still owner-only)', async () => {
+    const res = await supertest(app)
+      .post('/api/admin/countries/US/regions')
+      .send({ name: 'California', iso3166_2: 'US-CA' });
+    expect(res.status).toBe(403);
+    expect(res.body).toMatchObject({ error: 'Forbidden' });
+  });
+
+  it('PATCH /api/admin/countries/US/regions/1 → 403 (write still owner-only)', async () => {
+    const res = await supertest(app)
+      .patch('/api/admin/countries/US/regions/1')
+      .send({ name: 'Updated' });
+    expect(res.status).toBe(403);
+    expect(res.body).toMatchObject({ error: 'Forbidden' });
   });
 });

--- a/src/backend/routes/admin.ts
+++ b/src/backend/routes/admin.ts
@@ -3,6 +3,11 @@
  *
  * Manages admin list tables (categories, activities, companions) and country/region config.
  * All admin list items use soft-delete (is_active = 0) — never hard-delete (AD-06).
+ *
+ * Auth model (BUG-61 / ADL-38): the router is owner-gated by default via a router-level
+ * requireOwner guard, EXCEPT the two global reference-data GET routes (countries + regions),
+ * which are registered above the guard and require only authentication. See the guard block
+ * below for the fail-closed invariant.
  */
 
 import { and, eq } from 'drizzle-orm';
@@ -22,8 +27,77 @@ import {
 
 export const adminRouter = Router();
 
-// ADL-27 / HC-04: All admin routes require owner status.
-// Applied at the router level — covers all current and future routes automatically.
+// ================================================================
+// Global reference-data READS — any authenticated user (BUG-61 / ADL-38)
+//
+// GE-04 / GE-05: countries and their region-tier config ship as global,
+// pre-seeded defaults available to every user out of the box (same tier as
+// AD-09 categories/activities) — NOT owner-configured, per-user data. The
+// trip-create country picker (TripForm.tsx → useCountries) must therefore be
+// readable by any authenticated account, or a non-owner cannot create a trip
+// at all (the picker renders empty and 403s).
+//
+// These GET routes are registered BEFORE the router-level requireOwner guard
+// below, so requireAuth (applied globally to /api/* in server.ts) is their
+// only gate. The matching WRITE operations (PATCH country config, POST/PATCH
+// regions) stay owner-only — they are registered AFTER the guard.
+//
+// FAIL-CLOSED INVARIANT: only reads of global reference data belong above the
+// guard. Every write, and everything else, MUST stay below it so the router
+// remains owner-gated by default — a newly added route is owner-only unless a
+// future author deliberately moves it into this block. Do not add write routes
+// or per-user data reads here.
+//
+// This is distinct from ADL-28 (BRD-AD07/AD08 per-user map-shading + companions):
+// that work makes genuinely owner-only data work per-user via a userId FK; this
+// is global, already-shared data that was wrongly gated as owner-only.
+// ================================================================
+
+// GET /api/admin/countries — global country list (read: any authenticated user)
+adminRouter.get(
+  '/countries',
+  asyncHandler(async (_req, res) => {
+    const db = getDb();
+    const rows = await db.select().from(countries).orderBy(countries.name);
+    res.json(
+      rows.map((r) => ({
+        country_code: r.countryCode,
+        name: r.name,
+        region_tier_enabled: r.regionTierEnabled === 1,
+        region_tier_label: r.regionTierLabel,
+      })),
+    );
+  }),
+);
+
+// GET /api/admin/countries/:countryCode/regions — global region list (read: any authenticated user)
+adminRouter.get(
+  '/countries/:countryCode/regions',
+  asyncHandler(async (req, res) => {
+    const countryCode = String(req.params.countryCode).toUpperCase();
+    const db = getDb();
+
+    const rows = await db
+      .select()
+      .from(regions)
+      .where(eq(regions.countryCode, countryCode))
+      .orderBy(regions.name);
+
+    res.json(
+      rows.map((r) => ({
+        id: r.id,
+        country_code: r.countryCode,
+        name: r.name,
+        iso_3166_2: r.iso3166_2,
+        created_at: r.createdAt,
+        updated_at: r.updatedAt,
+      })),
+    );
+  }),
+);
+
+// ADL-27 / HC-04: everything registered BELOW this line requires owner status.
+// The read/write split above (BUG-61 / ADL-38) is the sole, deliberate exception.
 adminRouter.use(requireOwner);
 
 // ----------------------------------------------------------------
@@ -154,25 +228,9 @@ adminRouter.use('/activities', createAdminListRouter(activities, 'Activity'));
 adminRouter.use('/companions', createAdminListRouter(companions, 'Companion'));
 
 // ----------------------------------------------------------------
-// Country admin
+// Country admin — WRITES (owner-only; below the requireOwner guard).
+// The GET reads for countries/regions live above the guard (BUG-61 / ADL-38).
 // ----------------------------------------------------------------
-
-// GET /api/admin/countries
-adminRouter.get(
-  '/countries',
-  asyncHandler(async (_req, res) => {
-    const db = getDb();
-    const rows = await db.select().from(countries).orderBy(countries.name);
-    res.json(
-      rows.map((r) => ({
-        country_code: r.countryCode,
-        name: r.name,
-        region_tier_enabled: r.regionTierEnabled === 1,
-        region_tier_label: r.regionTierLabel,
-      })),
-    );
-  }),
-);
 
 // PATCH /api/admin/countries/:countryCode
 adminRouter.patch(
@@ -213,32 +271,6 @@ adminRouter.patch(
       region_tier_enabled: r.regionTierEnabled === 1,
       region_tier_label: r.regionTierLabel,
     });
-  }),
-);
-
-// GET /api/admin/countries/:countryCode/regions
-adminRouter.get(
-  '/countries/:countryCode/regions',
-  asyncHandler(async (req, res) => {
-    const countryCode = String(req.params.countryCode).toUpperCase();
-    const db = getDb();
-
-    const rows = await db
-      .select()
-      .from(regions)
-      .where(eq(regions.countryCode, countryCode))
-      .orderBy(regions.name);
-
-    res.json(
-      rows.map((r) => ({
-        id: r.id,
-        country_code: r.countryCode,
-        name: r.name,
-        iso_3166_2: r.iso3166_2,
-        created_at: r.createdAt,
-        updated_at: r.updatedAt,
-      })),
-    );
   }),
 );
 


### PR DESCRIPTION
Closes #225
BRD §GE-04 / §GE-05 · ADL-38

## Problem
`GET /api/admin/countries` and `GET /api/admin/countries/:code/regions` were registered directly on `adminRouter`, which gates the **whole router** with `requireOwner`. So a non-owner authenticated account got 403 on the country list, `TripForm`'s country picker (`useCountries`) rendered empty, and **no non-owner could create a trip at all** (found live in staging).

Per GE-04/GE-05, every country ships as a global, pre-seeded default available to all users out of the box (same tier as AD-09 categories/activities) — not owner-configured data. Gating the **read** behind owner status was wrong.

## Fix (read/write split — ADL-38)
- **Reads** (`GET /countries`, `GET /countries/:code/regions`) → `requireAuth` only (already applied globally to `/api/*` in `server.ts`).
- **Writes** (`PATCH /countries/:code`, `POST /countries/:code/regions`, `PATCH /countries/:code/regions/:regionId`) → stay `requireOwner`, unchanged.

Implementation moves the two GET handlers **above** the router-level `requireOwner` guard rather than removing the blanket guard, keeping the router **fail-closed by default**: a newly added admin route is owner-gated unless deliberately placed in the small, labelled reads block above the guard (avoids the BUG-22 fail-open class). Change confined to `admin.ts`.

## Not ADL-28
This is global, already-shared data wrongly gated as owner-only. It is **not** ADL-28 (BRD-AD07/AD08 per-user map-shading/companions, which adds a `userId` FK). No `userId` scoping here.

## Verification
- `security.access-matrix.test.ts`: added **Part E** (non-owner GET → 200, non-owner writes → 403); removed the two now-invalid GET-403 cases from Part B; Part A (401 unauthenticated) unchanged. Suite 67 passed / 1 pre-existing skip.
- Full backend suite 538 passed; frontend 154 passed; type-check + biome clean.
- Manual live check with a non-owner bypass user (`isOwner:0`): `GET /api/admin/countries` → 200 (250 rows), `GET .../US/regions` → 200, `PATCH .../US` → 403, `POST .../US/regions` → 403, `GET /api/admin/categories` → 403 (fail-closed intact).

## Docs
- ADL-38 added to the main ADL log with full access matrix.
- ADL-27 standalone file stamped `SUPERSEDED IN PART` for the two GET routes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)