### PR TITLE
chore: add scripts/ci-wait.sh — canonical CI-wait helper for all roles

### DIFF
--- a/.claude/skills/coo-merge-and-close/SKILL.md
+++ b/.claude/skills/coo-merge-and-close/SKILL.md
@@ -13,9 +13,12 @@ Installed 2026-07-18 from the Session C draft (audits/session-c-workflow-extract
    review moment is the enforcement point for the document-lifecycle rule (CLAUDE.md);
    missed here, verdicts rot silently (the OP-06 failure class).
 2. Confirm the PR's CI is green — **by reading the actual job results, not an agent's
-   self-report.** If the PR adds a NEW CI job, open that job's own log: all pre-existing
-   jobs can be green while the new one fails (OP-11 first-round PR: 30/36 E2E specs
-   failing behind a green-looking check list; caught only by reading the raw log).
+   self-report.** Use `scripts/ci-wait.sh pr <n>` to block until every check finishes
+   rather than polling by hand — it does a final authoritative `--json` rollup check
+   itself, not just an agent's word for it. If the PR adds a NEW CI job, open that
+   job's own log: all pre-existing jobs can be green while the new one fails (OP-11
+   first-round PR: 30/36 E2E specs failing behind a green-looking check list; caught
+   only by reading the raw log).
 3. Merge:
    ```bash
    gh pr merge <n> --repo ryanv11/travel-tracker --squash --delete-branch
@@ -24,7 +27,7 @@ Installed 2026-07-18 from the Session C draft (audits/session-c-workflow-extract
    ```
 4. Post-merge verification (mandatory, before the next merge or session end):
    ```bash
-   gh run list --repo ryanv11/travel-tracker --branch main --limit 4
+   scripts/ci-wait.sh branch main
    ```
    A green PR does not guarantee a green main — two individually-green PRs can compose
    to a red main via squash-merge races (BUG-24). If main goes red, fixing it is the
@@ -104,7 +107,7 @@ Installed 2026-07-18 from the Session C draft (audits/session-c-workflow-extract
 
 ## Definition of done
 
-- [ ] Main's own CI green after the final merge (`gh run list --branch main`)
+- [ ] Main's own CI green after the final merge (`scripts/ci-wait.sh branch main`)
 - [ ] `git branch` shows only `main` + branches with open PRs awaiting review
 - [ ] `jobs/COO/inbox/` triaged; handled reports in `read/`
 - [ ] tracker.json statuses match merged reality; STATUS.md regenerated in same commit

--- a/.planning/drift-ledger.jsonl
+++ b/.planning/drift-ledger.jsonl
@@ -1345,3 +1345,8 @@
 {"ts":"2026-07-23T05:04:43Z","action":"write","file":"/home/node/.claude/projects/-workspace/memory/feedback_zsh_status_var_and_polling_pattern.md"}
 {"ts":"2026-07-23T05:04:53Z","action":"edit","file":"/home/node/.claude/projects/-workspace/memory/MEMORY.md"}
 {"ts":"2026-07-23T05:05:35Z","action":"write","file":"/workspace/jobs/COO/park-docs/20260723_0504-COO-park.txt"}
+{"ts":"2026-07-23T05:09:28Z","action":"write","file":"/workspace/scripts/ci-wait.sh"}
+{"ts":"2026-07-23T05:10:30Z","action":"edit","file":"/workspace/.claude/skills/coo-merge-and-close/SKILL.md"}
+{"ts":"2026-07-23T05:10:36Z","action":"edit","file":"/workspace/.claude/skills/coo-merge-and-close/SKILL.md"}
+{"ts":"2026-07-23T05:10:43Z","action":"edit","file":"/workspace/.claude/skills/coo-merge-and-close/SKILL.md"}
+{"ts":"2026-07-23T05:11:05Z","action":"edit","file":"/workspace/CLAUDE.md"}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,9 +155,13 @@ gh pr create --title "feat: description (#N)" --body "Closes #N\nBRD §X.X TR-XX
 
 ### After opening a PR
 ```bash
-gh run list --repo ryanv11/travel-tracker --limit=5
-gh run view <run-id> --log-failed   # if any job failed
+scripts/ci-wait.sh pr <PR_NUMBER>
+gh run view <run-id> --log-failed   # if ci-wait.sh reports a failure
 ```
+`scripts/ci-wait.sh` blocks until every check finishes and exits non-zero if any
+failed, instead of a hand-rolled polling loop — don't write your own (see the
+script's header comment for why: a past ad-hoc script broke outright from naming a
+variable `status`, a read-only special variable in this environment's zsh shell).
 - Do not consider a task complete until CI passes (all jobs green)
 - Fix any CI failures before filing your completion report
 
@@ -166,8 +170,8 @@ The COO merges via the `/coo-merge-and-close` skill — squash merge, branch hyg
 and the full session-close checklist live there. Two rules bind regardless:
 - Squash merge is standard; no stale local branches after a merge session
 - **Post-merge verification is mandatory**: main's own CI must go green after every
-  merge (`gh run list --branch main`) — a green PR does not guarantee a green main
-  (BUG-24). Red main is fixed immediately, never left unowned.
+  merge (`scripts/ci-wait.sh branch main`) — a green PR does not guarantee a green
+  main (BUG-24). Red main is fixed immediately, never left unowned.
 
 ### Recording decisions (ADL entries, BRD bumps)
 Load the `/record-decision` skill before editing the ADL log, a standalone ADL file,

--- a/jobs/architect/architect-system-prompt.txt
+++ b/jobs/architect/architect-system-prompt.txt
@@ -81,8 +81,12 @@ Never commit directly to main (adopted 2026-03-21). Every thread works on its ow
 6. Open a PR referencing the GitHub issue and BRD section:
    gh pr create --title "..." --body "Closes #N\nBRD §X.X TR-XX"
 7. Check CI before filing your completion report:
-   gh run list --repo ryanv11/travel-tracker --limit=5
-   gh run view <run-id> --log-failed   (for any failed job)
+   scripts/ci-wait.sh pr <PR_NUMBER>
+   This blocks until every check finishes and exits non-zero if any failed — use it
+   instead of a hand-rolled polling loop (a past incident: naming a variable `status`
+   in an ad-hoc script broke it outright, since `status` is a read-only special
+   variable in this environment's zsh shell). If it reports a failure:
+   gh run view <run-id> --log-failed   (for the failed job)
    Do not consider the thread complete until all jobs are green — fix failures first.
 8. Do not merge your own PR. COO reviews and merges via /coo-merge-and-close.
 

--- a/jobs/backend/backend-system-prompt.txt
+++ b/jobs/backend/backend-system-prompt.txt
@@ -70,8 +70,12 @@ Never commit directly to main (adopted 2026-03-21). Every thread works on its ow
 6. Open a PR referencing the GitHub issue and BRD section:
    gh pr create --title "..." --body "Closes #N\nBRD §X.X TR-XX"
 7. Check CI before filing your completion report:
-   gh run list --repo ryanv11/travel-tracker --limit=5
-   gh run view <run-id> --log-failed   (for any failed job)
+   scripts/ci-wait.sh pr <PR_NUMBER>
+   This blocks until every check finishes and exits non-zero if any failed — use it
+   instead of a hand-rolled polling loop (a past incident: naming a variable `status`
+   in an ad-hoc script broke it outright, since `status` is a read-only special
+   variable in this environment's zsh shell). If it reports a failure:
+   gh run view <run-id> --log-failed   (for the failed job)
    Do not consider the thread complete until all jobs are green — fix failures first.
 8. Do not merge your own PR. COO reviews and merges via /coo-merge-and-close.
 

--- a/jobs/database/database-system-prompt.txt
+++ b/jobs/database/database-system-prompt.txt
@@ -64,8 +64,12 @@ Never commit directly to main (adopted 2026-03-21). Every thread works on its ow
 6. Open a PR referencing the GitHub issue and BRD section:
    gh pr create --title "..." --body "Closes #N\nBRD §X.X TR-XX"
 7. Check CI before filing your completion report:
-   gh run list --repo ryanv11/travel-tracker --limit=5
-   gh run view <run-id> --log-failed   (for any failed job)
+   scripts/ci-wait.sh pr <PR_NUMBER>
+   This blocks until every check finishes and exits non-zero if any failed — use it
+   instead of a hand-rolled polling loop (a past incident: naming a variable `status`
+   in an ad-hoc script broke it outright, since `status` is a read-only special
+   variable in this environment's zsh shell). If it reports a failure:
+   gh run view <run-id> --log-failed   (for the failed job)
    Do not consider the thread complete until all jobs are green — fix failures first.
 8. Do not merge your own PR. COO reviews and merges via /coo-merge-and-close.
 

--- a/jobs/docs/docs-system-prompt.txt
+++ b/jobs/docs/docs-system-prompt.txt
@@ -62,8 +62,12 @@ Never commit directly to main (adopted 2026-03-21). Every thread works on its ow
 6. Open a PR referencing the GitHub issue and BRD section:
    gh pr create --title "..." --body "Closes #N\nBRD §X.X TR-XX"
 7. Check CI before filing your completion report:
-   gh run list --repo ryanv11/travel-tracker --limit=5
-   gh run view <run-id> --log-failed   (for any failed job)
+   scripts/ci-wait.sh pr <PR_NUMBER>
+   This blocks until every check finishes and exits non-zero if any failed — use it
+   instead of a hand-rolled polling loop (a past incident: naming a variable `status`
+   in an ad-hoc script broke it outright, since `status` is a read-only special
+   variable in this environment's zsh shell). If it reports a failure:
+   gh run view <run-id> --log-failed   (for the failed job)
    Do not consider the thread complete until all jobs are green — fix failures first.
 8. Do not merge your own PR. COO reviews and merges via /coo-merge-and-close.
 

--- a/jobs/frontend/frontend-system-prompt.txt
+++ b/jobs/frontend/frontend-system-prompt.txt
@@ -64,8 +64,12 @@ Never commit directly to main (adopted 2026-03-21). Every thread works on its ow
 6. Open a PR referencing the GitHub issue and BRD section:
    gh pr create --title "..." --body "Closes #N\nBRD §X.X TR-XX"
 7. Check CI before filing your completion report:
-   gh run list --repo ryanv11/travel-tracker --limit=5
-   gh run view <run-id> --log-failed   (for any failed job)
+   scripts/ci-wait.sh pr <PR_NUMBER>
+   This blocks until every check finishes and exits non-zero if any failed — use it
+   instead of a hand-rolled polling loop (a past incident: naming a variable `status`
+   in an ad-hoc script broke it outright, since `status` is a read-only special
+   variable in this environment's zsh shell). If it reports a failure:
+   gh run view <run-id> --log-failed   (for the failed job)
    Do not consider the thread complete until all jobs are green — fix failures first.
 8. Do not merge your own PR. COO reviews and merges via /coo-merge-and-close.
 

--- a/jobs/integrations/integrations-system-prompt.txt
+++ b/jobs/integrations/integrations-system-prompt.txt
@@ -64,8 +64,12 @@ Never commit directly to main (adopted 2026-03-21). Every thread works on its ow
 6. Open a PR referencing the GitHub issue and BRD section:
    gh pr create --title "..." --body "Closes #N\nBRD §X.X TR-XX"
 7. Check CI before filing your completion report:
-   gh run list --repo ryanv11/travel-tracker --limit=5
-   gh run view <run-id> --log-failed   (for any failed job)
+   scripts/ci-wait.sh pr <PR_NUMBER>
+   This blocks until every check finishes and exits non-zero if any failed — use it
+   instead of a hand-rolled polling loop (a past incident: naming a variable `status`
+   in an ad-hoc script broke it outright, since `status` is a read-only special
+   variable in this environment's zsh shell). If it reports a failure:
+   gh run view <run-id> --log-failed   (for the failed job)
    Do not consider the thread complete until all jobs are green — fix failures first.
 8. Do not merge your own PR. COO reviews and merges via /coo-merge-and-close.
 

--- a/jobs/qa/qa-system-prompt.txt
+++ b/jobs/qa/qa-system-prompt.txt
@@ -64,8 +64,12 @@ Never commit directly to main (adopted 2026-03-21). Every thread works on its ow
 6. Open a PR referencing the GitHub issue and BRD section:
    gh pr create --title "..." --body "Closes #N\nBRD §X.X TR-XX"
 7. Check CI before filing your completion report:
-   gh run list --repo ryanv11/travel-tracker --limit=5
-   gh run view <run-id> --log-failed   (for any failed job)
+   scripts/ci-wait.sh pr <PR_NUMBER>
+   This blocks until every check finishes and exits non-zero if any failed — use it
+   instead of a hand-rolled polling loop (a past incident: naming a variable `status`
+   in an ad-hoc script broke it outright, since `status` is a read-only special
+   variable in this environment's zsh shell). If it reports a failure:
+   gh run view <run-id> --log-failed   (for the failed job)
    Do not consider the thread complete until all jobs are green — fix failures first.
 8. Do not merge your own PR. COO reviews and merges via /coo-merge-and-close.
 

--- a/jobs/ux/ux-system-prompt.txt
+++ b/jobs/ux/ux-system-prompt.txt
@@ -66,8 +66,12 @@ Never commit directly to main (adopted 2026-03-21). Every thread works on its ow
 6. Open a PR referencing the GitHub issue and BRD section:
    gh pr create --title "..." --body "Closes #N\nBRD §X.X TR-XX"
 7. Check CI before filing your completion report:
-   gh run list --repo ryanv11/travel-tracker --limit=5
-   gh run view <run-id> --log-failed   (for any failed job)
+   scripts/ci-wait.sh pr <PR_NUMBER>
+   This blocks until every check finishes and exits non-zero if any failed — use it
+   instead of a hand-rolled polling loop (a past incident: naming a variable `status`
+   in an ad-hoc script broke it outright, since `status` is a read-only special
+   variable in this environment's zsh shell). If it reports a failure:
+   gh run view <run-id> --log-failed   (for the failed job)
    Do not consider the thread complete until all jobs are green — fix failures first.
 8. Do not merge your own PR. COO reviews and merges via /coo-merge-and-close.
 

--- a/scripts/ci-wait.sh
+++ b/scripts/ci-wait.sh
@@ -1,0 +1,113 @@
+#!/bin/bash
+# Travel Tracker — CI/deploy-check wait helper
+#
+# Every agent role (COO included) is instructed to "wait for CI to go green"
+# before merging a PR or filing a completion report. Left to ad-hoc scripts,
+# that has repeatedly meant a fresh polling loop written inline each time —
+# slow, inconsistent, and once (2026-07-22) broken outright by naming a shell
+# variable `status`, which is a read-only special variable in zsh (this
+# environment's shell) and kills the script immediately with no useful error
+# surfaced to the caller. This script is the one canonical replacement: it
+# wraps gh's own built-in watch commands (gh pr checks --watch, gh run watch
+# --exit-status) instead of hand-rolled grep/variable polling, then does one
+# final authoritative check via --json before reporting, rather than trusting
+# a watch command's own exit code alone.
+#
+# Usage:
+#   scripts/ci-wait.sh pr <PR_NUMBER> [TIMEOUT_SECONDS]
+#   scripts/ci-wait.sh branch <BRANCH_NAME> [TIMEOUT_SECONDS]
+#
+# Examples:
+#   scripts/ci-wait.sh pr 227
+#   scripts/ci-wait.sh branch main 300
+#
+# Exit codes:
+#   0   all checks/runs passed
+#   1   at least one check/run failed or was cancelled
+#   2   usage error
+#   124 timeout reached before checks reached a terminal state (from GNU timeout)
+#
+# Requires: gh CLI authenticated against this repo. No credentials of its own
+# (unlike scripts/agent-diagnostics/*, this needs no .env.agent-diagnostics).
+set -uo pipefail
+
+REPO="ryanv11/travel-tracker"
+MODE="${1:-}"
+TARGET="${2:-}"
+TIMEOUT="${3:-600}"
+INTERVAL=15
+
+usage() {
+    echo "Usage: $0 pr <PR_NUMBER> [TIMEOUT_SECONDS]" >&2
+    echo "       $0 branch <BRANCH_NAME> [TIMEOUT_SECONDS]" >&2
+    exit 2
+}
+
+if [ "$MODE" != "pr" ] && [ "$MODE" != "branch" ]; then
+    usage
+fi
+if [ -z "$TARGET" ]; then
+    usage
+fi
+
+if [ "$MODE" = "pr" ]; then
+    echo "[ci-wait] Watching PR #$TARGET checks (timeout ${TIMEOUT}s)..."
+    timeout "$TIMEOUT" gh pr checks "$TARGET" --repo "$REPO" --watch --interval "$INTERVAL"
+    watch_rc=$?
+
+    if [ "$watch_rc" -eq 124 ]; then
+        echo "[ci-wait] TIMEOUT — checks did not reach a terminal state within ${TIMEOUT}s." >&2
+        exit 124
+    fi
+
+    # Authoritative re-check via --json rather than trusting the watch exit code alone.
+    rollup=$(gh pr view "$TARGET" --repo "$REPO" --json statusCheckRollup \
+        --jq '[.statusCheckRollup[] | select(.conclusion != null and .conclusion != "SUCCESS" and .conclusion != "NEUTRAL" and .conclusion != "SKIPPED")] | length')
+
+    if [ "$rollup" -eq 0 ]; then
+        echo "[ci-wait] PASS — all checks green on PR #$TARGET."
+        exit 0
+    else
+        echo "[ci-wait] FAIL — $rollup check(s) not green on PR #$TARGET:" >&2
+        gh pr checks "$TARGET" --repo "$REPO" 2>&1 | grep -v $'\tpass\t' >&2 || true
+        exit 1
+    fi
+fi
+
+if [ "$MODE" = "branch" ]; then
+    echo "[ci-wait] Finding latest workflow runs for branch '$TARGET' (timeout ${TIMEOUT}s)..."
+    latest_sha=$(gh run list --repo "$REPO" --branch "$TARGET" --limit 1 --json headSha --jq '.[0].headSha')
+    if [ -z "$latest_sha" ] || [ "$latest_sha" = "null" ]; then
+        echo "[ci-wait] No workflow runs found for branch '$TARGET'." >&2
+        exit 2
+    fi
+
+    mapfile -t run_ids < <(gh run list --repo "$REPO" --branch "$TARGET" --limit 10 \
+        --json databaseId,headSha --jq ".[] | select(.headSha == \"$latest_sha\") | .databaseId")
+
+    if [ "${#run_ids[@]}" -eq 0 ]; then
+        echo "[ci-wait] No runs found for the latest commit ($latest_sha) on '$TARGET'." >&2
+        exit 2
+    fi
+
+    overall_rc=0
+    for run_id in "${run_ids[@]}"; do
+        echo "[ci-wait] Watching run $run_id..."
+        timeout "$TIMEOUT" gh run watch "$run_id" --repo "$REPO" --exit-status --interval "$INTERVAL"
+        run_rc=$?
+        if [ "$run_rc" -eq 124 ]; then
+            echo "[ci-wait] TIMEOUT — run $run_id did not finish within ${TIMEOUT}s." >&2
+            exit 124
+        fi
+        if [ "$run_rc" -ne 0 ]; then
+            overall_rc=1
+        fi
+    done
+
+    if [ "$overall_rc" -eq 0 ]; then
+        echo "[ci-wait] PASS — all runs green for '$TARGET' @ $latest_sha."
+    else
+        echo "[ci-wait] FAIL — at least one run failed for '$TARGET' @ $latest_sha." >&2
+    fi
+    exit "$overall_rc"
+fi


### PR DESCRIPTION
## Summary
- Adds `scripts/ci-wait.sh`, wrapping `gh pr checks --watch` / `gh run watch --exit-status` plus a final authoritative `--json` rollup check, instead of the ad-hoc polling loops every role (COO included) was writing inline before waiting for CI green.
- Root cause for building this now: two polling scripts this session failed identically with `(eval): read-only variable: status` — `status` is a read-only special variable in zsh (this environment's shell), not a tool reliability issue, but it went undiagnosed in the moment and led to reactively rewriting the approach instead of fixing a one-line bug.
- Wired into all 8 role system-prompts' "check CI before filing your completion report" step, `coo-merge-and-close`'s two CI-verification steps, and `CLAUDE.md`'s PR workflow section.

## Usage
```bash
scripts/ci-wait.sh pr <PR_NUMBER> [TIMEOUT_SECONDS]
scripts/ci-wait.sh branch <BRANCH_NAME> [TIMEOUT_SECONDS]
```
Exit 0 = all green, 1 = a check failed, 2 = usage/not-found error, 124 = timeout.

## Test plan
- [x] `npm run check` — clean
- [x] `npm run type:check:all` — clean
- [x] `npm run test:backend` — 538 passed, 1 skipped
- [x] `npm run test:frontend` — 154 passed
- [x] `npm run status:check` — STATUS.md in sync
- [x] Manually tested `scripts/ci-wait.sh branch main` against this repo's real completed runs — correct PASS output and exit 0
- [x] Manually tested usage-error and no-runs-found paths — correct exit 2 in both cases
- [ ] Will dogfood `scripts/ci-wait.sh pr 230` against this very PR's own CI before merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)