### PR TITLE
chore: session close addendum — ci-wait.sh shipped, git ref corruption fixed, D-10 opened

### DIFF
--- a/.planning/drift-ledger.jsonl
+++ b/.planning/drift-ledger.jsonl
@@ -1350,3 +1350,6 @@
 {"ts":"2026-07-23T05:10:36Z","action":"edit","file":"/workspace/.claude/skills/coo-merge-and-close/SKILL.md"}
 {"ts":"2026-07-23T05:10:43Z","action":"edit","file":"/workspace/.claude/skills/coo-merge-and-close/SKILL.md"}
 {"ts":"2026-07-23T05:11:05Z","action":"edit","file":"/workspace/CLAUDE.md"}
+{"ts":"2026-07-23T05:20:35Z","action":"edit","file":"/home/node/.claude/projects/-workspace/memory/project_onedrive_dehydration.md"}
+{"ts":"2026-07-23T05:20:54Z","action":"edit","file":"/workspace/jobs/COO/open-dialogues.md"}
+{"ts":"2026-07-23T05:21:38Z","action":"write","file":"/workspace/jobs/COO/park-docs/20260723_0521-COO-park.txt"}

--- a/jobs/COO/open-dialogues.md
+++ b/jobs/COO/open-dialogues.md
@@ -25,6 +25,28 @@ tracker.json but also weren't safe to let vanish.
 
 ## Open
 
+### D-10: Move the project off OneDrive — Ryan flagged this a priority (recurrence)
+**Raised:** 2026-07-23
+
+Second occurrence of the OneDrive Files-On-Demand dehydration issue first documented
+2026-07-02 (see memory `project_onedrive_dehydration.md`) — this time it corrupted git's
+own internals rather than just regular project files: 213 local branch refs got silently
+rewritten to the null SHA, which blocked `git fetch`/`git pull` outright
+(`fatal: bad object refs/heads/<branch>`) until COO diagnosed and fixed it in-session
+(raw `rm -f`/`xargs` on the corrupted ref files, since even `git update-ref -d` hit the
+same underlying `EDEADLK` the corrupted files themselves throw on read). Notably, Ryan
+had already applied the documented Finder-level workaround ("Always Keep on This Device"
+at the top level) after the first occurrence, and it recurred anyway — so that fix is not
+durable, just a stopgap.
+
+Ryan's direct instruction this session: "let's make that a priority to move off onedrive."
+Not yet actioned — this needs a real planning pass (target path outside OneDrive sync
+scope, e.g. `~/dev/travel-tracker`; whether `devcontainer.json`'s host bind-mount path
+needs updating to match; a clean before/after verification that no work is lost in the
+move) rather than something to improvise at the tail of a session. Next session should
+open with this, not treat it as background debt — Ryan's phrasing was a clear escalation
+from the first occurrence's "not yet done, someday" framing.
+
 ### D-09: COO worktree cleanup can race an agent's own lingering post-report process
 **Raised:** 2026-07-22
 

--- a/jobs/COO/park-docs/20260723_0521-COO-park.txt
+++ b/jobs/COO/park-docs/20260723_0521-COO-park.txt
@@ -1,0 +1,102 @@
+COO SESSION PARK — 2026-07-23 (addendum: ci-wait.sh shipped, git ref corruption found+fixed, OneDrive migration now priority)
+================================================================================
+
+## Session summary
+Continuation of the 0504 park doc from earlier today (BUG-60/BUG-61 closed, prod
+promoted). After that close-out, Ryan asked why CI-status polling had looked
+inconsistent this session — root cause diagnosed as a shell scripting bug, not a
+tool problem: two Monitor-based polling scripts failed identically with
+`(eval): read-only variable: status` because `status` is zsh's read-only special
+variable (this environment's shell), which had been misdiagnosed in the moment as
+Monitor unreliability and led to reactively switching approaches instead of fixing
+a one-line bug. Ryan then asked whether this belonged in a skill rather than just
+memory, and — when told a reusable script would be the stronger fix — asked for it
+to be built as part of this close-out.
+
+Built `scripts/ci-wait.sh`: wraps `gh pr checks --watch` / `gh run watch
+--exit-status` plus a final authoritative `--json` rollup check, replacing the
+ad-hoc per-check polling loops every role (COO included) had been writing inline.
+Wired into all 8 role system-prompts' CI-check step, `coo-merge-and-close`'s two
+CI-verification steps, and CLAUDE.md's PR workflow section. Tested standalone
+(branch mode against main's already-completed runs, usage-error paths, no-runs-found
+path) and dogfooded live against its own PR (#230) before merging — confirmed
+correct PASS/exit-0 behavior end to end. PR #230 merged.
+
+Immediately after merging #230, `git pull` failed outright:
+`fatal: bad object refs/heads/chore/adl-30-dep01-drizzle` / `did not send all
+necessary objects` — local `main` had NOT actually updated despite the merge
+succeeding on GitHub. Diagnosed via `git fsck --full`: 213 local branch refs (118
+`refs/heads/*`, 95 stale `refs/remotes/origin/*`) had been silently rewritten to
+the literal null SHA. Reading the corrupted files threw the exact `EDEADLK`/
+"Resource deadlock avoided" signature already documented in memory
+(`project_onedrive_dehydration.md`) from a first occurrence on 2026-07-02 — this is
+the same OneDrive Files-On-Demand dehydration issue, but this time it corrupted
+git's own ref files instead of regular tracked files, and it blocks `git fetch`/
+`git pull` entirely (unlike `git branch`/`git rev-parse`, which gracefully skip a
+broken ref with a warning, `git fetch`'s ref-enumeration has no such fallback and
+aborts hard on the first bad ref it hits).
+
+Fixed in-session: `git update-ref -d` itself hit the same deadlock (it needs to
+read-then-delete); a raw filesystem `rm -f` (batched via `xargs`, since a bash
+`while read` loop mysteriously threw `command not found: rm` inside this
+specific multi-line-script execution context — worked fine as single commands or
+via `xargs`) bypassed it reliably, since unlink() doesn't need to read the file's
+content first. Cleared all 213, `git fetch`/`git pull` immediately worked again.
+Also found and cleaned up ~24 legitimate (non-corrupted) stale local branches from
+past sessions where the post-merge `git branch -D` step had simply never been run
+historically — verified each was already deleted on origin
+(`git ls-remote --heads origin <branch>` empty) before force-deleting locally,
+excluding `chore/uat-note-country-picker-gap` (PR #126, still genuinely open).
+
+Ryan confirmed this is OneDrive recurring despite having already applied the
+documented Finder-level "Always Keep on This Device" fix after the first
+occurrence — meaning that fix is a stopgap, not durable — and set an explicit
+priority: move the project off OneDrive entirely. Logged as D-10 in
+open-dialogues.md (not actioned — needs a real planning session: target path,
+whether `devcontainer.json`'s host bind-mount needs updating, verified
+before/after migration) and the OneDrive memory file updated with the full
+second-occurrence writeup.
+
+## Completed this session (this addendum's portion)
+- PR #230 — `scripts/ci-wait.sh` added and wired into all 8 role system-prompts,
+  `coo-merge-and-close`, and CLAUDE.md. Merged, dogfooded successfully against its
+  own CI before merge.
+- Git repository health restored: 213 corrupted zero-SHA refs removed (both local
+  branches and stale remote-tracking refs), ~24 legitimate stale local branches
+  cleaned up, `git fetch`/`git pull` confirmed working again, local `main` now
+  correctly at `b254aca` (matches origin).
+- `jobs/COO/open-dialogues.md` D-10 added (OneDrive migration, Ryan's explicit
+  priority).
+- Memory `project_onedrive_dehydration.md` updated with the second-occurrence
+  writeup and the priority decision.
+
+## State of play
+- **Repo is healthy.** `git branch` → only `main` + `chore/uat-note-country-picker-gap`
+  (PR #126, untouched, genuinely open). `git fsck` shows only expected dangling
+  objects (harmless, from the branches just deleted — will be reclaimed by a future
+  routine `git gc`, no action needed). `git worktree list` → only `/workspace`.
+- **scripts/ci-wait.sh is live and documented** — next session's CI-waits (COO's
+  own and every dispatched agent's) should use it instead of ad-hoc scripts.
+- **D-10 (OneDrive migration) is the explicit top priority for next session**,
+  per Ryan's own framing — not backlog debt, an escalated ask. See open-dialogues.md
+  for the planning considerations already identified.
+- Everything from the 0504 park doc (BUG-60/BUG-61 closed, prod promoted, BRD-AD07/
+  AD08 handed off as the other next-session item) is unchanged and still accurate.
+
+## Open threads
+See jobs/COO/open-dialogues.md — D-10 added this session (OneDrive migration
+priority). D-04 through D-09 unchanged from the 0504 park doc.
+
+## Restart preview
+**Captured:** PR #230 merged (ci-wait.sh + doc wiring), git repo health restored
+(213 corrupted refs + ~24 legitimate stale branches cleaned up, fetch/pull
+confirmed working, verified main == origin/main), D-10 added to open-dialogues.md,
+OneDrive memory file updated with the second-occurrence writeup.
+**Captured, not actioned:** D-10 itself (OneDrive migration — logged as the
+explicit next-session priority, not yet planned or executed). Everything else
+unchanged from the 0504 park doc (BRD-AD07/AD08 handoff, BUG-50/BUG-51, D-04–D-09,
+OQ-03/OQ-05, PR #126).
+**Not captured:** none — the git corruption incident, its fix, and the OneDrive
+priority decision are all in this park doc, the open-dialogues.md D-10 entry, and
+the updated memory file; nothing from this addendum exists only in conversation.
+Shown to Ryan before writing this doc as part of confirming readiness to close.


### PR DESCRIPTION
Addendum to the earlier close-out this session. `scripts/ci-wait.sh` (PR #230) merged, then `git pull` failed outright — 213 local refs had been silently rewritten to the null SHA by OneDrive dehydration hitting `.git` internals. Fixed via raw filesystem removal (git's own `update-ref -d` hit the same underlying deadlock). Also cleaned ~24 legitimate stale local branches. D-10 opened: Ryan has made moving off OneDrive an explicit priority.

## Test plan
- [x] `npm run check` — clean
- [x] `npm run status:check` — STATUS.md in sync
- Doc/ledger-only change, no src/ touched this commit.
- Git repo health independently verified: `git fsck --full` clean, `git fetch`/`git pull` working, local main == origin/main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)