### PR TITLE
chore: update notify bridge WATCH_DIR for OneDrive migration (F1/ADL-39)

### DIFF
--- a/.claude/notify/host-setup/claude-notify-watch.sh
+++ b/.claude/notify/host-setup/claude-notify-watch.sh
@@ -7,7 +7,7 @@
 # Installed as a LaunchAgent — see com.ryanv.claude-notify.plist in this same
 # folder for the install commands.
 
-WATCH_DIR="/Users/ryanv/Library/CloudStorage/OneDrive-Personal/Work/ClaudeCode/my-project/.claude/notify/queue"
+WATCH_DIR="/Users/ryanv/Projects/travel-tracker/.claude/notify/queue"
 TERMINAL_NOTIFIER="/opt/homebrew/bin/terminal-notifier"
 ICON="/Applications/Visual Studio Code.app/Contents/Resources/Code.icns"
 


### PR DESCRIPTION
Fixes F1 from ADL-39: the macOS notification bridge's `WATCH_DIR` hardcoded the
OneDrive path. Updates it to `~/Projects/travel-tracker`, the D-10 migration target.

Part of D-10 / ADL-39. No functional change until the host-side move happens (see
runbook) — the installed LaunchAgent copy at `~/claude-notify-watch.sh` also needs
manual reinstall from this updated template once the repo actually moves.