### PR TITLE
chore(tracker): note AD07/AD08 schema migration shipped (PR #240)

### DIFF
--- a/_project/tracker.json
+++ b/_project/tracker.json
@@ -1395,7 +1395,7 @@
       "priority": "P2",
       "brdRefs": ["AD-07"],
       "phase": 3,
-      "notes": "Architect spec delivered 2026-03-24: ADL-28 (jobs/architect/tech/ADL-28-per-user-shading-companions.md). Decision: userId FK on map_shading_config with composite PK (state_key, user_id), lazy seeding on first access. SE-03 scope narrows — shading config moves to requireAuth (per-user) not requireOwner. Awaiting Backend implementation brief."
+      "notes": "Architect spec delivered 2026-03-24: ADL-28 (jobs/architect/tech/ADL-28-per-user-shading-companions.md). Decision: userId FK on map_shading_config with composite PK (state_key, user_id), lazy seeding on first access. SE-03 scope narrows — shading config moves to requireAuth (per-user) not requireOwner. BRD v3.6: success criteria added to AD-07 (PR #239). Schema/migration half (ADL-28 steps 1-4) shipped 2026-07-23: PR #240, migration 0012 — userId FK + composite PK live on main, owner-backfill verified. Route/service layer (steps 5-14 — shading.service.ts userId scoping, requireOwner removal, per-user cache) still open — Backend implementation brief in progress."
     },
     {
       "id": "BRD-AD08",
@@ -1406,7 +1406,7 @@
       "priority": "P2",
       "brdRefs": ["AD-08"],
       "phase": 3,
-      "notes": "Architect spec delivered 2026-03-24: ADL-28 (jobs/architect/tech/ADL-28-per-user-shading-companions.md). Decision: userId FK on companions, UNIQUE changes to (user_id, name), companions route moves from /api/admin/companions (requireOwner) to new /api/companions router (requireAuth). Cross-user companion assignment validated in tripRepository. Awaiting Backend implementation brief."
+      "notes": "Architect spec delivered 2026-03-24: ADL-28 (jobs/architect/tech/ADL-28-per-user-shading-companions.md). Decision: userId FK on companions, UNIQUE changes to (user_id, name), companions route moves from /api/admin/companions (requireOwner) to new /api/companions router (requireAuth). Cross-user companion assignment validated in tripRepository. BRD v3.6: success criteria added to AD-08 (PR #239). Schema/migration half (ADL-28 steps 1-4) shipped 2026-07-23: PR #240, migration 0012 — userId FK + (user_id, name) unique index live on main, owner-backfill verified. Old admin.ts companions POST route now 500s (no userId supplied) — 2 tests skipped with pointers to this gap, expected to be fixed by route relocation below. Route/repository layer (steps 5-14 — companions.ts + shadingConfig.ts repositories, new /api/companions router, admin.ts cleanup, cross-user validateOwnership) still open — Backend implementation brief in progress."
     },
     {
       "id": "BRD-AD09",


### PR DESCRIPTION
## Summary
- Updates BRD-AD07/BRD-AD08 tracker notes to record PR #240 (schema/migration half of ADL-28) landing on main.
- No status change — both stay `in-progress`, awaiting the follow-up Backend brief for the route/repository layer.

## Test plan
- [x] `npm run check`
- [x] `npm run status:check`