### PR TITLE
fix(DEP-02): npm audit — body-parser + postcss highs (#250)

### DIFF
--- a/.planning/drift-ledger.jsonl
+++ b/.planning/drift-ledger.jsonl
@@ -1527,3 +1527,7 @@
 {"ts":"2026-07-26T16:27:40Z","action":"edit","file":"/workspace/_project/tracker.json"}
 {"ts":"2026-07-26T16:35:16Z","action":"write","file":"/workspace/jobs/COO/park-docs/20260726_1634-COO-park.txt"}
 {"ts":"2026-07-26T16:35:32Z","action":"reviewed"}
+{"ts":"2026-07-26T16:42:45Z","action":"edit","file":"/workspace/_project/security-backlog.md"}
+{"ts":"2026-07-26T16:42:57Z","action":"edit","file":"/workspace/_project/security-backlog.md"}
+{"ts":"2026-07-26T16:43:06Z","action":"edit","file":"/workspace/_project/security-backlog.md"}
+{"ts":"2026-07-26T16:43:25Z","action":"edit","file":"/workspace/_project/tracker.json"}

--- a/_project/STATUS.md
+++ b/_project/STATUS.md
@@ -90,7 +90,7 @@ _Tracker last updated: 2026-07-21 (BUG-59 logged: staging Railway ALLOWED_ORIGIN
 | feature | `███████████▓░░░░░░░░` 29/54 | 29 | 25 | 3 |
 | requirement | `███████████████████░` 31/33 | 31 | 2 | 5 |
 | bug | `███████████████░░░░░` 41/55 | 41 | 14 | 4 |
-| task | `████████████████████` 8/8 | 8 | 0 | 0 |
+| task | `████████████████████` 9/9 | 9 | 0 | 0 |
 | chore | `████████████████░░░░` 7/9 | 7 | 2 | 0 |
 
 <details>
@@ -123,4 +123,4 @@ _Tracker last updated: 2026-07-21 (BUG-59 logged: staging Railway ALLOWED_ORIGIN
 
 ---
 
-_117 done · 10 deferred · 2 closed · 44 open — 173 tracked items_
+_118 done · 10 deferred · 2 closed · 44 open — 174 tracked items_

--- a/_project/security-backlog.md
+++ b/_project/security-backlog.md
@@ -1,6 +1,6 @@
 # Travel Tracker — Security Backlog
-**Version:** 1.1
-**Date:** 2026-07-07
+**Version:** 1.2
+**Date:** 2026-07-26
 **Author:** COO
 **Source:** BACKEND security report (20260308_1000-BACKEND-security-report.txt)
 
@@ -87,6 +87,25 @@ Ryan, 2026-07-08 ("I'm accepting of those moderates").
 
 ---
 
+## npm audit — DEP-02 (2026-07-26)
+
+Fresh drift accrued since DEP-01 (tracker DEP-02, issue #250). `npm audit --audit-level=high`
+went red on main again on a docs/tracker-only diff (advisories published post-DEP-01).
+2 fixed via `npm audit fix` (non-breaking):
+
+| Advisory | Package | Severity | Disposition |
+|----------|---------|----------|-------------|
+| GHSA-v422-hmwv-36x6 | body-parser <2.3.0 | High-gate-triggering | **FIXED** — 2.2.2 → 2.3.0, non-breaking. |
+| GHSA-r28c-9q8g-f849 | postcss ≤8.5.17 | High | **FIXED** — 8.5.16 → 8.5.23, non-breaking. |
+| GHSA-67mh-4wv8-2f99, GHSA-g7r4-m6w7-qqqr | esbuild ≤0.24.2 \|\| 0.27.3–0.28.0 (via drizzle-kit → @esbuild-kit chain) | Moderate | **ACCEPTED (unchanged from DEP-01)** — same cluster, same rationale (dev-only, below `--audit-level=high` gate, drizzle-kit downgrade to 0.18.1 would break the ADL-15 patch). No new action. |
+| GHSA-wrjc-x8rr-h8h6, GHSA-337j-9hxr-rhxg | react-router 6.0.0–7.17.0 / react-router-dom (same range) | Moderate | **DEFERRED** — new since DEP-01. Fix requires a major bump to react-router-dom@7.18.1 (breaking); below the `--audit-level=high` gate so not blocking, but needs its own upgrade-and-verify pass (routing behavior, e2e suite) before taking the major version. Not yet scheduled. |
+
+Gate status after this pass: `npm audit --audit-level=high` exits 0 (6 moderate
+vulnerabilities remain — the 4 already-accepted esbuild/drizzle-kit findings plus the
+2 new, deferred react-router findings — both below the gate threshold).
+
+---
+
 ## Accepted Risks
 
 | ID | Finding | Decision | Rationale | Date |
@@ -109,4 +128,5 @@ Ryan, 2026-07-08 ("I'm accepting of those moderates").
 |---------|------|--------|
 | 1.0 | 2026-03-08 | Initial security backlog created from BACKEND Phase 1 security report |
 | 1.1 | 2026-07-07 | DEP-01 (#98, ADL-30): npm audit pass — 23 non-breaking fixes, drizzle-orm GHSA-gpj5-g38j-94v9 fixed by 0.45.2, esbuild/drizzle-kit moderate cluster formally accepted; superseded the 2026-03-08 "npm Audit — Deferred" section |
+| 1.2 | 2026-07-26 | DEP-02 (#250): npm audit pass — body-parser + postcss highs fixed non-breaking, esbuild/drizzle-kit cluster re-affirmed accepted (unchanged), react-router moderate cluster newly deferred |
 

--- a/_project/tracker.json
+++ b/_project/tracker.json
@@ -1293,7 +1293,18 @@
       "priority": "P1",
       "brdRefs": [],
       "phase": 1,
-      "notes": "Dependency Vulnerability Scan job red since 2026-07-07 on a docs-only diff — advisories published post-freeze. Needs deliberate update pass (not audit fix --force): dev vs runtime split, majors assessed individually, full test suite + app verification, security-backlog.md npm-audit section updated in same PR per Document lifecycle rule. GitHub issue #98. RESOLVED 2026-07-08: ADL-30 ruling (PR #104) — drizzle-orm 0.38.4→0.45.2 (GHSA-gpj5-g38j-94v9 fixed), drizzle-kit stays 0.31.9 (ADL-15 patch intact); 23 non-breaking fixes via npm audit fix; 4 esbuild/drizzle-kit moderates formally ACCEPTED (security-backlog.md v1.1, revisit at drizzle 1.0 GA). Implementation PR #105 merged, all CI jobs green incl. Dependency Vulnerability Scan. Issue #98 closed."
+      "notes": "Dependency Vulnerability Scan job red since 2026-07-07 on a docs-only diff — advisories published post-freeze. Needs deliberate update pass (not audit fix --force): dev vs runtime split, majors assessed individually, full test suite + app verification, security-backlog.md npm-audit section updated in same PR per Document lifecycle rule. GitHub issue #98. RESOLVED 2026-07-08: ADL-30 ruling (PR #104) — drizzle-orm 0.38.4→0.45.2 (GHSA-gpj5-g38j-94v9 fixed), drizzle-kit stays 0.31.9 (ADL-15 patch intact); 23 non-breaking fixes via npm audit fix; 4 esbuild/drizzle-kit moderates formally ACCEPTED (security-backlog.md v1.1, revisit at drizzle 1.0 GA). Implementation PR #105 merged, all CI jobs green incl. Dependency Vulnerability Scan. Issue #98 closed. Superseded by fresh drift — see DEP-02 (this DEP-01 entry itself stays closed/done, it does not reopen)."
+    },
+    {
+      "id": "DEP-02",
+      "type": "task",
+      "title": "npm audit — fresh drift since DEP-01: body-parser + postcss highs, react-router moderate cluster newly deferred",
+      "status": "done",
+      "owner": "coo",
+      "priority": "P2",
+      "brdRefs": [],
+      "phase": 6,
+      "notes": "Found 2026-07-26 — Dependency Vulnerability Scan red on main again on an unrelated tracker-only diff (PR #248/#249), same symptom shape as DEP-01. GitHub issue #250. RESOLVED same day: npm audit fix (non-breaking) — body-parser 2.2.2→2.3.0 (GHSA-v422-hmwv-36x6, DoS via invalid limit value), postcss 8.5.16→8.5.23 (GHSA-r28c-9q8g-f849, high, path-traversal .map disclosure). Verified drizzle-kit stayed pinned at 0.31.9 (ADL-15 patch intact) and react-router-dom stayed at 6.30.4 — neither breaking upgrade taken. Full verification: type:check:all clean, backend tests 580/581 (1 pre-existing skip), frontend tests 154/154, npm audit --audit-level=high exits 0. Two moderate clusters remain, both below the CI gate: esbuild/drizzle-kit (re-affirmed ACCEPTED, unchanged from DEP-01 — fix would break ADL-15 patch) and react-router (newly DEFERRED — fix requires react-router-dom@7.18.1 major bump, needs its own routing/e2e verification pass before scheduling). security-backlog.md bumped to v1.2 with the DEP-02 section + updated change log, same PR. Issue #250 closed on merge."
     },
     {
       "id": "OP-08",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3106,21 +3106,34 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
-      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
       "license": "MIT",
       "dependencies": {
         "bytes": "^3.1.2",
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "debug": "^4.4.3",
-        "http-errors": "^2.0.0",
-        "iconv-lite": "^0.7.0",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
         "on-finished": "^2.4.1",
-        "qs": "^6.14.1",
-        "raw-body": "^3.0.1",
-        "type-is": "^2.0.1"
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
       },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       },
@@ -5934,9 +5947,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.15",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -6337,9 +6350,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
-      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "dev": true,
       "funding": [
         {
@@ -6357,7 +6370,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -7775,17 +7788,34 @@
       }
     },
     "node_modules/type-is": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
-      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
       "license": "MIT",
       "dependencies": {
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "media-typer": "^1.1.0",
         "mime-types": "^3.0.0"
       },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/typescript": {


### PR DESCRIPTION
## Summary
- Closes #250 — fresh npm audit drift since DEP-01: `npm audit fix` (non-breaking) resolved body-parser (GHSA-v422-hmwv-36x6) and postcss (GHSA-r28c-9q8g-f849, high).
- `drizzle-kit` stays pinned at 0.31.9 (ADL-15 patch intact) and `react-router-dom` stays at 6.30.4 — no breaking upgrades taken.
- Remaining moderates (esbuild/drizzle-kit cluster — re-affirmed accepted, unchanged from DEP-01; react-router cluster — newly deferred, needs its own major-version verification pass) are both below the `--audit-level=high` CI gate.
- security-backlog.md bumped to v1.2 with the DEP-02 section + change log entry (Document lifecycle rule).
- tracker.json: new DEP-02 entry, DEP-01 annotated as superseded-by-fresh-drift (stays closed/done, does not reopen).

## Test plan
- [x] `npm run type:check:all` clean
- [x] `npm run test:backend` — 580/581 (1 pre-existing skip)
- [x] `npm run test:frontend` — 154/154
- [x] `npm audit --audit-level=high` exits 0