### PR TITLE
fix(OP-23): exclude production from Security Checks push trigger (ADL-40)

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,8 +1,24 @@
 name: Security Checks
 
+# ADL-40: `production` is deliberately excluded from the push trigger.
+#
+# The dependency-scan job runs `npm audit`, which queries the GitHub Advisory
+# Database at run time — so its verdict is a function of commit *and date*, not
+# commit alone. That broke promotion: 299ab5c passed on main 2026-07-24 and the
+# identical tree failed on production 2026-07-26, because GHSA-v422-hmwv-36x6
+# (body-parser) was published in between. Railway gates prod deploys on CI green
+# and is all-or-nothing about which checks count, so a newly-published advisory
+# blocked prod deploys entirely — including the deploy that would have fixed it.
+#
+# Check runs attach to a commit SHA, not a branch, and `production` is only ever
+# fast-forwarded from main (never a PR target). So a promoted SHA already carries
+# this workflow's green statuses, earned on main. Skipping the re-run doesn't
+# remove the security verdict — it freezes it at the point it was earned, which
+# is what makes promotion deterministic. ci.yml still runs on every branch and
+# still gates production.
 on:
   push:
-    branches: ["**"]
+    branches-ignore: ["production"]
   pull_request:
     branches: [main, master]
 

--- a/.planning/drift-ledger.jsonl
+++ b/.planning/drift-ledger.jsonl
@@ -1531,3 +1531,10 @@
 {"ts":"2026-07-26T16:42:57Z","action":"edit","file":"/workspace/_project/security-backlog.md"}
 {"ts":"2026-07-26T16:43:06Z","action":"edit","file":"/workspace/_project/security-backlog.md"}
 {"ts":"2026-07-26T16:43:25Z","action":"edit","file":"/workspace/_project/tracker.json"}
+{"ts":"2026-07-26T16:48:02Z","action":"session_end","reason":"clear"}
+{"ts":"2026-07-26T16:49:09Z","action":"session_end","reason":"other"}
+{"ts":"2026-07-26T16:50:03Z","action":"session_end","reason":"other"}
+{"ts":"2026-07-26T16:51:27Z","action":"reviewed"}
+{"ts":"2026-07-26T17:26:42Z","action":"edit","file":"/workspace/.github/workflows/security.yml"}
+{"ts":"2026-07-26T17:29:48Z","action":"edit","file":"/workspace/_project/security-backlog.md"}
+{"ts":"2026-07-26T17:30:24Z","action":"edit","file":"/workspace/_project/tracker.json"}

--- a/_project/STATUS.md
+++ b/_project/STATUS.md
@@ -123,4 +123,4 @@ _Tracker last updated: 2026-07-21 (BUG-59 logged: staging Railway ALLOWED_ORIGIN
 
 ---
 
-_118 done · 10 deferred · 2 closed · 44 open — 174 tracked items_
+_119 done · 10 deferred · 2 closed · 44 open — 175 tracked items_

--- a/_project/security-backlog.md
+++ b/_project/security-backlog.md
@@ -1,5 +1,5 @@
 # Travel Tracker — Security Backlog
-**Version:** 1.2
+**Version:** 1.3
 **Date:** 2026-07-26
 **Author:** COO
 **Source:** BACKEND security report (20260308_1000-BACKEND-security-report.txt)
@@ -106,6 +106,34 @@ vulnerabilities remain — the 4 already-accepted esbuild/drizzle-kit findings p
 
 ---
 
+## Where the dependency scan runs (ADL-40, 2026-07-26)
+
+The `Dependency Vulnerability Scan` job **no longer runs on the `production` branch**
+(`.github/workflows/security.yml` uses `branches-ignore: ["production"]`). Canonical
+decision record: **ADL-40** — this section is a pointer, not a second authority.
+
+Why, in one line: `npm audit` queries the advisory database at run time, so its verdict is
+a function of commit **and date** — the identical tree passed on `main` (2026-07-24) and
+failed on `production` (2026-07-26) when GHSA-v422-hmwv-36x6 was published in between,
+which blocked all production deploys via Railway's CI gate.
+
+What this does **not** change:
+
+- The scan still runs on **every PR and every push to `main`** — unchanged detection. Both
+  DEP-01 and DEP-02 were found this way and would be found identically today.
+- Promoted commits keep their security verdict. Check runs attach to a **commit SHA, not a
+  branch**, and `production` is only ever fast-forwarded from `main`, so every promoted SHA
+  already carries this workflow's green statuses. The verdict is frozen at the point it was
+  earned, not removed.
+- `ci.yml` is unchanged and still gates production deploys.
+
+**Residual gap, accepted:** a commit pushed *directly* to `production`, bypassing `main`,
+would never be security-scanned. Contained by process only (CLAUDE.md makes `production`
+fast-forward-only and off-limits to agents), not by the workflow. Revisit if direct pushes
+to `production` ever become possible.
+
+---
+
 ## Accepted Risks
 
 | ID | Finding | Decision | Rationale | Date |
@@ -129,4 +157,5 @@ vulnerabilities remain — the 4 already-accepted esbuild/drizzle-kit findings p
 | 1.0 | 2026-03-08 | Initial security backlog created from BACKEND Phase 1 security report |
 | 1.1 | 2026-07-07 | DEP-01 (#98, ADL-30): npm audit pass — 23 non-breaking fixes, drizzle-orm GHSA-gpj5-g38j-94v9 fixed by 0.45.2, esbuild/drizzle-kit moderate cluster formally accepted; superseded the 2026-03-08 "npm Audit — Deferred" section |
 | 1.2 | 2026-07-26 | DEP-02 (#250): npm audit pass — body-parser + postcss highs fixed non-breaking, esbuild/drizzle-kit cluster re-affirmed accepted (unchanged), react-router moderate cluster newly deferred |
+| 1.3 | 2026-07-26 | ADL-40: Dependency Vulnerability Scan excluded from the `production` branch — time-varying checks must not gate deploys. Detection on PRs/`main` unchanged; `ci.yml` still gates production. |
 

--- a/_project/tracker.json
+++ b/_project/tracker.json
@@ -1697,6 +1697,17 @@
       "notes": "ADL-35 (2026-07-21, merged PR #193). Design decided: Staging keeps watching `main`; Production repoints to a long-lived `production` branch promoted by explicit `git merge --ff-only origin/main` + push. No tags-as-trigger, no GitHub Action — Railway's native branch-watching stays zero-glue per ADL-32's rationale. `production` branch created and pushed by COO 2026-07-21 (currently == main). CLOSED 2026-07-21: (1) Ryan repointed Railway's Production environment to watch `production` instead of `main`, staging left watching `main` — confirmed live; (2) CLAUDE.md git-workflow section now has an 'Environment promotion' subsection documenting this model, added same session per the document-lifecycle rule (only added once (1) was actually live). Branch-per-brief workflow (feat/fix/chore off main, PR to main) is unchanged — production is never a PR target, agents never touch it. D-05 (separate Clerk prod/staging apps) remains open and orthogonal — until resolved, staging and prod share one Clerk user pool even after this promotion model."
     },
     {
+      "id": "OP-23",
+      "type": "operational",
+      "title": "Time-varying CI checks must not gate deploys — Dependency Vulnerability Scan excluded from the production branch",
+      "status": "done",
+      "owner": "coo",
+      "priority": "P1",
+      "brdRefs": [],
+      "phase": 6,
+      "notes": "ADL-40 (2026-07-26). Trigger: production deploys blocked outright — `Security Checks` failed on production@299ab5c (run 30210259329) on GHSA-v422-hmwv-36x6 (body-parser, HIGH), and Railway gates prod deploys on CI green. Root cause is NOT the promotion: `npm audit` queries the advisory DB at run time, so the identical tree passed on main 2026-07-24 and failed on production 2026-07-26 (verified — `git diff 299ab5c 3889436 -- package-lock.json package.json` is empty; only drift-ledger/STATUS.md/tracker.json/park-doc changed between them). Deployability had become a function of the calendar. Fix: security.yml push trigger `branches: [\"**\"]` → `branches-ignore: [\"production\"]`; ci.yml deliberately unchanged and still gates prod. Does not weaken security — check runs attach to a commit SHA not a branch, and production is only ever fast-forwarded from main, so every promoted SHA already carries this workflow's green statuses; the re-run is skipped, the verdict is frozen at the point it was earned. Detection unchanged on PRs and main (how DEP-01/DEP-02 were both found). Residual accepted gap: a direct push to production bypassing main would be unscanned — contained by process (CLAUDE.md: production is ff-only, agents never touch it). Alternative of removing Railway's CI gate entirely rejected by PO. Deferred idea, not adopted: a scheduled nightly audit on main that opens an issue, which would also catch advisories landing against an unchanged main between PRs. Production promoted to ce5dbd5 same session, CI + Security Checks both green, deploy gate reopened. security-backlog.md bumped to v1.3 with a pointer section, same PR."
+    },
+    {
       "id": "WP-01",
       "type": "feature",
       "title": "Product rename to \"Waypoint\" (in-app UI only)",

--- a/jobs/architect/tech/20260307-architecture-decisions-log.md
+++ b/jobs/architect/tech/20260307-architecture-decisions-log.md
@@ -2573,3 +2573,93 @@ corrupt refs) plus a clean `git fsck`, not a plain file copy.
 location or OneDrive. It complements ADL-32 (Railway + Turso hosting) — that decision moved the
 *deployed* data off local/OneDrive; this one moves the *developer working copy* off OneDrive too,
 closing the last place OneDrive sync can still corrupt the project.
+
+---
+
+## ADL-40 — Time-varying checks must not gate deploys: `production` excluded from the Security Checks push trigger
+
+**Date:** 2026-07-26
+**Status:** Decided **and implemented** in the PR carrying this entry
+(`.github/workflows/security.yml`). Infrastructure/CI decision made by the PO directly
+rather than via an Architect dispatch — the standing guardrail
+(`feedback_architect_involvement.md`) exists to ensure infra changes get a reasoned,
+recorded decision before the COO acts, and the PO is the deciding authority here; this
+entry is that record.
+
+**Trigger:** Production deploys were blocked and the PO could not ship. `Security Checks`
+failed on `production` at `299ab5c` (run 30210259329, 2026-07-26T16:22Z) on
+GHSA-v422-hmwv-36x6 (`body-parser`, HIGH — DoS via an invalid `limit` silently disabling
+size enforcement). Railway gates production deploys on GitHub CI green
+(`reference_railway_ci_gated_deploy.md`), so the red check stopped all prod deploys.
+
+The decisive evidence is that **the identical tree produced opposite verdicts**:
+
+| Commit | Branch | Date | Security Checks |
+|---|---|---|---|
+| `299ab5c` | main | 2026-07-24 | success |
+| `299ab5c` | production | 2026-07-26 | **failure** |
+
+`git diff 299ab5c 3889436 -- package-lock.json package.json` is empty; the only files
+changed between those commits were `.planning/drift-ledger.jsonl`, `_project/STATUS.md`,
+`_project/tracker.json` and a COO park doc. Nothing about the code, the dependency tree,
+or the promotion caused the failure — `npm audit` queries the GitHub Advisory Database at
+run time, so the advisory's publication date changed the answer.
+
+**Decision:** `security.yml`'s push trigger changes from `branches: ["**"]` to
+`branches-ignore: ["production"]`. Every other branch, and the `pull_request` trigger, are
+unchanged. `ci.yml` is **not** modified — it keeps `branches: ["**"]` and continues to gate
+production.
+
+**Rationale — deterministic vs. time-varying checks.** A deploy gate is only sound if it is
+a pure function of the commit. Three of the four checks are: `CI` (tests, typecheck, build,
+E2E), `Secret Scanning (Gitleaks)` (scans the commit's history) and `Static Analysis
+(Semgrep)` (scans the commit's code) all return the same verdict for a given SHA forever.
+`npm audit` alone is a function of commit **and date**, which makes *deployability a
+function of the calendar* — it breaks the property the promotion model depends on, that a
+commit verified green on `main` stays promotable.
+
+The failure mode is worse than a nuisance: the gate blocks new deploys but does **not**
+remove the vulnerable code already running in production. During the window between an
+advisory landing and remediation, prod stays exposed *and* loses the ability to ship —
+including the ability to ship an unrelated urgent rollback or hotfix.
+
+**Why this does not weaken security.** GitHub check runs attach to a **commit SHA, not a
+branch**, and per CLAUDE.md `production` is only ever fast-forwarded from `main` and is
+never a PR target. Every promoted SHA has therefore already run this workflow on `main` and
+carries its green statuses. Skipping the re-run does not remove the security verdict from
+the promoted commit — it **freezes that verdict at the point it was earned**, converting a
+time-varying gate into a point-in-time one. Detection is fully retained: the scan still runs
+on every PR and every push to `main`, which is how DEP-01 and DEP-02 were both found. The
+gate contributed the block, not the detection.
+
+**Alternatives considered:**
+1. *Split `dependency-scan` into its own workflow and gate production on the other two
+   security jobs.* Rejected — Railway's CI gate is all-or-nothing about which checks count,
+   so it cannot be told to ignore one workflow. It also buys nothing: Gitleaks and Semgrep
+   are deterministic, so a fast-forwarded SHA already carries their green statuses from
+   `main`; re-running them on `production` is pure redundancy.
+2. *Remove the Railway CI gate entirely.* Rejected by the PO — it would let production
+   deploy code that never passed tests, a far larger exposure than the one being solved.
+3. *Promote more frequently so the drift window stays small.* Good practice and still
+   worth doing, but not a fix: it shrinks the window rather than removing the failure mode,
+   and an advisory can publish inside any window.
+4. *Move the audit to a scheduled nightly job on `main` that opens an issue.* Not adopted
+   now, but compatible with this decision and worth revisiting — it would catch advisories
+   against an unchanged `main` between PRs, which neither the current nor the new
+   configuration does.
+
+**Implementation implications:**
+- `.github/workflows/security.yml` — push trigger scoped via `branches-ignore`; the
+  rationale is duplicated as a comment at the trigger so the next reader does not "fix" it
+  back to `["**"]`.
+- `.github/workflows/ci.yml` — unchanged, deliberately. It remains production's deploy gate.
+- **Known residual gap:** a commit pushed *directly* to `production` without passing through
+  `main` would never be security-scanned. This is contained by process, not by the workflow
+  — CLAUDE.md's promotion rule makes `production` fast-forward-only and off-limits to agents.
+  If direct pushes to `production` ever become possible, this exclusion must be revisited.
+- Operationally unchanged: promotion is still the manual
+  `git push origin origin/main:refs/heads/production` fast-forward (ADL-35/OP-22).
+
+**Supersession:** none. ADL-35/OP-22 established the two-environment promotion model and is
+unaffected — this refines which checks evaluate on the `production` branch, not how
+promotion works.


### PR DESCRIPTION
## Summary

Production deploys were blocked. `Security Checks` failed on `production@299ab5c` on GHSA-v422-hmwv-36x6 (`body-parser`, HIGH), and Railway gates prod deploys on GitHub CI green.

**The promotion did not cause it.** `npm audit` queries the GitHub Advisory Database at run time, so its verdict is a function of commit **and date**:

| Commit | Branch | Date | Security Checks |
|---|---|---|---|
| `299ab5c` | main | 2026-07-24 | success |
| `299ab5c` | production | 2026-07-26 | **failure** |

Verified: `git diff 299ab5c 3889436 -- package-lock.json package.json` is empty. The only files that changed between those commits were `drift-ledger.jsonl`, `STATUS.md`, `tracker.json` and a park doc.

That made deployability a function of the calendar. Worse, the gate blocks *new* deploys without removing the vulnerable code already running in prod — so in that window prod stays exposed **and** loses the ability to ship, including an unrelated urgent rollback.

## Change

`security.yml` push trigger: `branches: ["**"]` → `branches-ignore: ["production"]`. `ci.yml` is deliberately unchanged and still gates production.

## Why this does not weaken security

Check runs attach to a **commit SHA, not a branch**, and `production` is only ever fast-forwarded from `main` (never a PR target). Every promoted SHA therefore already carries this workflow's green statuses, earned on `main`. Skipping the re-run doesn't remove the security verdict — it **freezes it at the point it was earned**, which is what makes promotion deterministic.

Detection is fully retained: the scan still runs on every PR and every push to `main`, which is how DEP-01 and DEP-02 were both found. The gate contributed the block, not the detection.

**Residual accepted gap:** a commit pushed directly to `production`, bypassing `main`, would never be scanned. Contained by process only (CLAUDE.md makes `production` fast-forward-only and off-limits to agents).

## Alternatives considered

Full reasoning in ADL-40. Briefly: splitting `dependency-scan` into its own workflow doesn't help (Railway's CI gate is all-or-nothing about which checks count, and the other two security jobs are deterministic so re-running them on a fast-forwarded SHA is pure redundancy); removing Railway's CI gate entirely was rejected by the PO as a far larger exposure. A scheduled nightly audit on `main` that opens an issue is noted as compatible and worth revisiting — it would also catch advisories landing against an unchanged `main` between PRs.

## Document lifecycle

- **ADL-40** recorded in `jobs/architect/tech/20260307-architecture-decisions-log.md`
- **security-backlog.md → v1.3** with a pointer section — it declares itself the authoritative record for security decisions, so it's updated in this same PR
- **tracker OP-23** + regenerated `STATUS.md`

## Test plan

- [x] `npm run check` — pass
- [x] `npm run type:check:all` — pass
- [x] `npm run test:backend` — 580 passed, 1 skipped
- [x] `npm run test:frontend` — 154 passed
- [x] `npm run status:check` — in sync
- [x] Production promoted to `ce5dbd5`; CI + Security Checks both green; deploy gate reopened
- [ ] Post-merge: confirm Security Checks does **not** fire on the next `production` push, and that `ci.yml` still does

🤖 Generated with [Claude Code](https://claude.com/claude-code)