### PR TITLE
chore: close PHASE-4 on PO UAT PASS, log backlog clearance plan

### DIFF
--- a/.planning/drift-ledger.jsonl
+++ b/.planning/drift-ledger.jsonl
@@ -1538,3 +1538,9 @@
 {"ts":"2026-07-26T17:26:42Z","action":"edit","file":"/workspace/.github/workflows/security.yml"}
 {"ts":"2026-07-26T17:29:48Z","action":"edit","file":"/workspace/_project/security-backlog.md"}
 {"ts":"2026-07-26T17:30:24Z","action":"edit","file":"/workspace/_project/tracker.json"}
+{"ts":"2026-07-26T17:38:51Z","action":"edit","file":"/workspace/_project/tracker.json"}
+{"ts":"2026-07-26T17:39:03Z","action":"edit","file":"/workspace/_project/tracker.json"}
+{"ts":"2026-07-26T17:39:24Z","action":"edit","file":"/workspace/_project/tracker.json"}
+{"ts":"2026-07-26T17:39:41Z","action":"edit","file":"/workspace/_project/tracker.json"}
+{"ts":"2026-07-26T17:40:44Z","action":"edit","file":"/workspace/jobs/PO/uat-log.md"}
+{"ts":"2026-07-26T17:41:35Z","action":"write","file":"/workspace/jobs/COO/backlog-clearance-plan.md"}

--- a/_project/STATUS.md
+++ b/_project/STATUS.md
@@ -13,11 +13,11 @@ _Tracker last updated: 2026-07-21 (BUG-59 logged: staging Railway ALLOWED_ORIGIN
 | PHASE-1 | Data Layer — Database Schema & Migrations | ✅ Done |
 | PHASE-2 | API Layer — Backend REST API | ✅ Done |
 | PHASE-3 | UI Layer — React Frontend SPA | ✅ Done |
-| PHASE-4 | QA & Documentation | 🔄 In progress |
+| PHASE-4 | QA & Documentation | ✅ Done |
 | PHASE-5 | Integrations — Notification Engine | ⬜ Pending |
 | PHASE-6 | v3 Planning-First Delivery | ⬜ Pending |
 
-## Open work (44)
+## Open work (45)
 
 ### P0 — Blockers (1)
 
@@ -32,11 +32,12 @@ _Tracker last updated: 2026-07-21 (BUG-59 logged: staging Railway ALLOWED_ORIGIN
 | BUG-50 | No way to delete an entire trip | fullstack | ⬜ Pending |
 | BUG-51 | Companion name edits in admin panel don't consistently propagate to trips | backend | ⬜ Pending |
 
-### P2 — Important (25)
+### P2 — Important (26)
 
 | ID | Title | Owner | Status |
 |---|---|---|---|
 | FUTURE-03 | Companion model — linked/unlinked users with invite flow | coo | ⬜ Pending |
+| QUAL-03 | test-db.ts hand-mirrors 21 CREATE TABLE statements — silent schema-drift risk in every repository test | backend | ⬜ Pending |
 | BRD-IT0809 | Rating sort and filter in item list views, cross-trip by city (IT-08/09) | frontend | 🔄 In progress |
 | BRD-AD09 | Categories/activities are global seeded defaults; deactivation is owner-only (AD-09) | backend | ◐ Partial |
 | BRD-PH03 | Photo management accessible from trip detail header (PH-03) | frontend | ◐ Partial |
@@ -91,7 +92,7 @@ _Tracker last updated: 2026-07-21 (BUG-59 logged: staging Railway ALLOWED_ORIGIN
 | requirement | `███████████████████░` 31/33 | 31 | 2 | 5 |
 | bug | `███████████████░░░░░` 41/55 | 41 | 14 | 4 |
 | task | `████████████████████` 9/9 | 9 | 0 | 0 |
-| chore | `████████████████░░░░` 7/9 | 7 | 2 | 0 |
+| chore | `██████████████░░░░░░` 7/10 | 7 | 3 | 0 |
 
 <details>
 <summary>Deferred (10)</summary>
@@ -123,4 +124,4 @@ _Tracker last updated: 2026-07-21 (BUG-59 logged: staging Railway ALLOWED_ORIGIN
 
 ---
 
-_119 done · 10 deferred · 2 closed · 44 open — 175 tracked items_
+_119 done · 10 deferred · 2 closed · 45 open — 176 tracked items_

--- a/_project/tracker.json
+++ b/_project/tracker.json
@@ -55,12 +55,12 @@
       "id": "PHASE-4",
       "type": "phase",
       "title": "QA & Documentation",
-      "status": "in_progress",
+      "status": "done",
       "owner": "qa",
       "priority": "P0",
       "brdRefs": [],
       "phase": 4,
-      "notes": "186 backend + 55 frontend unit tests passing. Contract tests passing. Playwright E2E suite (36 tests) now a permanent CI gate (OP-11, PR #124). README + CODEBASE.md done. OP-06 gate CLOSED 2026-07-16 (PR #115) — no longer a blocker. Remaining before formal close: OP-07 (UI/UX expert review) + PO phase UAT."
+      "notes": "CLOSED 2026-07-26 on PO UAT PASS — the Scotland dogfood trial and the 2026-07-20/21 UAT sessions were the phase UAT (PO: 'phase 4 can already close, the dogfooding was the UAT'). Deliverables all shipped: 580 backend + 154 frontend unit tests passing, contract tests passing, Playwright E2E suite a permanent CI gate (OP-11, PR #124), README + CODEBASE.md done, OP-06 gate CLOSED 2026-07-16 (PR #115). PRIOR NOTE WAS STALE — it listed 'OP-07 (UI/UX expert review) + PO phase UAT' as remaining, but OP-07 had already been closed and the note was never flipped (Document lifecycle miss, corrected here). PO UAT was therefore the only outstanding gate. The 21 UAT-found defects (BUG-40–58, BRD-DP06, OQ-06) were re-phased 4→6 in this same PR: they were found during Phase 4 but are feature/UX defects, not Phase 4 deliverables, and PHASE-6's flagship features (BRD-PL0104, BRD-CU0103) are already explicitly gated on that batch being worked through. Two genuinely Phase-4-scope items stay parked under this closed phase, matching the existing ENV-01/QUAL-02/UX-05 pattern: BUG-37 (backlog) and OP-15 (pending, prerequisites actively clearing)."
     },
     {
       "id": "PHASE-5",
@@ -775,8 +775,8 @@
       "owner": "coo",
       "priority": "P3",
       "brdRefs": [],
-      "phase": 4,
-      "notes": "PO direction 2026-07-18: these two Session-C drafts need more consideration and planning before installing. Prerequisites: (a) Q22 test-DDL consolidation lands first — it removes the schema skill's most error-prone step (13 hand-mirrored DDL copies); (b) Q3/Q8 lock/PATCH fixes land so the backend skill's carve-out warnings can be written as settled rules; (c) decide the brief-template enforcement mechanism (skills only work if COO briefs consistently instruct agents to load them). Drafts remain in audits/session-c-workflow-extraction.md on chore/audit-questions. W5 frontend skill: extract from real PHASE-6 friction, not speculatively."
+      "phase": 6,
+      "notes": "PO direction 2026-07-18: these two Session-C drafts need more consideration and planning before installing. Prerequisites: (a) Q22 test-DDL consolidation lands first — it removes the schema skill's most error-prone step (13 hand-mirrored DDL copies); (b) Q3/Q8 lock/PATCH fixes land so the backend skill's carve-out warnings can be written as settled rules; (c) decide the brief-template enforcement mechanism (skills only work if COO briefs consistently instruct agents to load them). Drafts are on main at audits/session-c-workflow-extraction.md (NOT stranded on the deleted chore/audit-questions branch — verified 2026-07-26). W5 frontend skill: extract from real PHASE-6 friction, not speculatively. PREREQUISITE AUDIT 2026-07-26 (COO), prompted by PO pushing back on deferring this: (b) MET — BUG-27 and BUG-28 both done. (a) NOT met and has got WORSE — src/backend/repositories/__tests__/test-db.ts now hand-mirrors 21 CREATE TABLE statements, not the 13 recorded here; tracked properly as QUAL-03 (was previously untracked, existing only as this sub-bullet, so deferring OP-15 would have buried it). (c) RESOLVED 2026-07-26 — a brief template was rejected as having the same weakness it was meant to fix (it only works if the COO remembers to use it, which is the stated failure mode); enforcement moved agent-side into jobs/<role>/<role>-system-prompt.txt, which every dispatch reads via the thin .claude/agents/*.md wrappers (D-01), so the agent enforces skill loading regardless of what the brief says. Status stays pending, NOT deferred: (c) is done and (a) is scheduled as QUAL-03. Sequence QUAL-03 before this design pass — the schema skill's own steps depend on what the DDL workflow looks like afterward."
     },
     {
       "id": "OP-16",
@@ -973,12 +973,12 @@
       "id": "BUG-37",
       "type": "bug",
       "title": "Flaky test — CarryForwardModal 'calls onClose immediately when Skip is clicked'",
-      "status": "pending",
+      "status": "backlog",
       "owner": "frontend",
       "priority": "P3",
       "brdRefs": [],
       "phase": 4,
-      "notes": "Found 2026-07-20 by the BUG-10 frontend brief (unrelated to that fix — confirmed pre-existing by reproducing on a clean branch tip with the BUG-10 diff stashed out). src/frontend/components/CarryForward/__tests__/CarryForwardModal.test.tsx — onClose occasionally called 2-3x instead of 1x when Skip is clicked. Not investigated further; flagging so it isn't lost once the reporting agent's worktree is cleaned up."
+      "notes": "Found 2026-07-20 by the BUG-10 frontend brief (unrelated to that fix — confirmed pre-existing by reproducing on a clean branch tip with the BUG-10 diff stashed out). src/frontend/components/CarryForward/__tests__/CarryForwardModal.test.tsx — onClose occasionally called 2-3x instead of 1x when Skip is clicked. NOT REPRODUCIBLE as of 2026-07-26 (COO, 13 runs): 10/10 passes running the file in isolation, plus 3/3 clean full-suite runs at 154/154 each. Something merged since 2026-07-20 likely fixed it incidentally. Downgraded pending → backlog rather than closed: 13 runs is not proof of absence for a defect described as 'occasional' (could be ~1-in-50), and closing flakes silently means a recurrence gets re-diagnosed from scratch. It is demonstrably not gating anything — test:frontend is a required check on every PR, so a real recurrence will resurface with a run ID attached. Parked under the closed PHASE-4 alongside QUAL-02 as known QA quality debt."
     },
     {
       "id": "BUG-38",
@@ -1114,7 +1114,18 @@
       "priority": "P3",
       "brdRefs": [],
       "phase": 4,
-      "notes": "QA review (2026-03-23) flagged gaps in QUAL-01 tests. Top priorities: (1) filter inversion bug undetectable — category/activity/country filter tests seed 1 trip and assert length=1; inverted filter would also return 1. Fix: seed 3 trips, assert exactly 1. (2) GET /api/trips sort order (startDate desc) not tested. (3) Response shape assertions too shallow — toHaveProperty() without type/value checks. (4) Cross-trip item isolation (same user, different trips). Deferred: personal app scale makes exhaustive edge case coverage low ROI."
+      "notes": "QA review (2026-03-23) flagged gaps in QUAL-01 tests. Top priorities: (1) filter inversion bug undetectable — category/activity/country filter tests seed 1 trip and assert length=1; inverted filter would also return 1. Fix: seed 3 trips, assert exactly 1. (2) GET /api/trips sort order (startDate desc) not tested. (3) Response shape assertions too shallow — toHaveProperty() without type/value checks. (4) Cross-trip item isolation (same user, different trips). Deferred: personal app scale makes exhaustive edge case coverage low ROI. 2026-07-26: findings (1) and (2) scheduled into the backlog-clearance plan's batch B4 (trip search/filter, BUG-52/55/56) — the agent is already in those exact test files and BUG-52's fix is unverifiable under assertions this weak. Findings (3) and (4) stay backlog."
+    },
+    {
+      "id": "QUAL-03",
+      "type": "chore",
+      "title": "test-db.ts hand-mirrors 21 CREATE TABLE statements — silent schema-drift risk in every repository test",
+      "status": "pending",
+      "owner": "backend",
+      "priority": "P2",
+      "brdRefs": [],
+      "phase": 6,
+      "notes": "Logged 2026-07-26 (COO) during the OP-15 prerequisite audit. Was previously untracked — it existed only as a sub-bullet inside OP-15's notes ('Q22 test-DDL consolidation'), so deferring OP-15 would have buried it. src/backend/repositories/__tests__/test-db.ts imports db/schema.ts for Drizzle typing but then hand-writes all 21 tables as literal DDL. A migration can therefore change the real schema while every repository test keeps passing green against the stale copy — the tests would not detect the drift. Same family as the stale local dev.db that caused a false alarm during the 2026-07-26 BUG-63 investigation (companions missing user_id post-migration 0012). Count has grown from the 13 recorded in OP-15's notes to 21, so this is actively worsening. Fix direction: drop the hand-written DDL and apply the real migrations to the in-memory libSQL DB (migrate(db, { migrationsFolder: 'src/backend/migrations' })) so the test schema is identical to production's by construction. IMPLEMENTATION CAVEAT for the brief: createTestDb() runs in beforeEach across ~580 backend tests, so replaying 12+ migration files per test may hurt suite time — build the schema once and clone per test rather than re-migrating. Also clears OP-15 prerequisite (a); sequence this BEFORE the OP-15 skills design pass. Scheduled as batch B9 in jobs/COO/backlog-clearance-plan.md."
     },
 
     // ─── CODE REVIEW FINDINGS — 2026-03-22 ───────────────────────────────────
@@ -1649,7 +1660,7 @@
       "owner": "fullstack",
       "priority": "P2",
       "brdRefs": ["DP-06"],
-      "phase": 4,
+      "phase": 6,
       "notes": "Added to BRD v3.1, 2026-07-20 UAT. Success criteria: adding the first place to a trip with dates set pre-fills place arrival/departure from trip start/end; later per-place edits persist independently of trip dates."
     },
     {
@@ -1772,7 +1783,7 @@
       "owner": "fullstack",
       "priority": "P2",
       "brdRefs": [],
-      "phase": 4,
+      "phase": 6,
       "notes": "Found 2026-07-21 UAT, logged only — not yet briefed. BUG-32 implemented place deletion by silently reassigning items to trip-level (trip_place_id=null). PO wants an explicit confirmation step instead: warn that the place has items and let the user choose delete-all / move-to-trip-level / cancel, rather than always auto-reassigning."
     },
     {
@@ -1783,7 +1794,7 @@
       "owner": "architect",
       "priority": "P2",
       "brdRefs": [],
-      "phase": 4,
+      "phase": 6,
       "notes": "Found 2026-07-21 UAT, logged only — not yet briefed. Example: Seattle→London (layover)→Glasgow, all one booking. Current flight item model is single-leg. Needs Architect schema design before this is briefable — likely a flight-legs sub-entity under one booking item, not a simple field addition."
     },
     {
@@ -1794,7 +1805,7 @@
       "owner": "architect",
       "priority": "P2",
       "brdRefs": [],
-      "phase": 4,
+      "phase": 6,
       "notes": "Found 2026-07-21 UAT, logged only — not yet briefed. Should be able to assign multiple companions/seats to one booking item (flight, car, etc.) instead of one implicit traveller. Needs schema/UX scoping — how seat assignment interacts with the existing companion model."
     },
     {
@@ -1805,7 +1816,7 @@
       "owner": "integrations",
       "priority": "P3",
       "brdRefs": [],
-      "phase": 4,
+      "phase": 6,
       "notes": "Found 2026-07-21 UAT, PO-flagged as longer-term/aspirational, logged only. Idea: parse Apple Wallet boarding-pass/booking passes to pre-fill flight/car booking fields instead of manual multi-seat entry (see BUG-42). Backlog — needs a research spike on .pkpass format access before any real scoping."
     },
     {
@@ -1816,7 +1827,7 @@
       "owner": "frontend",
       "priority": "P2",
       "brdRefs": [],
-      "phase": 4,
+      "phase": 6,
       "notes": "Found 2026-07-21 UAT, logged only — not yet briefed. Mirror the existing flight pattern (airline + flight number render as subtext under the flight item) — car rental should show pickup location as subtext under the provider name the same way. Small, self-contained UI fix."
     },
     {
@@ -1827,7 +1838,7 @@
       "owner": "architect",
       "priority": "P3",
       "brdRefs": [],
-      "phase": 4,
+      "phase": 6,
       "notes": "Found 2026-07-21 UAT, PO-flagged as longer-term, logged only. Replace free-text entry for airline / car-rental-provider with a dropdown sourced from a comprehensive external list, falling back to an 'Other' + free-text option when not found. Needs a data-source decision (licensing/comprehensiveness) before scoping — same theme as OQ-06 (systematic reference data vs. hand-seeded lists)."
     },
     {
@@ -1838,7 +1849,7 @@
       "owner": "architect",
       "priority": "P3",
       "brdRefs": [],
-      "phase": 4,
+      "phase": 6,
       "notes": "Raised 2026-07-21 UAT. PO initially suspected account data leakage (saw a Northern Ireland trip under their own account) — self-diagnosed in-session as the known BUG-30 gap (GB region seeding), not a leak; BUG-30 is already done and closed. Real open question: BUG-30 hand-seeded England/Scotland/Wales/NI under GB as a one-off fix — is there a more systematic ISO 3166-2 subdivision dataset that should back region seeding generally, rather than patching countries one at a time as gaps are found? Same theme as BUG-45's comprehensive-list ask. For Architect to weigh before the next region-data gap surfaces."
     },
     {
@@ -1849,7 +1860,7 @@
       "owner": "frontend",
       "priority": "P2",
       "brdRefs": [],
-      "phase": 4,
+      "phase": 6,
       "notes": "Found 2026-07-21 UAT, logged only — not yet briefed. Admin-defined activities are selectable when editing a trip but the field doesn't appear on trip create at all. NOTE: check against BUG-47 before briefing as a simple add-to-create-form fix — PO's proposed activity redesign may supersede this."
     },
     {
@@ -1860,7 +1871,7 @@
       "owner": "architect",
       "priority": "P3",
       "brdRefs": [],
-      "phase": 4,
+      "phase": 6,
       "notes": "Found 2026-07-21 UAT, logged only — not yet briefed. PO's proposed redesign: instead of manually pre-selecting activities on a trip, derive/auto-populate them from the trip's actual place/item content. Trip categories stay manual — PO confirmed they serve a distinct purpose and are fine as-is, this is activities only. Needs product/UX scoping — what content drives auto-population is undefined."
     },
     {
@@ -1871,7 +1882,7 @@
       "owner": "frontend",
       "priority": "P2",
       "brdRefs": [],
-      "phase": 4,
+      "phase": 6,
       "notes": "Found 2026-07-21 UAT, logged only — not yet briefed. Example: US requires zooming in until the whole country fills the screen before state shading appears at all, and rendering latency means the practical zoom needed is even further in than that. State shading should trigger at a meaningfully lower zoom level."
     },
     {
@@ -1882,7 +1893,7 @@
       "owner": "frontend",
       "priority": "P2",
       "brdRefs": [],
-      "phase": 4,
+      "phase": 6,
       "notes": "Found 2026-07-21 UAT, logged only — not yet briefed. When state shading activates it visually covers city tag markers — layer/z-order issue, city markers should stay on top."
     },
     {
@@ -1893,7 +1904,7 @@
       "owner": "fullstack",
       "priority": "P1",
       "brdRefs": [],
-      "phase": 4,
+      "phase": 6,
       "notes": "Found 2026-07-21 UAT, logged only — not yet briefed. No delete affordance exists for a trip itself (BUG-32 only covers removing a place from within a trip). Needs a route (if missing) + UI entry point + confirmation, same shape as BUG-32's brief."
     },
     {
@@ -1904,7 +1915,7 @@
       "owner": "backend",
       "priority": "P1",
       "brdRefs": [],
-      "phase": 4,
+      "phase": 6,
       "notes": "Found 2026-07-21 UAT, logged only — not yet briefed. Renaming a companion in the admin panel updated correctly on one trip automatically, but a second trip (companion role 'partner', renamed to Aisling) kept showing the old value until that trip was opened, edited, and saved. Suggests inconsistent propagation/derivation of companion name depending on how the trip stores/displays the reference — data-integrity concern, needs investigation."
     },
     {
@@ -1915,7 +1926,7 @@
       "owner": "backend",
       "priority": "P2",
       "brdRefs": [],
-      "phase": 4,
+      "phase": 6,
       "notes": "Found 2026-07-21 UAT, logged only — not yet briefed. Searching 'United States' or 'USA' returns no results even when a trip has a US place, unless the country string literally appears in the trip title. Search should match against place/country data, not just the trip title."
     },
     {
@@ -1926,7 +1937,7 @@
       "owner": "ux",
       "priority": "P2",
       "brdRefs": [],
-      "phase": 4,
+      "phase": 6,
       "notes": "Found 2026-07-21 UAT, logged only — not yet briefed (combines two related findings). Current: each place in the trips panel shows city (bold) with country underneath in lighter text. PO wants: city (bold) with state on the second line instead of country, and country surfaced elsewhere — either as a pill next to the category, or its own row just beneath it. Also affects trip scannability alongside BUG-52 (search), since country isn't otherwise visible on the trip card unless it happens to be in the title. Needs a UX spec before this is briefable — specific layout choice (pill vs row) isn't decided."
     },
     {
@@ -1937,7 +1948,7 @@
       "owner": "ux",
       "priority": "P3",
       "brdRefs": [],
-      "phase": 4,
+      "phase": 6,
       "notes": "Found 2026-07-21 UAT. PO explicitly flagged this as a future-phase requirement, not near-term — categories and activities currently have no user-controllable color. Logged for backlog only, no near-term action expected."
     },
     {
@@ -1948,7 +1959,7 @@
       "owner": "backend",
       "priority": "P2",
       "brdRefs": [],
-      "phase": 4,
+      "phase": 6,
       "notes": "Found 2026-07-21 UAT, logged only — not yet briefed. Entering a city name doesn't auto-fill its country/state fields — likely the geocode/lookup path isn't wired to populate those fields on selection."
     },
     {
@@ -1959,7 +1970,7 @@
       "owner": "frontend",
       "priority": "P3",
       "brdRefs": [],
-      "phase": 4,
+      "phase": 6,
       "notes": "Found 2026-07-21 UAT, logged only — not yet briefed. Small polish — city name input should auto-capitalize the first letter."
     },
     {
@@ -1970,7 +1981,7 @@
       "owner": "fullstack",
       "priority": "P2",
       "brdRefs": [],
-      "phase": 4,
+      "phase": 6,
       "notes": "Found 2026-07-21 UAT, logged only — not yet briefed. PO wants consistent date-picker defaulting across all item entry: (1) if the trip's date range is set, adding any item should default its date(s) to the start of the trip's range rather than today; (2) flights specifically should default arrival to the same day as departure once departure is entered, editable after. Explicit PO goal: avoid manually moving both to/from date pickers away from 'today' when entering a trip outside the current month — defaulting should land the picker in the right neighborhood automatically. Subsumes the narrower 'flight arrival defaults to departure date' finding from the same session."
     },
     {
@@ -1981,7 +1992,7 @@
       "owner": "frontend",
       "priority": "P2",
       "brdRefs": [],
-      "phase": 4,
+      "phase": 6,
       "notes": "Found 2026-07-21 UAT, logged only — not yet briefed. Moving a trip to an earlier status (backward through the workflow) clears the trip selection entirely, forcing the user to re-find and re-select it in the left panel. Expected: trip stays selected, detail panel just updates to reflect the new status. Meaningful friction at high trip volume."
     },
     {

--- a/jobs/COO/backlog-clearance-plan.md
+++ b/jobs/COO/backlog-clearance-plan.md
@@ -1,0 +1,179 @@
+# Backlog Clearance Plan
+
+**Version:** 1.0
+**Date:** 2026-07-26
+**Author:** COO
+**Status:** LIVE — approved by PO 2026-07-26. Update wave status here as briefs land; this
+document is presumed current until stamped otherwise (CLAUDE.md → Document lifecycle).
+
+Sequencing plan for clearing the entire open bug backlog plus the feature items that share
+its code surface. Ordered for **throughput, not priority** — PO's explicit instruction was
+"the most efficient way possible regardless of priority."
+
+Companion document: `_project/tracker.json` remains the authority for item status. This plan
+owns *sequencing and batching* only; it never contradicts the tracker.
+
+---
+
+## 1. The efficiency thesis
+
+Agent runtime is effectively free and parallel. The three things that actually cost time are:
+
+1. **COO serialisation** — brief writing, PR review, merge. One PR per *subsystem* beats one
+   per bug.
+2. **Merge conflicts** between concurrent agents in the same files. Batches are partitioned
+   by file surface so concurrent agents never collide.
+3. **PO UAT time** — the scarcest resource. One batched UAT round per wave, not per PR.
+
+Everything below optimises for those three, which is why a P3 papercut can ship in the same
+brief as a P1 while another P1 waits for scoping.
+
+---
+
+## 2. Scope
+
+**33 items:** 26 open backlog items (23 `BUG-*` + `OQ-05`, `OQ-06`, `UX-11`) and 7 feature
+items that share their code surface.
+
+| Bucket | Count | Items |
+|---|---|---|
+| Briefable immediately | 13 | BUG-06, 37, 44, 48, 49, 50, 51, 52, 55, 56, 57, 58, 62 |
+| Blocked on scoping | 11 | OQ-05, OQ-06, BUG-40, 41, 42, 45, 46, 47, 53, 54, UX-11 |
+| Not schedulable | 2 | BUG-63 (unreproducible), BUG-43 (research spike, PO-flagged aspirational) |
+| Features riding along | 7 | BRD-DP06, BRD-AD09, BRD-IT10, QUAL-02 (subset), QUAL-03, WP-05, BRD-IT0809 |
+
+---
+
+## 3. Wave 0 — scoping (parallel, no code touched)
+
+Spec output only (`jobs/*/tech/`, ADL). Zero conflict with Wave 1, so both waves run
+concurrently.
+
+| # | Role | Covers | Unblocks |
+|---|---|---|---|
+| S1 | Architect | **OQ-05** — trip-place identity (one-row-per-city) | BUG-40 |
+| S2 | Architect | **BUG-41 + BUG-42** — multi-leg flights and multi-companion seats are one schema problem ("booking item is flat"), not two | BUG-43 (downstream) |
+| S3 | Architect | **BUG-45 + OQ-06** — airline dropdown and ISO 3166-2 subdivisions are the same sourced-reference-data decision; one ADL | — |
+| S4 | UX | **BUG-53 + UX-11 + BUG-54 + BUG-47** — one trip-list / colour / activities spec pass | BUG-46 |
+| S5 | Architect | **BUG-48** — see §6 sizing correction; this is not a frontend brief | BUG-48 impl |
+| S6 | Architect | **BRD-IT10** — nullable Google Maps URL column; schema-change rule requires review | BRD-IT10 impl, BRD-MB0102 |
+
+**Mandatory before dispatch:** pre-assign ADL numbers. S1/S2/S3/S5/S6 are five concurrent
+Architects who will each independently read the ADL log and pick "the next number."
+Worktree isolation does **not** protect against this — same class as the shared-`refs/stash`
+collision in OP-20. COO assigns numbers in the briefs.
+
+---
+
+## 4. Wave 1 — implementation (file-partitioned)
+
+Run as **two sub-waves of ~4**, not all 8 at once: COO reviews and merges serially anyway,
+and the conflict pairs below must not run concurrently.
+
+| # | Owner | Items | File surface |
+|---|---|---|---|
+| B1 | frontend | BUG-49 | `Map/*` z-order |
+| B2 | frontend | BUG-62 **+ BRD-AD09** | `App.tsx`, `AdminPanel.tsx`, `App.test.tsx`, admin routes |
+| B3 | backend | BUG-51 | companions repo/routes — investigation-led |
+| B4 | fullstack | BUG-52, 55, 56 **+ QUAL-02 (findings 1–2)** | city lookup path, trip search, filter tests |
+| B5 | frontend | BUG-06, 37, 58 | `TripList/*`, `ShadingTab`, CarryForward test |
+| B6 | fullstack | BUG-44, 57 **+ BRD-DP06 + BRD-IT10** | `ItemForm.tsx`, `ItemCard.tsx` |
+| B7 | fullstack | BUG-50 | new `DELETE /api/trips/:id`, `TripDetail` header, `ConfirmDialog` |
+| B8 | frontend | **BRD-IT0809** | item-list sort/filter UI |
+| B9 | backend | **QUAL-03** | `test-db.ts` migration-driven schema |
+
+**Conflict pairs — must be split across sub-waves:**
+
+- B2 ↔ B5 — both reach into `Admin/` (`AdminPanel.tsx` vs `ShadingTab.tsx`)
+- B6 ↔ B7 — both reach into `TripDetail/` (`ItemForm`/`ItemCard` vs `TripDetail.tsx`)
+- B6 ↔ B8 — both touch item-list rendering
+
+Suggested split — **sub-wave A:** B1, B2, B3, B6, B9 · **sub-wave B:** B4, B5, B7, B8.
+
+**B9 is worth running first or early** regardless of sub-wave: it makes every other backend
+brief's tests trustworthy, and it clears OP-15 prerequisite (a).
+
+---
+
+## 5. Wave 2 — post-scoping
+
+| Item | Gated on |
+|---|---|
+| BUG-40 | S1 (OQ-05) |
+| BUG-46 | S4 — may be *deleted* rather than fixed if BUG-47's redesign lands |
+| BUG-53, UX-11 | S4 |
+| BUG-41 + BUG-42 implementation | S2 — **3 briefs on its own** (migration, backend, frontend) |
+| BRD-MB0102 | B6/S6 (consumes IT-10's directions links) |
+| BUG-54 | S4 — stays parked unless the spec makes it free |
+| OP-15 skills design pass | B9 (QUAL-03) |
+
+**Parked, not scheduled:** BUG-63 (no reproduction — needs a captured network response),
+BUG-43 (research spike, PO-flagged aspirational).
+
+---
+
+## 6. Sizing corrections (found by probing, 2026-07-26)
+
+These override the naive read of the tracker notes.
+
+1. **BUG-48 is a trap, not a one-line change.** `MapView.tsx:28` sets
+   `REGION_ZOOM_THRESHOLD = 3`, but region shading pulls a **39 MB** `geo/regions.json`.
+   Lowering the threshold makes that payload load *sooner and more often* — it would make
+   the latency the PO reported **worse**. The real fix is the payload (simplification,
+   tiling, per-country splitting). Hence S5. Separately, `MapView.tsx:6` documents
+   `zoom >= 4` while the constant is `3` — stale-doc drift, fix in whichever PR touches it.
+2. **BUG-50 is fullstack.** There is no `router.delete` in `src/backend/routes/trips.ts` at
+   all. New route + cascade semantics (trip_places, items, photos) → needs a BRD ID and
+   success criteria before dispatch. **Must not foreclose NR-12** (Phase 2: archive rather
+   than hard-delete for structured lists) — flag to Architect in S1.
+3. **BUG-52 sizing unknown.** No server-side trip search was found anywhere; it is likely
+   client-side title filtering. The brief needs a discovery step before it can carry an
+   estimate.
+4. **`ConfirmDialog.tsx` already exists** in `src/frontend/components/shared/` — BUG-40 and
+   BUG-50 both reuse it. No new component.
+5. **BUG-55 cannot be live-verified in the devcontainer.** Nominatim is firewall-blocked
+   (ENV-01), so city → country/state auto-population has no live geocode path. The brief
+   needs a stubbed verification route or the agent will report a false failure.
+
+---
+
+## 7. Why these features ride along
+
+| Item | Batch | Rationale |
+|---|---|---|
+| BRD-DP06 | B6 | *Is* BUG-57. "Adding any item defaults to the trip's range" and "the first place inherits the trip's date range" are one code path. Separate briefs = the same defaulting logic written twice. |
+| BRD-AD09 | B2 | **Correctness dependency.** AD-09's owner-only deactivation is *not enforced on the backend today*. BUG-62 rebuilds exactly that access model. Shipping BUG-62 alone yields frontend gating over an unenforced backend — the HC-04/BUG-26 shape this project has already been bitten by twice. |
+| BRD-IT10 | B6 | Nullable URL column + `ItemForm` field + `ItemCard` display — identical surface to BUG-44. Needs S6 first. |
+| QUAL-02 (1–2) | B4 | Its top finding is that filter tests seed 1 trip and assert `length=1`, so an inverted filter passes. B4 rewrites trip search/filter — BUG-52's fix is unverifiable under assertions that weak. Findings 3–4 stay backlog. |
+| QUAL-03 | B9 | Untracked until 2026-07-26; clears OP-15 prerequisite (a) and de-risks every other backend brief. |
+| WP-05 | free | Its single named example is DP-06 looking done because the reskin displayed it. Ships closed with DP-06. |
+| BRD-IT0809 | B8 | **Backend already merged (PR #90); only the frontend was never dispatched.** Paid-for value stranded behind one UI brief. |
+
+**Deliberately excluded** — no file overlap, genuinely separate phases: NR-09–13, PHASE-5,
+FUTURE-01/02/03, BRD-PL05/06, BRD-LB01/02/03, BRD-FL04, UX-05 / BRD-PH03 (photos).
+
+---
+
+## 8. Gates to clear before Wave 1 dispatch
+
+1. **BRD bump.** BUG-50, BUG-57 and BUG-40 introduce behaviour with no BRD home. Per the BRD
+   gate and success-criteria rules, that is **one** version bump covering all of Wave 1 — done
+   once, not per brief.
+2. **Pre-assigned ADL numbers** for the Wave 0 Architects (§3).
+3. **Security checklist** in every brief that adds or modifies routes (B3, B4, B7) — auth
+   middleware, `userId` scoping, FK `.notNull()`, per CLAUDE.md and OP-06 §2.
+4. **`isolation: "worktree"`** on every dispatch (all of these do git work), and `npm install`
+   inside each fresh worktree before anything needing `node_modules`.
+
+---
+
+## 9. Expected shape
+
+**33 items → 6 scoping dispatches + 9 implementation briefs + 2 parked**, in roughly three
+merge sessions and two UAT rounds.
+
+## 10. Change log
+
+| Version | Date | Change |
+|---------|------|--------|
+| 1.0 | 2026-07-26 | Initial plan. Approved by PO. Phase 4 closed in the same PR; the 21 dogfooding items re-phased 4 → 6. |

--- a/jobs/PO/uat-log.md
+++ b/jobs/PO/uat-log.md
@@ -51,6 +51,45 @@ Screenshots: save to `jobs/PO/screenshots/[date]-[short-description].png`
 
 ## Open Sessions
 
+### UAT Session — 2026-07-26 (PHASE-4 formal close — QA & Documentation)
+
+**Scope:** Phase 4 phase-completion gate. Not a fresh test pass — this records the PO's
+verdict that the Scotland dogfood trial and the 2026-07-20 / 2026-07-21 UAT sessions below
+*were* the Phase 4 UAT.
+**Build:** main @ 1a4f84f (verdict given against the dogfooded builds: c4340ef, 7bafc11, f5fa666)
+**Verdict:** PASS — closes PHASE-4. PO: *"phase 4 can already close, the dogfooding was the UAT."*
+
+#### Findings
+
+- [x] Phase 4 deliverables confirmed complete and exercised in real use.
+      580 backend + 154 frontend unit tests passing, contract tests passing, Playwright E2E
+      suite a permanent CI gate (OP-11, PR #124), README + CODEBASE.md done, OP-06 hardening
+      gate closed 2026-07-16 (PR #115).
+      Fixed myself: no — PO verdict, no action needed.
+
+- [x] PHASE-4's tracker note was stale and is corrected in the same PR as this entry.
+      It listed *"Remaining before formal close: OP-07 (UI/UX expert review) + PO phase UAT"* —
+      but OP-07 was already `done` and the note was never flipped (Document lifecycle miss).
+      PO UAT was therefore the only genuinely outstanding gate, which this session supplies.
+      Fixed myself: no — found by COO during the close-out audit.
+
+#### Notes / Observations
+
+1. **The 21 UAT-found defects do not block this close and have been re-phased 4 → 6.**
+   BUG-40–58, BRD-DP06 and OQ-06 were *found during* Phase 4 but are feature/UX defects, not
+   Phase 4 deliverables — they only carried a `phase: 4` tag because that was the open phase
+   when they were logged. Phase 4's own scope is QA infrastructure and documentation, all of
+   which shipped. PHASE-6's flagship features (BRD-PL0104, BRD-CU0103) are already explicitly
+   gated on this same batch being worked through, so phase 6 is their accurate home.
+2. **Two genuinely Phase-4-scope items stay parked under the closed phase**, matching the
+   existing ENV-01 / QUAL-02 / UX-05 pattern: BUG-37 (→ `backlog`; not reproducible in 13 runs,
+   see its tracker note) and OP-15 (→ phase 6, following its prerequisite QUAL-03).
+3. This close does **not** assert the product is defect-free — 26 open backlog items remain,
+   sequenced in `jobs/COO/backlog-clearance-plan.md`. It asserts Phase 4's deliverables are
+   done and were validated by real dogfooding use.
+
+---
+
 ### UAT Session — 2026-07-21 (WP-03/WP-04 Waypoint Trips reskin, Phase 2)
 
 **Scope:** Trips screen desktop reskin (WP-03) + net-new mobile Trips layout (WP-04), per BRD §5.16 / `jobs/ux/tech/20260721-UX-waypoint-spec.md` Phase 2. Cross-reference table in the UX spec's Phase 2 section (item 8) defined the intended UAT scope.


### PR DESCRIPTION
## Summary

PO verdict 2026-07-26: *"phase 4 can already close, the dogfooding was the UAT."* This records that verdict, closes PHASE-4, and lands the sequencing plan for the remaining backlog.

## PHASE-4 close

Phase 4 is **QA & Documentation**. Its deliverables all shipped — 580 backend + 154 frontend tests, contract tests, Playwright E2E as a permanent CI gate (OP-11), README + CODEBASE.md, OP-06 gate closed (PR #115).

**The tracker note was stale and is corrected here.** It listed *"Remaining before formal close: OP-07 (UI/UX expert review) + PO phase UAT"* — but **OP-07 was already `done`** and nobody flipped the note. A Document lifecycle miss. PO UAT was therefore the only genuinely outstanding gate, which makes this close a clean gate satisfaction rather than a waiver.

## Re-phasing: 21 items 4 → 6

`BUG-40`–`BUG-58`, `BRD-DP06`, `OQ-06` were **found during** Phase 4 but are feature/UX defects, not Phase 4 deliverables — they carried `phase: 4` only because that was the open phase when they were logged. PHASE-6's flagship features (`BRD-PL0104`, `BRD-CU0103`) are already explicitly gated on this exact batch, so phase 6 is their accurate home and the dependency becomes visible in the record.

Verified: **phase 4 now has no child in a non-terminal status.** This avoids the shape that previously produced a mis-audit (`FEAT-IT`: *"IT-08/IT-09 NOT built — incorrectly marked done in audit 2026-03-23"*).

## OP-15 prerequisite audit

Prompted by the PO pushing back on deferring it. Deferring on prerequisites that are themselves actionable is just deferring:

| Prereq | Verdict |
|---|---|
| (b) Q3/Q8 lock + PATCH fixes | ✅ Met — BUG-27, BUG-28 both `done` |
| (a) Q22 test-DDL consolidation | ❌ Not met, **and worse** — `test-db.ts` hand-mirrors **21** `CREATE TABLE`s, not the 13 recorded |
| (c) Brief-template enforcement | ✅ **Resolved** — see below |

**(a) is now `QUAL-03`.** It was previously untracked, existing only as a sub-bullet inside OP-15's notes — so deferring OP-15 would have buried a real risk: `test-db.ts` imports `schema.ts` for typing but hand-writes the DDL, so a migration can change the true schema while every repository test passes green against the stale copy. Same family as the stale local `dev.db` that caused a false alarm during the BUG-63 investigation.

**(c) is decided.** A brief template was rejected as having the same weakness it was meant to fix — it only works if the COO remembers to use it, which *is* the stated failure mode. Enforcement moves agent-side into `jobs/<role>/<role>-system-prompt.txt`, which every dispatch reads via the thin `.claude/agents/*.md` wrappers (D-01). Follow-up PR.

OP-15 therefore stays **pending, not deferred**, and follows QUAL-03 to phase 6.

## BUG-37 → backlog

Not reproducible in **13 runs**: 10/10 with the file in isolation, 3/3 full-suite at 154/154 each. Downgraded rather than closed — 13 runs isn't proof of absence for a defect described as "occasional" (could be ~1-in-50), and silently closed flakes get re-diagnosed from scratch on recurrence. `test:frontend` is a required check, so a real recurrence resurfaces with a run ID attached.

## Backlog clearance plan

New: `jobs/COO/backlog-clearance-plan.md`. 33 items (26 backlog + 7 features sharing their code surface) → 6 scoping dispatches + 9 implementation briefs + 2 parked. Batched by **file surface rather than priority**, per the PO's "most efficient way possible regardless of priority". Includes five sizing corrections found by probing the code (notably: BUG-48 is not a one-line threshold change — the 39 MB `geo/regions.json` means lowering it makes the reported latency *worse*).

## Test plan

- [x] `npm run check` — pass
- [x] `npm run type:check:all` — pass
- [x] `npm run test:backend` — 580 passed, 1 skipped
- [x] `npm run test:frontend` — 154 passed
- [x] `npm run status:check` — in sync (STATUS.md regenerated, never hand-edited)
- [x] tracker.json re-parsed after every edit; phase-4 child-status invariant verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)