### PR TITLE
chore(OP-15): enforce skill loading agent-side in all 8 role system prompts

### DIFF
--- a/jobs/architect/architect-system-prompt.txt
+++ b/jobs/architect/architect-system-prompt.txt
@@ -47,6 +47,14 @@ ON INITIALISATION, YOU MUST:
 4. Read jobs/architect/context/current.txt
 5. Read your inbox/ folder for any messages from COO. Do not read inbox/read/ — those are processed messages available for reference only
 6. If a Park Document exists in jobs/architect/park-docs/, read the most recent one
+7. List .claude/skills/ and load any skill that covers the work in your brief BEFORE
+   starting it — not after, and not only when your brief tells you to. A skill is this
+   project's settled procedure for a task; where one exists it overrides your default
+   approach. Read the directory listing rather than working from memory: the installed set
+   changes over time, and your brief may not name the relevant one. /pre-push is mandatory
+   before every push regardless (see the GIT REQUIREMENT section). Adopted 2026-07-26 as
+   OP-15 prerequisite (c): enforcement lives here, agent-side, rather than in a brief
+   template, precisely so it does not depend on the COO remembering to instruct you.
 
 AT THE END OF EVERY THREAD, YOU MUST:
 1. Update jobs/architect/context/current.txt with current state

--- a/jobs/backend/backend-system-prompt.txt
+++ b/jobs/backend/backend-system-prompt.txt
@@ -30,6 +30,14 @@ ON INITIALISATION, YOU MUST:
 5. Read jobs/backend/context/current.txt
 6. Read your inbox/ folder for any messages from COO. Do not read inbox/read/ — those are processed messages available for reference only
 7. If a Park Document exists in jobs/backend/park-docs/, read the most recent one
+8. List .claude/skills/ and load any skill that covers the work in your brief BEFORE
+   starting it — not after, and not only when your brief tells you to. A skill is this
+   project's settled procedure for a task; where one exists it overrides your default
+   approach. Read the directory listing rather than working from memory: the installed set
+   changes over time, and your brief may not name the relevant one. /pre-push is mandatory
+   before every push regardless (see the GIT REQUIREMENT section). Adopted 2026-07-26 as
+   OP-15 prerequisite (c): enforcement lives here, agent-side, rather than in a brief
+   template, precisely so it does not depend on the COO remembering to instruct you.
 
 AT THE END OF EVERY THREAD, YOU MUST:
 1. Update jobs/backend/context/current.txt with current state

--- a/jobs/database/database-system-prompt.txt
+++ b/jobs/database/database-system-prompt.txt
@@ -30,6 +30,14 @@ ON INITIALISATION, YOU MUST:
 5. Read jobs/database/context/current.txt
 6. Read your inbox/ folder for any messages from COO. Do not read inbox/read/ — those are processed messages available for reference only
 7. If a Park Document exists in jobs/database/park-docs/, read the most recent one
+8. List .claude/skills/ and load any skill that covers the work in your brief BEFORE
+   starting it — not after, and not only when your brief tells you to. A skill is this
+   project's settled procedure for a task; where one exists it overrides your default
+   approach. Read the directory listing rather than working from memory: the installed set
+   changes over time, and your brief may not name the relevant one. /pre-push is mandatory
+   before every push regardless (see the GIT REQUIREMENT section). Adopted 2026-07-26 as
+   OP-15 prerequisite (c): enforcement lives here, agent-side, rather than in a brief
+   template, precisely so it does not depend on the COO remembering to instruct you.
 
 AT THE END OF EVERY THREAD, YOU MUST:
 1. Update jobs/database/context/current.txt with current state

--- a/jobs/docs/docs-system-prompt.txt
+++ b/jobs/docs/docs-system-prompt.txt
@@ -29,6 +29,14 @@ ON INITIALISATION, YOU MUST:
 6. Read jobs/docs/context/current.txt
 7. Read your inbox/ folder for any messages from COO. Do not read inbox/read/ — those are processed messages available for reference only
 8. If a Park Document exists in jobs/docs/park-docs/, read the most recent one
+9. List .claude/skills/ and load any skill that covers the work in your brief BEFORE
+   starting it — not after, and not only when your brief tells you to. A skill is this
+   project's settled procedure for a task; where one exists it overrides your default
+   approach. Read the directory listing rather than working from memory: the installed set
+   changes over time, and your brief may not name the relevant one. /pre-push is mandatory
+   before every push regardless (see the GIT REQUIREMENT section). Adopted 2026-07-26 as
+   OP-15 prerequisite (c): enforcement lives here, agent-side, rather than in a brief
+   template, precisely so it does not depend on the COO remembering to instruct you.
 
 AT THE END OF EVERY THREAD, YOU MUST:
 1. Update jobs/docs/context/current.txt with current state

--- a/jobs/frontend/frontend-system-prompt.txt
+++ b/jobs/frontend/frontend-system-prompt.txt
@@ -30,6 +30,14 @@ ON INITIALISATION, YOU MUST:
 5. Read jobs/frontend/context/current.txt
 6. Read your inbox/ folder for any messages from COO. Do not read inbox/read/ — those are processed messages available for reference only
 7. If a Park Document exists in jobs/frontend/park-docs/, read the most recent one
+8. List .claude/skills/ and load any skill that covers the work in your brief BEFORE
+   starting it — not after, and not only when your brief tells you to. A skill is this
+   project's settled procedure for a task; where one exists it overrides your default
+   approach. Read the directory listing rather than working from memory: the installed set
+   changes over time, and your brief may not name the relevant one. /pre-push is mandatory
+   before every push regardless (see the GIT REQUIREMENT section). Adopted 2026-07-26 as
+   OP-15 prerequisite (c): enforcement lives here, agent-side, rather than in a brief
+   template, precisely so it does not depend on the COO remembering to instruct you.
 
 AT THE END OF EVERY THREAD, YOU MUST:
 1. Update jobs/frontend/context/current.txt with current state

--- a/jobs/integrations/integrations-system-prompt.txt
+++ b/jobs/integrations/integrations-system-prompt.txt
@@ -30,6 +30,14 @@ ON INITIALISATION, YOU MUST:
 6. Read jobs/integrations/context/current.txt
 7. Read your inbox/ folder for any messages from COO. Do not read inbox/read/ — those are processed messages available for reference only
 8. If a Park Document exists in jobs/integrations/park-docs/, read the most recent one
+9. List .claude/skills/ and load any skill that covers the work in your brief BEFORE
+   starting it — not after, and not only when your brief tells you to. A skill is this
+   project's settled procedure for a task; where one exists it overrides your default
+   approach. Read the directory listing rather than working from memory: the installed set
+   changes over time, and your brief may not name the relevant one. /pre-push is mandatory
+   before every push regardless (see the GIT REQUIREMENT section). Adopted 2026-07-26 as
+   OP-15 prerequisite (c): enforcement lives here, agent-side, rather than in a brief
+   template, precisely so it does not depend on the COO remembering to instruct you.
 
 AT THE END OF EVERY THREAD, YOU MUST:
 1. Update jobs/integrations/context/current.txt with current state

--- a/jobs/qa/qa-system-prompt.txt
+++ b/jobs/qa/qa-system-prompt.txt
@@ -29,6 +29,14 @@ ON INITIALISATION, YOU MUST:
 5. Read jobs/qa/context/current.txt
 6. Read your inbox/ folder for any messages from COO. Do not read inbox/read/ — those are processed messages available for reference only
 7. If a Park Document exists in jobs/qa/park-docs/, read the most recent one
+8. List .claude/skills/ and load any skill that covers the work in your brief BEFORE
+   starting it — not after, and not only when your brief tells you to. A skill is this
+   project's settled procedure for a task; where one exists it overrides your default
+   approach. Read the directory listing rather than working from memory: the installed set
+   changes over time, and your brief may not name the relevant one. /pre-push is mandatory
+   before every push regardless (see the GIT REQUIREMENT section). Adopted 2026-07-26 as
+   OP-15 prerequisite (c): enforcement lives here, agent-side, rather than in a brief
+   template, precisely so it does not depend on the COO remembering to instruct you.
 
 AT THE END OF EVERY THREAD, YOU MUST:
 1. Update jobs/qa/context/current.txt with current state

--- a/jobs/ux/ux-system-prompt.txt
+++ b/jobs/ux/ux-system-prompt.txt
@@ -33,6 +33,14 @@ ON INITIALISATION, YOU MUST:
 4. Read jobs/ux/context/current.txt
 5. Read your inbox/ folder for any messages from COO. Do not read inbox/read/ — those are processed messages available for reference only
 6. If a Park Document exists in jobs/ux/park-docs/, read the most recent one
+7. List .claude/skills/ and load any skill that covers the work in your brief BEFORE
+   starting it — not after, and not only when your brief tells you to. A skill is this
+   project's settled procedure for a task; where one exists it overrides your default
+   approach. Read the directory listing rather than working from memory: the installed set
+   changes over time, and your brief may not name the relevant one. /pre-push is mandatory
+   before every push regardless (see the GIT REQUIREMENT section). Adopted 2026-07-26 as
+   OP-15 prerequisite (c): enforcement lives here, agent-side, rather than in a brief
+   template, precisely so it does not depend on the COO remembering to instruct you.
 
 AT THE END OF EVERY THREAD, YOU MUST:
 1. Update jobs/ux/context/current.txt with current state


### PR DESCRIPTION
## Summary

Resolves **OP-15 prerequisite (c)** — *"decide the brief-template enforcement mechanism (skills only work if COO briefs consistently instruct agents to load them)."*

**A brief template was considered and rejected: it has the same weakness it was meant to fix.** A template only works if the COO remembers to use it — and "the COO might not remember" *is* the stated failure mode. It moves the single point of failure rather than removing it.

Enforcement therefore moves **agent-side**. Every role's `ON INITIALISATION` block now instructs the agent to list `.claude/skills/` and load any skill covering its brief *before* starting work. Those files are already read on every dispatch via the thin `.claude/agents/*.md` wrappers (D-01), so the agent enforces skill loading regardless of what the brief says.

## Design note

The rule deliberately tells the agent to **read the directory listing** rather than naming today's skills. Two reasons:

1. The installed set changes over time, and a hardcoded list goes stale silently.
2. Installing the deferred `schema-change` / `backend-route-change` skills — the remaining body of OP-15 — becomes a **one-line change**, not another 8-file edit.

Applied to all 8 roles: architect, backend, database, docs, frontend, integrations, qa, ux.

## OP-15 status after this

| Prereq | Status |
|---|---|
| (a) Q22 test-DDL consolidation | Tracked as **QUAL-03**, scheduled as batch B9 |
| (b) Q3/Q8 lock + PATCH fixes | Met (BUG-27, BUG-28 done) |
| (c) Enforcement mechanism | ✅ **This PR** |

OP-15 stays `pending` (not `deferred`) and follows QUAL-03. Sequencing lives in `jobs/COO/backlog-clearance-plan.md`.

## Test plan

- [x] `npm run check` — pass
- [x] `npm run type:check:all` — pass
- [x] `npm run status:check` — in sync
- [x] All 8 prompts verified to contain the rule, with correct step numbering per file (each role's init block had a different step count)
- Prompt-text only; no source files touched, so backend/frontend suites are unaffected (both were green on the immediately preceding commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)