### PR TITLE
chore: BRD↔tracker sync, drop stale BRD version from CLAUDE.md, gitignore agent worktrees

### DIFF
--- a/.claude/skills/record-decision/SKILL.md
+++ b/.claude/skills/record-decision/SKILL.md
@@ -38,6 +38,12 @@ happened — sources noted inline.
 1. Edit the body sections AND add the §13 changelog entry AND bump the **header** version
    field — three places, and the header is the one that has been forgotten (stuck at 2.5
    through v2.7).
+   **Three places, and only three.** CLAUDE.md's "Key files" list used to name the BRD
+   version too, and silently went stale by nine versions (said v2.7 while the BRD was at
+   v3.6 — found 2026-07-26). It was a fourth place nobody counted, so the version was
+   removed from it rather than added to this checklist. Do not reintroduce a BRD version
+   number anywhere outside the BRD itself; point at the file and let its header be the
+   single source.
 2. Changelog author/approval: every accepted entry lists the PO as approver. Do not treat
    COO-only sign-off as an accepted pattern (v2.7 is the outlier — its retroactive PO
    approval is still an open item, audit Q7). Identity-level rewrites get their own PO

--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,10 @@ test-results/
 # macOS notification bridge — runtime trigger files only; .claude/notify/host-setup/
 # (the watcher script + LaunchAgent plist) is checked in, see .claude/hooks/notify.sh
 .claude/notify/queue/
+
+# Agent worktrees (isolation: "worktree" dispatches, OP-19). Each is a full checkout of
+# this repo — currently ~492 MB across all of them. ADL-39 assumed these were already
+# ignored; they were not, so any `git add -A` from the main checkout would stage entire
+# duplicate copies of the repo. Nothing was ever committed (verified 2026-07-26), so this
+# is a guard against a future mistake, not a cleanup.
+.claude/worktrees/

--- a/.planning/drift-ledger.jsonl
+++ b/.planning/drift-ledger.jsonl
@@ -1544,3 +1544,7 @@
 {"ts":"2026-07-26T17:39:41Z","action":"edit","file":"/workspace/_project/tracker.json"}
 {"ts":"2026-07-26T17:40:44Z","action":"edit","file":"/workspace/jobs/PO/uat-log.md"}
 {"ts":"2026-07-26T17:41:35Z","action":"write","file":"/workspace/jobs/COO/backlog-clearance-plan.md"}
+{"ts":"2026-07-26T17:55:22Z","action":"edit","file":"/workspace/CLAUDE.md"}
+{"ts":"2026-07-26T17:55:38Z","action":"edit","file":"/workspace/.claude/skills/record-decision/SKILL.md"}
+{"ts":"2026-07-26T17:55:58Z","action":"edit","file":"/workspace/_project/tracker.json"}
+{"ts":"2026-07-26T17:56:06Z","action":"edit","file":"/workspace/_project/tracker.json"}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -203,6 +203,7 @@ Screenshots are stored in `jobs/PO/screenshots/`.
 ## Key files
 See [CODEBASE.md](./CODEBASE.md) for the full repository map. Essential references:
 - `_project/tracker.json` — Feature/bug tracker (COO-maintained)
-- `_project/travel-tracker-BRD.md` — Business requirements document (v2.7)
+- `_project/travel-tracker-BRD.md` — Business requirements document (version is in its own
+  header; deliberately not duplicated here so it cannot go stale)
 - `src/backend/db/schema.ts` — Drizzle schema (single source of truth)
 - `patches/drizzle-kit+0.31.9.patch` — drizzle-kit SQLite bug fixes (patch-package)

--- a/_project/STATUS.md
+++ b/_project/STATUS.md
@@ -17,7 +17,7 @@ _Tracker last updated: 2026-07-21 (BUG-59 logged: staging Railway ALLOWED_ORIGIN
 | PHASE-5 | Integrations — Notification Engine | ⬜ Pending |
 | PHASE-6 | v3 Planning-First Delivery | ⬜ Pending |
 
-## Open work (45)
+## Open work (46)
 
 ### P0 — Blockers (1)
 
@@ -32,7 +32,7 @@ _Tracker last updated: 2026-07-21 (BUG-59 logged: staging Railway ALLOWED_ORIGIN
 | BUG-50 | No way to delete an entire trip | fullstack | ⬜ Pending |
 | BUG-51 | Companion name edits in admin panel don't consistently propagate to trips | backend | ⬜ Pending |
 
-### P2 — Important (26)
+### P2 — Important (27)
 
 | ID | Title | Owner | Status |
 |---|---|---|---|
@@ -48,6 +48,7 @@ _Tracker last updated: 2026-07-21 (BUG-59 logged: staging Railway ALLOWED_ORIGIN
 | BRD-MB0102 | Mobile reference mode — bookings readable + directions links on phone (MB-01–02) | frontend | ⬜ Pending |
 | BRD-DP06 | First place added to a trip inherits the trip's date range (DP-06) | fullstack | ⬜ Pending |
 | OQ-05 | Same-city revisit within a trip — trip_places one-row-per-city constraint | architect | ⬜ Pending |
+| OQ-03 | Approximate/partial dates for shell trips — year-only or month-only, and their effect on shading and ordering | architect | ⬜ Pending |
 | BUG-40 | Place deletion should prompt (delete all / move to trip-level / cancel) when the place has items | fullstack | ⬜ Pending |
 | BUG-41 | Multi-leg / connecting flights within a single booking | architect | ⬜ Pending |
 | BUG-42 | Multiple companions/seats per booking item | architect | ⬜ Pending |
@@ -89,7 +90,7 @@ _Tracker last updated: 2026-07-21 (BUG-59 logged: staging Railway ALLOWED_ORIGIN
 | Type | Progress | Done | Open | Deferred/Closed |
 |---|---|---|---|---|
 | feature | `███████████▓░░░░░░░░` 29/54 | 29 | 25 | 3 |
-| requirement | `███████████████████░` 31/33 | 31 | 2 | 5 |
+| requirement | `██████████████████░░` 31/34 | 31 | 3 | 5 |
 | bug | `███████████████░░░░░` 41/55 | 41 | 14 | 4 |
 | task | `████████████████████` 9/9 | 9 | 0 | 0 |
 | chore | `██████████████░░░░░░` 7/10 | 7 | 3 | 0 |
@@ -124,4 +125,4 @@ _Tracker last updated: 2026-07-21 (BUG-59 logged: staging Railway ALLOWED_ORIGIN
 
 ---
 
-_119 done · 10 deferred · 2 closed · 45 open — 176 tracked items_
+_119 done · 10 deferred · 2 closed · 46 open — 177 tracked items_

--- a/_project/tracker.json
+++ b/_project/tracker.json
@@ -69,7 +69,7 @@
       "status": "pending",
       "owner": "integrations",
       "priority": "P2",
-      "brdRefs": ["N-01","N-02","N-03","N-04"],
+      "brdRefs": ["N-01","N-02","N-03","N-04","N-05"],
       "phase": 5,
       "notes": "Post-MVP. Not on critical path."
     },
@@ -260,9 +260,9 @@
       "status": "done",
       "owner": "frontend",
       "priority": "P0",
-      "brdRefs": ["TR-06","TR-07","RV-01","NR-05"],
+      "brdRefs": ["TR-06","TR-07","RV-01"],
       "phase": 3,
-      "notes": "Fixed in a60ec17 — Return to Planning button + confirm dialog added to ReviewPanel. Also closes NR-05. Closed 2026-03-09."
+      "notes": "Fixed in a60ec17 — Return to Planning button + confirm dialog added to ReviewPanel. Also closes NR-05. Closed 2026-03-09. 2026-07-26 data fix: NR-05 removed from brdRefs — it is a tracker item ID, not a BRD requirement ID, so it was the only phantom BRD reference in the file (found by a BRD↔tracker sync audit). The relationship to NR-05 is retained in these notes, which is its correct home."
     },
     {
       "id": "BUG-05",
@@ -1684,6 +1684,17 @@
       "brdRefs": ["OQ-05"],
       "phase": 5,
       "notes": "Added to BRD v3.1 §10, 2026-07-20 UAT. `uniq_trip_places_trip_city` (trip_id, city_id) currently blocks realistic itineraries like Glasgow → day trip to Edinburgh → back to Glasgow. Open question for Architect: move to one-row-per-visit? Knock-on effects on map shading, DP-05/DP-06 chronological ordering, and items.trip_place_id attachment need resolving before any brief touches trip-place identity."
+    },
+    {
+      "id": "OQ-03",
+      "type": "requirement",
+      "title": "Approximate/partial dates for shell trips — year-only or month-only, and their effect on shading and ordering",
+      "status": "pending",
+      "owner": "architect",
+      "priority": "P2",
+      "brdRefs": ["OQ-03"],
+      "phase": 6,
+      "notes": "BRD §10 open question, opened in BRD v3.0 (2026-07-18 PO requirements interview). Backfilled into the tracker 2026-07-26 during a BRD↔tracker sync audit — it was the ONLY BRD requirement/open-question ID with no tracker entry (121 IDs checked, 120 covered). Question: historic trips entered via the shell-trip flow may lack exact dates; do we need approximate/partial dates (year-only, month-only), and how do they interact with map shading and chronological ordering? BRD assigns it to PO + Architect, to resolve before CU-01 is briefed. THIS IS THE SPECIFIC UNBLOCK FOR BRD-CU0103 (shell trips / historic catch-up), which is otherwise only blocked by the general 2026-07-21 deprioritization — worth resolving in the same session as the next PO UAT round, since it is a product decision needing very little investigation, not a research task."
     },
     {
       "id": "UX-11",


### PR DESCRIPTION
## Summary

Doc-sync audit requested by the PO before Wave 0 dispatch. CODEBASE.md is also stale and is being handled separately by a dispatched Docs agent — deliberately untouched here to avoid a concurrent-edit conflict.

## 1. CLAUDE.md named the BRD as v2.7; it is v3.6

Nine versions stale, in the file loaded into every session and read by every dispatched agent. The BRD itself is internally consistent (header matches its own §13 changelog) — only the pointer was wrong.

**The root cause is structural, so the fix is structural.** `/record-decision` mandates a *"three places"* BRD bump (body, §13 changelog, header). CLAUDE.md was a **fourth place nobody counted**. Rather than add a fourth item to that checklist — another thing to forget — the version is removed from CLAUDE.md entirely. A pointer shouldn't duplicate a version that lives one file away. The skill now says so explicitly so it doesn't get reintroduced.

## 2. BRD ↔ tracker sync

Audited all **126** BRD requirement and open-question IDs against every `brdRefs` in the tracker:

| Fix | Detail |
|---|---|
| **OQ-03 backfilled** | The only BRD ID with no tracker entry. It's the specific unblock for `BRD-CU0103` (shell trips) and is a product decision rather than a research task — cheap to resolve in a PO session. |
| **BUG-04 phantom ref removed** | Its `brdRefs` listed `NR-05`, which is a *tracker* item ID, not a BRD requirement ID — the only phantom reference in the file. Relationship retained in the notes, which is its correct home. |
| **PHASE-5 gained N-05** | It listed `N-01`–`N-04`, but the BRD also defines `N-05` (trip lock-down confirmation flow). |

After these, **every BRD ID is covered** except `OQ-01`, `OQ-02` and `OQ-04` — all resolved open questions, which correctly need no tracker entry.

## 3. `.claude/worktrees/` was not gitignored

ADL-39 states these are *"gitignored, so untracked."* They were **not gitignored — merely untracked.** Any `git add -A` from the main checkout would have staged entire duplicate copies of the repo: **~492 MB** across the current worktrees.

Verified nothing was ever committed (`git ls-files .claude/worktrees/` is empty), so this is a guard against a future mistake, not a history cleanup. Found incidentally when a live agent worktree appeared as untracked-but-not-ignored in `git status` while committing the above.

## Test plan

- [x] `npm run check` — pass
- [x] `npm run type:check:all` — pass
- [x] `npm run test:backend` — 580 passed, 1 skipped
- [x] `npm run test:frontend` — 154 passed
- [x] `npm run status:check` — in sync (STATUS.md regenerated)
- [x] tracker.json re-parsed after every edit; phantom-ref and coverage checks re-run and clean
- [x] `git check-ignore` confirms `.claude/worktrees/` is now ignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)