### PR TITLE
chore: refresh CODEBASE.md src/ tree to match current codebase

### DIFF
--- a/CODEBASE.md
+++ b/CODEBASE.md
@@ -106,8 +106,17 @@ src/
 ├── frontend/
 │   ├── main.tsx                React entry point, Clerk + QueryClient providers
 │   ├── App.tsx                 Root router
+│   ├── index.css               Tailwind entry point + global reset (imports theme-waypoint.css)
+│   ├── theme-waypoint.css      Waypoint design-system tokens — colors, fonts (WP-02; wired into
+│   │                           Trips/TripDetail UI as of WP-03/WP-04)
 │   ├── types/
 │   │   └── api.ts              Shared TypeScript types (TripSummary, TripStatus, etc.)
+│   ├── pages/                  Route-level page components, used by App.tsx's <Routes>
+│   │   ├── MapPage.tsx         Full-screen map page
+│   │   ├── TripsPage.tsx       Legacy trips-list page — superseded by TripsLayout (App.tsx routes
+│   │   │                       /trips to TripsLayout directly; this file is unreferenced)
+│   │   ├── TripDetailPage.tsx  Trip detail or post-trip review, branched by trip status
+│   │   └── AdminPage.tsx       Admin panel page
 │   ├── hooks/                  TanStack Query hooks — one file per domain
 │   │   ├── useTrips.ts
 │   │   ├── usePlaces.ts
@@ -115,28 +124,50 @@ src/
 │   │   ├── useAdmin.ts
 │   │   ├── useCities.ts
 │   │   ├── useMapShading.ts
-│   │   └── useGeocodeRetryQueue.ts
+│   │   ├── useGeocodeRetryQueue.ts
+│   │   ├── useMe.ts            Identity endpoint (GET /api/me) — owner-gated nav (BUG-26)
+│   │   └── useIsMobile.ts      Viewport breakpoint hook driving the WP-04 mobile layout switch
+│   ├── utils/
+│   │   ├── apiClient.ts        Centralised fetch() wrapper — base URL, auth token, error handling
+│   │   ├── formatDate.ts       ISO date string → human-readable display format
+│   │   ├── resolvePlaceDateRange.ts Place date precedence: explicit > hotel dates > trip dates (ADL-24)
+│   │   └── urlSanitiser.ts     Restricts user-supplied URLs to https/file schemes (SEC-12)
+│   ├── services/
+│   │   └── geocodeRetryQueue.ts Offline geocoding status poll with progressive backoff (NR-06)
+│   ├── design/                 Waypoint design-system primitives (WP-02, spec §5)
+│   │   ├── Button.tsx          Button variants — primitive only, not yet wired into existing screens
+│   │   ├── Input.tsx           Text input — primitive only, not yet wired into existing screens
+│   │   └── badges.ts           Status/category badge hue lookup, wired into StatusBadge.tsx (WP-03/WP-04)
 │   └── components/
 │       ├── TripList/           Left panel — trip list, search, filters, sort
-│       │   ├── TripsLayout.tsx Two-panel shell (list + <Outlet />)
-│       │   ├── TripCard.tsx    Individual trip card
-│       │   └── TripList.tsx    Trip list rendering + filter/sort logic
+│       │   ├── TripsLayout.tsx        Routes to Desktop or Mobile trips layout via useIsMobile
+│       │   ├── DesktopTripsLayout.tsx Two-panel shell (list + <Outlet />) for ≥768px viewports
+│       │   ├── MobileTripsLayout.tsx  WP-04 single-panel list/detail slide layout for <768px
+│       │   ├── TripCard.tsx           Individual trip card
+│       │   └── TripList.tsx           filterAndSortTrips utility, shared by both layouts
 │       ├── TripDetail/         Right panel — trip detail view and edit form
-│       │   ├── TripDetail.tsx  Main detail view
+│       │   ├── TripDetail.tsx  Main detail view (desktop)
+│       │   ├── MobileTripDetailView.tsx WP-04 mobile detail view (shares logic via the hook below)
+│       │   ├── useTripDetailController.ts Status/lock/modal state shared by desktop + mobile detail views
+│       │   ├── StatusStepper.tsx 4-dot status stepper (Plan→Active→Review→Locked), WP-03, satisfies TR-12
 │       │   ├── TripForm.tsx    Create/edit trip modal
 │       │   ├── AddPlaceFlow.tsx Multi-step modal: city search → create → carry-forward
 │       │   ├── PlaceSection.tsx Place card with items list
 │       │   ├── PlaceDateForm.tsx Arrived/departed date inputs for a place
+│       │   ├── TripItemsSection.tsx Trip-level items with no parent place — flights/car rentals (BUG-36)
 │       │   ├── ItemForm.tsx    Add/edit item (hotel, restaurant, flight, etc.)
 │       │   └── ItemCard.tsx    Item display card
 │       ├── Map/                World map page
 │       │   ├── MapView.tsx     Full-screen MapLibre map, click/zoom handlers
 │       │   ├── CountryLayer.tsx Country fill shading (feature-state driven)
 │       │   ├── RegionLayer.tsx  State/province shading at zoom >= 3
-│       │   └── CityMarkers.tsx  City pins for geocoded cities
-│       ├── Admin/              Admin page — categories, activities, companions
+│       │   ├── CityMarkers.tsx  City pins for geocoded cities
+│       │   └── MapLegend.tsx    Shading-color legend, data-driven from GET /api/map/shading/config (MAP-02)
+│       ├── Admin/              Admin page — categories, activities, companions, map shading, countries
 │       ├── CarryForward/       Copy hotels/items from a previous trip
 │       ├── PostTripReview/     Post-trip checklist and lock flow
+│       ├── icons/              Waypoint SVG icon set (13 glyphs, inline <svg> JSX) — replaced the
+│       │                       old emoji-based item/status icons (WP-02, extended WP-03)
 │       └── shared/             Reusable primitives (LoadingSpinner, ErrorMessage, etc.)
 │
 └── backend/
@@ -148,21 +179,29 @@ src/
     │   ├── schema.ts           Drizzle schema — single source of truth for DB shape
     │   ├── index.ts            DB client singleton
     │   ├── seed.ts             Seed runner
-    │   ├── seed-data.ts        Default category/activity/companion data
+    │   ├── seed-data.ts        Default category/activity data + map shading defaults (companions
+    │   │                       are no longer globally seeded — per-user now, ADL-28)
+    │   └── reset-staging.ts    CLI: wipes user/trip data from a Turso DB for PR preview envs;
+    │                           refuses to run against a non-"staging" remote URL without an override flag
     ├── migrations/             SQL migration files (generated by drizzle-kit)
     ├── routes/                 Express route handlers — one file per resource
     │   ├── trips.ts
     │   ├── places.ts
     │   ├── items.ts
+    │   ├── items-helper.ts     Shared items-with-extensions query logic (used by items.ts and trips.ts)
     │   ├── cities.ts
     │   ├── admin.ts
     │   ├── map.ts
-    │   └── trip-countries.ts
+    │   ├── trip-countries.ts
+    │   ├── companions.ts       Per-user companions CRUD, requireAuth only (BRD-AD08)
+    │   └── me.ts               GET /api/me — authenticated identity + isOwner flag (BUG-26)
     ├── repositories/           DB query layer — called by routes
     │   ├── trips.ts
     │   ├── places.ts
     │   ├── items.ts
-    │   └── users.ts
+    │   ├── users.ts
+    │   ├── companions.ts       Per-user companions, every query scoped to userId (BRD-AD08)
+    │   └── shadingConfig.ts    Per-user map shading config, lazily seeded on first access (BRD-AD07)
     ├── services/               Business logic that spans multiple repositories
     │   ├── shading.service.ts  Map shading state computation (country + region)
     │   ├── items.service.ts    Carry-forward and item transaction logic
@@ -322,8 +361,12 @@ they run against the **real** server (`npm run start` with `BYPASS_AUTH=true`), 
 - **PRs:** COO reviews and merges. Squash merge is standard.
 - **Auth in local dev:** set `BYPASS_AUTH=true` in `.env.local` — the devcontainer
   firewall cannot reach Clerk's JWKS endpoint.
-- **Two-panel layout:** left panel is the trip list; right panel (`data-testid="trip-detail-panel"`)
-  is the `<Outlet />`. Locators and tests should scope to the correct panel.
+- **Two-panel layout (desktop, ≥768px):** left panel is the trip list; right panel
+  (`data-testid="trip-detail-panel"`) is the `<Outlet />` (`DesktopTripsLayout.tsx`).
+  Below 768px, `MobileTripsLayout.tsx` (WP-04) renders a single-panel list/detail
+  slide layout instead — no `<Outlet />` there, but the same `trip-detail-panel`
+  test id is kept on the detail surface. Locators and tests should scope to the
+  correct panel/viewport.
 - **Agent sections below** are maintained by the relevant agent and may be more
   detailed than what appears here.
 

--- a/jobs/COO/inbox/20260726_1120-DOCS-codebase-md-refresh-complete.txt
+++ b/jobs/COO/inbox/20260726_1120-DOCS-codebase-md-refresh-complete.txt
@@ -1,0 +1,45 @@
+Tracker ID: none (documentation maintenance) · PR #256 · BRD section: n/a · Branch: chore/codebase-md-refresh
+
+WHAT WAS DOCUMENTED
+Refreshed CODEBASE.md's "App source tree (src/)" section to match the actual src/ tree,
+stale since PR #110 (2026-07-15). Every added entry was verified by reading the file's
+actual content, not inferred from its name.
+
+COVERAGE
+- Backend: routes/companions.ts, routes/me.ts, routes/items-helper.ts, repositories/
+  companions.ts, repositories/shadingConfig.ts, db/reset-staging.ts (missed by the COO's
+  seed list) all now documented — BRD-AD07/AD08, BUG-26.
+- Frontend: hooks/useMe.ts, hooks/useIsMobile.ts, TripDetail/StatusStepper.tsx,
+  MobileTripDetailView.tsx, TripItemsSection.tsx, useTripDetailController.ts (missed by
+  the COO's list), Map/MapLegend.tsx, TripList/DesktopTripsLayout.tsx +
+  MobileTripsLayout.tsx (missed — TripsLayout.tsx no longer IS the shell, it now routes
+  between these two), and the previously-absent pages/, utils/, design/, services/
+  directories and the icons/ directory.
+- Corrected two prose sections the same reskin invalidated: seed-data.ts's description
+  (companions no longer globally seeded, ADL-28) and the "Key conventions" two-panel-
+  layout bullet (mobile doesn't use <Outlet/>, per MobileTripsLayout.tsx's own doc
+  comment).
+
+CI: gh pr checks 256 — all 9 jobs green (Biome, Type Check, Backend/Frontend/Contract/E2E
+Tests, Dependency Scan, Secret Scan, Semgrep). scripts/ci-wait.sh pr 256 confirmed PASS.
+
+FINDINGS BEYOND THE SEED LIST (not fixed — out of scope for a docs-only PR, flagging for
+triage)
+1. src/frontend/pages/TripsPage.tsx is dead code — App.tsx routes /trips directly to
+   TripsLayout, never to TripsPage, and nothing else imports it. Noted in CODEBASE.md
+   rather than deleted.
+2. src/backend/db/seed-data.ts still exports an unused `COMPANIONS` constant — dead code
+   left over from the ADL-28 migration that removed the global companions seed list
+   (grepped src/backend/, no importers). A Backend/cleanup candidate.
+3. src/frontend/theme-waypoint.css's own header comment says "PHASE 1 ONLY — defined-
+   but-unused," but badges.ts (WIRED, per its own header) and the reskinned Trips/
+   TripDetail components consume its wp-* tokens throughout. This is a source-code
+   comment, not a CODEBASE.md fact — left alone, flagging in case a WP cleanup brief
+   wants it fixed at the source.
+
+None of the three block anything.
+
+OPEN ISSUES/BLOCKERS: none.
+
+WHAT IS NOW UNBLOCKED: CODEBASE.md is accurate again for anyone (human or agent)
+orienting in src/ — no engineering work was gated on this, it was pure doc lag.

--- a/jobs/docs/context/current.txt
+++ b/jobs/docs/context/current.txt
@@ -1,7 +1,9 @@
-DOCS CONTEXT — 2026-03-07
+DOCS CONTEXT — 2026-07-26
 PROJECT: Travel Tracker
-CURRENT STATUS: Not yet started
-ACTIVE TASKS: None
-PENDING MESSAGES TO COO: None
-OPEN ISSUES: None
-LAST PARK DOC: None
+CURRENT STATUS: CODEBASE.md refresh complete, PR open, awaiting COO merge
+ACTIVE TASKS: None (thread closed pending merge)
+PENDING MESSAGES TO COO: Completion report filed in jobs/COO/inbox/
+OPEN ISSUES: See park doc for hygiene findings not fixed in-scope (dead TripsPage.tsx,
+  unused COMPANIONS constant in seed-data.ts, theme-waypoint.css's stale internal
+  "defined-but-unused" comment — none blocking, all noted for COO/Backend/Frontend triage)
+LAST PARK DOC: jobs/docs/park-docs/20260726-DOCS-park.txt

--- a/jobs/docs/park-docs/20260726-DOCS-park.txt
+++ b/jobs/docs/park-docs/20260726-DOCS-park.txt
@@ -1,0 +1,72 @@
+PARK DOCUMENT — Docs
+Date: 2026-07-26
+Branch: chore/codebase-md-refresh
+Dispatch: COO, CODEBASE.md staleness audit (no tracker ID — documentation maintenance)
+
+WHAT WAS DONE
+CODEBASE.md's "App source tree (src/)" section was refreshed against the actual src/
+tree (last updated 2026-07-15, PR #110; 33 commits had touched src/ since). Verified
+every file that appears in the diff by reading its content — no descriptions were
+inferred from filenames alone.
+
+Beyond the COO's seed list, I found and fixed:
+- src/backend/db/reset-staging.ts — missing from the itemized db/ list (db/ is fully
+  itemized in this doc, unlike routes/repositories' siblings such as middleware/ or
+  validation/, which are one-line directory summaries; reset-staging.ts's omission was
+  a genuine gap at the doc's own granularity).
+- src/frontend/components/TripDetail/useTripDetailController.ts — the hook WP-03/WP-04
+  extracted so desktop TripDetail.tsx and the new MobileTripDetailView.tsx share status/
+  lock/modal logic without duplicating it. Not in the COO's list; found by diffing the
+  actual TripDetail/ directory.
+- src/frontend/components/TripList/DesktopTripsLayout.tsx and MobileTripsLayout.tsx —
+  TripsLayout.tsx no longer IS the two-panel shell; WP-04 turned it into a router that
+  picks Desktop or Mobile based on useIsMobile(). The old one-line description ("Two-panel
+  shell (list + <Outlet />)") was actively wrong post-WP-04, not just incomplete.
+- src/frontend/{pages,utils,design,services}/ — all four were entirely absent from the
+  tree per the brief; itemized each at the doc's existing granularity.
+- src/frontend/index.css and theme-waypoint.css — added; theme-waypoint.css's own header
+  comment claims the Waypoint tokens are "defined-but-unused" (Phase 1 framing), but
+  badges.ts's header says WIRED as of WP-03/WP-04 and DesktopTripsLayout.tsx/
+  MobileTripsLayout.tsx/StatusStepper.tsx all consume wp-* Tailwind classes throughout —
+  described this accurately in CODEBASE.md without touching the (increasingly stale)
+  source comment itself, which is out of scope for a docs-only change.
+
+Also corrected two prose sections invalidated by the same drift:
+- seed-data.ts's description said it holds "companion" default data; ADL-28 removed
+  companions' global seed list entirely (seed.ts's own comment: "companions has no
+  default list post-migration"). Fixed to describe what's actually seeded now.
+- The "Key conventions" bullet on the two-panel layout described only the desktop
+  <Outlet/>-based mechanism as if it were universal. MobileTripsLayout.tsx explicitly
+  does NOT render <Outlet/> (documented in its own header comment) — it mounts both
+  panels and slides between them. Rewrote the bullet to cover both, while keeping the
+  fact that `data-testid="trip-detail-panel"` is present in both (still true, still the
+  right locator for tests).
+
+NOT FIXED — FLAGGED FOR COO/OTHER ROLES (out of scope for a docs-only PR)
+1. src/frontend/pages/TripsPage.tsx appears to be dead code — App.tsx routes /trips
+   directly to TripsLayout, never to TripsPage. Nothing else imports TripsPage. Noted
+   in CODEBASE.md's description ("this file is unreferenced") rather than deleted, since
+   deleting source files is not this brief's scope.
+2. src/backend/db/seed-data.ts still exports a `COMPANIONS` constant that nothing in
+   src/backend imports (grepped clean) — dead code left over from the ADL-28 migration
+   that removed the global companions seed. Not touched; a Backend/cleanup brief's call.
+3. theme-waypoint.css's own header comment ("PHASE 1 ONLY — these tokens are
+   defined-but-unused") is now stale relative to badges.ts and the reskinned Trips/
+   TripDetail components. This is a source-code comment, not a CODEBASE.md fact, so
+   left alone here — flagging in case a future WP cleanup brief wants to fix it at
+   the source.
+
+None of the three above block anything; they're hygiene notes only.
+
+CI / VERIFICATION
+- npm run check (Biome) — pass
+- npm run type:check:all — pass
+- npm run test:backend — 580 passed, 1 skipped
+- npm run test:frontend — 154 passed
+- npm run status:check — STATUS.md already in sync (this PR touches no tracker/status facts)
+- PR: see completion report in jobs/COO/inbox/ for the PR number and CI-wait confirmation
+
+NEXT SESSION
+Nothing queued. This was a self-contained doc-maintenance thread; no docs backlog left
+open beyond the three hygiene notes above, which belong to other roles' inboxes if COO
+wants them actioned.


### PR DESCRIPTION
## Summary
- Refreshes CODEBASE.md's "App source tree (src/)" section, stale since PR #110 (2026-07-15) — 33 commits had touched src/ since without a doc update.
- Adds every genuinely missing entry: backend routes/repositories for BRD-AD07/AD08 (per-user companions, map shading) and BUG-26 (`me.ts`); `items-helper.ts`; `db/reset-staging.ts`; frontend `useMe`/`useIsMobile` hooks; the WP-02/03/04 Waypoint reskin surface — `icons/`, `design/`, `pages/`, `utils/`, `services/`, `StatusStepper.tsx`, `MobileTripDetailView.tsx`, `TripItemsSection.tsx`, `MapLegend.tsx`, `DesktopTripsLayout.tsx`/`MobileTripsLayout.tsx`, `useTripDetailController.ts`.
- Corrects two prose sections the same drift invalidated: `seed-data.ts`'s description (companions are no longer globally seeded, ADL-28) and the "Key conventions" two-panel-layout bullet (mobile no longer uses `<Outlet/>`).
- Every added line was verified against the actual file content, not inferred from the filename.

No tracker ID — pure documentation maintenance, no issue exists for this.

## Test plan
- [x] `npm run check` (Biome) — pass
- [x] `npm run type:check:all` — pass
- [x] `npm run test:backend` — 580 passed, 1 skipped
- [x] `npm run test:frontend` — 154 passed
- [x] `npm run status:check` — STATUS.md already in sync (no tracker/status facts touched)
- [ ] CI green (`scripts/ci-wait.sh pr`)

COO dispatch 2026-07-26, CODEBASE.md staleness audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)