### PR TITLE
docs(ADL-42): booking item shape — multi-leg flights and multi-traveller seats (#272)

### DIFF
--- a/_project/STATUS.md
+++ b/_project/STATUS.md
@@ -50,8 +50,8 @@ _Tracker last updated: 2026-07-26 (QUAL-05 sweep + QUAL-06 doc-state cleanup com
 | OQ-05 | Same-city revisit within a trip — trip_places one-row-per-city constraint | architect | ⬜ Pending |
 | OQ-03 | Approximate/partial dates for shell trips — year-only or month-only, and their effect on shading and ordering | architect | ⬜ Pending |
 | BUG-40 | Place deletion should prompt (delete all / move to trip-level / cancel) when the place has items | fullstack | ⬜ Pending |
-| BUG-41 | Multi-leg / connecting flights within a single booking | architect | ⬜ Pending |
-| BUG-42 | Multiple companions/seats per booking item | architect | ⬜ Pending |
+| BUG-41 | Multi-leg / connecting flights within a single booking | coo | ⬜ Pending |
+| BUG-42 | Multiple companions/seats per booking item | coo | ⬜ Pending |
 | BUG-44 | Car rental pickup location should show as subtext under provider | frontend | ⬜ Pending |
 | BUG-46 | Activities selector missing from trip create flow (only present on edit) | frontend | ⬜ Pending |
 | BUG-48 | Country→state map shading zoom threshold too high / laggy | frontend | ⬜ Pending |

--- a/_project/tracker.json
+++ b/_project/tracker.json
@@ -1835,22 +1835,22 @@
       "type": "feature",
       "title": "Multi-leg / connecting flights within a single booking",
       "status": "pending",
-      "owner": "architect",
+      "owner": "coo",
       "priority": "P2",
       "brdRefs": [],
       "phase": 6,
-      "notes": "Found 2026-07-21 UAT, logged only — not yet briefed. Example: Seattle→London (layover)→Glasgow, all one booking. Current flight item model is single-leg. Needs Architect schema design before this is briefable — likely a flight-legs sub-entity under one booking item, not a simple field addition."
+      "notes": "Found 2026-07-21 UAT. Example: Seattle→London (layover)→Glasgow, all one booking. DESIGNED 2026-07-27 — Architect ADL-42 (issue #272, Wave 0 brief S2) decided jointly with BUG-42: one booking = one item, legs in a new item_flight_legs 1:N child table with explicit leg_order; item_flights shrinks to (item_id, booking_reference); airline/flight_number/airports/datetimes move to the leg. Full design jobs/architect/tech/ADL-42-booking-item-shape.md. Status 'designed', implementation pending. BLOCKED on the COO BRD gate: FL-01 ('each flight is logged as an individual leg') is superseded and must be rewritten + stamped, and this entry needs a new BRD requirement ID with success criteria (brdRefs currently empty). Sequencing: Database brief (schema + 2 migration files) first, then one combined Backend+Frontend brief. Note for ADL-43/BUG-45: airline moves to item_flight_legs.airline."
     },
     {
       "id": "BUG-42",
       "type": "feature",
       "title": "Multiple companions/seats per booking item",
       "status": "pending",
-      "owner": "architect",
+      "owner": "coo",
       "priority": "P2",
       "brdRefs": [],
       "phase": 6,
-      "notes": "Found 2026-07-21 UAT, logged only — not yet briefed. Should be able to assign multiple companions/seats to one booking item (flight, car, etc.) instead of one implicit traveller. Needs schema/UX scoping — how seat assignment interacts with the existing companion model."
+      "notes": "Found 2026-07-21 UAT. DESIGNED 2026-07-27 — Architect ADL-42 (issue #272, Wave 0 brief S2) decided jointly with BUG-41: one new item_travellers table with a nullable leg_id (scope) and a nullable companion_id (NULL = the owning user, since companions is a list of OTHER people and today's single seat column is implicitly the user's own). Row presence = travels this scope; seat NULL = seat unknown. Open to all item types; legs flight-only. ADL-28's companionRepository.validateOwnership guard is mandatory at this second write path (cross-user companion = 400, not 404). Full design jobs/architect/tech/ADL-42-booking-item-shape.md. Status 'designed', implementation pending. BLOCKED on the COO BRD gate: needs a new BRD requirement ID with success criteria covering the 'traveller on some legs but not others' case (brdRefs currently empty); FL-02 must also move seat off the flight field list."
     },
     {
       "id": "BUG-43",

--- a/jobs/COO/inbox/20260727_1500-ARCHITECT-adl42-booking-item-shape.txt
+++ b/jobs/COO/inbox/20260727_1500-ARCHITECT-adl42-booking-item-shape.txt
@@ -1,0 +1,56 @@
+ADL-42 · issue #272 (Wave 0 brief S2) · BRD §5.5 IT-01–11, §5.6 FL-01–04 · feat/adl42-booking-item-shape
+
+DECIDED: BUG-41 and BUG-42 are one defect — the booking item is flat, modelling one segment
+of travel carrying one implicit traveller. One booking = one item, with a new item_flight_legs
+1:N child and a single new item_travellers table whose nullable leg_id selects the scope.
+Spec only; no schema, migration or code changed. Status: Decided, implementation pending.
+
+PER-DECISION VERDICT (13 rulings, all adopted; full detail in the ADL):
+ D1  ADOPTED  item_flight_legs 1:N child; item_flights shrinks to (item_id, booking_reference)
+ D2  ADOPTED  explicit 1-based leg_order, full-replace on write — not a datetime sort
+ D3  ADOPTED  parent carries the PNR; airline/flight_number/airports/datetimes are per-leg
+ D4  ADOPTED  ONE item_travellers table, nullable leg_id; row presence = travels this scope
+ D5  ADOPTED  companion_id nullable, NULL = the owning user
+ D6  ADOPTED  manifest mode — per item, rows all leg-scoped or all booking-scoped, never mixed
+ D7  ADOPTED  validateOwnership mandatory (400 not 404); userId is the repo's first argument
+ D8  ADOPTED  no leg status — status stays item-level (IT-03/FL-03)
+ D9  ADOPTED  cost is booking-level when introduced, never per-leg; not added (no BRD req)
+ D10 ADOPTED  two migration files: additive backfill, then destructive shrink
+ D11 ADOPTED  legs/travellers via a second batched query, never left-joined
+ D12 ADOPTED  no compatibility shim; backend + frontend land together (Medium confidence)
+ D13 ADOPTED  item_travellers open to all item types; legs flight-only
+ REJECTED: booking_group_id; leg2_*/leg3_* columns; JSON legs array; a generalised
+ item_segments table across flights/hotels/car rentals; two separate traveller junctions;
+ an auto-created "Me" companion row. Reasoning per option is in the ADL and park doc.
+
+CI: no code commit — docs and tracker only. PR CI confirmed green before this report.
+
+BLOCKER — YOURS, AND IT GATES ALL DISPATCH:
+ This needs new BRD requirement IDs. I did NOT add them; the BRD gate is yours. Four items:
+  1. FL-01 is SUPERSEDED — "Each flight is logged as an individual leg" is exactly the model
+     ADL-42 replaces. Rewrite + stamp: > SUPERSEDED (2026-07-27) by ADL-42 — retained for history.
+  2. FL-02 must move `seat` off the flight field list (it becomes per-traveller, per-leg).
+  3. New requirement ID + success criteria for BUG-41 (brdRefs is [] today).
+  4. New requirement ID + success criteria for BUG-42, covering "traveller on some legs but
+     not others" explicitly (brdRefs also []).
+ I left the FL-01 stamp to your BRD-bump PR deliberately rather than splitting it across two
+ PRs and leaving the BRD internally inconsistent in between — not a skipped lifecycle step.
+
+OTHER FLAGS (none blocking):
+ - BUG-45/ADL-43 (S3) cross-dependency: airline moves to item_flight_legs.airline. If S3's
+   brief is written against item_flights.airline it will need reworking.
+ - Drift, not fixed: BRD IT-03 lists Shortlisted; chk_items_status (schema.ts:499) does not
+   have it and 'shortlisted' appears nowhere in src/. Never implemented. Not mine to fix.
+ - Stale doc: jobs/database/tech/schema.ts is an unmaintained COPY of the real schema file and
+   repeats the superseded FL-01 claim. Needs refreshing or a HISTORICAL banner.
+ - Frontend constraint to carry into the brief: leg datetimes are timezone-less, so layover
+   and journey durations across legs are wrong whenever a connection crosses a timezone.
+   Do not display connection durations until timezone data exists.
+
+NOW UNBLOCKED (once the BRD gate clears):
+ Database brief — schema + the two migration files; additive, safe to merge alone. Then ONE
+ combined Backend+Frontend brief on a single branch (no shim, so the flat flight keys
+ disappear from the API and both layers must land together). Quote D11 verbatim into the
+ Backend brief: legs/travellers are 1:N and left-joining them into fetchItemsWithExtensions
+ multiplies rows and silently corrupts the rating sort, minRating filter and item counts.
+ That is the one error this change is most likely to produce.

--- a/jobs/architect/context/current.txt
+++ b/jobs/architect/context/current.txt
@@ -1,62 +1,90 @@
-ARCHITECT CONTEXT — 2026-07-22
+ARCHITECT CONTEXT — 2026-07-27
 PROJECT: Travel Tracker
-CURRENT STATUS: ADL-38 decided AND implemented — BUG-61 (#225) non-owner country-picker fix.
-Root cause: src/backend/routes/admin.ts registered GET /countries and
-GET /countries/:countryCode/regions directly on adminRouter, and adminRouter.use(requireOwner)
-(admin.ts) gated the WHOLE router — reads included. So a non-owner account (Ryan's staging test
-sign-in) got 403 on GET /api/admin/countries; TripForm's country picker (useCountries) rendered
-empty and no non-owner could create a trip at all. Per GE-04/GE-05 every country ships as a
-global, pre-seeded default available to all users out of the box (same tier as AD-09
-categories/activities), so gating the READ behind owner status was wrong.
+CURRENT STATUS: ADL-42 DECIDED, IMPLEMENTATION PENDING — booking item shape (BUG-41 + BUG-42),
+Wave 0 scoping brief S2, GitHub issue #272, branch feat/adl42-booking-item-shape.
+Spec output only — no schema, migration or code change was made.
 
-DECISION (read/write split): the two country/region GET routes now require only requireAuth
-(already applied globally to /api/* in server.ts); the three WRITE routes (PATCH country config,
-POST region, PATCH region) stay owner-gated exactly as before. Implementation kept the router
-FAIL-CLOSED by default: I moved the two GET handlers ABOVE the router-level requireOwner guard
-rather than removing the blanket guard + adding per-route requireOwner. That means a future
-admin route is owner-gated unless deliberately moved into the small, labelled reads block —
-avoids the fail-open BUG-22 class (requireOwner forgotten on a write route). The guard block in
-admin.ts carries an explicit FAIL-CLOSED comment; only global-reference-data reads may sit above it.
+PROBLEM: BUG-41 (multi-leg flights on one booking) and BUG-42 (multiple companions/seats per
+booking) are ONE defect: the booking item is flat. It models one segment of travel carrying
+one implicit traveller. Seattle→London→Glasgow on a single PNR must today be two unrelated
+flight items (BRD FL-01; echoed at src/backend/db/schema.ts:507), duplicating the booking
+reference and giving one booking two statuses. Separately item_flights.seat is one TEXT column
+and there is NO per-item companion link anywhere in the schema — companions attach to trips
+only via trip_companions_map. Neither is fixable alone: a seat belongs to a person on a leg.
 
-DISTINCT FROM ADL-28 (BRD-AD07/AD08): ADL-28 = make genuinely owner-only data (map shading,
-companions) work PER-USER via a userId FK (still awaiting Backend brief). BUG-61 = global,
-already-shared data wrongly gated as owner-only. No userId scoping here; countries/regions have
-no per-user dimension. Did NOT expand into ADL-28's scope.
+DECISION (13 rulings, full design in jobs/architect/tech/ADL-42-booking-item-shape.md):
+ - One booking = one item. New item_flight_legs 1:N child table with explicit 1-based
+   contiguous leg_order (NOT sorted by departure_datetime — datetimes are optional under
+   PL-01 and naive/timezone-less). item_flights retained as the booking-level extension row,
+   shrunk to (item_id, booking_reference). airline/flight_number/airports/datetimes move to
+   the leg (interline itineraries genuinely change carrier between legs).
+ - ONE new item_travellers table with a nullable leg_id selecting scope and a nullable
+   companion_id. Row presence = travels this scope; seat NULL = seat unknown. This is the
+   load-bearing choice: two junctions (booking-level + leg-level) would give two homes for one
+   fact and make "on the booking but no row on leg 2" ambiguous. For flights the booking
+   roster is DERIVED, never stored.
+ - companion_id NULLABLE, NULL = the owning user. Reason nobody had written down: `companions`
+   is a list of OTHER people; the user is not in it, and today's single seat column IS the
+   user's own seat implicitly. A NOT NULL companion_id would have made the fix a regression.
+   Rejected auto-creating a "Me" companion (pollutes an AD-08 user-managed list, collides with
+   uniq_companions_user_name, self-row becomes soft-deletable).
+ - Four partial unique indexes — SQLite treats NULLs as distinct so a plain composite unique
+   accepts the same traveller twice. The two-index alternative (0 as a self sentinel) was
+   rejected because 0 cannot carry an FK to companions.id. Integrity > index count.
+ - NO leg status. Status stays item-level (IT-03/FL-03). Per-leg status has no correct
+   aggregate and every consumer reads one status.
+ - Cost is booking-level whenever introduced, never per-leg. Not added — no BRD requirement
+   for item cost exists anywhere.
+ - Migration in TWO files (additive create+backfill, then destructive shrink) — file 1 reads
+   columns file 2 destroys and Drizzle cannot know the ordering.
+ - AD-08 guard: item_travellers.companion_id is a SECOND write path to companions.id.
+   companionRepository.validateOwnership mandatory; 400 not 404; repository signature takes
+   userId FIRST so the junction cannot be written without it (structural, not a reminder).
 
-Change confined to admin.ts. Regression: security.access-matrix.test.ts Part E added (non-owner
-GET countries/regions -> 200; non-owner writes -> 403); the two old GET-403 cases removed from
-Part B. Full backend suite 538 passed / 1 skip; type:check:backend clean. Manual live check with
-a non-owner bypass user (BYPASS_AUTH=true, OWNER_CLERK_ID mismatch -> isOwner:0): GET countries
-200 (250 rows), GET regions 200, PATCH/POST writes 403, GET /api/admin/categories still 403
-(fail-closed intact). ADL-27 standalone file stamped SUPERSEDED IN PART for the two GET routes.
-Branch fix/bug61-country-picker-auth, PR pending CI. See 20260722-ARCHITECT-park-adl38.txt.
+REJECTED: booking_group_id on separate items (N statuses per booking); leg2_*/leg3_* columns
+(hard cap, unindexable); JSON legs array (ADL-11 rejected JSON precisely because SQLite cannot
+index JSON paths and leg dates are queried); a generalised item_segments table spanning
+flights/hotels/car rentals — most elegant, wrong on cost: it requires migrating three extension
+tables and rewriting every route/helper/test/component to buy a second segment for types that
+will never have one.
 
-PRIOR STATUS: ADL-37 decided AND implemented — BUG-60 (#221) trust-proxy fix.
-app.set('trust proxy', 1) in server.ts + server-test-app.ts. Integer hop count 1 (NOT true,
-which is client-spoofable). Regression test src/backend/__tests__/trust-proxy.test.ts.
-Branch fix/bug60-trust-proxy. See 20260722-ARCHITECT-park-adl37.txt.
-
-PRIOR STATUS: ADL-36 decided — BUG-39 (#209) FK review. items.carriedFromItemId gets
-onDelete: 'set null'. Database owned the migration (0011_majestic_nehzno.sql).
-
-PRIOR STATUS: ADL-35 decided — environment promotion model. Staging watches `main`
-(continuous soak); Production watches a long-lived `production` branch, promoted by explicit
-`git merge --ff-only origin/main` + push. Branch-per-brief UNCHANGED.
+SUPERSESSION: no ADL entry superseded. ADL-11 preserved and extended; ADL-28 reinforced. The
+one supersession is BRD FL-01 — deliberately NOT stamped by me, it belongs in the COO's
+BRD-bump PR alongside the new IDs and the header/§13 bump.
 
 ================================================================================
 OPEN / HANDOFF
 ================================================================================
 
-  1. COO: merge PR #225 (fix/bug61-country-picker-auth) after CI green — do not self-merge.
-     Then flip BUG-61 tracker status (tracker is COO-maintained; I did not edit it). Issue
-     title / tracker notes already carry BUG-61 <-> #225 cross-reference.
-  2. No new BRD requirement IDs — BUG-61 is a bug fix against existing GE-04/GE-05, brdRefs
-     already set; no BRD bump needed.
-  3. Frontend: no change required — the reported symptom (empty country picker for non-owners)
-     resolves end-to-end once this merges. Non-owner "share the app with a friend" path is
-     unblocked through trip creation.
-  4. Carried over, still open, unrelated to this thread:
-     - ADL-28 (BRD-AD07/AD08) per-user map-shading + companions still awaiting Backend brief.
+  1. COO BRD GATE BLOCKS ALL DISPATCH (CLAUDE.md rule). Four items: rewrite + stamp FL-01
+     ("each flight is logged as an individual leg" is exactly the model ADL-42 replaces);
+     amend FL-02 (seat moves off the flight field list); new requirement ID + success criteria
+     for BUG-41; new requirement ID + success criteria for BUG-42 covering the "traveller on
+     some legs but not others" case. Both tracker entries have brdRefs: [] today.
+  2. COO: merge PR for feat/adl42-booking-item-shape after CI green — do not self-merge.
+  3. Brief sequencing once the BRD gate clears: (a) Database brief — schema + the two migration
+     files, additive, safe to merge alone; (b) ONE combined Backend+Frontend brief on a single
+     branch, because there is no compatibility shim and the flat flight keys disappear from the
+     API. One branch per brief still holds — this is one brief spanning two layers.
+  4. BUG-45 / ADL-43 cross-dependency: airline moves to item_flight_legs.airline. If S3's brief
+     is written against item_flights.airline it will need reworking.
+  5. Frontend constraint to carry into that brief: leg datetimes are naive/timezone-less, so
+     layover and total-journey durations across legs are WRONG whenever a connection crosses a
+     timezone — the norm for the itinerary that motivated BUG-41. Do not display connection
+     durations until timezone data exists (depends on airport reference data, ADL-43).
+  6. Drift found, flagged not fixed: BRD IT-03 (v3.0) lists Shortlisted as an item status but
+     chk_items_status (src/backend/db/schema.ts:499) permits only consider/confirmed/completed/
+     cancelled/next_time and the string 'shortlisted' appears nowhere in src/. Added to the BRD
+     and never implemented; home is the deprioritized planning-core entry. ADL-42 does not
+     rebuild the items table so it neither depends on nor resolves this.
+  7. Stale doc flagged, not actioned: jobs/database/tech/schema.ts is an unmaintained COPY of
+     src/backend/db/schema.ts and repeats the superseded FL-01 claim at line 507. Needs
+     refreshing or a HISTORICAL banner. jobs/architect/tech/20260307-ER-schema.md:303 repeats
+     it too but already carries a HISTORICAL banner — no further stamp needed.
+  8. patches/drizzle-kit+0.31.9.patch Bug 4 (partial-index WHERE reading) is LOAD-BEARING for
+     the four partial unique indexes. If drizzle-kit is ever upgraded, re-verify before this
+     lands or migrations will churn.
+  9. Carried over, unrelated to this thread:
      - Clerk preview-origin question (ADL-32 §6) + §10 success criteria pending a real deploy.
-     - D-05 Clerk staging/prod user-pool split (shared pool today — jobs/COO/open-dialogues.md).
-     - OQ-03 (shell trip approximate dates), OQ-05 (trip_places one-row-per-city constraint).
+     - D-05 Clerk staging/prod user-pool split (jobs/COO/open-dialogues.md).
+     - OQ-03 (shell trip approximate dates). OQ-05 is ADL-41's (S1), not mine.

--- a/jobs/architect/park-docs/20260727-ARCHITECT-park-adl42.txt
+++ b/jobs/architect/park-docs/20260727-ARCHITECT-park-adl42.txt
@@ -1,0 +1,131 @@
+ARCHITECT PARK DOCUMENT — 2026-07-27
+THREAD: Wave 0 scoping brief S2 — ADL-42, booking item shape (BUG-41 + BUG-42)
+ISSUE: #272   BRANCH: feat/adl42-booking-item-shape
+DELIVERABLE TYPE: spec only — no schema, migration or code change
+
+================================================================================
+WHAT WAS ASKED
+================================================================================
+Decide one shape covering BUG-41 (multi-leg/connecting flights within a single booking,
+e.g. Seattle→London layover→Glasgow, all one booking) and BUG-42 (multiple companions/seats
+per booking item). Resolve: leg ordering; leg fields vs parent fields; how seat/companion
+assignment attaches given a companion may be on some legs and not others; interaction with
+the per-user companion model (AD-08/ADL-28) without creating a path around it; interaction
+with item statuses (IT-03); migration for existing flat flight items. BUG-43 (Apple Wallet)
+out of scope, note implications only.
+
+================================================================================
+WHAT I FOUND BEFORE DECIDING
+================================================================================
+1. BRD FL-01 ("Each flight is logged as an individual leg") is the CURRENT decision this
+   brief asks me to reverse. It is echoed in three places: src/backend/db/schema.ts:507,
+   jobs/architect/tech/20260307-ER-schema.md:303 (already HISTORICAL-bannered), and
+   jobs/database/tech/schema.ts:507 (an unmaintained COPY of the schema file).
+2. There is NO per-item companion link anywhere in the schema. Companions attach to trips
+   only (trip_companions_map). BUG-42 is not "extend the existing link" — there is nothing
+   to extend.
+3. THE KEY FINDING, which nobody had written down: `companions` is a list of OTHER people.
+   The owning user is not in it. So today's single item_flights.seat column IS the user's own
+   seat, implicitly — that is exactly what BUG-42 means by "one implicit traveller". Any
+   traveller junction keyed on a NOT NULL companion_id would have nowhere to put the user's
+   own seat, making the "fix" a regression. This finding drove D5.
+4. There is no cost/price column anywhere in the schema, and no BRD requirement for one.
+   The brief's "what the parent carries (confirmation number, provider, cost)" assumes a
+   field that does not exist. Ruled on it forward-looking rather than inventing it.
+5. fetchItemsWithExtensions (src/backend/routes/items-helper.ts:82) left-joins five 1:1
+   extension tables into ONE FLAT ROW per item. Legs and travellers are 1:N. This is the
+   trap the implementation will fall into if not told.
+6. Drift, unrelated but found en route: BRD IT-03 (v3.0) lists Shortlisted as an item status;
+   chk_items_status (schema.ts:499) does not have it and 'shortlisted' appears nowhere in
+   src/. Added to the BRD, never implemented.
+
+================================================================================
+THE 13 DECISIONS (summary — full reasoning in the ADL)
+================================================================================
+D1  One booking = one item. New item_flight_legs 1:N child. item_flights retained, shrunk
+    to (item_id, booking_reference).
+D2  Explicit 1-based contiguous leg_order, full-replace on write. NOT a datetime sort —
+    datetimes are optional (PL-01 quick capture) and naive/timezone-less.
+D3  Parent: booking_reference. Leg: airline, flight_number, both airports, both datetimes.
+    airline is per-leg because interline/codeshare itineraries genuinely change carrier.
+D4  ONE item_travellers table, nullable leg_id selects the scope. Row presence = travels
+    this scope. seat NULL = seat unknown (unambiguously different from "not on this leg").
+D5  companion_id NULLABLE, NULL = the owning user. See finding 3 above.
+D6  Manifest mode: per item, rows are all leg-scoped (flights) or all booking-scoped
+    (everything else). Never mixed. Keeps the flight roster derived, never stored.
+D7  companionRepository.validateOwnership mandatory at this second write path; 400 not 404;
+    userId is the repository's FIRST argument so the junction cannot be written without it.
+D8  No leg status. Status stays item-level.
+D9  Cost is booking-level whenever introduced, never per-leg. Not added here.
+D10 TWO migration files: additive create+backfill, then destructive shrink.
+D11 Legs/travellers fetched in a SECOND batched query, never left-joined.
+D12 No compatibility shim. Backend + frontend land together.
+D13 item_travellers open to all item types; legs flight-only.
+
+================================================================================
+WHY NOT THE OBVIOUS ALTERNATIVES
+================================================================================
+- booking_group_id linking separate leg-items: leaves N statuses for one booking, so IT-06
+  bulk review and PL-03 grouping stay broken. Also puts a grouping key on the generic items
+  table for one type's benefit.
+- leg2_*/leg3_* columns on item_flights: hard cap in the schema, unindexable, and exactly
+  the "dozens of nullable columns" failure ADL-11 already rejected.
+- JSON legs array: ADL-11 rejected JSON for item fields because SQLite cannot efficiently
+  index JSON paths, and leg departure dates ARE queried (tech-blueprint.md:292).
+- A generalised item_segments table spanning flights, hotels and car rentals: the most
+  elegant option and the wrong one. It requires migrating all three existing extension
+  tables and rewriting every route, helper, test and component, to buy a second segment for
+  types that will never have one (a multi-city car hire is a second rental). That is a
+  rebuild sold as a refactor. Rejected on cost, not on taste. Worth re-reading if anyone
+  proposes it later — the reasoning is in ADL-42 §3.
+- Two junctions (booking-level roster + leg-level seat map): two homes for one fact, and
+  "on the booking but no row on leg 2" becomes ambiguous between not-travelling and
+  seat-unknown. Rejected; this is what D4's nullable leg_id exists to avoid.
+- A "Me" companion row auto-created per user: pollutes an AD-08 user-managed list with a row
+  the user can rename/deactivate/delete, collides with uniq_companions_user_name, and makes
+  the self-row soft-deletable — orphaning the meaning of every seat attached to it.
+- A NOT NULL traveller_ref with 0 as a self sentinel (2 indexes instead of 4): 0 cannot
+  carry an FK to companions.id. Referential integrity outranks index count.
+
+================================================================================
+THINGS I VERIFIED RATHER THAN ASSUMED
+================================================================================
+- uniqueIndex(...).on(...).where(...) is expressible in the INSTALLED drizzle-orm:
+  uniqueIndex() and index() share one builder (node_modules/drizzle-orm/sqlite-core/
+  indexes.d.ts — IndexBuilderOn -> IndexBuilder.where()). The four partial unique indexes
+  are not hypothetical.
+- patches/drizzle-kit+0.31.9.patch Bug 4 (partial-index WHERE reading) is load-bearing for
+  this design. Without it drizzle-kit will churn these migrations.
+- Every file path and line number cited in the ADL was checked against the tree. One was
+  wrong on first write (schema.ts:508 -> 507) and was corrected — the exact ADL-27/29
+  failure /record-decision warns about. Check them again if the ADL is ever edited.
+- tracker.json round-trips cleanly after my edits: 15 // ─── section headers intact,
+  190 entries parse. Edited in place with the Edit tool, never through a script.
+
+================================================================================
+STATE AT PARK
+================================================================================
+- ADL-42 reserved stub REWRITTEN IN PLACE in jobs/architect/tech/
+  20260307-architecture-decisions-log.md. Other reserved stubs (ADL-41, 43, 44, 45) not
+  touched — four other Architects were running concurrently on the same file.
+- Standalone design: jobs/architect/tech/ADL-42-booking-item-shape.md.
+- tracker.json: BUG-41 and BUG-42 notes rewritten with the decision + #272; owner moved
+  architect -> coo (the next actor is the BRD gate, not me); status left "pending" because
+  NOTHING is implemented. Deliberately did not invent a "designed" status value or use
+  "partial" — "partial" is used in this tracker for partially-SHIPPED features and would
+  read to a UAT reviewer as "some of this works", which is exactly the status decay the
+  doc-lifecycle rules exist to stop.
+- BRD NOT edited. See handoff item 1.
+
+================================================================================
+IF I PICKED THIS UP COLD TOMORROW
+================================================================================
+The design is complete and self-contained; nothing is half-decided. The only thing standing
+between this and a dispatchable brief is the COO's BRD bump (FL-01 supersession + FL-02
+amendment + two new requirement IDs with success criteria). Do not let a Database brief go
+out before that lands — BUG-41 and BUG-42 both still have brdRefs: [].
+
+The single highest-risk item at implementation time is D11 (row multiplication in
+fetchItemsWithExtensions). If the Backend brief is written without that warning quoted
+verbatim, expect corrupted rating sorts and wrong item counts that will look like a
+frontend bug.

--- a/jobs/architect/tech/20260307-architecture-decisions-log.md
+++ b/jobs/architect/tech/20260307-architecture-decisions-log.md
@@ -2705,15 +2705,149 @@ ordering (DP-05/DP-06) and item attachment (`items.trip_place_id`). Must also ru
 cascade semantics TR-14 (trip deletion) depends on, and must not foreclose NR-12 (Phase 2
 archive-instead-of-delete). Unblocks BUG-40, TR-14/TR-15 implementation.
 
-## ADL-42 — RESERVED (S2: booking-item shape / BUG-41 + BUG-42)
+## ADL-42 — Booking item shape: multi-leg flights and multi-traveller seats
 
-**Date:** reserved 2026-07-27
-**Status:** RESERVED — Wave 0 brief S2 not yet dispatched. No decision recorded.
-**Scope:** Multi-leg/connecting flights (BUG-41) and multiple companions/seats per booking
-item (BUG-42) are one schema problem — the booking item is flat — not two. Decide the shape
-(likely sub-entities under a single booking item) covering both, including how seat
-assignment interacts with the existing per-user companion model (AD-08). Downstream: BUG-43
-(Apple Wallet import, research spike only).
+**Date:** 2026-07-27
+**Status:** **Decided, implementation pending.** No schema, migration or code change was made
+by this ADL — it is the design that unblocks those briefs. **Blocked on a COO BRD bump before
+any brief dispatches** (see "COO action required" below).
+**Trigger:** Wave 0 scoping brief S2, GitHub issue #272. Tracker BUG-41 and BUG-42, both
+raised at the 2026-07-21 Scotland dogfood UAT.
+**BRD refs:** §5.5 IT-01–IT-11, §5.6 FL-01–FL-04, CR-01–CR-02.
+**Full ADL:** `jobs/architect/tech/ADL-42-booking-item-shape.md` — the standalone file carries
+the table definitions, migration SQL, API shape and rejected alternatives. This entry is the
+decision of record.
+
+**Problem.** BUG-41 (multi-leg flights on one booking) and BUG-42 (multiple companions/seats
+per booking) are one defect, not two: the booking item is flat. It models one segment of
+travel carrying one implicit traveller. A Seattle→London→Glasgow itinerary on a single PNR
+must today be two unrelated `flight` items (BRD FL-01, echoed at `src/backend/db/schema.ts:507`),
+duplicating the booking reference with nothing keeping them equal and giving one booking two
+statuses. Separately, `item_flights.seat` is one `TEXT` column and **no per-item companion
+link exists anywhere in the schema** — companions attach to trips only, via
+`trip_companions_map`. Neither is fixable alone: a seat belongs to a person on a leg.
+
+**Decisions.**
+
+| # | Decision | Recommendation | Confidence |
+|---|----------|----------------|------------|
+| D1 | Booking shape | New `item_flight_legs` child table under **one** flight item; `item_flights` retained as the booking-level extension row | High |
+| D2 | Leg ordering | Explicit 1-based contiguous `leg_order`, full-replace on write — **not** sorted by `departure_datetime` | High |
+| D3 | Parent vs leg fields | Parent: `booking_reference` (the PNR). Leg: airline, flight number, both airports, both datetimes | High |
+| D4 | Traveller / seat model | **One** table `item_travellers` with a **nullable `leg_id`** selecting the scope; row presence = travels this scope; `seat` on the row | High |
+| D5 | The owning user | `companion_id` **nullable**, `NULL` = "me". Do not synthesise a "Me" companion | High |
+| D6 | Manifest mode | Per item, traveller rows are all leg-scoped (flights) or all booking-scoped (all other types) — never mixed | High |
+| D7 | Cross-user companion guard | Mandatory `companionRepository.validateOwnership` (ADL-28 R4) at the new write path; `userId` is the repository's first argument | High |
+| D8 | Does a leg have a status? | **No.** Status stays item-level (IT-03, FL-03) | High |
+| D9 | Cost | Booking-level whenever introduced, never per-leg. Not added — no BRD requirement exists | High |
+| D10 | Migration | **Two** files: additive create-and-backfill, then a separate destructive shrink of `item_flights` | High |
+| D11 | API read path | Legs/travellers fetched in a **second batched query** — never `leftJoin`ed into `fetchItemsWithExtensions` | High |
+| D12 | Compatibility shim | **None.** Backend and frontend land together | Medium |
+| D13 | Traveller scope by type | `item_travellers` open to all item types; legs flight-only | High |
+
+**Why one table for travellers (D4/D5/D6) — the load-bearing choice.** Three requirements
+pull apart: multiple seats per leg, a companion who is on some legs but not others, and
+non-flight items that have travellers but no legs. Having both a booking-level and a
+leg-level junction is the trap — two homes for one fact, and "on the booking but no row on
+leg 2" becomes ambiguous between *not travelling that leg* and *seat unknown*. A single table
+with a nullable `leg_id` resolves it: **row presence is the assertion**, `seat IS NULL` means
+"on this leg, seat unknown", and for flights the booking roster is derived
+(`SELECT DISTINCT companion_id ... WHERE item_id = ?`), never stored, so a stored roster and
+manifest cannot disagree. Uniqueness needs **four partial unique indexes**, because SQLite
+treats NULLs as distinct and a plain composite unique would accept the same traveller twice;
+the cheaper two-index alternative (a `0` self-sentinel) was rejected because `0` cannot carry
+an FK to `companions.id` — referential integrity outranks index count.
+
+`companion_id` must be nullable because **`companions` is a list of *other* people — the user
+is not in it.** Today's single `seat` column *is* the user's own seat, implicitly; a
+`NOT NULL companion_id` junction would have nowhere to put it, making the "fix" a regression.
+
+**Why no leg status (D8).** A PNR is confirmed or cancelled as a unit. Per-leg status has no
+correct aggregate (leg 1 Completed, leg 2 Cancelled → what does the item show?) and every
+consumer reads one status: `itemRepository.findByTrip`'s `filters.status`, IT-06 bulk review,
+IT-08/IT-09 rating filters, PL-03 planning-stage grouping. The real need behind it — "the
+airline cancelled my second leg" — is an operational disruption, not a planning stage, and
+belongs on its own nullable per-leg marker if the PO ever asks.
+
+**Alternatives rejected:** legs as separate items joined by a `booking_group_id` (leaves N
+statuses per booking); widening `item_flights` with `leg2_*`/`leg3_*` columns (hard cap,
+unindexable); a JSON `legs` array (ADL-11 rejected JSON for item fields precisely because
+SQLite cannot index JSON paths, and leg departure dates are queried —
+`20260307-tech-blueprint.md:292`); and a generalised `item_segments` table spanning flights,
+hotels and car rentals — the most elegant option and the wrong one, since it requires
+migrating three extension tables and rewriting every route, helper, test and component to buy
+a second segment for types that will never have one. Rejected on cost, not taste.
+
+**Implementation implications.**
+- Two new tables; `item_flights` shrinks to `(item_id, booking_reference)`. `items`,
+  `item_hotels`, `item_car_rentals`, `item_restaurants` and `item_experiences` are untouched —
+  blast radius stays small and ADL-11's pattern stays intact.
+- **The most likely implementation bug:** `fetchItemsWithExtensions`
+  (`src/backend/routes/items-helper.ts:82`) left-joins five **1:1** tables into one flat row.
+  Legs and travellers are **1:N** — joining them multiplies rows (a 3-leg flight with 2
+  travellers returns 6 rows for one item) and silently corrupts `effectiveRating`, the rating
+  sort and the `minRating` filter. Second batched query, always.
+- `item_travellers.companion_id` is a second write path to `companions.id` and therefore a
+  path around AD-08. The repository signature must be
+  `itemTravellerRepository.replace(userId, itemId, assignments)` — `userId` first and
+  mandatory, so the junction cannot be written without the scoping value. Cross-user IDs are
+  **400, not 404**, matching ADL-28. The Backend brief must mirror ADL-28's rejection tests
+  from `src/backend/repositories/__tests__/trips.test.ts` into
+  `src/backend/repositories/__tests__/items.test.ts`.
+- Migration is **two files**: file 1 creates the tables and backfills one leg per existing
+  flight plus the legacy `seat` as the owning user's seat on leg 1; file 2 drops the seven
+  moved columns. Steps in file 1 read columns file 2 destroys, and Drizzle cannot know the
+  ordering — two files make inverting it structurally impossible and leave a safe, reversible
+  resting point. Verify row counts on staging between them. `db:push` remains forbidden (ADL-15).
+- `patches/drizzle-kit+0.31.9.patch` Bug 4 (partial-index `WHERE` reading) is **load-bearing**
+  for the four partial unique indexes; without it drizzle-kit will churn these migrations.
+  Verified expressible: `uniqueIndex()` and `index()` share one builder in the installed
+  drizzle-orm (`sqlite-core/indexes.d.ts`, `IndexBuilder.where()`).
+- **BUG-45/ADL-43 cross-dependency:** `airline` moves to `item_flight_legs`. The sourced
+  airline dropdown must target `item_flight_legs.airline`, not `item_flights.airline`, or that
+  brief will need reworking.
+- No back-compat shim, so the Database brief may merge alone (additive), but the Backend and
+  Frontend changes must land on one branch as a single brief —
+  `src/frontend/types/api.ts:133–141`, `ItemCard.tsx`, `ItemForm.tsx` and `useItems.ts` all
+  read the flat flight keys that disappear.
+- **Naive datetimes make one UI feature unsafe:** leg datetimes carry no timezone, so layover
+  and total-journey durations computed across legs are wrong whenever a connection crosses a
+  timezone — which is the norm for the itinerary that motivated BUG-41. The frontend must not
+  display connection durations until timezone data exists (depends on airport reference data,
+  ADL-43's territory).
+
+**Drift found while checking, flagged not fixed:** BRD IT-03 (v3.0) lists **Shortlisted** as
+an item status, but `chk_items_status` (`src/backend/db/schema.ts:499`) permits only
+`consider, confirmed, completed, cancelled, next_time` and the string `shortlisted` appears
+nowhere in `src/`. It was added to the BRD and never implemented; its home is the
+deprioritized planning-core tracker entry. ADL-42 does not rebuild the `items` table so it
+neither depends on nor resolves this.
+
+**COO action required before any brief dispatches** (CLAUDE.md BRD gate): **FL-01 is
+superseded** — "Each flight is logged as an individual leg" is the exact model this replaces —
+and must be rewritten and stamped `> SUPERSEDED (2026-07-27) by ADL-42 — retained for history.`
+FL-02 must move `seat` off the flight field list. BUG-41 and BUG-42 both have empty `brdRefs`
+and need new requirement IDs with measurable success criteria. **The BRD was deliberately not
+edited here** — the FL-01 stamp belongs in the COO's BRD-bump PR alongside the new IDs and the
+header/§13 changelog bump, not split across two PRs leaving the BRD internally inconsistent in
+between. The implementing Database brief must also rewrite `src/backend/db/schema.ts:507`,
+which still asserts the superseded FL-01 model; `jobs/database/tech/schema.ts:507` is a stale
+copy carrying the same claim and needs refreshing or a HISTORICAL banner.
+`jobs/architect/tech/20260307-ER-schema.md:303` repeats it but already has a HISTORICAL banner
+and needs no further stamp.
+
+**Supersession:** no ADL entry is superseded. **ADL-11** (base + extension tables) is preserved
+and extended — `item_flights` remains the 1:1 booking extension and the leg table is a new 1:N
+child beneath it. **ADL-28** (per-user companions) is reinforced — its `validateOwnership`
+guard becomes mandatory at a second write path. The one supersession is BRD FL-01, stamped by
+the COO per the paragraph above.
+
+**Out of scope:** BUG-43 (Apple Wallet `.pkpass` import) — not designed. Two notes only for
+whoever picks up the spike: a boarding pass carries exactly *(flight number, both airports,
+both times, seat, passenger name, PNR)*, mapping 1:1 onto one leg row plus one traveller row,
+so this design is import-shaped by construction; and an importer would dedupe on
+`booking_reference`, so that column must **not** be made globally unique — dedupe within
+`(user_id, booking_reference)` at the application layer.
 
 ## ADL-43 — RESERVED (S3: sourced reference data / BUG-45 + OQ-06)
 

--- a/jobs/architect/tech/ADL-42-booking-item-shape.md
+++ b/jobs/architect/tech/ADL-42-booking-item-shape.md
@@ -1,0 +1,564 @@
+# ADL-42 — Booking item shape: multi-leg flights and multi-traveller seats
+
+**Date:** 2026-07-27
+**Status:** Decided, implementation pending
+**Trigger:** GitHub issue #272 (Wave 0 scoping brief S2). Tracker BUG-41 (multi-leg /
+connecting flights within a single booking) and BUG-42 (multiple companions/seats per
+booking item), both raised at the 2026-07-21 Scotland dogfood UAT.
+**BRD refs:** §5.5 IT-01–IT-11, §5.6 FL-01–FL-04, CR-01–CR-02. **FL-01 is superseded by
+this decision and must be amended by the COO before any brief dispatches** (see §11).
+**Depends on:** ADL-11 (base + extension tables), ADL-28 (per-user companions, AD-08).
+**Supersedes:** BRD FL-01 (COO action — see §11). No ADL entry is superseded.
+**Downstream, not designed here:** BUG-43 (Apple Wallet `.pkpass` import — research spike).
+
+---
+
+## 1. Summary table
+
+| # | Decision | Recommendation | Confidence |
+|---|----------|----------------|------------|
+| D1 | Booking shape | New `item_flight_legs` child table under **one** flight item. `item_flights` is retained as the booking-level extension row. One booking = one item. | High |
+| D2 | Leg ordering | Explicit `leg_order` integer, 1-based and contiguous, written by the backend. **Not** derived by sorting on `departure_datetime`. | High |
+| D3 | Parent vs leg fields | Parent (`item_flights`): `booking_reference` — the PNR, one per booking. Leg: `airline`, `flight_number`, both airports, both datetimes. | High |
+| D4 | Traveller / seat model | **One** new table `item_travellers` with a **nullable `leg_id`**. Row presence = "travels this scope"; `seat` is a nullable column on the row. | High |
+| D5 | Representing the owning user | `companion_id` is **nullable**; `NULL` means the owning user ("me"). Do not synthesise a "Me" companion row. | High |
+| D6 | Manifest mode invariant | Per item, traveller rows are either **all** leg-scoped (flights) or **all** booking-scoped (every other type). Never mixed. | High |
+| D7 | Cross-user companion guard | The new write path must call `companionRepository.validateOwnership` (ADL-28 R4). Repository signature takes `userId` as its first, mandatory argument. | High |
+| D8 | Does a leg have a status? | **No.** Status stays on the item only (IT-03, FL-03). A leg has no independent status axis. | High |
+| D9 | Cost | Booking-level whenever it is introduced; never per-leg. Not added by this ADL — no BRD requirement for item cost exists. | High |
+| D10 | Migration | **Two** migration files: an additive create-and-backfill, then a separate destructive shrink of `item_flights`. Never one file. | High |
+| D11 | API read path | Legs and travellers are fetched in a **second, batched query** and attached as arrays. They must **never** be added as `leftJoin`s in `fetchItemsWithExtensions`. | High |
+| D12 | Backward-compatibility shim | **None.** No deprecated flat aliases. Backend and frontend land together. | Medium |
+| D13 | Which types get travellers | `item_travellers` is open to **all** item types. Legs are flight-only. | High |
+
+---
+
+## 2. The problem, stated once
+
+BUG-41 and BUG-42 are the same defect seen from two sides: **the booking item is flat.**
+It models exactly one segment of travel carrying exactly one implicit traveller.
+
+Today a Seattle → London → Glasgow itinerary on a single PNR must be entered as two
+separate `flight` items (BRD FL-01: "Each flight is logged as an individual leg";
+`src/backend/db/schema.ts:507` repeats it). Consequences:
+
+- The booking reference is duplicated across both items with nothing keeping them equal.
+- Nothing links them. Cancelling "the booking" means finding and editing N unrelated items.
+- Their order is incidental — `fetchItemsWithExtensions` orders by `items.createdAt`.
+- Carry-forward (IT-07), post-trip bulk status update (IT-06) and the planning view
+  (PL-03) each see N unrelated rows where the user sees one booking.
+
+And `item_flights.seat` is a single `TEXT` column. There is **no per-item companion link
+anywhere in the schema** — `companions` attach to trips only, via `trip_companions_map`.
+So "two of us flew, seats 12A and 12B" is unrepresentable, and the one seat that *can* be
+stored belongs to nobody in particular.
+
+Fixing either one alone would entrench the other. A seat belongs to a *person on a leg*;
+you cannot model seats correctly until legs exist, and you cannot model a leg's occupancy
+correctly until travellers exist. Hence one design.
+
+---
+
+## 3. D1 — Booking shape: a leg sub-entity, not more items and not more columns
+
+**Decision:** one flight booking is one `items` row. Its legs live in a new
+`item_flight_legs` child table. `item_flights` is kept as the 1:1 booking-level extension
+row (ADL-11's pattern is preserved, not replaced).
+
+**Reasoning:**
+
+- The invariant that matters is *one booking = one confirmation = one status = one item*.
+  That is what the user cancels, confirms and completes. Legs are its parts.
+- Alternatives rejected:
+  - **Keep legs as separate items joined by a `booking_group_id`.** Leaves N statuses for
+    one booking with no defined aggregate, so IT-06 bulk review and PL-03 grouping stay
+    broken. It also puts a grouping key on the generic `items` table for one type's benefit.
+  - **Widen `item_flights` with `leg2_*`, `leg3_*` columns.** A hard cap in the schema,
+    unindexable, and the exact "dozens of nullable columns" failure ADL-11 rejected.
+  - **A JSON `legs` array on `item_flights`.** Rejected for the same reason ADL-11 rejected
+    JSON for item fields: SQLite cannot efficiently index JSON paths, and legs must be
+    queryable (departure date drives trip timelines; `jobs/architect/tech/20260307-tech-blueprint.md:292`
+    already reads `item_flights.departure_datetime` directly).
+  - **A generalised `item_segments` table covering flights, hotels and car rentals.** The
+    most "elegant" option and the wrong one. It requires migrating all three existing
+    extension tables, rewriting every route, helper, test and component, to buy a second
+    segment for types that will never have one. Hotels and car rentals are single-segment
+    by nature; a multi-city car hire is a second rental. This is a rebuild sold as a
+    refactor. Rejected on cost, not on taste.
+
+**Table:**
+
+```typescript
+export const itemFlightLegs = sqliteTable(
+  'item_flight_legs',
+  {
+    id: integer('id').primaryKey({ autoIncrement: true }),
+    itemId: integer('item_id')
+      .notNull()
+      .references(() => items.id, { onDelete: 'cascade' }),
+    legOrder: integer('leg_order').notNull(),   // 1-based, contiguous — see D2
+    airline: text('airline'),
+    flightNumber: text('flight_number'),
+    departureAirport: text('departure_airport'), // IATA preferred, not enforced
+    arrivalAirport: text('arrival_airport'),
+    departureDatetime: text('departure_datetime'), // ISO 8601, naive — see §9
+    arrivalDatetime: text('arrival_datetime'),
+    createdAt: text('created_at').notNull().default(sql`(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))`),
+    updatedAt: text('updated_at').notNull().default(sql`(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))`),
+  },
+  (t) => [
+    uniqueIndex('uniq_item_flight_legs_order').on(t.itemId, t.legOrder),
+    index('idx_item_flight_legs_item').on(t.itemId),
+    index('idx_item_flight_legs_departure').on(t.departureDatetime),
+    check('chk_item_flight_legs_order', sql`${t.legOrder} >= 1`),
+  ],
+)
+```
+
+**Deliberate omission — no per-leg `notes` column.** IT-04 puts notes on the item and a
+second notes home invites the "which notes did I write?" problem. If the PO asks for
+gate/terminal notes later it is a nullable column add with no migration risk. Recorded so
+a future reader knows it was considered, not overlooked.
+
+**Enforcement:** a leg may only reference an item with `item_type = 'flight'`. SQLite
+cannot express this (no cross-table CHECK), so the backend enforces it — the same
+application-layer contract every existing extension table already relies on.
+
+---
+
+## 4. D2 — Ordering, and D3 — what the parent carries vs the leg
+
+**D2 — `leg_order`, an explicit integer. Do not sort by `departure_datetime`.**
+
+- Datetimes are optional. PL-01 requires a flight to exist as a quick-capture idea with a
+  name and type only; an idea with three unscheduled legs must still hold its order.
+- The stored order is *user intent*. A datetime sort silently reorders the itinerary the
+  moment a user fixes a typo in a date.
+- Datetimes are stored naive, with no timezone (§9). Ordering a westbound long-haul by
+  naive local arrival time can invert legs. `leg_order` is immune.
+
+Write semantics: **full replace.** `PATCH` sends the complete ordered leg array; the
+backend deletes and reinserts, assigning `leg_order` 1..N from array position. This makes
+"insert a leg in the middle" and "reorder" trivial for the client and makes gaps
+structurally impossible. `uniq_item_flight_legs_order` catches any violation.
+
+A flight item has **at least one** leg. A zero-leg flight is invalid; the create path
+writes leg 1 even when every field on it is null. This is what keeps "single-leg flight"
+and "multi-leg flight" one code path instead of two.
+
+**D3 — the split:**
+
+| Field | Home | Why |
+|-------|------|-----|
+| `booking_reference` (PNR) | **Parent** `item_flights` | One booking, one record locator. Duplicating it per leg is exactly today's bug. |
+| Cost | **Parent** (when introduced — D9) | A fare is priced for the itinerary, not per segment. |
+| Confirmation number | **Parent** (if added) | Same reasoning. |
+| `airline` | **Leg** | Interline and codeshare itineraries genuinely change carrier between legs. There is no correct single booking-level airline. |
+| `flight_number` | **Leg** | Per-segment by definition. |
+| Departure/arrival airport | **Leg** | Per-segment by definition. |
+| Departure/arrival datetime | **Leg** | Per-segment by definition. |
+| Status | **Parent only** | D8. |
+
+**Consequence for the UI and for ADL-43:** the booking has no single airline. The item card
+should render leg 1's airline, or "Multi-airline" when carriers differ — it must not invent
+a booking-level airline field. **BUG-45 (sourced airline dropdown, ADL-43's scope) must
+target `item_flight_legs.airline`, not `item_flights.airline`.** If ADL-43's brief is
+written against the old column it will need reworking; the two waves must be sequenced or
+cross-referenced.
+
+---
+
+## 5. D4/D5/D6 — the traveller model
+
+This is the load-bearing part of the design. Three requirements pull against each other:
+
+1. Multiple travellers with a seat each, per leg (BUG-42).
+2. A companion may be on some legs and not others (brief S2).
+3. Car rentals, hotels and restaurants have travellers but no legs.
+
+Requirement 3 pushes toward a booking-level junction. Requirements 1 and 2 push toward a
+leg-level junction. **Having both is the trap** — it creates two homes for one concept, and
+makes "on the booking but with no row on leg 2" ambiguous between *not travelling that leg*
+and *seat not yet known*.
+
+**Decision (D4): one table, with a nullable `leg_id` that selects the scope.**
+
+```typescript
+export const itemTravellers = sqliteTable(
+  'item_travellers',
+  {
+    id: integer('id').primaryKey({ autoIncrement: true }),
+    itemId: integer('item_id')
+      .notNull()
+      .references(() => items.id, { onDelete: 'cascade' }),
+    // NULL = this row applies to the whole booking (non-flight items).
+    // NOT NULL = this row applies to one specific leg (flight items).
+    legId: integer('leg_id').references(() => itemFlightLegs.id, { onDelete: 'cascade' }),
+    // NULL = the owning user ("me") — see D5. NOT NULL = one of their companions.
+    companionId: integer('companion_id').references(() => companions.id),
+    seat: text('seat'), // NULL = travels this scope, seat not known
+    createdAt: text('created_at').notNull().default(sql`(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))`),
+    updatedAt: text('updated_at').notNull().default(sql`(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))`),
+  },
+  (t) => [
+    // Four partial unique indexes — see the note below on why four.
+    uniqueIndex('uniq_item_travellers_leg_companion')
+      .on(t.legId, t.companionId)
+      .where(sql`${t.legId} IS NOT NULL AND ${t.companionId} IS NOT NULL`),
+    uniqueIndex('uniq_item_travellers_leg_self')
+      .on(t.legId)
+      .where(sql`${t.legId} IS NOT NULL AND ${t.companionId} IS NULL`),
+    uniqueIndex('uniq_item_travellers_item_companion')
+      .on(t.itemId, t.companionId)
+      .where(sql`${t.legId} IS NULL AND ${t.companionId} IS NOT NULL`),
+    uniqueIndex('uniq_item_travellers_item_self')
+      .on(t.itemId)
+      .where(sql`${t.legId} IS NULL AND ${t.companionId} IS NULL`),
+    index('idx_item_travellers_item').on(t.itemId),
+    index('idx_item_travellers_leg').on(t.legId),
+    index('idx_item_travellers_companion').on(t.companionId),
+  ],
+)
+```
+
+**Semantics — row presence is the assertion:**
+
+- A row exists → this traveller **is on** this scope (this leg, or this booking).
+- `seat IS NULL` → on the scope, seat unknown. Unambiguously different from "not on it".
+- No row → not on this scope.
+
+That single rule resolves requirement 2 cleanly. "Partner flew SEA→LHR but not LHR→GLA" is
+a row on leg 1 and no row on leg 2. Nothing is implied, overridden or inherited.
+
+**Why four partial unique indexes.** SQLite treats `NULL`s as distinct in a unique index,
+so a plain `UNIQUE(item_id, leg_id, companion_id)` would happily accept duplicate
+`(item, NULL, NULL)` rows — the same traveller twice. Each of the four indexes covers one
+quadrant of the (leg NULL/NOT NULL × companion NULL/NOT NULL) space with no NULLs left in
+its key columns, which is the only way to make uniqueness real here. The cheaper-looking
+alternative — a NOT NULL `traveller_ref` column using `0` as a self sentinel, needing only
+two indexes — was rejected because `0` cannot carry a foreign key to `companions.id`.
+**Referential integrity outranks index count.**
+
+Partial indexes are already used in this schema (`idx_cities_geocode`, `idx_items_carried`),
+and `patches/drizzle-kit+0.31.9.patch` Bug 4 exists specifically to make drizzle-kit read
+partial-index `WHERE` clauses. That patch is **load-bearing for this design** — without it,
+drizzle-kit does not round-trip these indexes and will churn migrations. Verified against
+the installed version: `uniqueIndex()` and `index()` share one builder
+(`node_modules/drizzle-orm/sqlite-core/indexes.d.ts` — `IndexBuilderOn` → `IndexBuilder.where()`),
+so `uniqueIndex(...).on(...).where(...)` is expressible.
+
+### D5 — the owning user is not a companion
+
+The gap nobody has written down yet: **`companions` is a list of *other* people.** The user
+is not in it. Today's single `item_flights.seat` column *is* the user's own seat, implicitly
+— that is precisely what BUG-42 means by "one implicit traveller".
+
+So a traveller junction keyed on a `NOT NULL companion_id` would have nowhere to put the
+user's own seat. Moving seat to such a table would be a **regression**, not a fix.
+
+**Decision: `companion_id` is nullable and `NULL` means the owning user.**
+
+Alternatives rejected:
+- **Auto-create a "Me" companion per user.** Pollutes a user-managed list (AD-08) with a row
+  they did not create and can rename, deactivate or delete; collides with
+  `uniq_companions_user_name` if they already have one named "Me"; and makes the self-row
+  soft-deletable, which would orphan the meaning of every seat attached to it.
+- **A separate `self_seat` column on `item_flights` or on the leg.** A second home for seat
+  — the exact smell this ADL exists to remove.
+
+The API surfaces this as an explicit `is_self: true` flag rather than making clients infer
+meaning from a null, so no consumer has to know the storage convention.
+
+### D6 — manifest mode: never mix scopes on one item
+
+**For any single item, every traveller row is leg-scoped, or every one is booking-scoped.**
+
+- Flight items → **leg-scoped** (`leg_id NOT NULL`) always, since a flight always has ≥1 leg.
+- All other types → **booking-scoped** (`leg_id NULL`) always.
+
+This is what keeps the model non-redundant. For a flight, the booking-level roster is
+*derived*, never stored:
+
+```sql
+SELECT DISTINCT companion_id FROM item_travellers WHERE item_id = ?
+```
+
+There is exactly one home for the fact, and no way for a stored roster and a stored manifest
+to disagree. SQLite cannot enforce mode (it depends on `items.item_type` in another table),
+so the backend enforces it and the repository tests must cover both violation directions:
+a leg-scoped row on a hotel, and a booking-scoped row on a flight. Both are 400s.
+
+---
+
+## 6. D7 — the per-user companion model must not be routed around
+
+ADL-28 (AD-08) made companions per-user and established that a cross-user companion
+assignment must be rejected. SQLite cannot enforce the invariant
+(`companions.user_id == items.user_id`) — no cross-table CHECK, no deferred FK validation —
+so ADL-28 R4 named `companionRepository.validateOwnership(userId, companionIds)` as the
+**sole** guard, called from `tripRepository.replaceAssociations`.
+
+`item_travellers.companion_id` is a **second write path to `companions.id`**, and it is
+exactly the path around AD-08 this brief warns about. Two binding rules:
+
+1. **Same guard, same semantics.** The traveller writer calls
+   `companionRepository.validateOwnership` (`src/backend/repositories/companions.ts`) before
+   any insert. Any companion ID that fails produces a **400 ValidationError, not a 404** —
+   the companion may well exist; it just is not the caller's. This matches ADL-28 exactly and
+   avoids leaking existence.
+2. **Make it structural, not a reminder.** The repository signature is
+   `itemTravellerRepository.replace(userId: string, itemId: number, assignments: TravellerAssignment[])`
+   — `userId` first and mandatory. A route cannot write this junction without having the
+   scoping value in hand. "Remember to validate" is not a control; a signature that cannot
+   be called without the user is.
+
+The Backend brief must carry the cross-user rejection test for the item path, mirroring the
+cases ADL-28 added to `src/backend/repositories/__tests__/trips.test.ts`, into
+`src/backend/repositories/__tests__/items.test.ts`. Per CLAUDE.md's Backend security
+checklist, `item_travellers` writes must also be `requireAuth`-gated and every read scoped
+through `items.user_id`.
+
+**Two related rulings:**
+
+- **No subset constraint against `trip_companions_map`.** An item traveller need *not* be a
+  trip companion. Requiring it creates an ordering trap (book the flight before adding
+  people to the trip → rejected) and an undefined cascade (remove a companion from the trip
+  → silently delete their seats?). Removing a companion from a trip **must not** delete
+  `item_travellers` rows. The UI should offer trip companions first; that is a presentation
+  affordance, not a constraint.
+- **No `onDelete` on `companion_id`.** This matches `trip_companions_map.companionId`
+  exactly. Companions are soft-deleted (`is_active = 0`), never hard-deleted, so RESTRICT is
+  correct. Note in passing: `companions.user_id` cascades on user delete while
+  `trip_companions_map` restricts, so hard user deletion is already undefined in this schema.
+  That is a **pre-existing** condition; ADL-42 deliberately neither fixes nor worsens it, and
+  the new table follows the established pattern rather than inventing a third.
+
+---
+
+## 7. D8 — a leg does not have its own status
+
+**Decision: status stays on `items` only. No `status` column on `item_flight_legs`.**
+
+- IT-03 and FL-03 define one status workflow per item. A PNR is confirmed or cancelled as a
+  unit — that is what a booking *is*.
+- Per-leg status creates an aggregation problem with no correct answer. If leg 1 is
+  Completed and leg 2 Cancelled, what does the item show? Every consumer reads a single
+  status: `itemRepository.findByTrip`'s `filters.status`
+  (`src/backend/repositories/items.ts:52`), IT-06 bulk review, IT-08/IT-09 rating filters,
+  and PL-03's planning-stage grouping. A second status axis breaks all of them and buys
+  nothing they can use.
+- The genuine underlying need — "the airline cancelled my second leg" — is an **operational
+  disruption**, not a planning stage. It does not belong on the same enum as
+  Consider/Shortlisted/Confirmed. If the PO asks for it, the right shape is a separate
+  nullable per-leg `disruption` marker, which is a cheap additive column later. Overloading
+  IT-03 now would be the mistake.
+- IT-07 carry-forward and IT-06 bulk update both operate on items. Per-leg status would force
+  a second dimension through both.
+
+**Related drift found while checking this, flagged not fixed:** BRD IT-03 (v3.0) lists
+**Shortlisted** as an item status, but `chk_items_status` in `src/backend/db/schema.ts:499`
+permits only `consider, confirmed, completed, cancelled, next_time`, and the string
+`shortlisted` appears nowhere in `src/`. The status was added to the BRD and never
+implemented; its tracker home is the deprioritized planning-core entry (BRD-PL01–04). ADL-42
+does not rebuild the `items` table, so it neither depends on nor resolves this — but any
+future migration that rebuilds that CHECK must handle it. Recorded so it is not rediscovered
+a third time.
+
+---
+
+## 8. D9–D13 — remaining rulings
+
+**D9 — Cost.** There is no cost or price column anywhere in the schema today, and no BRD
+requirement for one. This ADL does not add it. The forward ruling exists so a later brief
+does not put it in the wrong place: **cost is booking-level.** A fare is priced for an
+itinerary, not per segment; per-leg cost would immediately need a "total" that disagrees with
+the sum. If the PO wants item cost, it needs a BRD requirement ID first (CLAUDE.md's BRD
+gate) — it is not a free rider on this change.
+
+**D10 — Migration, in two files.** Existing `item_flights` rows must become single-leg
+bookings with no user-visible change.
+
+*File 1 — additive and reversible (`00NN_adl42_booking_shape.sql`):*
+1. `CREATE TABLE item_flight_legs`, `CREATE TABLE item_travellers` and their indexes.
+2. Backfill one leg per existing flight:
+   `INSERT INTO item_flight_legs (item_id, leg_order, airline, flight_number, departure_airport, arrival_airport, departure_datetime, arrival_datetime) SELECT item_id, 1, airline, flight_number, departure_airport, arrival_airport, departure_datetime, arrival_datetime FROM item_flights;`
+3. Backfill the legacy seat as the **owning user's** seat on leg 1:
+   `INSERT INTO item_travellers (item_id, leg_id, companion_id, seat) SELECT f.item_id, l.id, NULL, f.seat FROM item_flights f JOIN item_flight_legs l ON l.item_id = f.item_id AND l.leg_order = 1 WHERE f.seat IS NOT NULL AND TRIM(f.seat) <> '';`
+   `companion_id = NULL` is the correct reading of the legacy column: it was always the
+   user's own seat (D5).
+
+*File 2 — destructive, separate (`00NN+1_adl42_shrink_item_flights.sql`):*
+4. Recreate `item_flights` as `(item_id PK, booking_reference)` only, dropping the seven
+   moved columns.
+
+**Why two files and not one.** Steps 2–3 read columns that step 4 destroys. Drizzle generates
+step 4 as a table recreation and has no way to know the backfill must precede it — reviewing
+a single generated file for correct statement ordering is exactly the manual step ADL-28's
+own migration review (step 3) flagged as error-prone. Two files make the ordering
+structurally impossible to invert, make each independently reviewable, and leave a safe
+resting point: after file 1 the database is fully backward-compatible and file 1 alone can be
+rolled back trivially. **Verify row counts between the two files on staging** (`item_flight_legs`
+count == `item_flights` count; `item_travellers` count == non-empty `seat` count) before
+applying file 2 — after it, recovery needs a reverse backfill.
+
+Generate via `npm run db:generate` and hand-correct; `db:push` remains forbidden (ADL-15).
+The `items`, `item_hotels`, `item_car_rentals`, `item_restaurants` and `item_experiences`
+tables are **not** touched — this keeps blast radius small and leaves ADL-11's pattern intact.
+
+**D11 — the read path, and the bug engineers will otherwise hit.**
+`fetchItemsWithExtensions` (`src/backend/routes/items-helper.ts:82`) builds one flat row per
+item by left-joining all five 1:1 extension tables. Legs and travellers are **1:N**. Adding
+them as `leftJoin`s multiplies rows — a 3-leg flight with 2 travellers each returns 6 rows for
+one item — which silently corrupts the `effectiveRating` COALESCE, the rating sort, the
+`minRating` post-filter (`items-helper.ts:152`) and every item count in the UI.
+
+**Binding rule: do not join legs or travellers into that query.** Fetch them in a second,
+batched query (`WHERE item_id IN (...)`) over the already-selected item IDs and attach as
+arrays in `flattenItem`. Two queries, no N+1, no row multiplication. This is the single most
+likely implementation error in this change and the Backend brief must call it out explicitly.
+
+Response shape for a flight:
+
+```json
+{
+  "id": 42, "item_type": "flight", "status": "confirmed",
+  "booking_reference": "ABC123",
+  "legs": [
+    { "id": 7, "leg_order": 1, "airline": "BA", "flight_number": "BA49",
+      "departure_airport": "SEA", "arrival_airport": "LHR",
+      "departure_datetime": "2026-08-01T18:30", "arrival_datetime": "2026-08-02T12:15",
+      "travellers": [
+        { "companion_id": null, "companion_name": null, "is_self": true,  "seat": "12A" },
+        { "companion_id": 7,    "companion_name": "Partner", "is_self": false, "seat": "12B" }
+      ] }
+  ],
+  "travellers": [
+    { "companion_id": null, "companion_name": null, "is_self": true, "legs": [7] },
+    { "companion_id": 7, "companion_name": "Partner", "is_self": false, "legs": [7] }
+  ]
+}
+```
+
+The top-level `travellers` array is the **derived** roster (D6) — computed, never stored — and
+carries which legs each traveller is on, so a client can render "Partner: SEA→LHR only"
+without walking the leg array itself. Non-flight items get `travellers` with no `legs` key and
+no top-level `legs` array.
+
+**D12 — no compatibility shim.** The flat keys `airline`, `flight_number`,
+`departure_airport`, `arrival_airport`, `departure_datetime`, `arrival_datetime` and `seat`
+disappear from the flight response (`src/backend/routes/items-helper.ts:183–193`;
+`src/frontend/types/api.ts:133–141`). Keeping deprecated aliases populated from `legs[0]` was
+considered and rejected: a "temporary" alias reliably becomes permanent — this project's whole
+document-lifecycle ruleset exists because deferred cleanup does not happen — and it would
+recreate the two-homes-for-one-fact problem this ADL removes, for the duration.
+
+The cost of no shim is that the backend and frontend changes **must not land separately on
+`main`**. Recommended sequencing:
+1. **Database brief** — schema + the two migration files (additive; nothing reads the new
+   tables yet, safe to merge alone).
+2. **One combined Backend + Frontend brief on a single branch** — the API shape and its
+   consumers (`src/frontend/types/api.ts`, `src/frontend/components/TripDetail/ItemCard.tsx`,
+   `src/frontend/components/TripDetail/ItemForm.tsx`, `src/frontend/hooks/useItems.ts`) change
+   together. One branch per brief still holds; this is one brief spanning two layers, which the
+   branching rule permits.
+
+Contract tests (`npm run test:contract`) are the backstop that catches any missed reader.
+
+**D13 — traveller scope by type.** `item_travellers` is open to **all** item types — BUG-42
+says "flight, car, etc.", and "dinner for four, and who" is equally natural for restaurants
+and experiences. A type restriction would need a cross-table CHECK SQLite cannot express
+anyway. Legs stay flight-only.
+
+---
+
+## 9. Known limitation this change makes more visible: naive datetimes
+
+`departure_datetime` and `arrival_datetime` are stored as bare ISO strings with **no timezone
+or UTC offset** — both today and in `item_flight_legs`. For a single-leg flight this is
+harmless: each time is read as local-at-that-airport and displayed as entered.
+
+Multi-leg makes it dangerous, because the obvious next UI feature is **layover duration**
+("2h 45m in London"). Computing `legs[n+1].departure_datetime − legs[n].arrival_datetime` on
+naive strings gives a wrong answer whenever the connection crosses a timezone, which is most
+of the time for the itinerary that motivated BUG-41.
+
+**Ruling: the frontend must not compute or display layover/connection durations, or total
+journey time, until timezone data exists.** Show the leg times as entered. Fixing this
+properly means a per-leg offset or IANA zone column (derivable from the airport code once
+airport reference data exists — ADL-43's territory, BUG-45/OQ-06). Out of scope here;
+recorded so it is a known constraint rather than a shipped bug.
+
+---
+
+## 10. What this ADL does not decide
+
+- **BUG-43 (Apple Wallet `.pkpass` import)** — research spike, not designed here. Two
+  observations only, for whoever picks it up: (a) a boarding pass carries exactly
+  *(flight number, both airports, both times, seat, passenger name, PNR)*, which maps 1:1 onto
+  one `item_flight_legs` row plus one `item_travellers` row — this design is import-shaped by
+  construction, no adapter layer needed; (b) an importer would dedupe on
+  `item_flights.booking_reference`, so that column must **not** be made globally unique — a
+  second user can hold the same record locator. Dedupe within `(user_id, booking_reference)`
+  at the application layer. No passenger-name column is added; matching a pass to a companion
+  is a user-mapping step, not a stored field.
+- **Item cost** (D9) — needs a BRD requirement first.
+- **Per-leg disruption/cancellation marker** (D8) — deferred until the PO asks.
+- **The `shortlisted` status gap** (§7) — belongs to the planning-core work.
+- **Timezone-aware datetimes** (§9) — depends on airport reference data (ADL-43).
+- **Sharing / co-planning (PL-06, NF-07)** — `item_travellers` names companions, which is not
+  the same as granting them access. Access remains out of scope and this design does not
+  foreclose it.
+
+---
+
+## 11. COO action required before any brief dispatches
+
+Per CLAUDE.md's **BRD gate before dispatching briefs**, this design cannot be implemented
+until the BRD has a home for it. Four items, all COO-owned:
+
+1. **FL-01 is superseded.** It currently reads "Each flight is logged as an individual leg" —
+   the exact model this ADL replaces. It must be rewritten (a flight booking is one item with
+   one or more ordered legs) and the old text stamped
+   `> SUPERSEDED (2026-07-27) by ADL-42 — retained for history.`
+2. **FL-02 must change.** `seat` moves off the flight field list; it becomes a per-traveller,
+   per-leg value. The remaining leg fields (airline, flight number, airports, datetimes) should
+   be described as per-leg and `booking reference` as per-booking.
+3. **A new requirement for multi-leg bookings** (BUG-41 — `brdRefs` is currently empty), with
+   measurable success criteria.
+4. **A new requirement for multiple travellers and seats per booking item** (BUG-42 —
+   `brdRefs` also empty), with measurable success criteria, and covering the "traveller on some
+   legs but not others" case explicitly.
+
+**I have deliberately not edited the BRD.** The supersession stamp for FL-01 belongs in the
+COO's BRD-bump PR alongside the new IDs and the header/§13 changelog bump (three places,
+`/record-decision`), not split across two PRs where the BRD would sit internally inconsistent
+in between. This is a deferral to the correct owner, not a skipped lifecycle step.
+
+Also required in the implementing **Database** brief (code, not docs, so not done here):
+`src/backend/db/schema.ts:507` asserts "Each leg of a multi-leg journey is a separate item
+(FL-01)" and must be rewritten in the same PR that adds the leg table. `jobs/database/tech/schema.ts:507`
+is a stale copy of the schema file carrying the same claim — it is unmaintained and should
+either be refreshed or given a `> HISTORICAL` banner; flagged to the COO, not actioned here.
+
+`jobs/architect/tech/20260307-ER-schema.md:303` repeats the claim but already carries a
+HISTORICAL banner at its head, so it needs no further stamp.
+
+---
+
+## 12. Summary of schema changes
+
+| Table | Change |
+|-------|--------|
+| `item_flight_legs` | **NEW.** 1:N under a flight item. `leg_order`, airline, flight number, both airports, both datetimes. |
+| `item_travellers` | **NEW.** Nullable `leg_id` (scope) and nullable `companion_id` (NULL = owning user). `seat` per row. Four partial unique indexes. |
+| `item_flights` | **SHRUNK** to `(item_id, booking_reference)`. Seven columns move to the leg or to `item_travellers`. |
+| `items` | **No change.** Status, type and carry-forward semantics untouched. |
+| `companions` | **No change.** ADL-28's model is reinforced, not altered. |
+| `trip_companions_map` | **No change.** Trip roster and item manifest stay independent. |
+| `item_hotels` / `item_car_rentals` / `item_restaurants` / `item_experiences` | **No change.** |
+
+**Relationship to prior decisions:** ADL-11 (base + extension tables) is **preserved and
+extended**, not superseded — `item_flights` remains the 1:1 booking extension; the leg table
+is a new 1:N child beneath it. ADL-28 (per-user companions) is **reinforced** — its
+`validateOwnership` guard becomes mandatory at a second write path (D7). No ADL entry is
+superseded by ADL-42.


### PR DESCRIPTION
Closes #272
BRD §5.5 IT-01–IT-11, §5.6 FL-01–FL-04, CR-01–CR-02

Wave 0 scoping brief S2. **Spec output only** — no schema, migration or code change.

## What was decided

BUG-41 (multi-leg/connecting flights on one booking) and BUG-42 (multiple companions/seats
per booking item) are **one** defect, not two: the booking item is flat, modelling one segment
of travel carrying one implicit traveller.

- One booking = one item. New `item_flight_legs` 1:N child with explicit 1-based `leg_order`
  (not a datetime sort — datetimes are optional under PL-01 and carry no timezone).
  `item_flights` is retained as the booking-level extension row, shrunk to
  `(item_id, booking_reference)`.
- **One** new `item_travellers` table with a **nullable `leg_id`** selecting the scope. Row
  presence = travels this scope; `seat IS NULL` = seat unknown. Two separate junctions were
  rejected: two homes for one fact, and "on the booking but no row on leg 2" becomes ambiguous.
- `companion_id` is **nullable, NULL = the owning user**. `companions` is a list of *other*
  people — the user is not in it, and today's single `seat` column is implicitly theirs. A
  `NOT NULL companion_id` would have made the fix a regression.
- No leg status (status stays item-level, IT-03/FL-03). Cost is booking-level when introduced.
- ADL-28's `validateOwnership` guard becomes mandatory at this second write path to
  `companions.id` — 400 not 404, with `userId` as the repository's first argument so the
  junction cannot be written without it.

Full design: `jobs/architect/tech/ADL-42-booking-item-shape.md`. The reserved ADL-42 stub was
rewritten in place; the other reserved stubs (ADL-41, 43, 44, 45) were not touched.

## Blocked on the COO BRD gate

Status is **Decided, implementation pending**. No brief can dispatch until the BRD has a home
for this:
1. **FL-01 is superseded** ("Each flight is logged as an individual leg") — rewrite + stamp.
2. **FL-02** must move `seat` off the flight field list.
3. New requirement ID + success criteria for **BUG-41** (`brdRefs` is `[]` today).
4. New requirement ID + success criteria for **BUG-42**, covering "traveller on some legs but
   not others".

The BRD was deliberately not edited here — the FL-01 stamp belongs in the COO's BRD-bump PR
alongside the new IDs and the header/§13 changelog bump, rather than split across two PRs
leaving the BRD internally inconsistent in between.

## Also in this PR

- `_project/tracker.json` — BUG-41/BUG-42 notes carry the decision and issue #272; owner moved
  `architect` → `coo` (the next actor is the BRD gate). Status left `pending` because nothing
  is implemented. Edited in place; all 15 `// ───` section headers intact.
- `_project/STATUS.md` — regenerated via `npm run status` (generated file, never hand-edited).
- Architect context + park doc + COO completion report.

## Pre-push

`npm run check`, `type:check:all`, `test:backend` (580 passed / 1 skipped),
`test:frontend` (154 passed), `status:check` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)