### PR TITLE
chore(ADL-45): item map URL column spec — base-table field, https-only, no host allowlist (#276)

### DIFF
--- a/_project/tracker.json
+++ b/_project/tracker.json
@@ -1705,7 +1705,7 @@
       "priority": "P3",
       "brdRefs": ["IT-10"],
       "phase": 5,
-      "notes": "Added to BRD v3.1, 2026-07-20 UAT. Small schema addition (nullable URL column) — needs Architect review before a Database brief per the schema-change rule. Success criteria in BRD §5.5. Also covers item-level phone/address access without separate structured fields, per PO rationale."
+      "notes": "Added to BRD v3.1, 2026-07-20 UAT. GitHub issue #276. DESIGNED 2026-07-27 — Architect ADL-45 (jobs/architect/tech/20260307-architecture-decisions-log.md, Wave 0 brief S6) decided: nullable map_url TEXT column on base items table (not per-extension-table); https-only scheme allowlist, deliberately no Google-host restriction; server-side Zod (zMapUrl) authoritative, frontend sanitiseUrl() extended (not forked) for render-time defense in depth; single additive db:generate/db:migrate migration, no DB CHECK (Zod-only length/scheme cap, matches zName precedent). Status 'designed', implementation pending. Success criteria unchanged, still in BRD §5.5 — no BRD edit needed. Flagged, not fixed: trips.photo_album_ref has no server-side URL scheme validation today and its existing sanitiseUrl() utility has no call site yet — follow-up candidate, not bundled into this item."
     },
     {
       "id": "OQ-05",

--- a/jobs/COO/inbox/20260727_1600-ARCHITECT-adl45-item-map-url.txt
+++ b/jobs/COO/inbox/20260727_1600-ARCHITECT-adl45-item-map-url.txt
@@ -1,0 +1,53 @@
+TO: COO
+FROM: Architect
+DATE: 2026-07-27
+RE: ADL-45 decided — item map URL column (BRD-IT10)
+
+ADL-45 · Issue #276 · BRD §5.5 IT-10 · Branch chore/adl45-item-maps-url
+
+Decided: nullable `map_url` TEXT column on the base `items` table (not per extension
+table); https-only scheme, deliberately NO Google-host allowlist; server-side Zod
+authoritative, frontend reuses (extends, doesn't fork) the existing but currently-unused
+`sanitiseUrl()` utility for render-time defense in depth; one additive migration file, no
+DB CHECK. Spec only — no schema/migration/code change made. Full entry rewritten in place
+at jobs/architect/tech/20260307-architecture-decisions-log.md (ADL-45).
+
+Per-decision verdicts:
+- Column on base `items` table, not extension tables: adopted
+- `map_url` name (not `google_maps_url`): adopted — see host-restriction ruling below
+- https:// scheme required, no Google-host allowlist: adopted
+- Server Zod authoritative + frontend `sanitiseUrl()` extended for a second scheme param: adopted
+- `target="_blank" rel="noopener noreferrer"` mandatory on the rendered anchor: adopted
+- 2048-char cap, Zod-only (no DB CHECK), matches `zName` precedent: adopted
+- Single additive migration (db:generate/db:migrate), no two-file split: adopted
+- No conflict/edit needed to §5.6 structured fields: confirmed, no action
+
+No BRD gate action needed: IT-10 already has success criteria in BRD §5.5, unchanged by
+this decision. tracker.json BRD-IT10 updated in place (status stays "pending", notes record
+"DESIGNED 2026-07-27" — same convention ADL-42 used for BUG-41/BUG-42).
+
+Finding, flagged not fixed (real, pre-existing, not introduced by this ADL): the frontend
+`sanitiseUrl()` utility SEC-12 specifies has ZERO call sites in any component today, and its
+one existing target field, `trips.photo_album_ref`, has no server-side scheme validation
+either (`CreateTripSchema`/`UpdateTripSchema` type it as plain `zOptionalString`). A
+`javascript:` value could be written to that field today and would only be harmless because
+nothing renders it as a link yet. Recommend a small separate follow-up tracker item —
+NOT bundling it into BRD-IT10's implementation, and not a blocker for it.
+
+CI: no code commit made, nothing to run — spec-only branch. `/pre-push` run clean (below).
+
+Open issues or blockers: none. Every file path/line number cited in the ADL entry was
+verified against actual file contents before writing.
+
+Unblocked: Database brief (schema.ts + one migration file for `map_url`), then
+Backend (zMapUrl + itemBase wiring) and Frontend (ItemForm input, ItemCard affordance,
+urlSanitiser.ts scheme-param extension) — no forced sequencing between Backend/Frontend
+like ADL-42 required (this is purely additive, no compatibility break). Also unblocks
+BRD-MB0102 (§5.15 MB-02 directions link).
+
+Also noted, not actioned (out of scope for this thread): two unread COO→Architect inbox
+messages dated 2026-03-21 and 2026-03-23 (backend type-errors DB strategy, ADL-27/OP-06
+corrections) are still sitting in jobs/architect/inbox/ rather than inbox/read/. Both
+appear long superseded by later work (ADL-15, ADL-27, ADL-28, NR-14 all closed since), but
+flagging since they were never formally moved/closed — worth a quick COO sweep if inbox
+hygiene matters, not urgent.

--- a/jobs/architect/context/current.txt
+++ b/jobs/architect/context/current.txt
@@ -1,90 +1,76 @@
-ARCHITECT CONTEXT — 2026-07-27
+ARCHITECT CONTEXT — 2026-07-27 (S6 / ADL-45)
 PROJECT: Travel Tracker
-CURRENT STATUS: ADL-42 DECIDED, IMPLEMENTATION PENDING — booking item shape (BUG-41 + BUG-42),
-Wave 0 scoping brief S2, GitHub issue #272, branch feat/adl42-booking-item-shape.
+CURRENT STATUS: ADL-45 DECIDED, IMPLEMENTATION PENDING — item map URL column (BRD-IT10),
+Wave 0 scoping brief S6, GitHub issue #276, branch chore/adl45-item-maps-url.
 Spec output only — no schema, migration or code change was made.
 
-PROBLEM: BUG-41 (multi-leg flights on one booking) and BUG-42 (multiple companions/seats per
-booking) are ONE defect: the booking item is flat. It models one segment of travel carrying
-one implicit traveller. Seattle→London→Glasgow on a single PNR must today be two unrelated
-flight items (BRD FL-01; echoed at src/backend/db/schema.ts:507), duplicating the booking
-reference and giving one booking two statuses. Separately item_flights.seat is one TEXT column
-and there is NO per-item companion link anywhere in the schema — companions attach to trips
-only via trip_companions_map. Neither is fixable alone: a seat belongs to a person on a leg.
+NOTE: this file is shared across concurrent Wave 0 Architect dispatches (S1/S2/S3/S5/S6
+each ran or are running in their own worktree). Whichever session closes last will show
+here; see jobs/architect/park-docs/ for the full set of session-specific park docs
+(20260727-ARCHITECT-park-adl42.txt, and this session's 20260727-ARCHITECT-park-adl45.txt)
+if this summary looks like it's missing another wave's work — it is not necessarily stale,
+just single-slotted.
 
-DECISION (13 rulings, full design in jobs/architect/tech/ADL-42-booking-item-shape.md):
- - One booking = one item. New item_flight_legs 1:N child table with explicit 1-based
-   contiguous leg_order (NOT sorted by departure_datetime — datetimes are optional under
-   PL-01 and naive/timezone-less). item_flights retained as the booking-level extension row,
-   shrunk to (item_id, booking_reference). airline/flight_number/airports/datetimes move to
-   the leg (interline itineraries genuinely change carrier between legs).
- - ONE new item_travellers table with a nullable leg_id selecting scope and a nullable
-   companion_id. Row presence = travels this scope; seat NULL = seat unknown. This is the
-   load-bearing choice: two junctions (booking-level + leg-level) would give two homes for one
-   fact and make "on the booking but no row on leg 2" ambiguous. For flights the booking
-   roster is DERIVED, never stored.
- - companion_id NULLABLE, NULL = the owning user. Reason nobody had written down: `companions`
-   is a list of OTHER people; the user is not in it, and today's single seat column IS the
-   user's own seat implicitly. A NOT NULL companion_id would have made the fix a regression.
-   Rejected auto-creating a "Me" companion (pollutes an AD-08 user-managed list, collides with
-   uniq_companions_user_name, self-row becomes soft-deletable).
- - Four partial unique indexes — SQLite treats NULLs as distinct so a plain composite unique
-   accepts the same traveller twice. The two-index alternative (0 as a self sentinel) was
-   rejected because 0 cannot carry an FK to companions.id. Integrity > index count.
- - NO leg status. Status stays item-level (IT-03/FL-03). Per-leg status has no correct
-   aggregate and every consumer reads one status.
- - Cost is booking-level whenever introduced, never per-leg. Not added — no BRD requirement
-   for item cost exists anywhere.
- - Migration in TWO files (additive create+backfill, then destructive shrink) — file 1 reads
-   columns file 2 destroys and Drizzle cannot know the ordering.
- - AD-08 guard: item_travellers.companion_id is a SECOND write path to companions.id.
-   companionRepository.validateOwnership mandatory; 400 not 404; repository signature takes
-   userId FIRST so the junction cannot be written without it (structural, not a reminder).
+PROBLEM: BRD §5.5 IT-10 — each item can optionally store a Google Maps URL; when present
+the trip detail view shows a one-click map/directions link, and no separate address/phone
+fields are required when a URL is set. Small schema addition (one nullable column) but the
+schema-change rule requires Architect review before any Database brief — this ADL is that
+gate. The brief called out validation/sanitisation of the user-supplied URL as the main
+reason it exists (it renders as a clickable href).
 
-REJECTED: booking_group_id on separate items (N statuses per booking); leg2_*/leg3_* columns
-(hard cap, unindexable); JSON legs array (ADL-11 rejected JSON precisely because SQLite cannot
-index JSON paths and leg dates are queried); a generalised item_segments table spanning
-flights/hotels/car rentals — most elegant, wrong on cost: it requires migrating three extension
-tables and rewriting every route/helper/test/component to buy a second segment for types that
-will never have one.
+DECISION (10 rulings, full text in jobs/architect/tech/20260307-architecture-decisions-log.md
+ADL-45 entry — rewritten in place, no standalone file needed for a decision this size):
+ - `map_url text`, nullable, no default, on the BASE `items` table (schema.ts:453-503) —
+   same placement as `notes`, not on any item_* extension table. Applies to every item_type
+   including `note`; no per-type special-casing needed or added.
+ - Not named `google_maps_url` — deliberately provider-agnostic. https:// scheme required,
+   but NO Google-host allowlist: real Google Maps share links come from several domains
+   (google.com/maps, maps.google.com, goo.gl/maps, maps.app.goo.gl, g.page) and a host
+   allowlist is a maintenance liability that would silently break the feature the day
+   Google issues from an unlisted domain. Scheme allowlisting is the correct control for
+   the actual threat (javascript:/data: injection); host is not.
+ - Server (Zod, new `zMapUrl` in validation/common.ts) is authoritative. Client re-validates
+   at render via the EXISTING `src/frontend/utils/urlSanitiser.ts` `sanitiseUrl()` —
+   extended to take an optional allowed-scheme list rather than forked into a second
+   function. Call it with `['https:']` (narrower than its current default `['https:',
+   'file:']` — file:// dropped, it doesn't make sense for a directions link).
+ - `target="_blank" rel="noopener noreferrer"` mandatory on the rendered anchor
+   (reverse-tabnabbing control) — stated explicitly because there is no existing
+   anchor-rendering precedent in this app to copy: `sanitiseUrl()` exists and is tested but
+   has ZERO call sites in any component today. IT-10 is the first real caller.
+ - No DB CHECK for scheme or length. Length capped at 2048 via Zod `.max()` only, matching
+   the `zName` precedent (75-char cap, no matching `LENGTH()` CHECK anywhere in schema.ts —
+   verified by grep). A CHECK would also force SQLite table recreation for this column,
+   which a plain `ALTER TABLE items ADD COLUMN` avoids.
+ - One additive migration file (db:generate + db:migrate). No two-file split needed (unlike
+   ADL-42) — nullable column, no default, no CHECK, nothing to backfill.
+ - No conflict with §5.6 structured fields (HT-01 address etc.) — IT-10's "no separate
+   fields required" is about optionality, not field removal; nothing there to reconcile.
 
-SUPERSESSION: no ADL entry superseded. ADL-11 preserved and extended; ADL-28 reinforced. The
-one supersession is BRD FL-01 — deliberately NOT stamped by me, it belongs in the COO's
-BRD-bump PR alongside the new IDs and the header/§13 bump.
+FINDING, flagged not fixed (real security gap, pre-existing, NOT introduced by this ADL):
+`trips.photo_album_ref` — the field SEC-12 (security-spec.md:330-331) was originally written
+for — has NO server-side scheme validation today (CreateTripSchema/UpdateTripSchema both
+type it as plain `zOptionalString`, trips.schemas.ts:22,37). The only control that exists is
+the frontend `sanitiseUrl()`, which nothing calls. So a `javascript:` value could be written
+via the API today and would pass through harmlessly only because nothing renders it as a
+link yet. Recommended as a small COO follow-up tracker item — NOT bundled into BRD-IT10,
+and not blocking it.
 
 ================================================================================
 OPEN / HANDOFF
 ================================================================================
-
-  1. COO BRD GATE BLOCKS ALL DISPATCH (CLAUDE.md rule). Four items: rewrite + stamp FL-01
-     ("each flight is logged as an individual leg" is exactly the model ADL-42 replaces);
-     amend FL-02 (seat moves off the flight field list); new requirement ID + success criteria
-     for BUG-41; new requirement ID + success criteria for BUG-42 covering the "traveller on
-     some legs but not others" case. Both tracker entries have brdRefs: [] today.
-  2. COO: merge PR for feat/adl42-booking-item-shape after CI green — do not self-merge.
-  3. Brief sequencing once the BRD gate clears: (a) Database brief — schema + the two migration
-     files, additive, safe to merge alone; (b) ONE combined Backend+Frontend brief on a single
-     branch, because there is no compatibility shim and the flat flight keys disappear from the
-     API. One branch per brief still holds — this is one brief spanning two layers.
-  4. BUG-45 / ADL-43 cross-dependency: airline moves to item_flight_legs.airline. If S3's brief
-     is written against item_flights.airline it will need reworking.
-  5. Frontend constraint to carry into that brief: leg datetimes are naive/timezone-less, so
-     layover and total-journey durations across legs are WRONG whenever a connection crosses a
-     timezone — the norm for the itinerary that motivated BUG-41. Do not display connection
-     durations until timezone data exists (depends on airport reference data, ADL-43).
-  6. Drift found, flagged not fixed: BRD IT-03 (v3.0) lists Shortlisted as an item status but
-     chk_items_status (src/backend/db/schema.ts:499) permits only consider/confirmed/completed/
-     cancelled/next_time and the string 'shortlisted' appears nowhere in src/. Added to the BRD
-     and never implemented; home is the deprioritized planning-core entry. ADL-42 does not
-     rebuild the items table so it neither depends on nor resolves this.
-  7. Stale doc flagged, not actioned: jobs/database/tech/schema.ts is an unmaintained COPY of
-     src/backend/db/schema.ts and repeats the superseded FL-01 claim at line 507. Needs
-     refreshing or a HISTORICAL banner. jobs/architect/tech/20260307-ER-schema.md:303 repeats
-     it too but already carries a HISTORICAL banner — no further stamp needed.
-  8. patches/drizzle-kit+0.31.9.patch Bug 4 (partial-index WHERE reading) is LOAD-BEARING for
-     the four partial unique indexes. If drizzle-kit is ever upgraded, re-verify before this
-     lands or migrations will churn.
-  9. Carried over, unrelated to this thread:
-     - Clerk preview-origin question (ADL-32 §6) + §10 success criteria pending a real deploy.
-     - D-05 Clerk staging/prod user-pool split (jobs/COO/open-dialogues.md).
-     - OQ-03 (shell trip approximate dates). OQ-05 is ADL-41's (S1), not mine.
+  1. COO: this ADL does NOT require a BRD edit — IT-10 already has success criteria stated
+     in BRD §5.5 and this decision doesn't change them. tracker.json BRD-IT10 updated in
+     place (status stays "pending", notes now say "DESIGNED 2026-07-27" — same convention
+     ADL-42 used for BUG-41/BUG-42).
+  2. COO: merge PR for chore/adl45-item-maps-url after CI green — do not self-merge.
+  3. Once merged, unblocks: Database brief (schema.ts + one migration file — safe to merge
+     alone, nothing depends on the column existing yet) and the Frontend/Backend brief that
+     consumes it (map_url in items.schemas.ts + ItemForm.tsx + ItemCard.tsx +
+     urlSanitiser.ts extension). Also unblocks BRD-MB0102 (§5.15 MB-02 directions link),
+     which was blocked on this column existing.
+  4. Optional follow-up for COO to raise as its own tracker item (not gating IT-10): add
+     server-side scheme validation to `photo_album_ref` and give `sanitiseUrl()` its first
+     real call site — see FINDING above.
+  5. Nothing in this ADL touches ADL-41/ADL-43/ADL-44 stubs or ADL-42's completed entry —
+     verified untouched after edit (grep confirms all five headers intact and distinct).

--- a/jobs/architect/park-docs/20260727-ARCHITECT-park-adl45.txt
+++ b/jobs/architect/park-docs/20260727-ARCHITECT-park-adl45.txt
@@ -1,0 +1,110 @@
+ARCHITECT PARK DOCUMENT — 2026-07-27
+THREAD: Wave 0 scoping brief S6 — ADL-45, item map URL column (BRD-IT10)
+ISSUE: #276   BRANCH: chore/adl45-item-maps-url
+DELIVERABLE TYPE: spec only — no schema, migration or code change
+
+================================================================================
+WHAT WAS ASKED
+================================================================================
+BRD §5.5 IT-10: each item can optionally store a Google Maps URL; when present the trip
+detail view shows a one-click map/directions link, no separate address/phone fields needed.
+Small change (nullable URL column) but the schema-change rule requires Architect review
+before any Database brief — rule on column placement/name/type/nullability/length cap,
+migration approach, and (the main reason the brief exists) validation and sanitisation of
+the user-supplied URL: scheme allowlisting, host restriction or not, where validation runs,
+rel/target attributes on the rendered anchor. Also: check for overlap/conflict with the
+§5.6 structured confirmation fields, and consistency with ADL-42's item-shape direction
+(read first — it reshapes item_flights/adds item_flight_legs/item_travellers, all merged).
+
+================================================================================
+WHAT I FOUND BEFORE DECIDING
+================================================================================
+1. ADL-42 (merged, read in full) makes NO change to the base `items` table or to
+   item_hotels/item_restaurants/item_car_rentals/item_experiences — only item_flights
+   shrinks and two new tables appear. So there's no fresh churn to avoid on the base table,
+   and `notes` (schema.ts:464) is a clean precedent for "field IT-04/IT-10 requires on all
+   item types lives on `items`, not duplicated into five extension tables."
+2. `_project/security-spec.md` SEC-12 already has a rule for exactly this class of field:
+   "URL fields (e.g. photo_album_ref) rendered as links must be sanitised... only https://
+   and file:// permitted... reject javascript:/data:." This isn't aspirational text — a
+   real, tested implementation exists: `src/frontend/utils/urlSanitiser.ts`'s
+   `sanitiseUrl()`, with a full test suite at `__tests__/urlSanitiser.test.ts`.
+3. THE FINDING: `sanitiseUrl()` has ZERO call sites in any component.
+   `grep -rln "sanitiseUrl" src/frontend` returns only the utility file and its own test.
+   Nothing renders `trips.photo_album_ref` as a link anywhere today. Worse — the server side
+   doesn't validate it either: `CreateTripSchema`/`UpdateTripSchema`
+   (trips.schemas.ts:22,37) type `photo_album_ref` as plain `zOptionalString`, no scheme
+   check. So the one existing precedent field is unprotected end-to-end; it's silently safe
+   only because nothing currently renders it. Flagged to COO as a follow-up, not fixed here
+   (out of scope for IT-10, and not gating it).
+4. No LENGTH() CHECK anywhere in schema.ts (`grep -n "LENGTH(" src/backend/db/schema.ts`
+   empty) — confirms length caps in this codebase are Zod-only (`zName`, 75 chars, no DB
+   CHECK), which is the precedent I followed for map_url's 2048-char cap.
+5. BRD §12 (line 435) already has a "Restaurant note: Link to Google Maps location —
+   https://maps.google.com/..." example — evidence this is a real, previously-worked-around
+   need (users were pasting map links into the free-text notes field before IT-10 existed).
+6. §5.6 checked for phone/address overlap: no item type has a phone field anywhere in the
+   BRD. HT-01 has `address`; IT-10's "no separate fields required" text is about optionality
+   (you don't need both), not about removing HT-01's address field. No conflict, no §5.6
+   edit needed.
+
+================================================================================
+DECISION
+================================================================================
+10 rulings, full text + code snippets in jobs/architect/tech/20260307-architecture-decisions-log.md
+(ADL-45 entry, rewritten in place from the RESERVED stub):
+ - `map_url text`, nullable, no default, on the base `items` table. All item types get it,
+   including `note` — no per-type special-casing.
+ - NOT named `google_maps_url` — https:// scheme required, but deliberately NO Google-host
+   allowlist (real share links come from several Google domains; a host allowlist would be
+   a maintenance liability with no real security benefit — scheme allowlisting is the actual
+   control against the injection threat, host is not).
+ - Server-side Zod (`zMapUrl`, new primitive in common.ts, same style as zName/zHexColor) is
+   authoritative. Frontend re-validates at render via `sanitiseUrl()` — EXTENDED to accept
+   an optional allowed-scheme list, not forked into a second function. Called with
+   `['https:']` for map_url (narrower than its current default, which also allows file://).
+ - `target="_blank" rel="noopener noreferrer"` mandatory on the rendered anchor — stated
+   explicitly since there's no existing anchor-rendering code in this app to copy (finding
+   #3 above — this is literally the first real caller of the sanitiser).
+ - No DB CHECK for scheme or length (Zod-only, matches zName precedent; also avoids forcing
+   a SQLite table-recreation migration for a column that doesn't otherwise need one).
+ - One additive migration file, db:generate + db:migrate. No two-file split needed (unlike
+   ADL-42) — nullable, no default, no CHECK, nothing to backfill.
+ - No conflict with §5.6 (finding #6). No BRD edit needed anywhere — IT-10's success
+   criteria are unchanged by this decision.
+
+REJECTED: `google_maps_url` naming (misleading given no host restriction); Google-domain
+allowlist (brittle, wrong threat model); a second, independently-written sanitiser function
+(same "two homes for one fact" trap ADL-42 called out at larger scale); a DB CHECK for
+scheme/length (inconsistent with the zName precedent, forces unnecessary table recreation).
+
+SUPERSESSION: none. Extends SEC-12's scope (one URL field covered → two) without changing
+its rule.
+
+================================================================================
+OPEN / HANDOFF
+================================================================================
+  1. COO: no BRD gate action needed for this one — IT-10 already has success criteria and
+     an existing tracker entry (BRD-IT10), which I updated in place (status stays "pending",
+     notes now record "DESIGNED 2026-07-27" per the same convention ADL-42 used for
+     BUG-41/BUG-42 — see tracker.json).
+  2. COO: merge PR for chore/adl45-item-maps-url after CI green — do not self-merge.
+  3. Unblocks: Database brief (schema.ts + one migration file), then Backend (zMapUrl +
+     itemBase wiring) + Frontend (ItemForm input, ItemCard affordance, urlSanitiser.ts
+     extension) — no ordering constraint like ADL-42's "must land together" (this field has
+     no compatibility-breaking shape change, it's purely additive). Also unblocks
+     BRD-MB0102 (§5.15 MB-02 directions link), which was blocked on this column existing.
+  4. Recommend COO raise a small separate follow-up tracker item (not gating IT-10): give
+     `photo_album_ref` the same server-side scheme validation and an actual `sanitiseUrl()`
+     call site — see finding #3. Not bundled into this brief; flagged loudly per the
+     Architect's "unreviewed gap" mandate, not silently left for someone to rediscover.
+  5. Verified before closing: ADL-41/ADL-43/ADL-44 stubs and the completed ADL-42 entry are
+     byte-for-byte untouched (grep of all `## ADL-4` headers confirms five distinct, intact
+     entries in the log). Only the ADL-45 stub was rewritten.
+  6. Every file path and line number cited in the ADL entry was verified against the actual
+     file contents before writing (schema.ts:453-503/464, common.ts:12-16, items.schemas.ts:10-17,
+     trips.schemas.ts:22/37, urlSanitiser.ts:9, ItemCard.tsx:132, api.ts:114, BRD:180,
+     security-spec.md:330-331) — none are guessed.
+
+No blockers. No open questions left for the implementing Database brief to resolve — the
+column shape, name, validation model and migration approach are all fully specified.

--- a/jobs/architect/tech/20260307-architecture-decisions-log.md
+++ b/jobs/architect/tech/20260307-architecture-decisions-log.md
@@ -2871,12 +2871,265 @@ splitting, or lazy per-country fetch) that lets the threshold drop without regre
 performance. Note the stale-doc drift for whichever PR touches it: `MapView.tsx:6` documents
 `zoom >= 4` while the constant is `3`.
 
-## ADL-45 — RESERVED (S6: item Google Maps URL column / BRD-IT10)
+## ADL-45 — Item map URL: base-table column, https-only + no host allowlist, reuse (don't fork) the existing sanitiser
 
-**Date:** reserved 2026-07-27
-**Status:** RESERVED — Wave 0 brief S6 not yet dispatched. No decision recorded.
-**Scope:** IT-10 adds a nullable Google Maps URL column on items. Small, but the
-schema-change rule requires Architect review before any Database brief. Rule on column
-placement, nullability, validation/sanitisation of a user-supplied URL (it is rendered as a
-clickable link — this is the security-relevant part), and migration. Unblocks BRD-IT10
-implementation in B6 and BRD-MB0102, which consumes the directions link.
+**Date:** 2026-07-27
+**Status:** Decided, implementation pending.
+**Trigger:** GitHub issue #276 (Wave 0 scoping brief S6). BRD §5.5 IT-10 (added v3.1,
+2026-07-20 UAT) — each item can optionally store a Google Maps URL; when present it
+surfaces a one-click map/directions link and no separate address/phone fields are required.
+**BRD refs:** §5.5 IT-10 (success criteria already stated — unchanged by this decision).
+Unblocks BRD-IT10 (tracker) and feeds BRD-MB0102 (§5.15 MB-02, directions link on phone).
+**Depends on:** ADL-11 (base + extension table split), ADL-15 (migrate-only workflow),
+security-spec.md SEC-12 (output encoding / URL sanitisation, Phase 1).
+**Supersedes:** nothing. Extends SEC-12's scope from one field (`trips.photo_album_ref`) to
+two; does not change SEC-12's rule.
+
+---
+
+### Summary table
+
+| # | Decision | Recommendation | Confidence |
+|---|----------|-----------------|------------|
+| D1 | Column placement | New nullable `map_url` on the **base** `items` table, not on any `item_*` extension table. | High |
+| D2 | Column name/type | `map_url text`, nullable, no default. Not `google_maps_url` — see D4 on why. | High |
+| D3 | Length cap | Zod `.max(2048)` at the validation layer only. No DB `CHECK(LENGTH(...))` — matches the existing `zName` precedent (75-char cap, zod-only, no DB check). | High |
+| D4 | Host restriction | **No** Google-host allowlist. Accept any well-formed `https://` URL. | High |
+| D5 | Scheme allowlist | `https://` only — narrower than the existing `sanitiseUrl()` (`https:`/`file:`). `file://` is dropped for this field. | High |
+| D6 | Where validation runs | Both. Server (Zod, new `zMapUrl` in `common.ts`) is authoritative and rejects on write (400). Client re-validates at render via `sanitiseUrl()` before using the value as an `href` — never trust a stored value just because it once passed the server check. | High |
+| D7 | Sanitiser implementation | **Extend** `src/frontend/utils/urlSanitiser.ts`'s `sanitiseUrl()` to take an optional allowed-scheme list (default preserves current `https:`/`file:` behaviour for `photo_album_ref`); call it with `['https:']` for `map_url`. Do not write a second sanitiser. | High |
+| D8 | Rendered anchor attributes | `target="_blank" rel="noopener noreferrer"`. Mandatory, not optional. | High |
+| D9 | Migration | One additive file, `db:generate` + `db:migrate`. Plain `ALTER TABLE items ADD COLUMN map_url text` — no table recreation, no backfill, no two-file split (unlike ADL-42). | High |
+| D10 | Overlap with §5.6 structured fields | None. `map_url` is additive; existing fields (`item_hotels.address` etc.) are untouched and can coexist with a populated `map_url`. | High |
+
+---
+
+### D1 — column placement: base `items` table
+
+**Recommendation:** `map_url` belongs on `items`, alongside `notes`, not on any of the five
+`item_*` extension tables (`src/backend/db/schema.ts:453-503`).
+
+- IT-10's own text is type-agnostic ("each item can optionally store…"); the brief's
+  framing confirms it — this applies to restaurants, hotels and experiences, not only
+  flights. A base-table column is the only placement that covers all six `item_type`
+  values without a per-type migration times five.
+- `notes` (`schema.ts:464`) is the direct precedent: a field IT-04 requires on *all* item
+  types lives on `items`, not duplicated into every extension table. `map_url` is the same
+  shape of requirement.
+- Every `item_type` value, including `note`, gets the column. No per-type conditional is
+  needed anywhere in the schema or in Zod — `notes`-type items simply leave it unset. This
+  is a deliberate non-decision: special-casing `note` out would need a CHECK SQLite cannot
+  express against another table's data (`items.item_type`), the same class of constraint
+  ADL-42 D13 already declined to add for `item_travellers`.
+- Rejected: adding `map_url` independently to `item_hotels`, `item_restaurants`,
+  `item_car_rentals`, `item_experiences` and (for symmetry) `item_flights`. Five migrations
+  instead of one, and a base-table field would still be needed for `note`/uncovered future
+  types — no actual benefit for the extra tables touched.
+
+### D2/D3 — name, type, length
+
+**Recommendation:** `map_url text`, nullable, no DB default. Length capped at 2048 chars,
+enforced only in the Zod schema (`common.ts`), not via a DB `CHECK`.
+
+- `google_maps_url` was considered and rejected — see D4, the column deliberately does not
+  enforce a Google-only constraint, so a name promising one would mislead the next reader.
+- 2048 is the conventional practical URL length ceiling (the historical IE limit, still
+  the norm most apps borrow) — generous for any real Google Maps share link (which run to a
+  few hundred characters) while bounding storage and JSON payload size.
+- No DB `CHECK` for length: `zName` (`common.ts:12-16`) caps trip/item names at 75 chars
+  and there is no matching `CHECK(LENGTH(name) <= 75)` anywhere in `schema.ts` — confirmed,
+  `grep -n "LENGTH(" src/backend/db/schema.ts` returns nothing. This project's existing
+  split is: relational/enum invariants (`chk_items_item_type`, `chk_items_status`,
+  `chk_items_is_carried_forward`) get a DB `CHECK`; field-level formatting and length
+  constraints are Zod-only. A URL length cap is the latter kind. Following the split also
+  avoids forcing SQLite table recreation for a `CHECK`-constrained column add (see D9).
+
+### D4/D5 — validation: scheme allowlist, no host allowlist
+
+This is the security-relevant decision the brief exists for.
+
+**D5 — scheme: `https://` only, narrower than the existing sanitiser.**
+`src/frontend/utils/urlSanitiser.ts` already implements exactly this class of control for
+`trips.photo_album_ref`, per SEC-12 (`_project/security-spec.md:330-331`: "only `https://`
+and `file://` schemes are permitted... Reject `javascript:` and `data:` schemes"). Reuse it
+(D7) rather than invent a second control — but narrow the allowed set for this field:
+`file://` is dropped. A local file path is a legitimate way to reference a photo album on
+the same machine; it is never a legitimate value for a "get directions" link a user taps
+from their phone (BRD MB-02). Widening the accepted scheme set beyond what the field can
+legitimately use only grows the injection surface for no product benefit.
+
+**D4 — no Google-host allowlist. Accept any well-formed `https://` URL.**
+
+- Real Google Maps links are not one host. `google.com/maps`, `maps.google.com`,
+  `goo.gl/maps`, `maps.app.goo.gl` and `g.page` have all been live Google-issued share-link
+  domains at different times (the BRD's own §12 example note uses `maps.google.com`). A
+  host allowlist is a maintenance liability that silently breaks the feature the day Google
+  issues a link from a domain not on the list — a false rejection is a worse failure mode
+  for this field than accepting a non-Google link, because it makes IT-10 *appear* broken.
+- The security control this field needs is scheme allowlisting, not host allowlisting.
+  Rendering `<a href>` to an attacker-controlled `https://` host is not an XSS vector — the
+  browser navigates the tab (or a new one, per D8), it does not execute injected script or
+  read local files. `javascript:`/`data:`/`vbscript:` are the vectors SEC-12 exists to
+  block, and scheme allowlisting blocks all of them regardless of host.
+- IT-10's text names "a Google Maps URL" as the illustrative, expected case, not an
+  exclusivity requirement — nothing in the requirement or its success criteria says a
+  non-Google link must be rejected. Staying host-agnostic also leaves room for an Apple
+  Maps or other provider link without a future schema/validation change, which is exactly
+  the kind of foreclosure this project's future-proofing principle exists to avoid.
+- Rejected alternative: allowlist `google.com`, `maps.google.com`, `goo.gl`,
+  `maps.app.goo.gl`, `g.page` (suffix-matched). Considered and set aside — it adds ongoing
+  maintenance risk (new Google short-domains have appeared before) for a control that does
+  not address the actual threat model (scheme, not host) and BRD IT-10 does not ask for it.
+
+### D6/D7 — where validation runs, and reusing the existing control
+
+**Server-side (authoritative):** add `zMapUrl` to `src/backend/validation/common.ts`,
+alongside `zName`/`zHexColor`/`zCountryCode`:
+
+```typescript
+export const zMapUrl = z
+  .string()
+  .trim()
+  .url()
+  .max(2048, 'Map URL must be 2048 characters or fewer')
+  .refine((u) => u.startsWith('https://'), {
+    message: 'Map URL must use https://',
+  })
+  .optional();
+```
+
+Wire it into `CreateItemSchema` and `UpdateItemSchema`
+(`src/backend/validation/items.schemas.ts:10-17`, `itemBase`) as `map_url: zMapUrl` —
+base-table field, so it belongs in `itemBase`, not `extensionFields`.
+
+**Finding, flagged not fixed:** `trips.photo_album_ref` — the field SEC-12 was written for
+— has **no** server-side scheme validation today. `CreateTripSchema`/`UpdateTripSchema`
+(`src/backend/validation/trips.schemas.ts:22,37`) both type it as plain `zOptionalString`.
+The only enforcement point that exists is the frontend `sanitiseUrl()`, and (next finding)
+that function is not currently called from any component —
+`grep -rln "sanitiseUrl" src/frontend` returns only the utility file and its own test file.
+So `photo_album_ref` can be written today with a `javascript:` value and the server accepts
+it; it happens to be harmless only because nothing renders it as a link yet. This is a
+pre-existing gap this ADL does not fix (`photo_album_ref` is out of scope for IT-10), but it
+should not be repeated for `map_url` — `zMapUrl` above is the authoritative check this field
+gets that its predecessor didn't. Recommend a small follow-up tracker item: add the same
+scheme check to `photo_album_ref`'s schema and wire `sanitiseUrl()` into wherever it is
+(or will be) rendered.
+
+**Client-side (defense in depth, not authoritative):** extend `sanitiseUrl()`:
+
+```typescript
+export function sanitiseUrl(
+  url: string | null | undefined,
+  allowedSchemes: string[] = ['https:', 'file:'],
+): string | null {
+  if (!url) return null;
+  try {
+    const scheme = new URL(url).protocol; // throws on unparseable input
+    return allowedSchemes.includes(scheme) ? url : null;
+  } catch {
+    return null;
+  }
+}
+```
+
+(Switching from `startsWith` string checks to `new URL(url).protocol` is optional hardening
+noted here for completeness, not mandatory — `startsWith('https://')` remains correct for
+this use since scheme confusion tricks like `https:/\evil` are a redirect/parsing concern,
+not a script-execution one. Either implementation satisfies this ADL; do not block the
+brief on this detail.) Call it as `sanitiseUrl(item.map_url, ['https:'])` wherever the item
+card renders the map affordance (`src/frontend/components/TripDetail/ItemCard.tsx`, near the
+existing `item.notes` rendering at line 132). Update the file's header comment — it
+currently says "The only Phase 1 user-supplied URL field is trip.photo_album_ref"
+(`urlSanitiser.ts:9`), which becomes false the moment this lands.
+
+**Why one function, not two:** ADL-42 (D4-D6) rejected a two-junction traveller model
+specifically because two homes for one fact make later disagreement possible and silent.
+The same argument applies here at smaller scale — a second, independently-written
+`sanitiseMapUrl()` is one more place the scheme allowlist can drift out of sync with SEC-12
+the next time either field's rule changes. One function, parameterised, is not just less
+code; it is the only version of this control that structurally cannot disagree with itself.
+
+### D8 — rendered anchor attributes
+
+**Recommendation:** every rendered map-link anchor carries `target="_blank"
+rel="noopener noreferrer"`. Not optional.
+
+- `target="_blank"` without `rel="noopener"` lets the opened page reach back into
+  `window.opener` and repoint the original tab (reverse tabnabbing) — a standard,
+  well-documented control for exactly this pattern (user-supplied external link, opened in
+  a new tab). `noreferrer` additionally suppresses the `Referer` header, which is a
+  reasonable default when the destination host is unvalidated (D4).
+- There is no existing anchor-rendering code in this app to pattern-match against —
+  `sanitiseUrl()` is written and tested but never called from a component (D6 finding), so
+  IT-10 is the first place this pattern is actually established, not just specified. Being
+  explicit here is why this ADL states it rather than leaving it to be re-derived.
+
+### D9 — migration
+
+**Recommendation:** one migration file via `npm run db:generate` + `npm run db:migrate`.
+`db:push` remains forbidden (ADL-15).
+
+Because `map_url` is nullable with no default and adds no new `CHECK` constraint, SQLite's
+native `ALTER TABLE items ADD COLUMN map_url text` applies directly — no table recreation is
+needed (recreation is only required when a new `CHECK`/`NOT NULL` needs backfill, or an
+existing constraint must be redefined). This is a second, independent reason (besides the
+D3 reasoning) to skip a DB-level scheme or length `CHECK` on this column: adding one would
+force the same expensive recreate-and-copy migration path, touching the same
+`patches/drizzle-kit+0.31.9.patch`-dependent CHECK-regex machinery ADL-15 documents as
+previously buggy, for a control that is already authoritatively enforced at the Zod layer
+(D6). Unlike ADL-42, this does not need a two-file split — there is no data to backfill and
+nothing later in the same change destroys columns the first step reads.
+
+### D10 — relationship to §5.6 structured confirmation fields
+
+**Recommendation:** no conflict, no schema change to any `item_*` extension table.
+
+IT-10's "no separate address or phone fields are required when a URL is set" describes
+*optionality*, not field removal: a hotel item can still populate `item_hotels.address`
+(HT-01, `travel-tracker-BRD.md:180`) independently of `map_url`, and neither field implies
+or requires the other. No BRD field is a phone number anywhere in §5.6 today (restaurants,
+hotels, car rentals, experiences — none list one), so there is nothing to reconcile there
+either; the BRD clause is forward cover for a field that does not yet exist, not a
+description of a current overlap. Nothing in this ADL asks the COO to touch §5.6.
+
+---
+
+### What this ADL does not decide
+
+- **Whether `photo_album_ref` gets the same server-side scheme check.** Flagged in D6 as a
+  pre-existing gap; fixing it is a separate, small follow-up, not bundled into IT-10's
+  brief.
+- **Wiring `sanitiseUrl()` into an actual `photo_album_ref` render.** Same status — flagged,
+  not actioned. Whoever picks up `map_url` will write the first real caller of this
+  function; extending it to `photo_album_ref` at the same time would be a reasonable, small
+  scope increase for that brief to accept, but is not required by this decision.
+- **Any change to `security-spec.md` SEC-12 itself.** The rule text ("URL fields (e.g.
+  `photo_album_ref`)...") already reads as illustrative, not exhaustive, so `map_url` fits
+  under it without an edit. The implementing brief should still add `map_url` as a second
+  named example there, for the next reader — noted as a nice-to-have, not gating.
+
+---
+
+**Implementation implications:**
+- `src/backend/db/schema.ts` — add `mapUrl: text('map_url')` to the `items` table
+  definition (`schema.ts:453-503`), nullable, no default, no CHECK.
+- `src/backend/migrations/` — one new file (`db:generate`), e.g.
+  `00NN_adl45_item_map_url.sql`.
+- `src/backend/validation/common.ts` — add `zMapUrl` (D6).
+- `src/backend/validation/items.schemas.ts` — add `map_url: zMapUrl` to `itemBase`
+  (`items.schemas.ts:10-17`).
+- `src/frontend/types/api.ts` — add `map_url: string | null` to `Item`
+  (`api.ts:114`).
+- `src/frontend/utils/urlSanitiser.ts` — extend `sanitiseUrl()` with an optional
+  allowed-scheme parameter (D7); update its stale header comment.
+- `src/frontend/components/TripDetail/ItemCard.tsx` — render the map/directions affordance
+  when `sanitiseUrl(item.map_url, ['https:'])` is non-null; `target="_blank"
+  rel="noopener noreferrer"` (D8). No affordance when null (covers both "not set" and
+  "failed validation" — same rendering for both is correct, a rejected scheme should never
+  surface as a broken or suspicious link).
+- `src/frontend/components/TripDetail/ItemForm.tsx` — add the optional URL input field.
+- `_project/security-spec.md` SEC-12 — optional, non-blocking addition of `map_url` as a
+  second named example (see "What this ADL does not decide").
+
+**Supersession:** none.


### PR DESCRIPTION
Closes #276
BRD §5.5 IT-10

## Summary
- Decides the schema-change gate for BRD-IT10 (optional Google Maps URL per item, one-click directions link).
- `map_url` TEXT column on the base `items` table (not per extension table) — applies to all item types, same placement as `notes`.
- https-only scheme allowlist, deliberately **no** Google-host restriction — scheme is the real injection control, host allowlisting is brittle and Google issues share links from several domains.
- Server-side Zod (`zMapUrl`) is authoritative; frontend re-validates at render by **extending** the existing (but currently uncalled) `sanitiseUrl()` utility rather than forking a second sanitiser.
- `target="_blank" rel="noopener noreferrer"` mandatory on the rendered anchor (reverse-tabnabbing control) — stated explicitly since this is the first real caller of the sanitiser.
- Single additive migration (`db:generate` + `db:migrate`), no DB `CHECK` for scheme/length (Zod-only, matches the `zName` precedent; also avoids forcing a SQLite table recreation).
- No conflict with §5.6 structured confirmation fields; no BRD edit needed — IT-10's success criteria already cover this.

Spec only — no schema, migration, or application code changed. Full decision:
`jobs/architect/tech/20260307-architecture-decisions-log.md` (ADL-45 entry, rewritten in place from the RESERVED stub).

## Finding flagged, not fixed
`sanitiseUrl()` (`src/frontend/utils/urlSanitiser.ts`) has zero call sites in any component today, and its one existing target field (`trips.photo_album_ref`) has no server-side scheme validation either. Not in scope for IT-10 — recommended as a separate COO follow-up tracker item.

## Test plan
- [x] `npm run check` (Biome) — clean
- [x] `npm run type:check:all` — clean
- [x] `npm run test:backend` — 580 passed / 1 skipped
- [x] `npm run test:frontend` — 154 passed
- [x] `npm run status:check` — STATUS.md in sync
- [x] All file paths/line numbers cited in the ADL entry verified against actual file contents