### PR TITLE
docs(ADL-44): region-shading geometry payload — per-country split, not a lower threshold (#275)

### DIFF
--- a/_project/tracker.json
+++ b/_project/tracker.json
@@ -1927,7 +1927,7 @@
       "priority": "P2",
       "brdRefs": [],
       "phase": 6,
-      "notes": "Found 2026-07-21 UAT, logged only — not yet briefed. Example: US requires zooming in until the whole country fills the screen before state shading appears at all, and rendering latency means the practical zoom needed is even further in than that. State shading should trigger at a meaningfully lower zoom level."
+      "notes": "Found 2026-07-21 UAT. DESIGNED 2026-07-27 — Architect ADL-44 (issue #275, Wave 0 brief S5, jobs/architect/tech/ADL-44-region-shading-payload.md) diagnosed this as a payload-size bug, not a threshold bug. geo/regions.json is a real, verified 40.7MB unscoped world file with no compression/caching, refetched in full on every zoom-threshold crossing; lowering REGION_ZOOM_THRESHOLD would make the latency worse, not better. ADL-44 decides: split into per-country static files (geo/regions/{ISO_A2}.json, still fully bundled per GE-10), strip unused Natural Earth properties (121→2 per feature), simplify large-country geometry, add compression + cache headers to the /geo static mount. No schema/DB change; shading.service.ts untouched (ADL-41 DISTINCT invariant preserved by construction). Status 'designed', implementation pending — ready for a Frontend brief. No new BRD requirement ID needed."
     },
     {
       "id": "BUG-49",

--- a/jobs/COO/inbox/20260727_0645-ARCHITECT-adl44-region-shading-payload.txt
+++ b/jobs/COO/inbox/20260727_0645-ARCHITECT-adl44-region-shading-payload.txt
@@ -1,0 +1,60 @@
+ADL-44 · BUG-48 · GitHub issue/PR #275 / PR #282 · BRD refs: GE-10, MP-01, MP-02 (no new ID)
+Branch: chore/adl44-region-shading-payload
+
+WHAT WAS DECIDED
+BUG-48 read as "lower REGION_ZOOM_THRESHOLD" and is not. Verified the reported payload
+myself first, per the brief: geo/regions.json is a real 40,726,851 bytes (38.8 MiB), served
+uncompressed/uncached, as ONE unscoped world file for all 241 countries, refetched in full
+on every zoom-threshold crossing (the shading-state fetch was already per-country; the
+geometry fetch never was). Lowering the threshold would have made it worse, not better.
+Decision: split into geo/regions/{ISO_A2}.json (one file per country, still fully bundled —
+satisfies GE-10), strip 119 of 121 unused Natural Earth properties, topology-preserving
+simplification for the largest countries, add compression + cache headers to the /geo
+static mount. No server/DB compute. Measured evidence: per-country median 92KB, worst case
+Russia 3.26MB, the bug's own US example 1.39MB (30x-400x smaller than the world file).
+Full design: jobs/architect/tech/ADL-44-region-shading-payload.md
+
+PER-DECISION VERDICT
+- Per-country static split (primary fix): adopted, High confidence
+- Property whitelist (iso_3166_2 + name only): adopted, High confidence
+- Topology-preserving simplification for RU/CA/US/GB/ID/PH: adopted, Medium confidence
+  (exact tolerance left to implementation QA)
+- compression + Cache-Control on /geo: adopted, High confidence
+- Vector tiles (MVT): rejected — either violates GE-10 (hosted tiles) or trades a 40MB
+  problem for a ~100MB self-hosted pmtiles basemap (blueprint's own prior estimate)
+- Shade only visited countries: rejected — breaks browsing an unvisited country's map,
+  turns static reference data into per-user filtered data
+- REGION_ZOOM_THRESHOLD value itself: left at 3, not decided here — deferred to a follow-up
+  PO/UAT call once the payload fix removes the perceptual confound
+
+DOCUMENT LIFECYCLE
+- 20260307-tech-blueprint.md §2.3 stamped SUPERSEDED (2026-07-27) by ADL-44 — its own ~4MB
+  estimate was ~10x under the shipped 40.7MB file, and its "load once, cache in memory"
+  delivery model no longer matches either the pre-existing lazy-fetch design or this change.
+- 20260307-map-shading-spec.md checked in full (404 lines) — specifies only shading-STATE
+  SQL, never geometry delivery. No stamp applied; confirmed unaffected.
+- tracker.json BUG-48: notes rewritten with diagnosis + #275 + ADL-44 pointer, status left
+  "pending" (matched ADL-42's precedent rather than inventing a new status value — see park
+  doc for the self-correction). Owner left "frontend" — no BRD gate blocks this.
+
+BRD
+No new requirement ID needed — this is a performance defect against existing GE-10/MP-01/
+MP-02, not new functional scope. Reporting per "report, don't add"; COO's call whether a
+project-wide non-functional payload/latency budget requirement is worth adding separately.
+
+CI: gh pr checks 282 — all 9 checks green (Biome, Type Check, Backend Tests 580/580+1
+skipped, Frontend Tests 154/154, Contract Tests, E2E Tests, Semgrep, Gitleaks, Dependency
+Scan). No src/ files touched — spec-only brief.
+
+OPEN ISSUES / BLOCKERS
+None. Dispatchable to Frontend as-is, no BRD gate. Two things the implementing brief must
+be told explicitly (both in the ADL §6 and park doc): (1) simplification must be
+topology-preserving, not independent per-feature rounding, or adjacent regions can get
+gaps/overlaps at shared borders; (2) verify react-map-gl's <Source> refetches when its
+`data` URL changes country code while RegionLayer stays mounted (panning between two
+zoomed-in countries) — not verified by me, requires running the app, out of spec-only scope.
+Also flagged, not fixed: MapView.tsx:6 comment says "zoom >= 4", the constant at line 28 is
+3 — whoever implements this must correct it in the same PR.
+
+WHAT'S NOW UNBLOCKED
+A Frontend brief for BUG-48/ADL-44 can be dispatched immediately — no BRD bump needed first.

--- a/jobs/architect/context/current.txt
+++ b/jobs/architect/context/current.txt
@@ -1,90 +1,95 @@
 ARCHITECT CONTEXT — 2026-07-27
 PROJECT: Travel Tracker
-CURRENT STATUS: ADL-42 DECIDED, IMPLEMENTATION PENDING — booking item shape (BUG-41 + BUG-42),
-Wave 0 scoping brief S2, GitHub issue #272, branch feat/adl42-booking-item-shape.
-Spec output only — no schema, migration or code change was made.
+CURRENT STATUS: ADL-44 DECIDED, IMPLEMENTATION PENDING — region-shading geometry payload
+(BUG-48), Wave 0 scoping brief S5, GitHub issue #275, branch
+chore/adl44-region-shading-payload. Spec output only — no code, asset, or schema change made.
 
-PROBLEM: BUG-41 (multi-leg flights on one booking) and BUG-42 (multiple companions/seats per
-booking) are ONE defect: the booking item is flat. It models one segment of travel carrying
-one implicit traveller. Seattle→London→Glasgow on a single PNR must today be two unrelated
-flight items (BRD FL-01; echoed at src/backend/db/schema.ts:507), duplicating the booking
-reference and giving one booking two statuses. Separately item_flights.seat is one TEXT column
-and there is NO per-item companion link anywhere in the schema — companions attach to trips
-only via trip_companions_map. Neither is fixable alone: a seat belongs to a person on a leg.
+PROBLEM: BUG-48 read as "lower REGION_ZOOM_THRESHOLD" and was explicitly not that.
+MapView.tsx:28 sets the threshold to 3; region shading's GEOMETRY fetch (RegionLayer.tsx,
+/geo/regions.json) is a separate, unscoped, uncompressed 40.7MB (verified with `ls -la`, not
+assumed) file covering all 241 countries' admin-1 boundaries, refetched in full every time
+the threshold is crossed. Lowering the threshold would fire that fetch sooner and more often
+and make the reported latency worse while looking like a fix in a quick manual test. The
+shading-STATE fetch (GET /api/map/shading/regions/:countryCode) is already per-country and
+was never the problem.
 
-DECISION (13 rulings, full design in jobs/architect/tech/ADL-42-booking-item-shape.md):
- - One booking = one item. New item_flight_legs 1:N child table with explicit 1-based
-   contiguous leg_order (NOT sorted by departure_datetime — datetimes are optional under
-   PL-01 and naive/timezone-less). item_flights retained as the booking-level extension row,
-   shrunk to (item_id, booking_reference). airline/flight_number/airports/datetimes move to
-   the leg (interline itineraries genuinely change carrier between legs).
- - ONE new item_travellers table with a nullable leg_id selecting scope and a nullable
-   companion_id. Row presence = travels this scope; seat NULL = seat unknown. This is the
-   load-bearing choice: two junctions (booking-level + leg-level) would give two homes for one
-   fact and make "on the booking but no row on leg 2" ambiguous. For flights the booking
-   roster is DERIVED, never stored.
- - companion_id NULLABLE, NULL = the owning user. Reason nobody had written down: `companions`
-   is a list of OTHER people; the user is not in it, and today's single seat column IS the
-   user's own seat implicitly. A NOT NULL companion_id would have made the fix a regression.
-   Rejected auto-creating a "Me" companion (pollutes an AD-08 user-managed list, collides with
-   uniq_companions_user_name, self-row becomes soft-deletable).
- - Four partial unique indexes — SQLite treats NULLs as distinct so a plain composite unique
-   accepts the same traveller twice. The two-index alternative (0 as a self sentinel) was
-   rejected because 0 cannot carry an FK to companions.id. Integrity > index count.
- - NO leg status. Status stays item-level (IT-03/FL-03). Per-leg status has no correct
-   aggregate and every consumer reads one status.
- - Cost is booking-level whenever introduced, never per-leg. Not added — no BRD requirement
-   for item cost exists anywhere.
- - Migration in TWO files (additive create+backfill, then destructive shrink) — file 1 reads
-   columns file 2 destroys and Drizzle cannot know the ordering.
- - AD-08 guard: item_travellers.companion_id is a SECOND write path to companions.id.
-   companionRepository.validateOwnership mandatory; 400 not 404; repository signature takes
-   userId FIRST so the junction cannot be written without it (structural, not a reminder).
+DECISION (full reasoning + measured numbers in jobs/architect/tech/
+ADL-44-region-shading-payload.md):
+ - Split geo/regions.json into geo/regions/{ISO_A2}.json, one static file per country, still
+   fully bundled/committed (satisfies GE-10 — see below), fetched lazily for the visible
+   country only. Measured: median country 92KB, worst case Russia 3.26MB, the bug's own US
+   example 1.39MB — 30x-400x smaller than the world file, per country, before any other
+   optimisation. This is the load-bearing fix.
+ - Property whitelist: iso_3166_2 + name only (the only property the frontend actually
+   reads is iso_3166_2 — grepped every Map/*.tsx to confirm). Drops 119 of 121 Natural Earth
+   columns. Tested in isolation: this alone only cuts the WORLD file 40.7MB -> 29.5MB — real
+   but not the dominant cost. The dominant cost is raw geometry point density
+   (1.3M coordinate pairs across 4,596 features), which splitting attacks directly.
+ - Topology-preserving geometry simplification (e.g. mapshaper -simplify ... keep-shapes, NOT
+   independent per-feature coordinate rounding, which risks gaps at shared borders) for the
+   handful of large/complex countries: Russia, Canada, US, GB, Indonesia, Philippines.
+ - Add `compression` middleware + long-lived Cache-Control to the /geo express.static mount
+   (server.ts:195) — currently has neither.
+ - No server/DB compute anywhere in this fix. Stays a build-time static-asset problem;
+   Railway/Turso (ADL-32) are not involved.
+ - REGION_ZOOM_THRESHOLD left at 3 — not touched by this ADL. Whether to tune it further once
+   the payload no longer confounds the perceived latency is a PO/UAT call, not an
+   architecture call, and is explicitly deferred.
+ - ADL-41's DISTINCT invariant (trips.id / regions.id) is untouched by construction — this
+   ADL's diff surface is static assets + RegionLayer.tsx + server.ts static options only;
+   shading.service.ts is not touched, stated as a success criterion (zero-line diff expected).
 
-REJECTED: booking_group_id on separate items (N statuses per booking); leg2_*/leg3_* columns
-(hard cap, unindexable); JSON legs array (ADL-11 rejected JSON precisely because SQLite cannot
-index JSON paths and leg dates are queried); a generalised item_segments table spanning
-flights/hotels/car rentals — most elegant, wrong on cost: it requires migrating three extension
-tables and rewriting every route/helper/test/component to buy a second segment for types that
-will never have one.
+WHY NOT VECTOR TILES / VISITED-ONLY / MULTI-TIER: vector tiles (MVT) require either
+MapTiler-hosted tiles (violates GE-10 outright) or self-hosted pmtiles, which the original
+tech blueprint itself already flags at ~100MB for a world basemap — trading a 40MB problem
+for a 100MB one; revisit only if a future requirement needs city-level detail. Shading only
+visited countries' regions was rejected as the primary mechanism — a user planning a future
+trip needs to see boundaries for a country with no visits yet, and it would turn a static
+reference asset into per-user filtered data. Precomputed multi-tier detail levels are
+unnecessary once per-country splitting means only one country loads at a time.
 
-SUPERSESSION: no ADL entry superseded. ADL-11 preserved and extended; ADL-28 reinforced. The
-one supersession is BRD FL-01 — deliberately NOT stamped by me, it belongs in the COO's
-BRD-bump PR alongside the new IDs and the header/§13 bump.
+GE-10 (bundled/offline boundary data — flagged as the hardest constraint, addressed
+directly): per-country files are generated once at build time and committed as static
+assets, served by the app's OWN Express instance — same trust boundary as geo/countries.json
+and every /api/* route today, on localhost (offline Electron) or hosted Railway alike.
+Today's implementation already issues a network fetch to a locally bundled file (MapLibre's
+GeoJSON Source XHRs /geo/regions.json) — GE-10 has never meant zero HTTP requests, only zero
+dependency on the internet or a third-party host. Splitting changes only the granularity of
+what's requested from the same local/bundled source.
+
+SUPERSESSION: 20260307-tech-blueprint.md Section 2.3 (single-file ~4MB estimate — the shipped
+file is ~10x that — and the "load once at init, cache in memory" delivery model) stamped
+`> SUPERSEDED (2026-07-27) by ADL-44`. 20260307-map-shading-spec.md read in full (404 lines)
+and found to specify only shading-STATE SQL, never geometry delivery — no stamp applied,
+nothing in it is affected.
 
 ================================================================================
 OPEN / HANDOFF
 ================================================================================
 
-  1. COO BRD GATE BLOCKS ALL DISPATCH (CLAUDE.md rule). Four items: rewrite + stamp FL-01
-     ("each flight is logged as an individual leg" is exactly the model ADL-42 replaces);
-     amend FL-02 (seat moves off the flight field list); new requirement ID + success criteria
-     for BUG-41; new requirement ID + success criteria for BUG-42 covering the "traveller on
-     some legs but not others" case. Both tracker entries have brdRefs: [] today.
-  2. COO: merge PR for feat/adl42-booking-item-shape after CI green — do not self-merge.
-  3. Brief sequencing once the BRD gate clears: (a) Database brief — schema + the two migration
-     files, additive, safe to merge alone; (b) ONE combined Backend+Frontend brief on a single
-     branch, because there is no compatibility shim and the flat flight keys disappear from the
-     API. One branch per brief still holds — this is one brief spanning two layers.
-  4. BUG-45 / ADL-43 cross-dependency: airline moves to item_flight_legs.airline. If S3's brief
-     is written against item_flights.airline it will need reworking.
-  5. Frontend constraint to carry into that brief: leg datetimes are naive/timezone-less, so
-     layover and total-journey durations across legs are WRONG whenever a connection crosses a
-     timezone — the norm for the itinerary that motivated BUG-41. Do not display connection
-     durations until timezone data exists (depends on airport reference data, ADL-43).
-  6. Drift found, flagged not fixed: BRD IT-03 (v3.0) lists Shortlisted as an item status but
-     chk_items_status (src/backend/db/schema.ts:499) permits only consider/confirmed/completed/
-     cancelled/next_time and the string 'shortlisted' appears nowhere in src/. Added to the BRD
-     and never implemented; home is the deprioritized planning-core entry. ADL-42 does not
-     rebuild the items table so it neither depends on nor resolves this.
-  7. Stale doc flagged, not actioned: jobs/database/tech/schema.ts is an unmaintained COPY of
-     src/backend/db/schema.ts and repeats the superseded FL-01 claim at line 507. Needs
-     refreshing or a HISTORICAL banner. jobs/architect/tech/20260307-ER-schema.md:303 repeats
-     it too but already carries a HISTORICAL banner — no further stamp needed.
-  8. patches/drizzle-kit+0.31.9.patch Bug 4 (partial-index WHERE reading) is LOAD-BEARING for
-     the four partial unique indexes. If drizzle-kit is ever upgraded, re-verify before this
-     lands or migrations will churn.
-  9. Carried over, unrelated to this thread:
+  1. No BRD gate blocks dispatch — no new requirement ID was needed (this is a performance
+     defect against existing GE-10/MP-01/MP-02, not new functional scope). Reported to COO in
+     the ADL per "report, don't add"; COO decides if a project-wide perf-budget requirement is
+     worth adding separately. Dispatchable to Frontend as-is.
+  2. COO: merge PR for chore/adl44-region-shading-payload after CI green — do not self-merge.
+  3. Implementing brief must be told explicitly, both easy to get wrong:
+     (a) simplification must be topology-preserving, not independent per-feature rounding —
+         naive per-polygon simplification can open gaps/overlaps at shared region borders;
+     (b) verify react-map-gl's <Source> behaviour when its `data` URL changes between country
+         codes while RegionLayer stays mounted (panning between two zoomed countries without
+         crossing back below the threshold) — must fetch the new country's file, not silently
+         keep serving the old one's cached GeoJSON. Flagged as a risk to verify, not verified
+         by me — requires running the app, out of this spec-only brief's scope.
+  4. Comment drift flagged, not fixed (spec-only scope): MapView.tsx:6 says region shading
+     loads "at zoom >= 4"; the constant at line 28 is 3. Whoever implements this brief and
+     touches MapView.tsx must correct the comment to match the final threshold value.
+  5. data/regions.json (8KB, DB seed data for the regions table) is unrelated to
+     geo/regions.json (40MB, boundary geometry) despite the identical filename — noted as a
+     minor naming trap for future engineers, not actioned.
+  6. Carried over, unrelated to this thread — from the prior ADL-42 session, still open:
      - Clerk preview-origin question (ADL-32 §6) + §10 success criteria pending a real deploy.
      - D-05 Clerk staging/prod user-pool split (jobs/COO/open-dialogues.md).
      - OQ-03 (shell trip approximate dates). OQ-05 is ADL-41's (S1), not mine.
+     - ADL-42's own handoff items (BRD gate, brief sequencing, BUG-45/ADL-43 cross-dependency)
+       are unaffected by this thread — see jobs/architect/park-docs/20260727-ARCHITECT-park-
+       adl42.txt for that thread's own handoff if still relevant when this is read.

--- a/jobs/architect/park-docs/20260727-ARCHITECT-park-adl44.txt
+++ b/jobs/architect/park-docs/20260727-ARCHITECT-park-adl44.txt
@@ -1,0 +1,132 @@
+ARCHITECT PARK DOCUMENT — 2026-07-27
+THREAD: Wave 0 scoping brief S5 — ADL-44, region-shading geometry payload (BUG-48)
+ISSUE: #275   BRANCH: chore/adl44-region-shading-payload
+DELIVERABLE TYPE: spec only — no code, asset, or schema change
+
+================================================================================
+WHAT WAS ASKED
+================================================================================
+BUG-48 was reported as "region shading requires zooming in far too much." The brief warned
+this reads like "lower REGION_ZOOM_THRESHOLD" and explicitly said that fix is wrong, and told
+me to verify the reported 39MB geo/regions.json figure myself before designing anything, and
+to stop and say so if the premise didn't hold. Decide the payload strategy that lets the
+threshold drop without regressing performance, honouring GE-10 (bundled/offline boundary
+data — the hardest constraint) and the concurrent ADL-41 DISTINCT invariant for shading
+aggregates.
+
+================================================================================
+WHAT I FOUND BEFORE DECIDING
+================================================================================
+1. The premise HOLDS. geo/regions.json is 40,726,851 bytes (38.8 MiB) — the COO's "39MB"
+   probe was correct, not inflated. Verified with `ls -la`, not taken on faith.
+2. The geometry fetch (RegionLayer.tsx, /geo/regions.json) is a SEPARATE, UNSCOPED fetch from
+   the shading-state fetch (GET /api/map/shading/regions/:countryCode, already per-country).
+   RegionLayer's Source URL is a constant — every mount pulls all 241 countries' admin-1
+   boundaries regardless of which one is visible. RegionLayer unmounts/remounts on every
+   REGION_ZOOM_THRESHOLD crossing (MapView.tsx:155), so this isn't a one-time session cost.
+3. No compression middleware anywhere in server.ts/package.json. No cache headers on the
+   /geo express.static mount. Confirmed by grep, not assumed.
+4. Root cause of the size is genuinely geometry point density, NOT primarily property bloat.
+   Tested directly: stripping 121 properties/feature down to the 1 actually used
+   (iso_3166_2 — grepped every Map/*.tsx, nothing else reads region properties) only cuts
+   40.7MB -> 29.5MB. The 1.3M coordinate pairs across 4,596 features are the real cost.
+5. Per-country split is the load-bearing fix, and the numbers prove it: grouped by country,
+   median is 92KB, worst case Russia 3.26MB, the bug's own US example 1.39MB — 30x-400x
+   smaller than the world file, per country, before any other optimisation.
+6. The original tech blueprint (20260307-tech-blueprint.md:227-236, 2026-03-07) estimated
+   this exact file at ~4MB. The shipped file is ~10x that. Whether the estimate was wrong or
+   a higher-fidelity extract got bundled than intended is moot — either way nobody caught a
+   10x miss against the architecture's own stated budget. Stamped superseded (see below).
+7. countries.json (838KB, 177 features, avg 60 coord pairs/feature) is clear evidence the
+   simplification step WAS done correctly for the country tier and simply never applied to
+   the region tier (avg 282 coord pairs/feature, no simplification visible). The fix pattern
+   already exists in this codebase; it just wasn't extended to regions.
+
+================================================================================
+THE DECISION (full reasoning + numbers in the standalone ADL)
+================================================================================
+D1 Split geo/regions.json into geo/regions/{ISO_A2}.json, one file per country, still fully
+   bundled/committed like today's single file — fetched lazily for the visible country only.
+D2 Property whitelist: iso_3166_2 + name only. Drop the other 119 Natural Earth columns.
+D3 Topology-preserving geometry simplification (mapshaper -simplify ... keep-shapes, not
+   independent per-feature rounding, which risks gaps at shared borders) for the handful of
+   large/complex countries: Russia, Canada, US, GB, Indonesia, Philippines.
+D4 Coordinate precision <=5dp — tolerance left to implementation QA, not mandated exactly.
+D5 Add `compression` middleware + long-lived Cache-Control to the /geo static mount.
+D6 No server/DB compute. Stays a build-time static-asset problem — Railway/Turso irrelevant.
+D7 REGION_ZOOM_THRESHOLD left at 3 in this ADL. Whether to tune it further once the payload
+   no longer confounds perception is a PO/UAT call, not decided here.
+D8 ADL-41 DISTINCT invariant: NOT touched. This ADL's diff surface is static assets,
+   RegionLayer.tsx, and server.ts static options only — shading.service.ts is untouched by
+   construction, stated as a success criterion (zero-line diff expected from the brief).
+
+================================================================================
+WHY NOT THE OBVIOUS ALTERNATIVES
+================================================================================
+- Vector tiles (MVT/tippecanoe): the "correct" long-term answer, rejected here. Either
+  MapTiler-hosted tiles (violates GE-10 outright) or self-hosted pmtiles, which the blueprint
+  itself flags at ~100MB for a world basemap (tech-blueprint.md:223) — trading a 40MB problem
+  for a 100MB one. Revisit only if a future requirement needs city-level polygon detail.
+- Shading only visited countries' regions: rejected as primary mechanism — a user planning a
+  future trip needs to see boundaries for a country with no visits yet (GE-09 isn't
+  conditioned on visit history), and it would turn a static reference asset into per-user
+  filtered data, which doesn't fit "bundled, offline".
+- Precomputed multi-tier detail levels: unnecessary once per-country splitting means only one
+  country's data loads at a time — there's no intermediate zoom range where a coarser-than-
+  full region tier is shown (region shading is binary: off below threshold, full detail above).
+- Coordinate rounding alone, no splitting: tested directly. 4dp rounding on the WORLD file
+  only gets to 24.3MB (7.3MB gzipped) — still an unscoped fetch on every threshold crossing.
+  Splitting is load-bearing; rounding/stripping are additive, not substitutes.
+
+================================================================================
+GE-10 — ADDRESSED DIRECTLY (this was flagged as the hardest constraint)
+================================================================================
+Per-country files are generated once at build time and committed as static assets, served by
+the app's OWN Express instance — same trust boundary as geo/countries.json and every /api/*
+route today, whether the server is localhost (offline Electron) or hosted Railway. Today's
+implementation ALREADY issues a network fetch to a locally bundled file (MapLibre's GeoJSON
+Source XHRs /geo/regions.json) — GE-10 has never meant zero HTTP requests, only zero
+dependency on the internet or a third-party host. Splitting one locally-served file into many
+locally-served files does not change that guarantee. What WOULD violate GE-10 — third-party
+geodata host, MapTiler-hosted vector tiles at render time — was considered and rejected above.
+
+================================================================================
+STATE AT PARK
+================================================================================
+- ADL-44 reserved stub REWRITTEN IN PLACE in jobs/architect/tech/
+  20260307-architecture-decisions-log.md. ADL-41/43/45 stubs and the completed ADL-42 entry
+  not touched — other Architects running concurrently on the same file.
+- Standalone design: jobs/architect/tech/ADL-44-region-shading-payload.md (9 sections:
+  problem, verified facts table, decision matrix, GE-10 compliance, rejected alternatives,
+  implementation implications, success criteria, BRD note, supersession).
+- Supersession stamp applied: 20260307-tech-blueprint.md Section 2.3 (the ~4MB single-file
+  estimate and "load once at init, cache in memory" model) stamped
+  `> SUPERSEDED (2026-07-27) by ADL-44`. 20260307-map-shading-spec.md was read in full
+  (all 404 lines) and found to specify only shading-STATE SQL, never geometry delivery —
+  no stamp applied there, nothing in it is affected by this decision.
+- tracker.json: BUG-48 notes rewritten with the diagnosis + #275 + ADL-44 pointer. Owner left
+  "frontend" (no BRD gate blocks this — no new requirement ID needed, unlike ADL-42). Status
+  left "pending", NOT set to an invented "spec-complete" value — checked ADL-42's precedent
+  (BUG-41/BUG-42) first and matched it: "DESIGNED YYYY-MM-DD" goes in the notes text, the
+  status enum stays one of the pre-existing values. (I actually wrote "spec-complete" first,
+  caught it wasn't a real value anywhere else in the tracker, and corrected it before commit.)
+- BRD: not touched. No new requirement ID needed — reported to COO in the ADL, not added.
+- Comment drift flagged, not fixed (spec-only scope): MapView.tsx:6 says "zoom >= 4",
+  the actual constant at line 28 is 3. Whoever implements this brief and touches MapView.tsx
+  must correct the comment in the same PR.
+
+================================================================================
+IF I PICKED THIS UP COLD TOMORROW
+================================================================================
+The design is complete and self-contained. Nothing is half-decided and there is no BRD
+blocker — this is dispatchable to Frontend as-is. The two things an implementing brief needs
+to be told explicitly, because they're easy to get wrong:
+1. Simplification must be topology-preserving (mapshaper keep-shapes or equivalent), not
+   independent per-feature coordinate rounding — naive per-polygon simplification can open
+   gaps or create overlaps at borders shared between adjacent regions.
+2. Verify how react-map-gl's <Source> behaves when its `data` URL prop changes between
+   country codes while RegionLayer stays mounted (panning between two zoomed-in countries
+   without crossing back below the threshold) — it must issue a fresh fetch for the new
+   country's file, not silently keep serving the previous country's cached GeoJSON. I flagged
+   this as a risk to verify in the standalone doc §6; I did not verify it myself since it
+   requires running the app, out of this brief's spec-only scope.

--- a/jobs/architect/tech/20260307-architecture-decisions-log.md
+++ b/jobs/architect/tech/20260307-architecture-decisions-log.md
@@ -2859,17 +2859,79 @@ maintained dataset or continues hand-seeding per-country gaps as they are found 
 one such patch). One ADL covering licensing, bundle size, offline behaviour (GE-10 requires
 boundary data ship offline) and refresh strategy.
 
-## ADL-44 — RESERVED (S5: region-shading payload / BUG-48)
+## ADL-44 — Region-shading geometry payload: per-country split, not a lower threshold
 
-**Date:** reserved 2026-07-27
-**Status:** RESERVED — Wave 0 brief S5 not yet dispatched. No decision recorded.
-**Scope:** BUG-48 reads as "lower the zoom threshold" but is not — `MapView.tsx` sets
-`REGION_ZOOM_THRESHOLD = 3` while region shading pulls a **39 MB** `geo/regions.json`, so
-lowering the threshold loads that payload sooner and more often and makes the reported
-latency worse. Decide the payload strategy (geometry simplification, tiling, per-country
-splitting, or lazy per-country fetch) that lets the threshold drop without regressing
-performance. Note the stale-doc drift for whichever PR touches it: `MapView.tsx:6` documents
-`zoom >= 4` while the constant is `3`.
+**Date:** 2026-07-27
+**Status:** **Decided, implementation pending.** No code, asset, or schema change was made
+by this ADL — it is the design that unblocks the implementing brief.
+**Tracker:** BUG-48 | **GitHub:** #275 | **Full ADL:** `jobs/architect/tech/ADL-44-region-shading-payload.md`
+
+**Trigger:** Wave 0 scoping brief S5. BUG-48 reads as "lower the zoom threshold" — it is
+not. `MapView.tsx:28` sets `REGION_ZOOM_THRESHOLD = 3`, but region shading's geometry
+fetch (`RegionLayer.tsx:16,77`, `/geo/regions.json`) pulls **one unscoped, uncompressed,
+world-covering file for all 241 countries** on every threshold crossing. Lowering the
+threshold fires that fetch sooner and more often — it makes the reported latency worse
+while appearing to fix the complaint in a quick manual test.
+
+**Verified, not assumed** (full measurements in the standalone doc §2): the file is
+40,726,851 bytes (38.8 MiB) — the COO's "39 MB" probe was correct. No compression
+middleware exists on the `/geo` static mount (`server.ts:195`) and no cache headers are
+set. The fetch is not scoped by country (`REGIONS_GEOJSON_URL` is a constant), even
+though the shading-*state* API it pairs with already is
+(`GET /api/map/shading/regions/:countryCode`). Grouped by country, the same source data
+is 30×–400× smaller per country than the world file (median 92 KB; worst case Russia
+3.26 MB; the bug's own US example, 1.39 MB) — the per-country split is the load-bearing
+fix, not a nice-to-have. The bundled file is also ~10× the tech blueprint's own original
+budget (`20260307-tech-blueprint.md:227-236`, ~4 MB estimate for the 10 m admin-1
+extract) — stamped superseded, see below.
+
+**Decision:** Split `geo/regions.json` into one static, still-fully-bundled file per
+country (`geo/regions/{ISO_A2}.json`), fetched lazily for only the visible country.
+Combine with: property whitelist (`iso_3166_2` + `name` only — 119 of 121 Natural Earth
+columns are dead weight, nothing else is read by the frontend), topology-preserving
+geometry simplification for the handful of large/complex countries (Russia, Canada, US,
+GB, Indonesia, Philippines), `compression` middleware + long-lived `Cache-Control` on the
+`/geo` static mount. No server/DB compute involved (Railway/Turso irrelevant — this stays
+a build-time static-asset problem). `REGION_ZOOM_THRESHOLD` itself is left at `3` in this
+ADL; further tuning is a product-feel call for a follow-up PO/UAT once the payload no
+longer confounds it.
+
+**GE-10 compliance (the hardest constraint) — addressed directly, not glossed:**
+per-country files are generated once at build time and committed as static assets exactly
+like today's single file; they are served by the app's own Express instance
+(`express.static`), the same trust boundary already used for `geo/countries.json` and
+every `/api/*` route, whether that server is `localhost` (offline Electron) or the hosted
+Railway deployment. Today's implementation already issues a network fetch to a locally
+bundled file (MapLibre's GeoJSON `Source` XHRs `/geo/regions.json`) — GE-10 has never
+meant zero HTTP requests, only zero dependency on the internet or a third-party host.
+Splitting one locally-served file into many locally-served files does not change that
+guarantee. What *would* violate GE-10 — fetching geometry from a third-party geodata host
+or MapTiler-hosted vector tiles at render time — was considered and explicitly rejected
+(standalone doc §5).
+
+**ADL-41 DISTINCT invariant:** no conflict. This ADL never touches
+`shading.service.ts` or any SQL aggregate — it changes only how boundary *geometry*
+reaches the client, never how shading *state* is computed. The implementing brief's diff
+to `shading.service.ts` must be zero lines; that is a stated success criterion (standalone
+doc §7).
+
+**Supersession:** `20260307-tech-blueprint.md` §2.3 (single-file ~4 MB estimate,
+"loaded once … cached in memory for the session" delivery model) stamped
+`> SUPERSEDED (2026-07-27) by ADL-44` in this PR. `20260307-map-shading-spec.md` was
+checked in full and found to specify only shading-state SQL, never geometry delivery —
+no stamp applied, nothing there is affected.
+
+**Drift flagged, not fixed (spec-only scope):** `MapView.tsx:6` documents region shading
+loading "at zoom >= 4"; the constant at line 28 is `3`. Whoever implements this brief and
+touches `MapView.tsx` must correct the comment.
+
+**Implications:** see standalone doc §6 for the full implementation surface
+(`RegionLayer.tsx` URL parameterisation and a `<Source>` re-fetch-on-country-change risk
+to verify, `server.ts:195` / `server-test-app.ts:112` static options, the new build-time
+preprocessing step) and §7 for measurable success criteria (per-country payload budget,
+render-latency target, simplification QA checklist) satisfying the CLAUDE.md
+success-criteria-before-dispatch gate. No new BRD requirement ID needed — reported to
+COO per §8, not added by this ADL.
 
 ## ADL-45 — RESERVED (S6: item Google Maps URL column / BRD-IT10)
 

--- a/jobs/architect/tech/20260307-tech-blueprint.md
+++ b/jobs/architect/tech/20260307-tech-blueprint.md
@@ -224,6 +224,14 @@ The Express server in Electron is started by the main process and is identical t
 
 ### 2.3 GeoJSON Boundary Data
 
+> SUPERSEDED (2026-07-27) by ADL-44 — retained for history. The regions file this section
+> estimates at ~4MB shipped at 40.7MB (~10x), was never scoped per-country, and is no
+> longer "loaded once at initialisation and cached in memory" — it is now split into one
+> file per country under `geo/regions/{ISO_A2}.json`, fetched lazily for the visible
+> country only. See `jobs/architect/tech/ADL-44-region-shading-payload.md` for the current
+> design, measured sizes, and rationale. The `countries.json` row below is unaffected and
+> still accurate.
+
 **Source: Natural Earth** (public domain, no attribution required for basic use)
 
 Two files bundled with the app:

--- a/jobs/architect/tech/ADL-44-region-shading-payload.md
+++ b/jobs/architect/tech/ADL-44-region-shading-payload.md
@@ -1,0 +1,182 @@
+# ADL-44 — Region-shading geometry payload
+
+**Date:** 2026-07-27
+**Status:** Decided, implementation pending.
+**Tracker:** BUG-48 | **GitHub:** #275 | **Wave 0 brief:** S5
+**BRD refs:** GE-10, MP-01, MP-02 (no new requirement ID — see §7)
+
+---
+
+## 1. The reported bug, and why the obvious fix is wrong
+
+BUG-48: country→state map shading "requires zooming in far too much (the US must nearly
+fill the screen before state shading appears), made worse by rendering latency."
+
+Read literally this asks to lower `REGION_ZOOM_THRESHOLD` (`src/frontend/components/Map/MapView.tsx:28`,
+currently `3`). That is the wrong fix. Region shading is driven by two independent fetches
+when zoom crosses the threshold:
+
+1. `GET /api/map/shading/regions/:countryCode` — the shading **state** (colours), a few KB,
+   already scoped to one country (`src/backend/routes/map.ts:151`, `getRegionShading` in
+   `src/backend/services/shading.service.ts:323`).
+2. `/geo/regions.json` — the region **geometry** (polygon boundaries), fetched by
+   `RegionLayer` (`src/frontend/components/Map/RegionLayer.tsx:16,77`) as a MapLibre GeoJSON
+   `Source`. This is **one static file containing every admin-1 region for all 241
+   countries**, unscoped, refetched every time `RegionLayer` mounts (i.e. every time zoom
+   crosses the threshold — `MapView.tsx:155`).
+
+Lowering the threshold makes the second fetch fire sooner and more often. It does not
+shrink it. The fix belongs entirely in item 2.
+
+## 2. Verified facts (not assumed)
+
+| Claim | Verification | Result |
+|---|---|---|
+| Reported "39 MB" file size | `ls -la geo/regions.json` | **40,726,851 bytes (38.8 MiB / 40.7 MB decimal).** The COO's probe was correct. |
+| Compression in transit | `grep -n compression src/backend/server.ts package.json` | **None.** No `compression` middleware; `express.static('/geo', …)` (`server.ts:195`) serves the raw file. `gzip -6` of the file measured locally: 12.2 MB (30% of raw) — still large, and not applied today regardless. |
+| Cache headers | `express.static(path.join(__dirname, '../../geo'))` — no options object | Default Express static config: no `Cache-Control`/`maxAge` set. Repeat fetches are not guaranteed to skip the network. |
+| Fetch scope | `RegionLayer.tsx:77` — `<Source data={REGIONS_GEOJSON_URL} …>`, `REGIONS_GEOJSON_URL = '/geo/regions.json'` (a constant, not parameterised by country) | Every mount fetches **the whole world**, not the one visible country. `RegionLayer` unmounts/remounts on every crossing of `REGION_ZOOM_THRESHOLD` (`MapView.tsx:155`), so this is not a one-time cost per session. |
+| Feature/property bloat | `python3` parse of `geo/regions.json`: 4,596 features, **121 properties/feature**, of which the frontend reads exactly **one** (`iso_3166_2` — `RegionLayer.tsx:59,77`, `MapView.tsx:104`) | Confirmed: `name` is not read either (no tooltip/label consumer found by grep across `src/frontend/components/Map/*.tsx`). Everything else (translated name variants, `FCLASS_*`, `woe_*`, `gn_*`, etc.) is dead weight shipped to the client. |
+| Where the size actually comes from | Stripped to `{iso_3166_2, name}` only, full-precision geometry retained: 40.7 MB → **29.5 MB** (27% cut). Coordinates additionally rounded to 4dp (~11 m): → **24.3 MB**, gzip **7.3 MB** | Properties are real bloat but not the dominant cost. **Geometry point density is** — 1,295,319 coordinate pairs across 4,596 features (avg. 282/feature). Stripping alone does not fix this; the file is fundamentally too much geometry for what any single map view needs. |
+| Per-country distribution | Same parse, grouped by `iso_a2`: 241 countries, **median 92 KB**, worst case Russia (86 regions) 3.26 MB, Canada 1.81 MB, **US (the bug's own example) 1.39 MB**, GB 1.14 MB. 90th-percentile country well under 1 MB. | A single country's regions are 30×–400× smaller than the world file. This is the actual lever. |
+| Original design intent | `jobs/architect/tech/20260307-tech-blueprint.md:227-236` (§2.3, 2026-03-07): "`ne_10m_admin_1_states_provinces.json` | State/province outlines for region zoom | **~4 MB**". | The shipped file is **~10× the blueprint's own budget.** Whether the estimate was simply wrong or a higher-fidelity extract got bundled than intended is now moot — either way the file was never fit for the "load once, cache in memory" model the blueprint describes, and nothing was corrected when it clearly missed by an order of magnitude. |
+| Precedent in this codebase | `geo/countries.json`: 177 features, **168 properties/feature but only 838 KB total**, avg. **60 coordinate pairs/feature** (vs. regions.json's 282) | `countries.json` was evidently generated from Natural Earth's low-resolution (110 m) admin-0 extract and/or simplified before bundling. `regions.json` (10 m, admin-1) never got the equivalent treatment. The fix pattern already exists in this repo for the country tier; it was simply never applied to the region tier. |
+
+**Conclusion: the premise holds.** The file is real, unscoped, uncompressed, uncached, and
+carries 10–100× more data than any single map interaction needs. This is not a
+"lower the threshold" bug; the threshold was never the problem.
+
+## 3. Decision
+
+| # | Decision | Recommendation | Confidence |
+|---|---|---|---|
+| D1 | Primary fix | Split `geo/regions.json` into one static file **per country** (`geo/regions/{ISO_A2}.json`), still fully bundled/local; fetch the one visible country's file instead of the world | High |
+| D2 | Property whitelist | Keep only `iso_3166_2` (required — `promoteId`, click handling) and `name` (cheap, future-proofs a hover/label feature); drop the other 119 Natural Earth columns | High |
+| D3 | Geometry simplification | Topology-preserving simplification (e.g. mapshaper `-simplify … keep-shapes`) for the small set of large/complex countries (Russia, Canada, US, GB, Indonesia, Philippines) to bring worst-case payload in line with the rest | Medium |
+| D4 | Coordinate precision | Round to ≤5 decimal places (~1 m) — lossless at any zoom this app renders; exact tolerance left to implementation QA, not mandated numerically here | Medium |
+| D5 | Compression | Add `compression` middleware (or pre-gzip + `Content-Encoding`) to the `/geo` static mount | High |
+| D6 | Cache headers | Add `{ maxAge, immutable }` to `express.static('/geo', …)` — this is static reference data, not per-user | High |
+| D7 | Server/DB involvement | None. Stays a build-time static-asset problem; no Turso/Postgres query, no Railway compute at request time | High |
+| D8 | `REGION_ZOOM_THRESHOLD` | Leave at `3` in this ADL. The payload fix should make shading appear promptly at the existing threshold; whether to tune the number further is a product-feel call for a follow-up PO/UAT, not bundled into this fix | Medium |
+| D9 | ADL-41 DISTINCT invariant | No conflict — this ADL does not touch `shading.service.ts` or any SQL aggregate. It changes only how boundary **geometry** is delivered to the client, never how shading **state** is computed. Verified: the shading-state fetch (`getRegionShading`, per-country, DISTINCT-safe per ADL-41 §3) is unaffected | High |
+| D10 | GE-10 compliance | Preserved — see §4 | High |
+
+## 4. GE-10 — the hardest constraint, addressed directly
+
+GE-10: *"Country and region boundary polygon data is bundled with the app and no internet
+connection is required to render country or region shading."*
+
+Per-country lazy fetch does **not** violate this:
+
+- The split files (`geo/regions/{ISO_A2}.json`) are generated once at build/preprocessing
+  time and **committed as static assets**, exactly like today's single `geo/regions.json` —
+  they ship in every deploy, Electron package, or Railway image. Nothing is generated or
+  fetched at request time from any external source.
+- They are served by the **app's own** Express instance (`express.static`, same mount
+  point pattern as today, just pointed at a directory of per-country files instead of one
+  file). This is the same trust boundary already used for `geo/countries.json` and every
+  `/api/*` route — same-origin, same server, whether that server is `localhost` (Electron/
+  offline Mac app) or the hosted Railway deployment.
+- **Today's implementation already uses a network fetch** (MapLibre's GeoJSON `Source`
+  issues an XHR to `/geo/regions.json`) — it is not inlined into the JS bundle. GE-10's
+  guarantee has never meant "zero HTTP requests"; it means "zero dependency on the
+  internet / a third-party host." Splitting one locally-served file into many
+  locally-served files changes nothing about that guarantee — it changes only the
+  granularity of what's requested from the same local/bundled source.
+- Consequence for offline use: a fully offline Electron instance still resolves
+  `/geo/regions/US.json` against its own embedded Express server, with zero external
+  network dependency, identically to how it resolves `/geo/regions.json` today.
+
+**What would violate GE-10** (and is explicitly rejected here): fetching region geometry
+from a third-party geodata host or CDN at render time. Not proposed. Vector-tile serving
+from a MapTiler-hosted tileset was considered and rejected for the same reason (§5).
+
+## 5. Alternatives considered and rejected
+
+- **Vector tiles (MVT / tippecanoe pipeline).** The "correct" long-term answer for
+  world-scale boundary data, and explicitly not chosen here: it requires a tile-generation
+  pipeline and a tile server, and either (a) MapTiler-hosted tiles, which violates GE-10
+  outright, or (b) self-hosted `pmtiles`, which the tech blueprint already flags as a
+  ~100 MB world basemap option (`20260307-tech-blueprint.md:223`) — solving a 40 MB problem
+  by introducing a 100 MB one. Per-country static GeoJSON is simpler, fits the existing
+  `express.static` delivery model unchanged, and the measured per-country sizes (§2) show
+  it is sufficient. Revisit if a future requirement needs city-level polygon detail, where
+  per-country splitting alone would not be enough.
+- **Serving regions only for countries the user has visited.** Rejected as the primary
+  mechanism: a user planning a future trip or just exploring the map needs to see region
+  boundaries for countries with no logged visits yet (GE-09's "clicking into any level"
+  is not conditioned on visit history). It would also turn a static reference asset into
+  per-user filtered data, which doesn't fit the "bundled, offline" model GE-10 describes.
+  Per-country lazy fetch already captures the real saving (you only ever pay for the one
+  country you're looking at) without this restriction.
+- **Precomputed detail levels (multiple simplification tiers).** Unnecessary on top of
+  per-country splitting — once only one country's data loads at a time, a single
+  appropriately-simplified tier per country is enough; there is no intermediate zoom
+  range in this app's UI where a coarser-than-full region tier is shown (region shading is
+  binary: off below the threshold, on at full detail above it).
+- **Coordinate rounding alone, no splitting.** Tested directly (§2): rounding to 4dp only
+  gets the world file to 24.3 MB (7.3 MB gzipped) — still an unscoped, oversized fetch on
+  every threshold crossing. Splitting is the load-bearing fix; rounding and property
+  stripping are additive, not substitutes.
+
+## 6. Implementation implications
+
+- **New build-time preprocessing step** (owner: whichever brief implements this — Frontend
+  or a small tooling script, COO to assign) that reads the source Natural Earth admin-1
+  data, applies D2–D4, and writes `geo/regions/{ISO_A2}.json` (241 files, one per country
+  present in the current `geo/regions.json`). Output is committed to the repo like the
+  current file is — no runtime generation.
+- **`RegionLayer.tsx` changes:** `REGIONS_GEOJSON_URL` becomes a function of the visible
+  country code (`` `/geo/regions/${countryCode}.json` ``) rather than a fixed constant.
+  `RegionLayer` needs the `countryCode` (currently `MapView` tracks `visibleCountryCode`
+  in state but only passes `regionData`, not the code itself, into `RegionLayer` —
+  `MapView.tsx:155-157`). **Implementation risk to verify, not decide here:** confirm how
+  react-map-gl's `<Source>` behaves when its `data` URL prop changes between country codes
+  while the component stays mounted (pan between two zoomed-in countries without crossing
+  back below the threshold) — it must issue a fresh fetch for the new country, not silently
+  keep serving the old one's cached GeoJSON.
+- **`server.ts:195` / `server-test-app.ts:112`:** add compression + cache headers to the
+  `/geo` `express.static` mount (D5/D6). Trivial, no route logic change.
+- **Comment drift (flagged, not fixed by this ADL — spec-only scope):**
+  `MapView.tsx:6` says region shading loads "at zoom >= 4"; the constant at `MapView.tsx:28`
+  is `3`. Whoever implements this brief and touches `MapView.tsx` must correct the comment
+  to match whatever the final threshold value is.
+- **No schema or DB change.** No backend query change. `shading.service.ts` is untouched —
+  confirmed against ADL-41's binding DISTINCT rule (§3 there); this ADL's diff surface is
+  static assets, `RegionLayer.tsx`, and `server.ts`'s static-file options only.
+
+## 7. Success criteria (for the CLAUDE.md dispatch gate)
+
+- Every per-country GeoJSON file ≤ 1.5 MB gzipped; ≤ 500 KB at the 90th percentile across
+  all 241 countries. Russia and Canada (the two largest measured) are the required stress
+  tests during implementation QA.
+- Region shading for a country not previously fetched this session visibly renders within
+  ~1 second of crossing `REGION_ZOOM_THRESHOLD`, measured on a throttled connection profile
+  (e.g. Chrome DevTools "Fast 3G"/comparable) — replacing today's multi-second stall on the
+  full 40 MB fetch.
+- No visual regressions from simplification: spot-check Russia, Canada, GB, US, and at
+  least one archipelago (Philippines or Indonesia) pre/post — no gaps, slivers, or missing
+  shared borders between adjacent regions.
+- GE-10 preserved: the feature functions with the app's own server reachable but the
+  external network blocked (i.e. no dependency on any third-party host).
+- `shading.service.ts` has a zero-line diff from this brief (ADL-41 invariant untouched).
+
+## 8. BRD
+
+No new requirement ID is needed. This is a performance defect against the existing
+GE-10 / MP-01 / MP-02 requirements, not new functional scope — reported to COO per the
+"report, don't add" instruction; COO owns the BRD gate decision on whether a
+non-functional performance budget requirement is worth adding project-wide (out of scope
+for this ADL to decide).
+
+## 9. Supersession
+
+`jobs/architect/tech/20260307-tech-blueprint.md` §2.3 (single-file ~4 MB estimate,
+"loaded once at map initialisation and cached in memory for the session" delivery model)
+is stamped superseded in the same PR as this ADL — the actual file was 10× the estimate
+and the delivery model has since evolved to lazy zoom-triggered fetch (`MapView.tsx`,
+predating this ADL) which §2.3 does not describe either.
+
+`jobs/architect/tech/20260307-map-shading-spec.md` was checked in full (all 404 lines) —
+it specifies only the SQL shading-**state** computation, never the geometry delivery
+mechanism. No section of it is affected by this decision; no stamp applied.


### PR DESCRIPTION
Closes #275
BRD refs: GE-10, MP-01, MP-02 (no new requirement ID — see ADL-44 §7/§8)

## Summary

BUG-48 read as "lower REGION_ZOOM_THRESHOLD" and is not — that fix was verified to make
the reported latency *worse*, not better. `geo/regions.json` is a real, verified 40.7MB
(38.8 MiB) unscoped world file covering all 241 countries' admin-1 boundaries, with no
compression or cache headers, refetched in full on every zoom-threshold crossing. The
per-country shading-*state* fetch was already scoped; the geometry fetch never was.

**Decision:** split into `geo/regions/{ISO_A2}.json` (still fully bundled, satisfies
GE-10), strip 119 of 121 unused Natural Earth properties, topology-preserving
simplification for the largest countries, add compression + cache headers to the `/geo`
static mount. No server/DB compute involved. `REGION_ZOOM_THRESHOLD` left at `3` — a
follow-up PO/UAT call, not an architecture call. `shading.service.ts` untouched,
preserving ADL-41's DISTINCT invariant by construction.

Spec only — no code, asset, or schema change. Implementation status: **decided, pending.**

## Changes

- `jobs/architect/tech/ADL-44-region-shading-payload.md` — full design: measured facts
  (§2), decision matrix (§3), GE-10 compliance analysis (§4), rejected alternatives (§5),
  implementation implications (§6), success criteria (§7)
- ADL-44 stub in `20260307-architecture-decisions-log.md` rewritten in place (other
  reserved stubs untouched)
- `20260307-tech-blueprint.md` §2.3 stamped `SUPERSEDED` (its ~4MB estimate was ~10x
  under the shipped file); `20260307-map-shading-spec.md` checked in full (404 lines),
  found unaffected — no stamp applied there
- `_project/tracker.json` BUG-48 updated with diagnosis + issue #275 + ADL-44 pointer

## Test plan

- [x] `npm run check` (biome) — clean
- [x] `npm run type:check:all` — clean
- [x] `npm run test:backend` — 580 passed, 1 skipped
- [x] `npm run test:frontend` — 154 passed
- [x] `npm run status:check` — STATUS.md in sync
- [x] No `src/` files touched — spec-only brief, nothing to functionally test

🤖 Generated with [Claude Code](https://claude.com/claude-code)