### PR TITLE
chore(QUAL-15/QUAL-16): negative-findings guard + fix a broken BRD path in all 8 role prompts

### DIFF
--- a/.planning/drift-ledger.jsonl
+++ b/.planning/drift-ledger.jsonl
@@ -1777,3 +1777,6 @@
 {"ts":"2026-07-28T12:30:21Z","action":"edit","file":"/workspace/jobs/COO/backlog-clearance-plan.md"}
 {"ts":"2026-07-28T12:30:30Z","action":"edit","file":"/workspace/jobs/COO/backlog-clearance-plan.md"}
 {"ts":"2026-07-28T12:30:35Z","action":"edit","file":"/workspace/_project/tracker.json"}
+{"ts":"2026-07-28T12:38:56Z","action":"edit","file":"/workspace/CLAUDE.md"}
+{"ts":"2026-07-28T12:43:22Z","action":"edit","file":"/workspace/_project/tracker.json"}
+{"ts":"2026-07-28T12:43:29Z","action":"edit","file":"/workspace/_project/tracker.json"}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,6 +87,45 @@ will hit confusing missing-module errors that look like a worktree-isolation bug
 aren't. Run `npm install` inside the worktree before anything else that needs
 `node_modules`, same as a fresh clone would.
 
+### Negative findings need two probes (mandatory)
+Adopted 2026-07-28 after three confidently-stated false premises came out of one wave of
+Architect work (Wave 0), each caught only because someone later re-ran the probe:
+
+1. **"`PRAGMA foreign_keys` is off at runtime"** — false. `@libsql/client` enables FK
+   enforcement by default (a libSQL divergence from stock SQLite). The design built on it
+   proposed eight hand-ordered deletes duplicating the FK graph in application code.
+2. **"There is no `router.delete` in `trips.ts`"** — false. `tripsRouter.delete('/:id')`
+   exists at `src/backend/routes/trips.ts:429`. The probe grepped `router.delete` against a
+   router actually named `tripsRouter`. The COO then propagated it into a tracker note
+   without re-verifying, and it mis-sized a brief until corrected.
+3. **"This environment's firewall reaches no Turso host"** — false. The ADL-33 / OP-21
+   diagnostic path is allowlisted; `scripts/agent-diagnostics/turso-query.mjs` reaches
+   staging fine. An open question sat recorded as unanswerable for a day.
+
+All three share a shape: **an agent probes once, gets a negative result, and reports the
+absence as established fact.** A grep that missed on a naming assumption, a probe that
+covered one driver, a connection attempt that didn't use the allowlisted path. Positive
+findings self-verify — the thing is there, you can see it. Negative findings don't, and
+they are disproportionately load-bearing because designs get built on top of "X doesn't
+exist" without anyone thinking to check again.
+
+**The rule.** Any claim that something does not exist, is not enabled, is unreachable, or
+is not implemented must either:
+- be established by **two independent probes** that could fail differently — e.g. a grep
+  *and* reading the file; a network probe *and* checking the allowlist config; a code
+  search *and* running the thing — where "independent" means a single wrong assumption
+  cannot produce both results; **or**
+- be **explicitly marked unverified** in the deliverable, with the probe that was run and
+  its known blind spot stated, so the next reader knows what was and wasn't checked.
+
+Never silently upgrade a single negative probe into a stated fact. "I grepped for X and
+found nothing" is a finding; "X does not exist" is a claim, and it needs the second probe.
+
+This binds **agents writing deliverables** and **the COO propagating agent findings into
+tracker notes, briefs, or plans** — failure 2 above was a COO failure, not an agent one.
+Applies to every role. Briefs should not need to restate it, but a brief whose core task is
+to establish an absence should call it out explicitly.
+
 ### BRD → tracker rule (mandatory)
 Whenever the BRD is updated (a changelog entry is written), the COO must create tracker
 entries for every new requirement ID introduced before closing the session. No BRD version

--- a/_project/STATUS.md
+++ b/_project/STATUS.md
@@ -3,7 +3,7 @@
 > **Generated** from `_project/tracker.json` — do not edit by hand.
 > Regenerate with `npm run status`. Staleness is gated by `npm run status:check` (pre-push).
 
-_Tracker last updated: 2026-07-28 (QUAL-11 remote-Turso half verified against staging + assertion assigned to B9; DEP-04 closed as leave-as-is with the analysis recorded. QUAL-09 resolved by BRD v3.11 — PO removed the never-implemented Shortlisted item status rather than building it; planning loop is two-stage, PL-02/PL-03 unblocked, zero code change. Previous: 2026-07-27 Wave 0 complete 6/6, ADL-41-45 + UX trip-list spec merged (PRs #278, #281-285), BRD v3.8-v3.10, QUAL-08..14 and DEP-04 logged)_
+_Tracker last updated: 2026-07-28 (negative-findings guard adopted into CLAUDE.md + all 8 role system prompts; QUAL-15 fixed — every role prompt's mandatory init step pointed at a nonexistent BRD path; QUAL-16 logged. QUAL-11 remote-Turso half verified against staging + assertion assigned to B9; DEP-04 closed as leave-as-is with the analysis recorded. QUAL-09 resolved by BRD v3.11 — PO removed the never-implemented Shortlisted item status rather than building it; planning loop is two-stage, PL-02/PL-03 unblocked, zero code change. Previous: 2026-07-27 Wave 0 complete 6/6, ADL-41-45 + UX trip-list spec merged (PRs #278, #281-285), BRD v3.8-v3.10, QUAL-08..14 and DEP-04 logged)_
 
 ## Phases
 
@@ -17,7 +17,7 @@ _Tracker last updated: 2026-07-28 (QUAL-11 remote-Turso half verified against st
 | PHASE-5 | Integrations — Notification Engine | ⬜ Pending |
 | PHASE-6 | v3 Planning-First Delivery | ⬜ Pending |
 
-## Open work (53)
+## Open work (54)
 
 ### P0 — Blockers (1)
 
@@ -66,7 +66,7 @@ _Tracker last updated: 2026-07-28 (QUAL-11 remote-Turso half verified against st
 | QUAL-11 | Assert PRAGMA foreign_keys=1 at startup (remote Turso path verified 2026-07-28) | backend | ⬜ Pending |
 | QUAL-12 | Concurrent role dispatches collide on the single shared jobs/<role>/context/current.txt | coo | ⬜ Pending |
 
-### P3 — Minor (21)
+### P3 — Minor (22)
 
 | ID | Title | Owner | Status |
 |---|---|---|---|
@@ -91,6 +91,7 @@ _Tracker last updated: 2026-07-28 (QUAL-11 remote-Turso half verified against st
 | QUAL-10 | jobs/database/tech/schema.ts is an unmaintained copy of the real schema | docs | ⬜ Pending |
 | QUAL-13 | Stale unread COO->Architect inbox messages from March 2026 | coo | ⬜ Pending |
 | QUAL-14 | MapView.tsx comment documents zoom >= 4 while the constant is 3 | frontend | ⬜ Pending |
+| QUAL-16 | Role system prompts' 'Read _shared/frameworks.txt' init step is ambiguous — two different docs share that filename | coo | ⬜ Pending |
 
 ## Coverage by type
 
@@ -98,9 +99,9 @@ _Tracker last updated: 2026-07-28 (QUAL-11 remote-Turso half verified against st
 |---|---|---|---|---|
 | feature | `███████████▓░░░░░░░░` 29/54 | 29 | 25 | 3 |
 | requirement | `███████████████████░` 32/33 | 32 | 1 | 6 |
-| bug | `███████████████░░░░░` 43/57 | 43 | 14 | 4 |
+| bug | `███████████████░░░░░` 44/58 | 44 | 14 | 4 |
 | task | `████████████████████` 9/9 | 9 | 0 | 0 |
-| chore | `█████████░░░░░░░░░░░` 9/21 | 9 | 12 | 1 |
+| chore | `████████░░░░░░░░░░░░` 9/22 | 9 | 13 | 1 |
 
 <details>
 <summary>Deferred (10)</summary>
@@ -134,4 +135,4 @@ _Tracker last updated: 2026-07-28 (QUAL-11 remote-Turso half verified against st
 
 ---
 
-_124 done · 10 deferred · 4 closed · 53 open — 191 tracked items_
+_125 done · 10 deferred · 4 closed · 54 open — 193 tracked items_

--- a/_project/tracker.json
+++ b/_project/tracker.json
@@ -2,7 +2,7 @@
   "meta": {
     "project": "Travel Tracker",
     "version": "1.0",
-    "updated": "2026-07-28 (QUAL-11 remote-Turso half verified against staging + assertion assigned to B9; DEP-04 closed as leave-as-is with the analysis recorded. QUAL-09 resolved by BRD v3.11 — PO removed the never-implemented Shortlisted item status rather than building it; planning loop is two-stage, PL-02/PL-03 unblocked, zero code change. Previous: 2026-07-27 Wave 0 complete 6/6, ADL-41-45 + UX trip-list spec merged (PRs #278, #281-285), BRD v3.8-v3.10, QUAL-08..14 and DEP-04 logged)"
+    "updated": "2026-07-28 (negative-findings guard adopted into CLAUDE.md + all 8 role system prompts; QUAL-15 fixed — every role prompt's mandatory init step pointed at a nonexistent BRD path; QUAL-16 logged. QUAL-11 remote-Turso half verified against staging + assertion assigned to B9; DEP-04 closed as leave-as-is with the analysis recorded. QUAL-09 resolved by BRD v3.11 — PO removed the never-implemented Shortlisted item status rather than building it; planning loop is two-stage, PL-02/PL-03 unblocked, zero code change. Previous: 2026-07-27 Wave 0 complete 6/6, ADL-41-45 + UX trip-list spec merged (PRs #278, #281-285), BRD v3.8-v3.10, QUAL-08..14 and DEP-04 logged)"
   },
   "items": [
 
@@ -2208,6 +2208,28 @@
       "brdRefs": [],
       "phase": 6,
       "notes": "Found 2026-07-26 during clearance-plan sizing, re-confirmed 2026-07-27 by ADL-44/S5 (issue #275). src/frontend/components/Map/MapView.tsx:6 documents 'zoom >= 4' while REGION_ZOOM_THRESHOLD on line 28 is 3. Trivial stale-doc drift, but it sits on exactly the constant BUG-48's implementation will change, so it should be corrected by whichever PR touches that file rather than tracked forever. Fold into the BUG-48 implementation brief; this entry exists only so it is not lost if that brief is deferred."
+    },
+    {
+      "id": "QUAL-15",
+      "type": "bug",
+      "title": "All 8 role system prompts had a mandatory init step pointing at a nonexistent BRD path",
+      "status": "done",
+      "owner": "coo",
+      "priority": "P2",
+      "brdRefs": [],
+      "phase": 6,
+      "notes": "Found 2026-07-28 while adding the negative-findings guard to the role system prompts. Every one of the 8 jobs/<role>/<role>-system-prompt.txt files listed 'Read _project/BRD.md' as init step 2 — a MANDATORY step — but that file does not exist; the BRD is at _project/travel-tracker-BRD.md. So every dispatched agent since the prompts were written either silently skipped the BRD at init or found it by hunting, in a project whose first rule is that the BRD is law. Same class as QUAL-06's orphaned COO system prompt, and directly foreshadowed by it: the 2026-07-26 park doc explicitly recorded 'the broken _project/BRD.md reference in its mandatory init list' for the COO prompt, which was resolved by DELETING that file — nobody checked whether the 8 live role prompts carried the identical broken path. They all did. The lesson is the one in the feedback_verify_docs_are_loaded_not_just_resolvable memory, inverted: that memory covers docs nothing reads; this is a doc everything reads pointing somewhere nothing is. FIXED in the same PR — all 8 now read _project/travel-tracker-BRD.md, verified 0 remaining references to the broken path and 8 to the correct one, and the target verified to exist."
+    },
+    {
+      "id": "QUAL-16",
+      "type": "chore",
+      "title": "Role system prompts' 'Read _shared/frameworks.txt' init step is ambiguous — two different docs share that filename",
+      "status": "pending",
+      "owner": "coo",
+      "priority": "P3",
+      "brdRefs": [],
+      "phase": 6,
+      "notes": "Found 2026-07-28 alongside QUAL-15, while sweeping the same init lists for broken paths. NOT broken — flagged, not fixed, because resolving it needs a judgment call rather than a correction. All 8 role prompts say 'Read _shared/frameworks.txt' as init step 1, and TWO different files answer to that name: /_shared/frameworks.txt (8397 bytes, 'SHARED FRAMEWORKS' — the 30 numbered binding standards covering coding, communication, quality, security SEC rules 19-22, spec review 23-24, and bug classification 25-30) and /jobs/_shared/frameworks.txt (1562 bytes, 'TRAVEL TRACKER — SHARED TECH STACK' — languages, frameworks, versions, env vars). They are not duplicates of each other; they are unrelated documents that collide on filename. From the repo root, which is where a worktree-isolated agent starts, the bare path resolves to the 30-standards doc — which is probably the intended one, since /coo-startup references 'Shared Standards 23/24' as living in _shared/frameworks.txt. So current behaviour is likely correct and no agent is reading nothing. But an agent reading the prompt from jobs/<role>/ could reasonably resolve it the other way, and the tech-stack doc is genuinely useful at init too. Success criteria: init step 1 names its target(s) by explicit path from the repo root — probably both files, since both are relevant — so there is no resolution ambiguity; consider renaming one file if the collision is worth removing outright."
     },
     {
       "id": "DEP-04",

--- a/jobs/architect/architect-system-prompt.txt
+++ b/jobs/architect/architect-system-prompt.txt
@@ -42,7 +42,7 @@ You are the technical authority. Database, Backend and Frontend all work from yo
 
 ON INITIALISATION, YOU MUST:
 1. Read _shared/frameworks.txt
-2. Read _project/BRD.md
+2. Read _project/travel-tracker-BRD.md
 3. Read _project/seed-data.txt
 4. Read jobs/architect/context/current.txt
 5. Read your inbox/ folder for any messages from COO. Do not read inbox/read/ — those are processed messages available for reference only
@@ -55,6 +55,20 @@ ON INITIALISATION, YOU MUST:
    before every push regardless (see the GIT REQUIREMENT section). Adopted 2026-07-26 as
    OP-15 prerequisite (c): enforcement lives here, agent-side, rather than in a brief
    template, precisely so it does not depend on the COO remembering to instruct you.
+
+REPORTING FINDINGS — NEGATIVE CLAIMS NEED TWO PROBES (MANDATORY):
+Any claim that something does NOT exist, is NOT enabled, is unreachable, or was never
+implemented must either be established by TWO INDEPENDENT probes that could fail
+differently (a grep AND reading the file; a network probe AND checking the allowlist
+config; a code search AND running the thing), or be marked EXPLICITLY UNVERIFIED in your
+deliverable with the probe you ran and its blind spot stated.
+
+"I grepped for X and found nothing" is a finding. "X does not exist" is a claim — it needs
+the second probe. Never silently upgrade one into the other.
+
+Positive findings self-verify; negative ones don't, and designs get built on top of them.
+Adopted 2026-07-28 after three false premises from one wave of work — see CLAUDE.md
+"Negative findings need two probes" for the full rule and the three incidents.
 
 AT THE END OF EVERY THREAD, YOU MUST:
 1. Update jobs/architect/context/current.txt with current state

--- a/jobs/backend/backend-system-prompt.txt
+++ b/jobs/backend/backend-system-prompt.txt
@@ -24,7 +24,7 @@ You are the bridge between the database and the frontend. You implement what the
 
 ON INITIALISATION, YOU MUST:
 1. Read _shared/frameworks.txt
-2. Read _project/BRD.md
+2. Read _project/travel-tracker-BRD.md
 3. Read jobs/architect/tech/ for the current technical blueprint
 4. Read jobs/database/tech/ for the current schema
 5. Read jobs/backend/context/current.txt
@@ -38,6 +38,20 @@ ON INITIALISATION, YOU MUST:
    before every push regardless (see the GIT REQUIREMENT section). Adopted 2026-07-26 as
    OP-15 prerequisite (c): enforcement lives here, agent-side, rather than in a brief
    template, precisely so it does not depend on the COO remembering to instruct you.
+
+REPORTING FINDINGS — NEGATIVE CLAIMS NEED TWO PROBES (MANDATORY):
+Any claim that something does NOT exist, is NOT enabled, is unreachable, or was never
+implemented must either be established by TWO INDEPENDENT probes that could fail
+differently (a grep AND reading the file; a network probe AND checking the allowlist
+config; a code search AND running the thing), or be marked EXPLICITLY UNVERIFIED in your
+deliverable with the probe you ran and its blind spot stated.
+
+"I grepped for X and found nothing" is a finding. "X does not exist" is a claim — it needs
+the second probe. Never silently upgrade one into the other.
+
+Positive findings self-verify; negative ones don't, and designs get built on top of them.
+Adopted 2026-07-28 after three false premises from one wave of work — see CLAUDE.md
+"Negative findings need two probes" for the full rule and the three incidents.
 
 AT THE END OF EVERY THREAD, YOU MUST:
 1. Update jobs/backend/context/current.txt with current state

--- a/jobs/database/database-system-prompt.txt
+++ b/jobs/database/database-system-prompt.txt
@@ -24,7 +24,7 @@ You work from the Architect's blueprint and you protect it. Backend works from y
 
 ON INITIALISATION, YOU MUST:
 1. Read _shared/frameworks.txt
-2. Read _project/BRD.md
+2. Read _project/travel-tracker-BRD.md
 3. Read _project/seed-data.txt
 4. Read jobs/architect/tech/ for the current technical blueprint and data model
 5. Read jobs/database/context/current.txt
@@ -38,6 +38,20 @@ ON INITIALISATION, YOU MUST:
    before every push regardless (see the GIT REQUIREMENT section). Adopted 2026-07-26 as
    OP-15 prerequisite (c): enforcement lives here, agent-side, rather than in a brief
    template, precisely so it does not depend on the COO remembering to instruct you.
+
+REPORTING FINDINGS — NEGATIVE CLAIMS NEED TWO PROBES (MANDATORY):
+Any claim that something does NOT exist, is NOT enabled, is unreachable, or was never
+implemented must either be established by TWO INDEPENDENT probes that could fail
+differently (a grep AND reading the file; a network probe AND checking the allowlist
+config; a code search AND running the thing), or be marked EXPLICITLY UNVERIFIED in your
+deliverable with the probe you ran and its blind spot stated.
+
+"I grepped for X and found nothing" is a finding. "X does not exist" is a claim — it needs
+the second probe. Never silently upgrade one into the other.
+
+Positive findings self-verify; negative ones don't, and designs get built on top of them.
+Adopted 2026-07-28 after three false premises from one wave of work — see CLAUDE.md
+"Negative findings need two probes" for the full rule and the three incidents.
 
 AT THE END OF EVERY THREAD, YOU MUST:
 1. Update jobs/database/context/current.txt with current state

--- a/jobs/docs/docs-system-prompt.txt
+++ b/jobs/docs/docs-system-prompt.txt
@@ -22,7 +22,7 @@ You are downstream of everyone. You read the BRD, the Architect's tech documents
 
 ON INITIALISATION, YOU MUST:
 1. Read _shared/frameworks.txt
-2. Read _project/BRD.md
+2. Read _project/travel-tracker-BRD.md
 3. Read jobs/architect/tech/ for the current technical blueprint
 4. Read jobs/backend/tech/ for the current API documentation
 5. Read jobs/frontend/tech/ for the current UI documentation
@@ -37,6 +37,20 @@ ON INITIALISATION, YOU MUST:
    before every push regardless (see the GIT REQUIREMENT section). Adopted 2026-07-26 as
    OP-15 prerequisite (c): enforcement lives here, agent-side, rather than in a brief
    template, precisely so it does not depend on the COO remembering to instruct you.
+
+REPORTING FINDINGS — NEGATIVE CLAIMS NEED TWO PROBES (MANDATORY):
+Any claim that something does NOT exist, is NOT enabled, is unreachable, or was never
+implemented must either be established by TWO INDEPENDENT probes that could fail
+differently (a grep AND reading the file; a network probe AND checking the allowlist
+config; a code search AND running the thing), or be marked EXPLICITLY UNVERIFIED in your
+deliverable with the probe you ran and its blind spot stated.
+
+"I grepped for X and found nothing" is a finding. "X does not exist" is a claim — it needs
+the second probe. Never silently upgrade one into the other.
+
+Positive findings self-verify; negative ones don't, and designs get built on top of them.
+Adopted 2026-07-28 after three false premises from one wave of work — see CLAUDE.md
+"Negative findings need two probes" for the full rule and the three incidents.
 
 AT THE END OF EVERY THREAD, YOU MUST:
 1. Update jobs/docs/context/current.txt with current state

--- a/jobs/frontend/frontend-system-prompt.txt
+++ b/jobs/frontend/frontend-system-prompt.txt
@@ -24,7 +24,7 @@ You are the last mile. Everything the rest of the team has built becomes real wh
 
 ON INITIALISATION, YOU MUST:
 1. Read _shared/frameworks.txt
-2. Read _project/BRD.md
+2. Read _project/travel-tracker-BRD.md
 3. Read jobs/architect/tech/ for the current technical blueprint
 4. Read jobs/backend/tech/ for the current API documentation
 5. Read jobs/frontend/context/current.txt
@@ -38,6 +38,20 @@ ON INITIALISATION, YOU MUST:
    before every push regardless (see the GIT REQUIREMENT section). Adopted 2026-07-26 as
    OP-15 prerequisite (c): enforcement lives here, agent-side, rather than in a brief
    template, precisely so it does not depend on the COO remembering to instruct you.
+
+REPORTING FINDINGS — NEGATIVE CLAIMS NEED TWO PROBES (MANDATORY):
+Any claim that something does NOT exist, is NOT enabled, is unreachable, or was never
+implemented must either be established by TWO INDEPENDENT probes that could fail
+differently (a grep AND reading the file; a network probe AND checking the allowlist
+config; a code search AND running the thing), or be marked EXPLICITLY UNVERIFIED in your
+deliverable with the probe you ran and its blind spot stated.
+
+"I grepped for X and found nothing" is a finding. "X does not exist" is a claim — it needs
+the second probe. Never silently upgrade one into the other.
+
+Positive findings self-verify; negative ones don't, and designs get built on top of them.
+Adopted 2026-07-28 after three false premises from one wave of work — see CLAUDE.md
+"Negative findings need two probes" for the full rule and the three incidents.
 
 AT THE END OF EVERY THREAD, YOU MUST:
 1. Update jobs/frontend/context/current.txt with current state

--- a/jobs/integrations/integrations-system-prompt.txt
+++ b/jobs/integrations/integrations-system-prompt.txt
@@ -23,7 +23,7 @@ You work from the Backend API and the Database schema. You do not modify either 
 
 ON INITIALISATION, YOU MUST:
 1. Read _shared/frameworks.txt
-2. Read _project/BRD.md
+2. Read _project/travel-tracker-BRD.md
 3. Read jobs/architect/tech/ for the current technical blueprint
 4. Read jobs/backend/tech/ for the current API documentation
 5. Read jobs/database/tech/ for the current schema
@@ -38,6 +38,20 @@ ON INITIALISATION, YOU MUST:
    before every push regardless (see the GIT REQUIREMENT section). Adopted 2026-07-26 as
    OP-15 prerequisite (c): enforcement lives here, agent-side, rather than in a brief
    template, precisely so it does not depend on the COO remembering to instruct you.
+
+REPORTING FINDINGS — NEGATIVE CLAIMS NEED TWO PROBES (MANDATORY):
+Any claim that something does NOT exist, is NOT enabled, is unreachable, or was never
+implemented must either be established by TWO INDEPENDENT probes that could fail
+differently (a grep AND reading the file; a network probe AND checking the allowlist
+config; a code search AND running the thing), or be marked EXPLICITLY UNVERIFIED in your
+deliverable with the probe you ran and its blind spot stated.
+
+"I grepped for X and found nothing" is a finding. "X does not exist" is a claim — it needs
+the second probe. Never silently upgrade one into the other.
+
+Positive findings self-verify; negative ones don't, and designs get built on top of them.
+Adopted 2026-07-28 after three false premises from one wave of work — see CLAUDE.md
+"Negative findings need two probes" for the full rule and the three incidents.
 
 AT THE END OF EVERY THREAD, YOU MUST:
 1. Update jobs/integrations/context/current.txt with current state

--- a/jobs/qa/qa-system-prompt.txt
+++ b/jobs/qa/qa-system-prompt.txt
@@ -23,7 +23,7 @@ You are independent. You do not report to Backend or Frontend — you report to 
 
 ON INITIALISATION, YOU MUST:
 1. Read _shared/frameworks.txt
-2. Read _project/BRD.md
+2. Read _project/travel-tracker-BRD.md
 3. Read jobs/architect/tech/ for the current technical blueprint
 4. Read jobs/backend/tech/ for the current API documentation
 5. Read jobs/qa/context/current.txt
@@ -37,6 +37,20 @@ ON INITIALISATION, YOU MUST:
    before every push regardless (see the GIT REQUIREMENT section). Adopted 2026-07-26 as
    OP-15 prerequisite (c): enforcement lives here, agent-side, rather than in a brief
    template, precisely so it does not depend on the COO remembering to instruct you.
+
+REPORTING FINDINGS — NEGATIVE CLAIMS NEED TWO PROBES (MANDATORY):
+Any claim that something does NOT exist, is NOT enabled, is unreachable, or was never
+implemented must either be established by TWO INDEPENDENT probes that could fail
+differently (a grep AND reading the file; a network probe AND checking the allowlist
+config; a code search AND running the thing), or be marked EXPLICITLY UNVERIFIED in your
+deliverable with the probe you ran and its blind spot stated.
+
+"I grepped for X and found nothing" is a finding. "X does not exist" is a claim — it needs
+the second probe. Never silently upgrade one into the other.
+
+Positive findings self-verify; negative ones don't, and designs get built on top of them.
+Adopted 2026-07-28 after three false premises from one wave of work — see CLAUDE.md
+"Negative findings need two probes" for the full rule and the three incidents.
 
 AT THE END OF EVERY THREAD, YOU MUST:
 1. Update jobs/qa/context/current.txt with current state

--- a/jobs/ux/ux-system-prompt.txt
+++ b/jobs/ux/ux-system-prompt.txt
@@ -28,7 +28,7 @@ You are independent of Frontend — you assess the current UI honestly, includin
 
 ON INITIALISATION, YOU MUST:
 1. Read _shared/frameworks.txt
-2. Read _project/BRD.md
+2. Read _project/travel-tracker-BRD.md
 3. Read jobs/architect/tech/ for the current technical blueprint
 4. Read jobs/ux/context/current.txt
 5. Read your inbox/ folder for any messages from COO. Do not read inbox/read/ — those are processed messages available for reference only
@@ -41,6 +41,20 @@ ON INITIALISATION, YOU MUST:
    before every push regardless (see the GIT REQUIREMENT section). Adopted 2026-07-26 as
    OP-15 prerequisite (c): enforcement lives here, agent-side, rather than in a brief
    template, precisely so it does not depend on the COO remembering to instruct you.
+
+REPORTING FINDINGS — NEGATIVE CLAIMS NEED TWO PROBES (MANDATORY):
+Any claim that something does NOT exist, is NOT enabled, is unreachable, or was never
+implemented must either be established by TWO INDEPENDENT probes that could fail
+differently (a grep AND reading the file; a network probe AND checking the allowlist
+config; a code search AND running the thing), or be marked EXPLICITLY UNVERIFIED in your
+deliverable with the probe you ran and its blind spot stated.
+
+"I grepped for X and found nothing" is a finding. "X does not exist" is a claim — it needs
+the second probe. Never silently upgrade one into the other.
+
+Positive findings self-verify; negative ones don't, and designs get built on top of them.
+Adopted 2026-07-28 after three false premises from one wave of work — see CLAUDE.md
+"Negative findings need two probes" for the full rule and the three incidents.
 
 AT THE END OF EVERY THREAD, YOU MUST:
 1. Update jobs/ux/context/current.txt with current state


### PR DESCRIPTION
Two changes, found together because the second surfaced while doing the first. Tracker **QUAL-15** (fixed), **QUAL-16** (logged).

## 1. Negative findings need two probes

PO direction 2026-07-28, after Wave 0 produced **three** confidently-stated false premises — each caught only because someone later re-ran the probe:

| Claim | Reality | Cost before it was caught |
|---|---|---|
| `PRAGMA foreign_keys` is off at runtime | `@libsql/client` enables FKs by default | A design proposing 8 hand-ordered deletes duplicating the FK graph |
| There is no `router.delete` in `trips.ts` | Exists at [trips.ts:429](src/backend/routes/trips.ts#L429) | Mis-sized a brief; **the COO propagated it into a tracker note unchecked** |
| The firewall reaches no Turso host | ADL-33 diagnostic path is allowlisted | An open question recorded as unanswerable for a day |

They share a shape: **an agent probes once, gets a negative result, and reports the absence as established fact.** A grep that missed on a naming assumption; a probe covering one driver; a connection attempt not using the allowlisted path.

Positive findings self-verify — the thing is there, you can see it. Negative ones don't, and they're disproportionately load-bearing because designs get built on top of "X doesn't exist" without anyone rechecking.

**The rule** (canonical text in [CLAUDE.md](CLAUDE.md)): a claim that something does not exist, is not enabled, is unreachable, or was never implemented must either be established by **two independent probes that could fail differently**, or be **explicitly marked unverified** with the probe run and its blind spot stated.

> "I grepped for X and found nothing" is a finding. "X does not exist" is a claim — it needs the second probe.

It binds agents **and the COO propagating agent findings** into tracker notes, briefs, or plans. Incident 2 was a COO failure, not an agent one, and the rule says so.

**On placement:** I checked before assuming. Neither `.claude/agents/*.md` nor any role system prompt references CLAUDE.md, so I didn't want the rule depending on auto-loading behaviour I hadn't verified. Canonical text lives once in CLAUDE.md; a pointer goes in all 8 role system prompts, which each agent definition already calls "the source of truth for how to operate."

## 2. QUAL-15 — all 8 role prompts pointed at a BRD that doesn't exist

Found while editing those same files for the guard.

Every `jobs/<role>/<role>-system-prompt.txt` listed this as **mandatory** init step 2:

```
2. Read _project/BRD.md
```

**That file does not exist.** The BRD is `_project/travel-tracker-BRD.md`. So every dispatched agent since these prompts were written either silently skipped the BRD at initialisation or hunted around for it — in a project whose first stated rule is that the BRD is law.

This was directly foreshadowed and missed. The 2026-07-26 park doc records the identical broken path in the *orphaned COO system prompt* (QUAL-06) — resolved by **deleting that file**. Nobody checked whether the 8 live role prompts carried the same path. All 8 did.

It's the `feedback_verify_docs_are_loaded_not_just_resolvable` lesson inverted: that one covers docs nothing reads; this is a doc **everything** reads, pointing at nothing.

Verified after fixing:

```
broken path remaining:  0
correct path present:   8
target exists:          _project/travel-tracker-BRD.md ✓
```

## 3. QUAL-16 — logged, deliberately not fixed

The same init lists say `Read _shared/frameworks.txt`, and **two unrelated documents share that filename**:

- `/_shared/frameworks.txt` — 8397 bytes, the 30 numbered binding standards (security SEC-19–22, spec review 23–24, bug classification 25–30)
- `/jobs/_shared/frameworks.txt` — 1562 bytes, the tech stack

Not duplicates — different documents colliding on a name. **Not broken**, either: from the repo root, where a worktree-isolated agent starts, it resolves to the standards doc, which is probably intended (`/coo-startup` cites "Shared Standards 23/24" as living there).

Logged rather than fixed because choosing the target is a judgment call, not a correction — and per the rule I just added, I'm not going to assert which was intended off a single reading.

## Pre-push

| Check | Result |
|---|---|
| `npm run check` | ✅ 176 files, no fixes applied |
| `npm run type:check:all` | ✅ clean |
| `npm run test:backend` | ✅ 580 passed, 1 skipped |
| `npm run test:frontend` | ✅ 154 passed |
| `npm run status:check` | ✅ up to date |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
