### PR TITLE
chore(QUAL-03/QUAL-11): migration-driven test schema + FK startup assertion (#291)

### DIFF
--- a/jobs/COO/inbox/20260728_0608-BACKEND-b9-qual03-qual11-complete.txt
+++ b/jobs/COO/inbox/20260728_0608-BACKEND-b9-qual03-qual11-complete.txt
@@ -1,0 +1,58 @@
+Tracker: QUAL-03, QUAL-11 · Issue/PR: #291 / (PR to be opened) · BRD: none (internal quality) · Branch: chore/b9-migration-driven-test-schema
+
+WHAT WAS BUILT
+test-db.ts now derives its schema from the real migrations (drizzle-orm's
+libsql migrator applied to src/backend/migrations/*.sql, snapshotted once
+per module instance, replayed per test via client.batch()) instead of
+hand-writing 21 tables as literal DDL. Added assertForeignKeysEnabled() to
+startup.service.ts, wired into server.ts, which reads (never sets) PRAGMA
+foreign_keys on the real app connection and fails boot loudly if it isn't 1.
+
+ACCEPTANCE CRITERIA
+1. Test schema derives from real migrations, no hand-written CREATE TABLE remains: PASS
+2. Drift now detectable (demonstrated): PASS — see below
+3. Backend suite green, 580/1 skipped baseline: PASS (583/1 skipped — +3 new startup tests, explained)
+4. Suite runtime not materially regressed: PASS — 6.73-6.75s baseline vs 6.91-6.93s after (noise-level)
+5. Startup asserts PRAGMA foreign_keys=1, fails loudly, covered by test: PASS
+6. type:check:all and check clean: PASS
+
+DRIFT-DETECTION DEMONSTRATION
+Temporarily added `ALTER TABLE companions DROP COLUMN is_active;` to
+migrations/0012_grey_ultimates.sql. All 17 companions.test.ts tests failed
+(migrate() itself errored — SQLite refused the drop because a CHECK
+constraint in that same migration still references the column). Reverted
+via `git checkout --` (confirmed clean, no bare stash per OP-20); re-ran,
+17/17 green again. Before this brief, this exact edit would have had zero
+effect on any test.
+
+REAL DRIFT FOUND ALONG THE WAY (not injected — pre-existing)
+items.test.ts used `status: 'booked'` in 8 places. Real chk_items_status
+CHECK constraint has never allowed it (valid: consider/confirmed/completed/
+cancelled/next_time); grep confirms 'booked' appears nowhere in application
+code. Only the old hand-written DDL (no CHECK at all) let it silently pass.
+Fixed: replaced with 'confirmed' in all 8 spots — preserves test intent
+(a non-default status value), doesn't change what's being verified.
+
+SECURITY CHECKLIST
+N/A — no routes added or modified. Confirmed: touched files are test
+infra, a service, and server.ts's startup sequence only.
+
+CI: not yet opened — opening PR next, will run scripts/ci-wait.sh and report separately if needed.
+
+OPEN ISSUES / FINDINGS FOR COO
+1. Scope-sizing gap in the brief: 14 files beyond test-db.ts's 7 consumers
+   (12 in routes/__tests__/, 2 in services/__tests__/) independently
+   hand-roll the SAME 21-table DDL rather than importing test-db.ts — same
+   staleness risk as QUAL-03, larger footprint. Confirmed via grep + reading
+   3 of the 15 files directly. Recommend sizing as its own follow-up QUAL
+   item; not touched here (brief scoped explicitly to test-db.ts).
+2. ADL-41 §7.2.1 residual gap 1 updated in this PR (stamped IMPLEMENTED,
+   citing QUAL-11) per document-lifecycle rule — same-PR update since this
+   brief closes exactly that gap.
+3. tracker.json is COO-maintained per CLAUDE.md — left untouched; QUAL-03/
+   QUAL-11 status update is for COO to make on merge.
+
+WHAT'S NOW UNBLOCKED
+Every other Wave 1 backend brief's repository tests are now trustworthy
+against real schema (this was flagged as "worth running first" in the
+backlog-clearance-plan). OP-15 prerequisite (a) is clear per that plan.

--- a/jobs/architect/tech/ADL-41-trip-place-identity.md
+++ b/jobs/architect/tech/ADL-41-trip-place-identity.md
@@ -460,8 +460,20 @@ The draft's instinct was right about one thing: the guarantee is currently **imp
 rests on a driver default that nothing in this repo states, tests, or would notice changing.
 Two residual gaps:
 
-1. A `@libsql/client` major bump could flip the default and nothing would fail loudly. The
-   symptom would be silent orphaning in production, discovered months later.
+1. ~~A `@libsql/client` major bump could flip the default and nothing would fail loudly. The
+   symptom would be silent orphaning in production, discovered months later.~~
+   > **IMPLEMENTED (2026-07-28) — Backend, QUAL-11 (#291).** The startup assertion this
+   > section calls for now exists: `assertForeignKeysEnabled()` in
+   > `src/backend/services/startup.service.ts`, wired into `server.ts`'s startup sequence
+   > right after `getDb()`. It reads (never sets) `PRAGMA foreign_keys` on the real
+   > application connection and throws — refusing to boot — if it is not exactly `1`; a
+   > no-op for `DB_TYPE=postgres`, which always enforces declared FKs. Covered by
+   > `src/backend/services/__tests__/startup.service.test.ts` (resolves at 1, throws when
+   > flipped OFF on a real connection, no-ops for postgres). This gap is now closed on both
+   > transports: embedded (this test) and remote (gap 2's VERIFIED entry below) — the
+   > residual on gap 2 (read vs. behavioural write test) still applies to the *verification*
+   > probe, not to this boot-time guard, which runs against the real production connection
+   > every time the process starts.
 2. ~~**The remote Turso (`libsql://`) path is unverified.** Production runs on
    `TURSO_DATABASE_URL`; this environment's firewall reaches no Turso host, so the probes
    above cover the embedded driver only.~~

--- a/jobs/backend/context/current.txt
+++ b/jobs/backend/context/current.txt
@@ -1,71 +1,56 @@
-BACKEND CONTEXT — 2026-07-23
+BACKEND CONTEXT — 2026-07-28
 PROJECT: Travel Tracker
-CURRENT STATUS: ADL-28 (AD-07/AD-08) routes/repositories/service brief, this thread.
-  1. BRD-AD07/BRD-AD08 (PR #243 — feat/ad07-ad08-routes-repos, issue #242): implemented
-     ADL-28's "Migration sequence for Backend agent" steps 5-14. Schema half (steps 1-4)
-     had already landed via PR #240 (Database brief).
-     - New repositories: src/backend/repositories/companions.ts (companionRepository —
-       findAll/findActive/findById/create/update/deactivate/validateOwnership) and
-       src/backend/repositories/shadingConfig.ts (shadingConfigRepository —
-       findAll/findByStateKey/update/seedDefaults, lazy-seeding from the
-       MAP_SHADING_CONFIG constant in db/seed-data.ts).
-     - New router src/backend/routes/companions.ts mounted at /api/companions
-       (requireAuth only, no requireOwner) — registered in server.ts AND
-       server-test-app.ts (both needed updating).
-     - src/backend/routes/admin.ts: removed the companions registration entirely
-       (companions are no longer an admin/owner resource).
-     - src/backend/routes/map.ts: dropped requireOwner from all 5 shading routes
-       (GET /shading, GET/PATCH /shading/config, GET /shading/countries/:code,
-       GET /shading/regions/:code) — requireAuth (global) is now the only gate.
-     - src/backend/services/shading.service.ts: getConfigMap is now per-userId
-       (Map<userId, ShadingConfigMap> cache, was a single global Map keyed by
-       stateKey — R2 fix); invalidateConfigCache(userId?) invalidates one user's
-       entry (or all, if called with no arg, for test resets). getCityShading also
-       gained a userId param and scopes its trips join (R1 fix — it was
-       unscoped, aggregating every user's trips). Note: getAllCountryShading/
-       getCountryShading/getRegionShading were ALREADY userId-scoped before this
-       brief (HC-03, 2026-07-15) — that part of R1 was not a gap this brief closed,
-       only getCityShading and the config layer were.
-     - src/backend/repositories/trips.ts: replaceAssociations gained a userId
-       param (all callers updated in routes/trips.ts) and now calls
-       companionRepository.validateOwnership before inserting
-       trip_companions_map rows, throwing ValidationError (400) for any
-       companionId not owned by the caller (R4 — the sole enforcement point,
-       SQLite can't do this at the schema level).
-     - Test coverage added: repositories/__tests__/companions.test.ts,
-       repositories/__tests__/shadingConfig.test.ts, routes/__tests__/
-       companions.test.ts, routes/__tests__/map.test.ts, plus cross-user
-       companion-assignment-rejection cases in repositories/__tests__/trips.test.ts.
-     - Existing tests updated: owner-access.test.ts (removed companion admin
-       tests + HC-05 map-shading-owner-gate describe, both superseded),
-       security.access-matrix.test.ts (DDL fix for map_shading_config/companions
-       userId columns, Part A/B/C rows updated for the new auth model),
-       qa-backend-fixes.test.ts (PATCH url moved to /api/companions). Both tests
-       the schema-migration brief had left `.skip`'d
-       (owner-access.test.ts's "POST /api/admin/companions → 201 for owner" and
-       e2e admin.spec.ts's "create companion appears in list") are resolved:
-       the backend one is deleted/replaced by non-skipped coverage in the new
-       companions.test.ts; the e2e one remains skipped (see Open Issues below).
-     - Document lifecycle: updated jobs/architect/tech/20260307-map-shading-spec.md's
-       HC-03 correction note (was "not yet userId-scoped", now accurate) and
-       ADL-28's own Migration status note (all 14 steps now recorded done).
-       Also updated jobs/backend/tech/20260307-api-reference.md (v1.5) — new
-       Companions section, Map Shading section per-user note, Admin section
-       companions removed — and _project/tracker.json notes for BRD-AD07/BRD-AD08.
-ACTIVE TASKS: None — PR #243 open, awaiting CI + COO review/merge.
-PENDING MESSAGES TO COO:
-  20260723_[time]-BACKEND-ad07-ad08-routes-repos-complete.txt (sent)
+CURRENT STATUS: B9 brief (QUAL-03 + QUAL-11), this thread.
+  1. QUAL-03/QUAL-11 (branch chore/b9-migration-driven-test-schema, issue #291):
+     - src/backend/repositories/__tests__/test-db.ts rewritten: no more
+       hand-written 21-table DDL. Now applies the real migrations
+       (src/backend/migrations/*.sql) via drizzle-orm's libsql migrator to a
+       template :memory: DB ONCE per module instance (Vitest isolate:true
+       default ⇒ effectively once per test file), snapshots the schema from
+       sqlite_master, and replays that cached snapshot into a fresh
+       :memory: DB per createTestDb() call via client.batch(). Exported API
+       (createTestDb, TestDb, TEST_USER_ID, OTHER_USER_ID, seedTestUser,
+       seedTrip, seedCountry, seedCity, seedCompanion) is unchanged — all 7
+       consumers needed no changes.
+     - This immediately surfaced real pre-existing drift: items.test.ts used
+       status: 'booked' in 8 places, which has never been valid against the
+       real chk_items_status CHECK constraint (schema.ts:497-500 —
+       consider/confirmed/completed/cancelled/next_time) and appears nowhere
+       in application code. Only the old hand-written DDL (no CHECK at all)
+       let it silently pass. Fixed by replacing with 'confirmed' — preserves
+       every test's actual intent (a non-default status for filter/update
+       assertions).
+     - src/backend/services/startup.service.ts: added
+       assertForeignKeysEnabled() — reads (never sets) PRAGMA foreign_keys on
+       the real application connection, throws if not exactly 1. No-op for
+       DB_TYPE=postgres. Wired into server.ts's startup() right after getDb().
+       Covered by new src/backend/services/__tests__/startup.service.test.ts
+       (3 tests: resolves at 1, throws when flipped OFF on a real connection,
+       no-ops for postgres).
+     - jobs/architect/tech/ADL-41-trip-place-identity.md §7.2.1: stamped
+       residual gap 1 IMPLEMENTED, citing this brief.
+     - Drift-detection demonstrated live: temporarily appended
+       `ALTER TABLE companions DROP COLUMN is_active;` to migrations/0012,
+       all 17 companions.test.ts tests failed, reverted via `git checkout --`,
+       re-ran green. See completion report for full detail.
+     - Backend suite: 583 passed (580 baseline + 3 new tests), 1 skipped.
+       Duration ~6.7-6.9s before and after — no material regression.
+     - Found but OUT OF SCOPE: 14 other test files (routes/__tests__/*,
+       services/__tests__/shading.*.test.ts) independently hand-roll the
+       SAME 21-table DDL rather than importing test-db.ts — the brief's "7
+       files consume test-db.ts" undercounts the total duplication. Same
+       staleness risk, not touched this thread; flagged to COO as a
+       follow-up-sized finding.
+ACTIVE TASKS: None — PR to be opened this thread, awaiting CI + COO review/merge.
+PENDING MESSAGES TO COO: 20260728_[time]-BACKEND-b9-qual03-qual11-complete.txt (to send)
 OPEN ISSUES:
-  - src/e2e/admin.spec.ts's companion e2e test remains `.skip`'d. Root cause: the
-    frontend (src/frontend/hooks/useAdmin.ts) still calls the old
-    /api/admin/companions path, which this brief removed. Fixing that hook is a
-    frontend change outside a Backend brief's scope. Needs a small Frontend
-    follow-up brief to repoint useAdmin.ts's companion calls at /api/companions,
-    after which this e2e test should be un-skipped and pass unmodified.
-  - Contract tests (npm run test:contract) were not run this thread — they
-    require a live backend and grep confirmed no contract test touches
-    /api/admin/companions or /api/map/shading directly (only the generic
-    trip.companions array shape, unaffected). Flagged as low-risk, not verified
-    live.
-LAST PARK DOC: jobs/backend/park-docs/20260723-BACKEND-ad07-ad08-park.txt
-  (see also 20260721-BACKEND-nf09-hosted-deployment-park.txt for prior thread)
+  - 14 test files beyond test-db.ts's 7 consumers hand-roll their own copy of
+    the same 21-table DDL (routes/__tests__/*.test.ts,
+    services/__tests__/shading.trip-countries.test.ts,
+    services/__tests__/shading.user-scope.test.ts). Same drift risk as
+    QUAL-03 described, at larger scale. Sizing a fix: likely a bigger lift
+    than B9 (touches more files, some may have per-test seed helpers beyond
+    what test-db.ts exports) — recommend COO size as its own QUAL item rather
+    than folding into this brief's scope.
+LAST PARK DOC: jobs/backend/park-docs/20260728-BACKEND-b9-park.txt
+  (see also 20260723-BACKEND-ad07-ad08-park.txt for prior thread)

--- a/jobs/backend/park-docs/20260728-BACKEND-b9-park.txt
+++ b/jobs/backend/park-docs/20260728-BACKEND-b9-park.txt
@@ -1,0 +1,167 @@
+PARK DOCUMENT — BACKEND — 2026-07-28
+BRIEF: B9 (Wave 1 sub-wave A) — QUAL-03 + QUAL-11
+BRANCH: chore/b9-migration-driven-test-schema
+GITHUB ISSUE: #291
+
+=== SCOPE ===
+Two backend items, one branch, no route changes:
+1. QUAL-03 — make src/backend/repositories/__tests__/test-db.ts derive its
+   schema from the real migrations instead of hand-written DDL.
+2. QUAL-11 — assert (never set) PRAGMA foreign_keys = 1 on the real
+   application connection at startup.
+
+=== QUAL-03 IMPLEMENTATION ===
+
+Old shape: test-db.ts imported db/schema.ts for Drizzle typing only, then
+hand-wrote all 21 tables as literal CREATE TABLE strings executed in a for
+loop against a fresh :memory: client per test. A migration could change the
+real schema (add a column, tighten a CHECK constraint, add a FK) and every
+repository test would keep passing against the stale copy.
+
+New shape:
+- getSchemaDdl() (module-scope, memoized via a single cached Promise):
+  spins up a throwaway template :memory: libsql client, runs
+  drizzle-orm/libsql/migrator's migrate(templateDb, { migrationsFolder })
+  against src/backend/migrations/ — the same 13 .sql files + meta/_journal.json
+  that `npm run db:migrate` applies in every real environment — then reads
+  `SELECT sql FROM sqlite_master WHERE sql IS NOT NULL AND name NOT LIKE
+  'sqlite_%' AND name != '__drizzle_migrations' ORDER BY rowid` to capture
+  the resulting schema as an ordered list of DDL statements. rowid order is
+  creation order, which is what makes replaying it back safe regardless of
+  how many migrations rewrote/recreated a given table along the way — by
+  the time we snapshot, sqlite_master reflects only the FINAL state, and
+  SQLite doesn't validate FK target existence at CREATE TABLE time, so
+  statement order relative to FK targets is a non-issue.
+- createTestDb() creates a fresh :memory: client (unchanged: still
+  PRAGMA foreign_keys = ON; explicitly, still isolated per test), then
+  replays the cached DDL snapshot via a single `client.batch(ddl, 'write')`
+  call instead of 21 sequential `client.execute()` round-trips.
+
+Cost model: migrate() (the expensive part — reading 13 files, applying each
+in its own transaction) runs ONCE per module instance. Vitest's default
+`isolate: true` gives each test FILE its own module registry (confirmed —
+vitest.config.backend.ts has no isolate override), so in practice this is
+"once per test file that imports test-db.ts" (7 files), not once globally
+and NOT once per test. Measured migrate() cost in isolation: ~37ms.
+client.batch() replay of the resulting ~40-50 statement snapshot into a
+fresh :memory: DB: ~3ms. Both are trivial next to the ~230ms per-file
+Vitest/transform overhead already present.
+
+Exported API unchanged: createTestDb, TestDb, TEST_USER_ID, OTHER_USER_ID,
+seedTestUser, seedTrip, seedCountry, seedCity, seedCompanion. All 7
+consumers (shadingConfig.test.ts, items.test.ts, users.test.ts,
+companions.test.ts, places.test.ts, trips.test.ts, lock-matrix.test.ts)
+needed zero changes beyond the one described below.
+
+=== REAL DRIFT SURFACED IMMEDIATELY ===
+
+items.test.ts used `status: 'booked'` in 8 places (lines 101, 107, 240, 250,
+252, 384, 390, 444 in the pre-fix file). Running against the real migrations
+failed with SQLITE_CONSTRAINT_CHECK: chk_items_status — 'booked' is not in
+('consider', 'confirmed', 'completed', 'cancelled', 'next_time')
+(schema.ts:493-500, present since migration 0000). Verified by two
+independent checks that this is genuinely dead/wrong test data, not a
+missing app feature: (1) grep for `'booked'` across src/backend outside
+__tests__/ returns nothing — no route, service, or repository ever writes
+this value; (2) the old hand-written test-db.ts DDL had NO CHECK constraint
+on items.status at all, so nothing before this fix could ever have caught
+it. Fixed by replacing all 8 occurrences with 'confirmed' — every affected
+test only used the value as "some non-default status" for filter/update
+assertions, never asserting on the literal word "booked", so intent is
+fully preserved.
+
+=== DRIFT-DETECTION DEMONSTRATION (success criterion 2) ===
+
+Temporarily appended one line to migrations/0012_grey_ultimates.sql:
+  ALTER TABLE `companions` DROP COLUMN `is_active`;
+Ran `npx vitest run --config vitest.config.backend.ts
+src/backend/repositories/__tests__/companions.test.ts`:
+  → migrate() itself failed: "SQLITE_ERROR: error in table companions after
+    drop column: no such column: companions.is_active" (SQLite refuses to
+    drop a column referenced by the CHECK constraint chk_companions_is_active
+    also defined in that same migration file) — all 17 companions.test.ts
+    tests failed as a result.
+Reverted via `git checkout -- src/backend/migrations/0012_grey_ultimates.sql`
+(confirmed clean via `git diff` — no bare stash used, per OP-20). Re-ran the
+same file: 17/17 pass again. Confirms the fix is real: before this brief,
+this exact migration edit would have had ZERO effect on any repository test,
+since test-db.ts's hand-written DDL never even referenced migrations/.
+
+=== QUAL-11 IMPLEMENTATION ===
+
+assertForeignKeysEnabled() added to startup.service.ts:
+- No-ops (logs + returns) when process.env.DB_TYPE !== 'sqlite' — Postgres
+  always enforces declared FK constraints, no PRAGMA equivalent, no driver-
+  default risk.
+- Otherwise calls getDb().get(sql`PRAGMA foreign_keys`) and throws a
+  descriptive Error (citing ADL-41 §7.2.1) if the result isn't exactly 1.
+- Per ADL-41 §7.2's transport analysis: this READS state, never SETS it.
+  Read is correct on both the embedded driver and the remote libsql://
+  HTTP transport (each statement independently dispatched — reading
+  reflects the per-statement default that every real cascade executes
+  under; setting once at connect would not persist across statements).
+
+Wired into server.ts's startup() as new step 2, immediately after
+`getDb()`/"Database connection: OK" and before any seeding — renumbered the
+existing steps 2-6 to 3-7 (module doc comment + inline `// N.` comments both
+updated, including the 4b/4c bypass-user/owner-reconciliation comments which
+are now 5b/5c).
+
+server-test-app.ts does not call the seed/startup functions at all (grepped
+directly — confirmed by reading the file, not just the negative grep), so
+no change needed there.
+
+Test coverage: src/backend/services/__tests__/startup.service.test.ts, 3
+cases, using the same vi.mock('../../db/index.js', ...) + createTestDb()
+pattern as every other repository/service test:
+  1. resolves silently when PRAGMA foreign_keys = 1 (createTestDb()'s
+     existing explicit PRAGMA foreign_keys = ON — the production-equivalent
+     state per the @libsql/client default).
+  2. throws with message matching /PRAGMA foreign_keys returned/ and
+     /Refusing to start/ after explicitly issuing
+     `PRAGMA foreign_keys = OFF;` on the real test connection — a genuine
+     read of genuine per-connection state, not a mocked return value.
+  3. no-op for DB_TYPE=postgres — getDb() is never even called in that
+     branch (testDb set to null to prove it).
+
+ADL-41 §7.2.1 updated: residual gap 1 ("a @libsql/client major bump could
+flip the default and nothing would fail loudly") struck through and stamped
+IMPLEMENTED (2026-07-28, Backend, QUAL-11 #291), same pattern as the
+existing gap-2 VERIFIED stamp already in that file.
+
+=== VERIFICATION RUN (all green) ===
+- npm run test:backend: 583 passed (580 + 3 new), 1 skipped — matches
+  baseline + new coverage exactly.
+- Suite duration: baseline (2 runs, pre-change) 6.75s / 6.73s. Post-change
+  (2 runs) 6.91s / 6.93s. Within run-to-run noise; not a material
+  regression.
+- npm run test:frontend: 154 passed (untouched by this brief, sanity check).
+- npm run type:check:all: clean.
+- npm run check (biome): clean.
+- npm run status:check: STATUS.md already in sync, no regen needed.
+
+=== FOUND, NOT ACTIONED (flagged for COO) ===
+14 files beyond test-db.ts's 7 consumers independently hand-roll the exact
+same 21-table DDL rather than importing test-db.ts at all:
+  src/backend/routes/__tests__/{cities.get-by-id,places,
+    items.rating-sort-filter,qa-backend-fixes,items,trips.crud,
+    owner-access,trip-countries,map,trips.delete,
+    security.access-matrix,cities.carry-forward}.test.ts
+  src/backend/services/__tests__/{shading.trip-countries,
+    shading.user-scope}.test.ts
+Confirmed by two probes: grep for the literal DDL string across all 15
+matches, then read three of them directly (cities.get-by-id.test.ts,
+security.access-matrix.test.ts, shading.trip-countries.test.ts) to confirm
+each has its own local `createTestDb()` function, not an import of
+test-db.ts. Same staleness risk QUAL-03 was raised for, at larger scale —
+the brief's "7 files consume test-db.ts" framing underrepresents how much
+of this pattern actually exists in the test suite. Not touched this thread
+(out of the brief's stated scope: "src/backend/repositories/__tests__/
+test-db.ts ... 7 files consume test-db.ts"). Recommend COO size this as its
+own follow-up QUAL item.
+
+=== NOTHING CONTRADICTS THE BRIEF'S CORE DIRECTION ===
+The "build once, clone per test" caveat, the "assert don't set" constraint,
+and the "already-verified remote gap" note in the brief all held up exactly
+as stated. The one thing the brief undersold is the true size of the
+duplicate-DDL problem (see above) — everything else matched what was found.

--- a/src/backend/repositories/__tests__/items.test.ts
+++ b/src/backend/repositories/__tests__/items.test.ts
@@ -98,13 +98,13 @@ describe('itemRepository.create', () => {
     const item = await itemRepository.create(
       TEST_USER_ID,
       trip.id,
-      { itemType: 'flight', status: 'booked' },
+      { itemType: 'flight', status: 'confirmed' },
       { airline: 'Air France', flight_number: 'AF001' },
     );
 
     expect(item).toHaveProperty('id');
     expect(item.item_type).toBe('flight');
-    expect(item.status).toBe('booked');
+    expect(item.status).toBe('confirmed');
     expect(item.airline).toBe('Air France');
     expect(item.flight_number).toBe('AF001');
     expect(item.is_carried_forward).toBe(false);
@@ -237,7 +237,7 @@ describe('itemRepository.findByTrip', () => {
     await itemRepository.create(
       TEST_USER_ID,
       trip.id,
-      { itemType: 'flight', status: 'booked' },
+      { itemType: 'flight', status: 'confirmed' },
       {},
     );
     await itemRepository.create(
@@ -247,9 +247,9 @@ describe('itemRepository.findByTrip', () => {
       {},
     );
 
-    const result = await itemRepository.findByTrip(TEST_USER_ID, trip.id, { status: 'booked' });
+    const result = await itemRepository.findByTrip(TEST_USER_ID, trip.id, { status: 'confirmed' });
     expect(result).toHaveLength(1);
-    expect(result[0].status).toBe('booked');
+    expect(result[0].status).toBe('confirmed');
   });
 
   it('filters by placeId', async () => {
@@ -381,13 +381,13 @@ describe('itemRepository.update', () => {
       TEST_USER_ID,
       trip.id,
       item.id as number,
-      { status: 'booked' },
+      { status: 'confirmed' },
       {},
       'flight',
     );
 
     expect(result).not.toBeNull();
-    expect(result!.status).toBe('booked');
+    expect(result!.status).toBe('confirmed');
   });
 
   it('updates notes field', async () => {
@@ -441,7 +441,7 @@ describe('itemRepository.update', () => {
       TEST_USER_ID,
       trip.id,
       item.id as number,
-      { status: 'booked' },
+      { status: 'confirmed' },
       {},
       'flight',
     );

--- a/src/backend/repositories/__tests__/test-db.ts
+++ b/src/backend/repositories/__tests__/test-db.ts
@@ -1,204 +1,95 @@
 /**
  * Shared in-memory test database factory for repository tests.
  *
- * Creates a fresh libSQL :memory: database with the full schema applied.
- * Each test should call createTestDb() in beforeEach for full isolation.
+ * QUAL-03: this used to hand-write all 21 tables as literal DDL, duplicating
+ * db/schema.ts. A migration could change the real schema while every
+ * repository test kept passing green against the stale hand-written copy —
+ * the tests could not detect the drift.
+ *
+ * Now migration-driven: the REAL migrations (src/backend/migrations/*.sql)
+ * are applied once per worker (via drizzle-orm's libsql migrator, the same
+ * programmatic path drizzle-kit's own migrate command wraps) to a template
+ * in-memory database. The resulting schema is captured as a DDL snapshot
+ * (`SELECT sql FROM sqlite_master`, in creation order) and cached at module
+ * scope. Every createTestDb() call replays that cached snapshot into a fresh
+ * :memory: database via a single client.batch() — no per-test migration
+ * replay, so suite time is not affected by the number of migration files.
+ * The snapshot itself is only ever built once (first createTestDb() call
+ * within this module instance — Vitest's default `isolate: true` gives each
+ * test file its own module registry, so in practice this is "once per test
+ * file", not once per test).
+ *
+ * Because the snapshot is derived from applying the real migrations, a
+ * migration/schema change that isn't reflected in the applied SQL now shows
+ * up as a genuine repository-test failure instead of passing silently
+ * against a stale hand-written copy.
+ *
+ * Each test should still call createTestDb() in beforeEach for full
+ * per-test isolation (a fresh :memory: database) — only the *schema build*
+ * is shared, never the data.
  */
 
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { createClient } from '@libsql/client';
 import { drizzle } from 'drizzle-orm/libsql';
+import { migrate } from 'drizzle-orm/libsql/migrator';
 import * as schema from '../../db/schema.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const MIGRATIONS_FOLDER = join(__dirname, '../../migrations');
+
+// ----------------------------------------------------------------
+// Schema snapshot — built once per module instance, reused by every
+// createTestDb() call thereafter.
+// ----------------------------------------------------------------
+
+let cachedDdlPromise: Promise<string[]> | null = null;
+
+/**
+ * Applies the real migrations to a throwaway template :memory: database and
+ * returns the resulting schema as an ordered list of DDL statements
+ * (CREATE TABLE / CREATE INDEX / …), lifted straight from sqlite_master.
+ *
+ * Excludes drizzle's own `__drizzle_migrations` bookkeeping table and
+ * SQLite's internal `sqlite_%` objects — neither is part of the application
+ * schema tests should see.
+ *
+ * Cached at module scope: only the first call in a given module instance
+ * pays the migration-replay cost. Every subsequent call (including from
+ * concurrent createTestDb() invocations) awaits the same in-flight promise.
+ */
+function getSchemaDdl(): Promise<string[]> {
+  if (!cachedDdlPromise) {
+    cachedDdlPromise = (async () => {
+      const templateClient = createClient({ url: ':memory:' });
+      try {
+        const templateDb = drizzle(templateClient, { schema });
+        await migrate(templateDb, { migrationsFolder: MIGRATIONS_FOLDER });
+
+        const { rows } = await templateClient.execute(
+          `SELECT sql FROM sqlite_master
+           WHERE sql IS NOT NULL
+             AND name NOT LIKE 'sqlite_%'
+             AND name != '__drizzle_migrations'
+           ORDER BY rowid`,
+        );
+        return rows.map((row) => row.sql as string);
+      } finally {
+        templateClient.close();
+      }
+    })();
+  }
+  return cachedDdlPromise;
+}
 
 export async function createTestDb() {
   const client = createClient({ url: ':memory:' });
 
   await client.execute('PRAGMA foreign_keys = ON;');
 
-  const ddlStatements = [
-    `CREATE TABLE IF NOT EXISTS countries (
-      country_code TEXT PRIMARY KEY NOT NULL,
-      name TEXT NOT NULL,
-      region_tier_enabled INTEGER DEFAULT 0 NOT NULL,
-      region_tier_label TEXT,
-      created_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')) NOT NULL,
-      updated_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')) NOT NULL
-    )`,
-    `CREATE TABLE IF NOT EXISTS regions (
-      id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-      country_code TEXT NOT NULL,
-      name TEXT NOT NULL,
-      iso_3166_2 TEXT NOT NULL DEFAULT 'XX-UNKNOWN',
-      created_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')) NOT NULL,
-      updated_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')) NOT NULL,
-      FOREIGN KEY (country_code) REFERENCES countries(country_code)
-    )`,
-    `CREATE TABLE IF NOT EXISTS cities (
-      id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-      country_code TEXT NOT NULL,
-      region_id INTEGER,
-      name TEXT NOT NULL,
-      latitude REAL,
-      longitude REAL,
-      geocode_status TEXT DEFAULT 'pending' NOT NULL,
-      geocode_attempted_at TEXT,
-      created_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')) NOT NULL,
-      updated_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')) NOT NULL,
-      FOREIGN KEY (country_code) REFERENCES countries(country_code),
-      FOREIGN KEY (region_id) REFERENCES regions(id)
-    )`,
-    `CREATE TABLE IF NOT EXISTS users (
-      id TEXT PRIMARY KEY NOT NULL,
-      clerk_id TEXT NOT NULL UNIQUE,
-      email TEXT NOT NULL,
-      is_owner INTEGER DEFAULT 0 NOT NULL,
-      created_at INTEGER NOT NULL,
-      updated_at INTEGER NOT NULL
-    )`,
-    `CREATE TABLE IF NOT EXISTS trips (
-      id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-      name TEXT NOT NULL,
-      start_date TEXT NOT NULL,
-      end_date TEXT NOT NULL,
-      status TEXT DEFAULT 'planning' NOT NULL,
-      photo_album_ref TEXT,
-      user_id TEXT,
-      created_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')) NOT NULL,
-      updated_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')) NOT NULL,
-      FOREIGN KEY (user_id) REFERENCES users(id)
-    )`,
-    `CREATE TABLE IF NOT EXISTS trip_categories (
-      id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-      name TEXT NOT NULL UNIQUE,
-      is_active INTEGER DEFAULT 1 NOT NULL,
-      created_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')) NOT NULL,
-      updated_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')) NOT NULL
-    )`,
-    `CREATE TABLE IF NOT EXISTS trip_categories_map (
-      trip_id INTEGER NOT NULL,
-      category_id INTEGER NOT NULL,
-      PRIMARY KEY (trip_id, category_id),
-      FOREIGN KEY (trip_id) REFERENCES trips(id) ON DELETE CASCADE,
-      FOREIGN KEY (category_id) REFERENCES trip_categories(id)
-    )`,
-    `CREATE TABLE IF NOT EXISTS companions (
-      id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-      user_id TEXT NOT NULL,
-      name TEXT NOT NULL,
-      is_active INTEGER DEFAULT 1 NOT NULL,
-      created_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')) NOT NULL,
-      updated_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')) NOT NULL,
-      UNIQUE (user_id, name),
-      FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
-    )`,
-    `CREATE TABLE IF NOT EXISTS trip_companions_map (
-      trip_id INTEGER NOT NULL,
-      companion_id INTEGER NOT NULL,
-      PRIMARY KEY (trip_id, companion_id),
-      FOREIGN KEY (trip_id) REFERENCES trips(id) ON DELETE CASCADE,
-      FOREIGN KEY (companion_id) REFERENCES companions(id)
-    )`,
-    `CREATE TABLE IF NOT EXISTS activities (
-      id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-      name TEXT NOT NULL UNIQUE,
-      is_active INTEGER DEFAULT 1 NOT NULL,
-      created_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')) NOT NULL,
-      updated_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')) NOT NULL
-    )`,
-    `CREATE TABLE IF NOT EXISTS trip_activities_map (
-      trip_id INTEGER NOT NULL,
-      activity_id INTEGER NOT NULL,
-      PRIMARY KEY (trip_id, activity_id),
-      FOREIGN KEY (trip_id) REFERENCES trips(id) ON DELETE CASCADE,
-      FOREIGN KEY (activity_id) REFERENCES activities(id)
-    )`,
-    `CREATE TABLE IF NOT EXISTS trip_places (
-      id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-      trip_id INTEGER NOT NULL,
-      city_id INTEGER NOT NULL,
-      user_id TEXT,
-      arrived_on TEXT,
-      departed_on TEXT,
-      created_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')) NOT NULL,
-      updated_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')) NOT NULL,
-      FOREIGN KEY (trip_id) REFERENCES trips(id) ON DELETE CASCADE,
-      FOREIGN KEY (city_id) REFERENCES cities(id),
-      FOREIGN KEY (user_id) REFERENCES users(id)
-    )`,
-    `CREATE TABLE IF NOT EXISTS trip_place_activities_map (
-      trip_place_id INTEGER NOT NULL,
-      activity_id INTEGER NOT NULL,
-      PRIMARY KEY (trip_place_id, activity_id),
-      FOREIGN KEY (trip_place_id) REFERENCES trip_places(id) ON DELETE CASCADE,
-      FOREIGN KEY (activity_id) REFERENCES activities(id)
-    )`,
-    `CREATE TABLE IF NOT EXISTS trip_countries (
-      trip_id INTEGER NOT NULL,
-      country_code TEXT NOT NULL,
-      created_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')) NOT NULL,
-      PRIMARY KEY (trip_id, country_code),
-      FOREIGN KEY (trip_id) REFERENCES trips(id) ON DELETE CASCADE,
-      FOREIGN KEY (country_code) REFERENCES countries(country_code) ON DELETE RESTRICT
-    )`,
-    `CREATE INDEX IF NOT EXISTS idx_trip_countries_country ON trip_countries (country_code)`,
-    `CREATE TABLE IF NOT EXISTS items (
-      id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-      trip_id INTEGER NOT NULL,
-      trip_place_id INTEGER,
-      item_type TEXT NOT NULL,
-      status TEXT DEFAULT 'consider' NOT NULL,
-      notes TEXT,
-      is_carried_forward INTEGER DEFAULT 0 NOT NULL,
-      carried_from_item_id INTEGER,
-      user_id TEXT,
-      created_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')) NOT NULL,
-      updated_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')) NOT NULL,
-      FOREIGN KEY (trip_id) REFERENCES trips(id) ON DELETE CASCADE,
-      FOREIGN KEY (trip_place_id) REFERENCES trip_places(id),
-      FOREIGN KEY (user_id) REFERENCES users(id)
-    )`,
-    `CREATE TABLE IF NOT EXISTS item_flights (
-      item_id INTEGER PRIMARY KEY NOT NULL,
-      airline TEXT, flight_number TEXT, departure_airport TEXT, arrival_airport TEXT,
-      departure_datetime TEXT, arrival_datetime TEXT, booking_reference TEXT, seat TEXT,
-      FOREIGN KEY (item_id) REFERENCES items(id) ON DELETE CASCADE
-    )`,
-    `CREATE TABLE IF NOT EXISTS item_hotels (
-      item_id INTEGER PRIMARY KEY NOT NULL,
-      property_name TEXT, address TEXT, check_in_date TEXT, check_out_date TEXT,
-      booking_reference TEXT, confirmation_number TEXT, rating INTEGER, post_visit_notes TEXT,
-      FOREIGN KEY (item_id) REFERENCES items(id) ON DELETE CASCADE
-    )`,
-    `CREATE TABLE IF NOT EXISTS item_car_rentals (
-      item_id INTEGER PRIMARY KEY NOT NULL,
-      provider TEXT, pickup_location TEXT, dropoff_location TEXT,
-      pickup_datetime TEXT, dropoff_datetime TEXT, booking_reference TEXT, vehicle_class TEXT,
-      FOREIGN KEY (item_id) REFERENCES items(id) ON DELETE CASCADE
-    )`,
-    `CREATE TABLE IF NOT EXISTS item_restaurants (
-      item_id INTEGER PRIMARY KEY NOT NULL,
-      name TEXT, neighbourhood_area TEXT, cuisine_type TEXT, source TEXT,
-      rating INTEGER, post_visit_notes TEXT,
-      FOREIGN KEY (item_id) REFERENCES items(id) ON DELETE CASCADE
-    )`,
-    `CREATE TABLE IF NOT EXISTS item_experiences (
-      item_id INTEGER PRIMARY KEY NOT NULL,
-      rating INTEGER, post_visit_notes TEXT,
-      FOREIGN KEY (item_id) REFERENCES items(id) ON DELETE CASCADE
-    )`,
-    `CREATE TABLE IF NOT EXISTS map_shading_config (
-      state_key TEXT NOT NULL,
-      user_id TEXT NOT NULL,
-      display_name TEXT NOT NULL,
-      color_hex TEXT NOT NULL,
-      updated_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')) NOT NULL,
-      PRIMARY KEY (state_key, user_id),
-      FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
-    )`,
-  ];
-
-  for (const sql of ddlStatements) {
-    await client.execute(sql);
-  }
+  const ddlStatements = await getSchemaDdl();
+  await client.batch(ddlStatements, 'write');
 
   return drizzle(client, { schema });
 }

--- a/src/backend/server.ts
+++ b/src/backend/server.ts
@@ -11,12 +11,14 @@
  *   7. global error handler — LAST (SEC-06)
  *
  * Startup sequence on launch:
- *   1. getDb()                  — verify DB connection
- *   2. seedAdminData()          — trip_categories, activities, companions, map_shading_config
- *   3. seedCountries()          — countries table from data/countries.json
- *   4. seedRegions()            — regions table from data/regions.json
- *   5. processQueue()           — resolve any pending city geocoding
- *   6. schedule processQueue every 15 minutes
+ *   1. getDb()                       — verify DB connection
+ *   2. assertForeignKeysEnabled()    — QUAL-11/ADL-41 §7.2.1: fail loudly if
+ *                                      PRAGMA foreign_keys != 1 (DB_TYPE=sqlite only)
+ *   3. seedAdminData()               — trip_categories, activities, companions, map_shading_config
+ *   4. seedCountries()               — countries table from data/countries.json
+ *   5. seedRegions()                 — regions table from data/regions.json
+ *   6. processQueue()                — resolve any pending city geocoding
+ *   7. schedule processQueue every 15 minutes
  */
 
 import 'dotenv/config';
@@ -43,7 +45,12 @@ import { mapRouter } from './routes/map.js';
 import { meRouter } from './routes/me.js';
 import { tripsRouter } from './routes/trips.js';
 import { processQueue } from './services/geocoding.service.js';
-import { seedAdminData, seedCountries, seedRegions } from './services/startup.service.js';
+import {
+  assertForeignKeysEnabled,
+  seedAdminData,
+  seedCountries,
+  seedRegions,
+} from './services/startup.service.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -270,16 +277,20 @@ async function startup(): Promise<void> {
   const db = getDb();
   console.info('[STARTUP] Database connection: OK');
 
-  // 2. Seed admin data (trip_categories, activities, companions, map_shading_config)
+  // 2. Assert FK enforcement is active (QUAL-11 / ADL-41 §7.2.1 decision 9) —
+  // read-only check, fails loudly rather than allowing silent orphaning.
+  await assertForeignKeysEnabled();
+
+  // 3. Seed admin data (trip_categories, activities, companions, map_shading_config)
   await seedAdminData();
 
-  // 3. Seed countries if empty
+  // 4. Seed countries if empty
   await seedCountries();
 
-  // 4. Seed regions if empty (US, AU, CA — Correction 2)
+  // 5. Seed regions if empty (US, AU, CA — Correction 2)
   await seedRegions();
 
-  // 4b. Seed bypass test user when BYPASS_AUTH=true (contract test / CI environment).
+  // 5b. Seed bypass test user when BYPASS_AUTH=true (contract test / CI environment).
   // The bypass auth middleware sets req.user.id to a fixed UUID without creating a DB row.
   // Since trips/items/places now have FK to users.id (ADL-18), the test user must exist.
   // We insert with the same fixed ID used by the bypass middleware in auth.ts.
@@ -299,7 +310,7 @@ async function startup(): Promise<void> {
     console.info('[STARTUP] Bypass test user seeded (BYPASS_AUTH=true)');
   }
 
-  // 4c. ADL-27: Reconciliation pass — set is_owner flag from OWNER_CLERK_ID env var.
+  // 5c. ADL-27: Reconciliation pass — set is_owner flag from OWNER_CLERK_ID env var.
   // This corrects any drift (manual DB edits, test data from BYPASS_AUTH sessions,
   // or OWNER_CLERK_ID changes after initial deployment).
   // The primary assignment is in findOrCreateByClerkId (handles fresh-DB case).
@@ -310,12 +321,12 @@ async function startup(): Promise<void> {
     console.warn('[SECURITY] OWNER_CLERK_ID is not set — no admin owner configured.');
   }
 
-  // 5. Process any pending geocoding (offline-safe — GE-12)
+  // 6. Process any pending geocoding (offline-safe — GE-12)
   processQueue().catch((err: unknown) => {
     console.error('[STARTUP] Geocoding queue error:', (err as Error).message);
   });
 
-  // 6. Schedule geocoding queue every 15 minutes
+  // 7. Schedule geocoding queue every 15 minutes
   setInterval(
     () => {
       processQueue().catch((err: unknown) => {

--- a/src/backend/services/__tests__/startup.service.test.ts
+++ b/src/backend/services/__tests__/startup.service.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Unit tests for assertForeignKeysEnabled() (src/backend/services/startup.service.ts).
+ *
+ * QUAL-11 / ADL-41 §7.2.1 decision 9 — this is a READ of PRAGMA foreign_keys on
+ * the real application connection, never a SET. Covers:
+ *   - resolves silently when PRAGMA foreign_keys = 1 (the expected state)
+ *   - throws loudly when PRAGMA foreign_keys is not 1 (driver default flipped)
+ *   - is a no-op for DB_TYPE=postgres, which always enforces declared FKs
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createTestDb, type TestDb } from '../../repositories/__tests__/test-db.js';
+
+// ----------------------------------------------------------------
+// Mock getDb — same pattern used by every repository/service test
+// ----------------------------------------------------------------
+
+let testDb: TestDb | null = null;
+
+vi.mock('../../db/index.js', async (importOriginal) => {
+  const real = await importOriginal<typeof import('../../db/index.js')>();
+  return {
+    ...real,
+    getDb: () => {
+      if (!testDb) throw new Error('[TEST] testDb not initialised');
+      return testDb;
+    },
+  };
+});
+
+const { assertForeignKeysEnabled } = await import('../startup.service.js');
+
+describe('assertForeignKeysEnabled()', () => {
+  const originalDbType = process.env.DB_TYPE;
+
+  beforeEach(async () => {
+    testDb = await createTestDb();
+    process.env.DB_TYPE = 'sqlite';
+  });
+
+  afterEach(() => {
+    process.env.DB_TYPE = originalDbType;
+  });
+
+  it('resolves without throwing when PRAGMA foreign_keys = 1', async () => {
+    // createTestDb() already issues `PRAGMA foreign_keys = ON;` — the expected
+    // production-equivalent state (ADL-41 §7.2: the @libsql/client default).
+    await expect(assertForeignKeysEnabled()).resolves.toBeUndefined();
+  });
+
+  it('throws loudly when PRAGMA foreign_keys is not 1 (driver default flipped)', async () => {
+    // Simulates the exact failure mode this assertion exists to catch: a
+    // connection where FK enforcement is off. Real read of real per-connection
+    // state, not a mocked return value.
+    await testDb!.$client.execute('PRAGMA foreign_keys = OFF;');
+
+    await expect(assertForeignKeysEnabled()).rejects.toThrow(/PRAGMA foreign_keys returned/);
+    await expect(assertForeignKeysEnabled()).rejects.toThrow(/Refusing to start/);
+  });
+
+  it('is a no-op for DB_TYPE=postgres — declared FKs are always enforced there', async () => {
+    process.env.DB_TYPE = 'postgres';
+    // No testDb needed for this branch — getDb() must not even be called.
+    testDb = null;
+
+    await expect(assertForeignKeysEnabled()).resolves.toBeUndefined();
+  });
+});

--- a/src/backend/services/startup.service.ts
+++ b/src/backend/services/startup.service.ts
@@ -13,13 +13,68 @@
 import { readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { count } from 'drizzle-orm';
+import { count, sql } from 'drizzle-orm';
 import { activities, countries, getDb, regions, tripCategories } from '../db/index.js';
 
 // Re-import seed data from the DATABASE seed script to avoid duplication
 import { ACTIVITIES, TRIP_CATEGORIES } from '../db/seed-data.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// ----------------------------------------------------------------
+// FK enforcement assertion (QUAL-11, ADL-41 §7.2.1 decision 9)
+// ----------------------------------------------------------------
+
+/**
+ * Asserts — does NOT set — that foreign-key enforcement is active on the
+ * real application connection, and fails loudly at boot if it is not.
+ *
+ * Every declared ON DELETE CASCADE / SET NULL in schema.ts (trips → items,
+ * trips → trip_places, items.carried_from_item_id, etc. — see ADL-41 §7) is
+ * only enforced because `@libsql/client` currently enables FK enforcement by
+ * default. That is a driver default nothing in this repo states, tests, or
+ * would notice changing — a future major-version bump could silently flip
+ * it, and the symptom would be silent orphaning in production discovered
+ * months later.
+ *
+ * Per ADL-41 §7.2/§7.2.1: the fix is NOT to issue `PRAGMA foreign_keys=ON`
+ * at connect. On the remote libsql:// HTTP transport each statement is
+ * independently dispatched, so a PRAGMA set once at connect time has no
+ * reliable session to persist into — it would look like a fix and guarantee
+ * nothing. Instead this reads the actual per-statement enforcement state,
+ * which is correct on both the embedded and remote transports because it
+ * reflects the condition every real cascade executes under.
+ *
+ * Postgres (DB_TYPE=postgres) always enforces declared FK constraints —
+ * there is no PRAGMA equivalent and no driver-default risk — so this is a
+ * deliberate no-op there.
+ *
+ * @throws {Error} if DB_TYPE=sqlite and PRAGMA foreign_keys does not return 1.
+ */
+export async function assertForeignKeysEnabled(): Promise<void> {
+  if (process.env.DB_TYPE !== 'sqlite') {
+    console.info(
+      '[STARTUP] FK enforcement check skipped — DB_TYPE=postgres always enforces declared FKs',
+    );
+    return;
+  }
+
+  const db = getDb();
+  const row = await db.get<{ foreign_keys: number }>(sql`PRAGMA foreign_keys`);
+  const value = row?.foreign_keys;
+
+  if (value !== 1) {
+    throw new Error(
+      `[STARTUP] FATAL: PRAGMA foreign_keys returned ${JSON.stringify(value)}, expected 1. ` +
+        'Foreign-key enforcement is OFF on the application connection — every declared ' +
+        'ON DELETE CASCADE / SET NULL in schema.ts (see ADL-41 §7) would silently stop ' +
+        'firing, orphaning child rows instead of cascading. Refusing to start. See ADL-41 ' +
+        '§7.2.1 decision 9.',
+    );
+  }
+
+  console.info('[STARTUP] FK enforcement: OK (PRAGMA foreign_keys = 1)');
+}
 
 // ----------------------------------------------------------------
 // Admin data seed


### PR DESCRIPTION
Closes #291

## Summary
- QUAL-03: `test-db.ts` no longer hand-writes 21 tables as literal DDL. It now applies the real migrations (`src/backend/migrations/*.sql`) via drizzle-orm's libsql migrator to a template `:memory:` DB once per module instance, snapshots the resulting schema from `sqlite_master`, and replays that snapshot into a fresh `:memory:` DB per `createTestDb()` call via `client.batch()`. Exported API unchanged — all 7 consumers needed no changes beyond a pre-existing test-data bug this surfaced (see below).
- QUAL-11: added `assertForeignKeysEnabled()` to `startup.service.ts`, wired into `server.ts`'s startup sequence right after `getDb()`. Reads (never sets) `PRAGMA foreign_keys` on the real application connection and throws if it isn't exactly `1`, per ADL-41 §7.2.1 decision 9. No-op for `DB_TYPE=postgres`. Covered by a new test file.
- `jobs/architect/tech/ADL-41-trip-place-identity.md` §7.2.1: stamped residual gap 1 IMPLEMENTED, citing this PR.

## Real drift surfaced immediately
`items.test.ts` used `status: 'booked'` in 8 places — never valid against the real `chk_items_status` CHECK constraint (`consider`/`confirmed`/`completed`/`cancelled`/`next_time`) and absent from application code entirely. Only the old hand-written DDL (no CHECK constraint at all) let it silently pass. Fixed by replacing with `'confirmed'` — preserves every test's actual intent (a non-default status value for filter/update assertions).

## Drift-detection demonstration
Temporarily appended `ALTER TABLE companions DROP COLUMN is_active;` to `migrations/0012_grey_ultimates.sql`. All 17 `companions.test.ts` tests failed (migrate() itself errored, since a CHECK constraint in that migration still referenced the column). Reverted via `git checkout --`; re-ran, 17/17 green. Before this PR, that edit would have had zero effect on any test.

## Test plan
- [x] `npm run test:backend` — 583 passed (580 baseline + 3 new startup tests), 1 skipped
- [x] `npm run test:frontend` — 154 passed (untouched, sanity check)
- [x] `npm run type:check:all` — clean
- [x] `npm run check` — clean
- [x] `npm run status:check` — up to date
- [x] Suite runtime: 6.73-6.75s baseline (2 runs) vs 6.91-6.93s after (2 runs) — noise-level, not a material regression

## Found, not actioned (flagged for COO)
14 files beyond test-db.ts's 7 consumers (`routes/__tests__/*.test.ts` ×12, `services/__tests__/shading.{trip-countries,user-scope}.test.ts`) independently hand-roll the same 21-table DDL rather than importing `test-db.ts`. Same staleness risk QUAL-03 addresses, larger footprint — the issue's "7 files consume test-db.ts" framing undercounts the true size of this pattern. Out of this PR's scope; recommend COO size as its own follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)