### PR TITLE
fix(BUG-49): keep city markers above the region shading layer (#296)

### DIFF
--- a/jobs/COO/inbox/20260728_1456-FRONTEND-bug49-map-marker-zorder-complete.txt
+++ b/jobs/COO/inbox/20260728_1456-FRONTEND-bug49-map-marker-zorder-complete.txt
@@ -1,0 +1,31 @@
+BUG-49 · GitHub #296 / PR #301 · BRD §MP-02 · branch fix/bug49-map-marker-zorder
+
+Fixed city markers rendering behind the region shading layer: RegionLayer's
+'regions-fill' MapLibre layer mounts conditionally (after zoom crosses
+REGION_ZOOM_THRESHOLD and data loads), well after CityMarkers' unconditional
+'city-markers' layer already exists — MapLibre inserts a newly-added layer at
+the top of the style stack with no beforeId, regardless of JSX sibling order,
+which is what put region shading above city markers. Pinned
+`beforeId: 'city-markers'` on regionFillLayer so it always inserts directly
+below city markers, confirmed against @vis.gl/react-maplibre's actual source
+(map.addLayer(options, props.beforeId) / map.moveLayer on update). Also fixed
+the stale MapView.tsx:6 comment (zoom >= 4 vs actual threshold of 3).
+
+Acceptance criteria:
+- City markers stay visually on top when region shading activates: PASS
+  (beforeId pins region layer below city-markers on mount and any remount)
+- REGION_ZOOM_THRESHOLD unchanged: PASS
+- Region-shading geometry payload untouched: PASS
+- Stale zoom-threshold comment corrected: PASS
+
+CI: gh pr checks 301 — all 18 checks green (biome, type check, backend
+583/1 skipped, frontend 156 incl. 2 new, contract, E2E, dependency scan,
+secret scan, semgrep).
+
+Open issues or blockers: none blocking. One minor note for COO: BUG-49's
+tracker entry has an empty brdRefs array; BRD MP-02 is the governing
+requirement and COO may want to backfill that cross-reference on close
+(doesn't itself need a BRD version bump — MP-02 isn't new/changed).
+
+What's now unblocked: BUG-49 ready for review + merge. No other Wave 1A brief
+shares Map/* as its file surface, so nothing else is gated on this landing.

--- a/jobs/frontend/context/current.txt
+++ b/jobs/frontend/context/current.txt
@@ -1,102 +1,77 @@
-FRONTEND CONTEXT — as of 2026-07-23 (BRD-AD08 companions API repoint, Phase 3)
+FRONTEND CONTEXT — as of 2026-07-28 (BUG-49 / brief B1, backlog-clearance-plan Wave 1A)
 
-STATUS: fix/companions-api-route branch, GitHub issue #244, closes out the last
-  piece of the ADL-28/AD-08 rollout. useAdmin.ts's five companion hooks
-  repointed from /api/admin/companions to /api/companions (PR #243 already
-  merged the backend half). src/e2e/admin.spec.ts's companion test un-skipped
-  and passing. All local checks green (npm run check, type:check:all,
-  test:backend 580/1 skipped unaffected, test:frontend 154 passed, status:check,
-  full Playwright suite 52/52 including the newly un-skipped companion test).
-  PR to be opened as the final step of this thread — see completion report for
-  the PR number and CI status. Awaiting COO review; no PO UAT gate applies here
-  (same-shape route rename, not a new user-facing feature).
+STATUS: fix/bug49-map-marker-zorder branch, GitHub issue #296, tracker BUG-49 (P2).
+  City markers were rendering behind the region/state shading layer once it
+  activated. Fixed by pinning RegionLayer's 'regions-fill' MapLibre layer with
+  beforeId: 'city-markers'. Also fixed the stale zoom-threshold doc comment on
+  MapView.tsx:6 (said `zoom >= 4`, constant is `3`) per CLAUDE.md's document
+  lifecycle rule, since this PR touched MapView.tsx. PR to be opened as the
+  final step of this thread — see completion report for PR number and CI
+  status.
 
-  This supersedes the prior (2026-07-21, WP-03/WP-04/#205) entry in this file
-  as the "current" thread; that thread's detail lives in
-  jobs/frontend/park-docs/20260721-FRONTEND-wp03wp04-park.txt and is not
-  repeated here.
+  This supersedes the prior (2026-07-23, BRD-AD08/#244) entry in this file as
+  the "current" thread; that thread's detail lives in
+  jobs/frontend/park-docs/20260723-FRONTEND-companions-api-route-park.txt and
+  is not repeated here.
 
-WHAT WAS DONE (this thread — BRD-AD08 / GitHub #244)
-  - src/frontend/hooks/useAdmin.ts: useCompanions, useActiveCompanions,
-    useCreateCompanion, useUpdateCompanion, useDeleteCompanion now call
-    /api/companions instead of /api/admin/companions. Query keys and hook
-    signatures unchanged (they're cache keys, not URLs — no bug from leaving
-    them as ['admin', 'companions']).
-  - src/e2e/admin.spec.ts: un-skipped 'create companion appears in list',
-    confirmed passing locally via the full Playwright suite (not just relying
-    on CI) — 5/5 admin.spec.ts tests, 52/52 full suite.
-  - Verified no other live /api/admin/companions references remain anywhere
-    in src/ (backend routes/tests only carry historical comments documenting
-    the ADL-28 move — nothing to change, per brief's "do not touch backend"
-    instruction).
-  - Read CompanionTab.tsx: no owner-only gating inside the component itself —
-    no change needed there, per the brief's own contingency clause.
-  - Updated jobs/architect/tech/ADL-28-per-user-shading-companions.md and
-    _project/tracker.json (BRD-AD08 notes) to close the "known follow-up gap"
-    note and record a new, deliberately out-of-scope finding (see OPEN FLAGS).
+ROOT CAUSE (BUG-49)
+  All three map layers (CountryLayer, RegionLayer, CityMarkers) are native
+  MapLibre GL layers added via react-map-gl's <Source>/<Layer> components, not
+  HTML DOM markers — so MapLibre's *paint stacking order* (which layer was
+  added to the style last wins the top) governs z-order, not JSX sibling
+  order. CountryLayer and CityMarkers both mount unconditionally on MapView's
+  initial render, in that JSX order, so their paint order is already correct
+  (countries below city markers). RegionLayer, though, is *conditionally*
+  rendered — it only mounts once `zoom >= REGION_ZOOM_THRESHOLD` AND region
+  data has loaded — so its 'regions-fill' layer gets added to the MapLibre
+  style well after 'city-markers' already exists. Verified by reading
+  node_modules/@vis.gl/react-maplibre/src/components/layer.ts directly: the
+  Layer component calls `map.addLayer(options, props.beforeId)` on mount, and
+  MapLibre's addLayer with no second argument always inserts at the very top
+  of the style's layer stack. So even though CityMarkers appears later than
+  RegionLayer in MapView.tsx's JSX, RegionLayer's *later mount* put its layer
+  above city-markers in the actual paint order the moment shading activated —
+  exactly the bug report's symptom.
 
-WHAT WAS DELIBERATELY NOT DONE
-  CompanionTab.tsx has no owner gating, but the brief's premise (a component-
-  level gate to check/fix) didn't match what's actually in the codebase: the
-  gate sits one layer up, in App.tsx's <RequireOwner> wrapping the entire
-  /admin route, plus the Admin nav link's `!!me?.isOwner` condition. Both are
-  BUG-26's tested, deliberate contract (src/frontend/__tests__/App.test.tsx —
-  6 tests asserting non-owners get "Not authorised", never the panel). Fixing
-  this for real (AD-08 says any authenticated user should manage their own
-  companions) means moving from page-level to per-tab gating inside
-  AdminPanel.tsx, touching the same nav/route code that legitimately still
-  owner-gates four other tabs (categories, activities, shading, countries),
-  and reversing part of BUG-26's tested behaviour. Judged too architecturally
-  significant to fold into this hook-URL-repoint brief — flagged to COO
-  instead of fixed unilaterally (mirrors the precedent in tracker.json's
-  BRD-AD07 GitHub #225/ADL-38 history: auth-scoping changes route through
-  Architect first, not a unilateral patch). See OPEN FLAGS below.
+FIX
+  src/frontend/components/Map/RegionLayer.tsx: regionFillLayer now carries
+  `beforeId: 'city-markers'`. The Layer component honours this on both
+  initial `addLayer` and on any later update via `map.moveLayer`, so region
+  shading is now pinned directly below city markers regardless of mount
+  timing or how many times RegionLayer mounts/unmounts as the user zooms in
+  and out or changes country. Exported `regionFillLayer` (was previously
+  module-private) purely so the new unit test can assert on it without
+  needing to mock the full MapLibre map instance.
+
+  src/frontend/components/Map/MapView.tsx:6 doc comment corrected from
+  `zoom >= 4` to `zoom >= 3` to match `REGION_ZOOM_THRESHOLD` on line 28.
+
+  Explicitly did NOT touch: REGION_ZOOM_THRESHOLD's value, the region-shading
+  geometry payload, or CountryLayer (already correctly ordered — mounts
+  unconditionally before CityMarkers, no beforeId needed there). Those are
+  BUG-48/ADL-44 per issue #296 and clearance-plan §6.1 — out of scope here.
 
 VERIFICATION
-  npm run check (biome, clean), type:check:all (clean), test:backend (580
-  passed/1 skipped, unaffected), test:frontend (154 passed), status:check
-  (STATUS.md in sync), full Playwright suite via `npx playwright test`
-  (52/52 passed, including the un-skipped companion test) — run live locally
-  in this worktree, not just left to CI. Manual browser sign-in sanity check
-  (start dev:api + dev, sign in via real Clerk, click through Admin →
-  Companions) was NOT possible in this sandbox — no real Clerk publishable
-  key is configured and the firewall only allows GitHub/npm/Anthropic, so
-  Clerk's hosted sign-in is unreachable. The full Playwright suite (BYPASS_AUTH
-  simulating a real authenticated owner user through real HTTP requests
-  against the real Express backend and real built/dev-served React frontend,
-  clicking the actual Admin UI) is the closest available equivalent and was
-  run to completion.
+  npm run type:check (frontend, clean). npm run test:frontend -- --run
+  src/frontend/components/Map (3 files, 11 tests passed, including the new
+  src/frontend/components/Map/__tests__/RegionLayer.test.ts asserting
+  regionFillLayer.beforeId === 'city-markers'). Full /pre-push checklist run
+  before pushing — see completion report for the outcome and PR/CI status.
 
 KEY FILE LOCATIONS (changed this thread)
-  src/frontend/hooks/useAdmin.ts (companion hooks' URLs only)
-  src/e2e/admin.spec.ts (un-skip)
-  jobs/architect/tech/ADL-28-per-user-shading-companions.md (doc lifecycle)
-  _project/tracker.json (BRD-AD08 notes — issue #244 cross-ref)
+  src/frontend/components/Map/RegionLayer.tsx (beforeId fix)
+  src/frontend/components/Map/MapView.tsx (stale comment fix, line 6)
+  src/frontend/components/Map/__tests__/RegionLayer.test.ts (new regression test)
 
 OPEN FLAGS FOR COO
-  FLAG-AD08-1 (MAJOR, functional gap, not fixed — flagged not actioned):
-    Non-owner authenticated users still cannot reach the Companions tab at
-    all — App.tsx's <RequireOwner> gates the whole /admin route and the Admin
-    nav link is `!!me?.isOwner`-only (BUG-26). AD-08's access model requires
-    companions to be usable by any authenticated user. Recommend a scoped
-    Frontend follow-up brief: move gating from page-level (RequireOwner
-    wrapping AdminPage) to per-tab inside AdminPanel.tsx (companions open to
-    all; categories/activities/shading/countries stay owner-only), update
-    App.tsx's nav-link condition to show Admin for any authenticated user,
-    and update App.test.tsx's BUG-26 assertions accordingly. Not blocking
-    this PR — it's a pre-existing gap this brief's hook fix does not worsen
-    (companions were just as unreachable for non-owners before this fix,
-    since the route was 404ing anyway).
-  FLAG-AD08-2 (MODERATE, pre-existing, unrelated to this change): `npm audit`
-    reports 7 vulnerabilities (1 low, 6 moderate) in this worktree's fresh
-    `npm install` — esbuild (dev-server-only, via drizzle-kit's transitive
-    dependency) and react-router (open-redirect / SSR-hydration CVEs, neither
-    applicable — this app doesn't use SSR). Both fixes are breaking-change
-    major-version bumps (`npm audit fix --force`). Not introduced by this
-    thread (no package.json/lockfile changes here) — flagged per frameworks.txt
-    rule 20, COO to decide whether to schedule the bump.
+  none blocking. BUG-49's tracker entry (_project/tracker.json) currently has
+  an empty brdRefs array — BRD MP-02 ("Zooming in on the map reveals
+  region-level shading (where enabled) and city-level pins") is the governing
+  requirement; COO may want to backfill that cross-reference when closing
+  this out, per the BRD → tracker rule, though MP-02 itself isn't a new/
+  changed requirement from this PR so it may not strictly need a version
+  bump — COO's call.
 
 NEXT STEPS (when resumed)
-  - COO: review PR #TBD, decide on FLAG-AD08-1 (likely a new tracker entry +
-    small Frontend brief, same pattern as BRD-AD07's GitHub #225/ADL-38).
-  - COO: decide on FLAG-AD08-2 (npm audit, moderate, pre-existing).
+  COO: review PR (see completion report for #), merge via
+  /coo-merge-and-close when CI is green.

--- a/jobs/frontend/park-docs/20260728-FRONTEND-bug49-map-marker-zorder-park.txt
+++ b/jobs/frontend/park-docs/20260728-FRONTEND-bug49-map-marker-zorder-park.txt
@@ -1,0 +1,111 @@
+PARK DOCUMENT — FRONTEND — BUG-49 map marker z-order — 2026-07-28
+
+BRIEF
+  B1, Wave 1 sub-wave A of jobs/COO/backlog-clearance-plan.md. GitHub issue
+  #296, tracker BUG-49 (P2). File surface: src/frontend/components/Map/* —
+  z-order/layer ordering only. Out of scope: REGION_ZOOM_THRESHOLD and the
+  region-shading geometry payload (BUG-48/ADL-44, clearance-plan §6.1).
+
+SYMPTOM
+  When region/state shading activates on the map (user zooms past
+  REGION_ZOOM_THRESHOLD and region data loads), city tag markers render
+  visually behind the shading fill layer instead of staying on top.
+
+INVESTIGATION
+  Read all four Map/* source files (MapView.tsx, CountryLayer.tsx,
+  RegionLayer.tsx, CityMarkers.tsx). All three shading/marker layers are
+  native MapLibre GL layers rendered through react-map-gl's <Source>/<Layer>
+  components — not HTML DOM markers — so MapLibre's internal style-stack
+  paint order governs on-screen z-order, not React/JSX sibling order.
+
+  MapView.tsx's JSX renders CountryLayer, then conditionally RegionLayer,
+  then CityMarkers — CityMarkers textually last, which reads as "on top" at
+  a glance. But CountryLayer and CityMarkers both mount *unconditionally* on
+  MapView's very first render (JSX order matches mount order there, so
+  MapLibre's addLayer calls happen countries-line, countries-fill,
+  city-markers — correct paint order, city markers on top). RegionLayer only
+  mounts *conditionally*, later, once zoom crosses the threshold and region
+  data has arrived from the API — by which point city-markers is already an
+  established layer in the style.
+
+  Confirmed via direct source read (not just the react-map-gl public API
+  docs, since this package re-exports through a vendored @vis.gl/react-maplibre
+  layer): node_modules/@vis.gl/react-maplibre/src/components/layer.ts's
+  createLayer() calls `map.addLayer(options, props.beforeId)`. MapLibre's
+  addLayer signature is `addLayer(layer, beforeId?)` — omitting beforeId
+  always inserts at the very top of the style stack, regardless of when
+  other layers were added or what order they appear in JSX. RegionLayer's
+  regionFillLayer object had no beforeId, so its conditional/late mount put
+  'regions-fill' above the already-existing 'city-markers' layer — the exact
+  reported symptom.
+
+FIX
+  Single change: src/frontend/components/Map/RegionLayer.tsx's
+  regionFillLayer object now sets `beforeId: 'city-markers'`. The Layer
+  component (same source file) applies beforeId on both initial mount
+  (`map.addLayer(options, props.beforeId)`) and on any subsequent prop
+  update (`map.moveLayer(id, beforeId)` in updateLayer()), so this holds
+  regardless of how many times RegionLayer mounts/unmounts as the user pans,
+  zooms, or switches visible country. Exported `regionFillLayer` (was
+  module-private) so the new unit test can assert on the layer config
+  directly without mocking a full MapLibre map instance.
+
+  Left CountryLayer untouched — its two layers ('countries-line',
+  'countries-fill') mount unconditionally before city-markers on every
+  MapView render, so they were never at risk of this bug and adding a
+  beforeId there would be defensive-but-unnecessary scope creep against a
+  brief explicitly limited to z-order.
+
+  Also fixed src/frontend/components/Map/MapView.tsx:6 — doc comment said
+  "Region shading loaded lazily at zoom >= 4" while REGION_ZOOM_THRESHOLD
+  (line 28) is 3. Brief called this out explicitly as in-scope per CLAUDE.md's
+  document lifecycle rule ("if this PR touches the file"). One-line fix.
+
+  Did NOT touch REGION_ZOOM_THRESHOLD's value or the region-shading GeoJSON
+  payload (39 MB) — that's BUG-48/ADL-44, a separate and larger piece of
+  work per the brief and clearance-plan §6.1.
+
+TESTS
+  New: src/frontend/components/Map/__tests__/RegionLayer.test.ts — 2 tests:
+    - regionFillLayer.beforeId === 'city-markers'
+    - regionFillLayer.id === 'regions-fill' (sanity: the id the beforeId of
+      other future layers would need to reference stays stable)
+  No existing test file covered RegionLayer or MapView before this change
+  (only CityMarkers.test.ts and MapLegend.test.tsx existed in
+  Map/__tests__/). Did not attempt to add a full MapView integration test
+  mocking MapLibre's Map instance — out of scope for a P2 z-order bugfix and
+  the existing test suite doesn't have that scaffolding; the layer-config
+  assertion is the right-sized regression test for "this specific layer
+  stays pinned below city-markers."
+
+VERIFICATION RUN
+  npm install (fresh worktree, no node_modules inherited)
+  npm run type:check — clean, no errors
+  npm run test:frontend -- --run src/frontend/components/Map — 3 files,
+    11 tests passed (9 pre-existing + 2 new)
+  /pre-push skill run before push — see completion report for full checklist
+    outcome and PR/CI status (this park doc was written before that final
+    step; completion report is authoritative for final CI state)
+
+NEGATIVE-FINDINGS COMPLIANCE
+  This brief's core deliverable is fundamentally a positive finding (the
+  beforeId mechanism exists and works, confirmed by reading the actual
+  library source) rather than a claim that something is absent — no
+  UNVERIFIED marker needed. The one adjacent negative-shaped statement ("no
+  existing test file covered RegionLayer or MapView") is established by two
+  independent probes that could fail differently: `ls
+  src/frontend/components/Map/__tests__/` (listing) AND `find ... -iname
+  "*MapView*" -o -iname "*RegionLayer*"` (targeted glob search across the
+  whole src/frontend tree, not just the __tests__ subfolder) — both returned
+  the same two pre-existing test files and no others.
+
+NOT DONE / OUT OF SCOPE (confirmed correctly excluded, not overlooked)
+  - REGION_ZOOM_THRESHOLD value — BUG-48/ADL-44
+  - Region-shading geometry payload size/format — BUG-48/ADL-44
+  - CountryLayer beforeId — not needed, already correctly ordered
+
+WHAT'S NOW UNBLOCKED
+  BUG-49 ready for COO PR review + merge. No other backlog item in Wave 1A
+  depends on this one landing first (per clearance-plan's file-surface
+  partitioning, B1 only touches Map/* and no other Wave 1A brief shares that
+  surface).

--- a/src/frontend/components/Map/MapView.tsx
+++ b/src/frontend/components/Map/MapView.tsx
@@ -3,7 +3,7 @@
  *
  * Renders the world map with:
  *   - Country fill shading driven by the /api/map/shading response (MP-01 to MP-06)
- *   - Region shading loaded lazily at zoom >= 4 (MP-02)
+ *   - Region shading loaded lazily at zoom >= 3 (MP-02)
  *   - City marker pins for resolved cities (MP-02, GE-13)
  *   - Click handlers for country, region, and city selection (MP-03, GE-09)
  *

--- a/src/frontend/components/Map/RegionLayer.tsx
+++ b/src/frontend/components/Map/RegionLayer.tsx
@@ -20,7 +20,7 @@ interface RegionLayerProps {
   regionData: RegionShading[];
 }
 
-const regionFillLayer: FillLayerSpecification = {
+export const regionFillLayer: FillLayerSpecification & { beforeId: string } = {
   id: 'regions-fill',
   type: 'fill',
   source: 'regions-source',
@@ -38,6 +38,17 @@ const regionFillLayer: FillLayerSpecification = {
     // state/province grid regardless of visit status.
     'fill-outline-color': '#64748B',
   },
+  // BUG-49: this layer mounts lazily (only once zoom crosses the region
+  // threshold and shading data has loaded), well after CityMarkers' unconditional
+  // 'city-markers' layer. react-map-gl/maplibre inserts a newly-added layer at
+  // the top of the style stack unless told otherwise, so without an explicit
+  // beforeId the region shading landed above the city markers as soon as it
+  // activated, even though CityMarkers renders later in this file's JSX
+  // sibling order — JSX order only reflects mount order, not paint order, once
+  // a layer is conditionally (re)mounted after the others are already present.
+  // Pinning beforeId to 'city-markers' keeps this layer directly below city
+  // markers regardless of when it mounts.
+  beforeId: 'city-markers',
 };
 
 /**

--- a/src/frontend/components/Map/__tests__/RegionLayer.test.ts
+++ b/src/frontend/components/Map/__tests__/RegionLayer.test.ts
@@ -1,0 +1,32 @@
+/**
+ * Tests for RegionLayer's layer ordering (BUG-49).
+ *
+ * Context: RegionLayer mounts lazily — only once zoom crosses
+ * REGION_ZOOM_THRESHOLD and region shading data has loaded — well after
+ * CityMarkers' unconditional 'city-markers' layer. react-map-gl/maplibre
+ * (@vis.gl/react-maplibre's Layer component, confirmed by reading
+ * node_modules/@vis.gl/react-maplibre/src/components/layer.ts) calls
+ * `map.addLayer(options, props.beforeId)` on mount and `map.moveLayer(id,
+ * beforeId)` on update — a layer added with no beforeId lands on top of the
+ * whole style stack, regardless of JSX sibling order. That's why region
+ * shading rendered above city markers as soon as it activated, even though
+ * CityMarkers appears later in MapView.tsx's JSX.
+ *
+ * The fix pins 'regions-fill' with beforeId: 'city-markers' so it always
+ * inserts directly below the city markers layer, independent of mount timing.
+ *
+ * Source: src/frontend/components/Map/RegionLayer.tsx
+ */
+
+import { describe, expect, it } from 'vitest';
+import { regionFillLayer } from '../RegionLayer.js';
+
+describe('regionFillLayer (BUG-49 z-order)', () => {
+  it('is pinned below the city-markers layer via beforeId', () => {
+    expect(regionFillLayer.beforeId).toBe('city-markers');
+  });
+
+  it('keeps its own layer id stable for the beforeId to make sense against', () => {
+    expect(regionFillLayer.id).toBe('regions-fill');
+  });
+});


### PR DESCRIPTION
Closes #296
BRD §MP-02

## Root cause

All three map layers (CountryLayer, RegionLayer, CityMarkers) are native MapLibre GL layers added through react-map-gl's `<Source>`/`<Layer>` components, not HTML DOM markers — so MapLibre's internal style-stack **paint order** governs on-screen z-order, not JSX sibling order.

CountryLayer and CityMarkers both mount unconditionally on `MapView`'s initial render, so their JSX order and mount order match (countries below city markers — correct). `RegionLayer`, however, mounts **conditionally** — only once `zoom >= REGION_ZOOM_THRESHOLD` and region shading data has loaded — well after `city-markers` already exists in the style. Confirmed by reading `node_modules/@vis.gl/react-maplibre/src/components/layer.ts` directly: the `Layer` component calls `map.addLayer(options, props.beforeId)` on mount, and MapLibre's `addLayer` with no `beforeId` always inserts at the top of the style stack — regardless of JSX order. So `regions-fill` landed above `city-markers` the moment region shading activated.

## Fix

- `src/frontend/components/Map/RegionLayer.tsx`: `regionFillLayer` now sets `beforeId: 'city-markers'`, pinning it directly below the city markers layer on both initial mount and any later re-mount (MapLibre also honours `beforeId` changes via `moveLayer` on update). Exported the constant so the new test can assert on it without mocking a full MapLibre map instance.
- `src/frontend/components/Map/MapView.tsx:6`: fixed a stale doc comment (`zoom >= 4`) to match `REGION_ZOOM_THRESHOLD` (`3`, line 28) — CLAUDE.md's document lifecycle rule, since this PR touches the file.

## Explicitly out of scope (per issue #296 / clearance-plan §6.1)

- `REGION_ZOOM_THRESHOLD`'s value
- The region-shading geometry payload (39 MB) — that's BUG-48/ADL-44, separate work

## Tests

New `src/frontend/components/Map/__tests__/RegionLayer.test.ts` (2 tests) asserting `regionFillLayer.beforeId === 'city-markers'`. Full `/pre-push` checklist green: biome, `type:check:all`, `test:backend` (583/1 skipped), `test:frontend` (156, incl. the 2 new), `status:check`.