### PR TITLE
feat(IT-10, IT-11, DP-06) + fix(BUG-44): item date defaults, map URL, car rental subtext (#300)

### DIFF
--- a/_project/security-spec.md
+++ b/_project/security-spec.md
@@ -327,8 +327,10 @@ BACKEND responsibility:
 FRONTEND responsibility (spec for when FRONTEND begins):
 - All user-supplied content rendered via React's JSX is automatically escaped. Do not use
   `dangerouslySetInnerHTML` anywhere. If it appears in a code review, it is a blocking defect.
-- URL fields (e.g. `photo_album_ref`) rendered as links must be sanitised before use:
-  only `https://` and `file://` schemes are permitted. Reject `javascript:` and `data:` schemes.
+- URL fields (e.g. `photo_album_ref`, `items.map_url` — ADL-45) rendered as links must be
+  sanitised before use: only `https://` and `file://` schemes are permitted by default.
+  Reject `javascript:` and `data:` schemes. `map_url` narrows this further to `https://`
+  only (ADL-45 D5) via `sanitiseUrl()`'s optional allowed-scheme parameter.
 - MapLibre map labels or popups containing user data must use MapLibre's text rendering,
   not innerHTML injection.
 

--- a/jobs/COO/inbox/20260728_1520-BACKEND-b6-item-dates-map-url-complete.txt
+++ b/jobs/COO/inbox/20260728_1520-BACKEND-b6-item-dates-map-url-complete.txt
@@ -1,5 +1,5 @@
 BACKEND completion report
-Tracker: BUG-57, BRD-DP06, BUG-44, BRD-IT10 · GitHub issue #300 · PR: (see below)
+Tracker: BUG-57, BRD-DP06, BUG-44, BRD-IT10 · GitHub issue #300 · PR #306
 BRD: §5.5 IT-10/IT-11 · §5.x DP-06 · §5.16 WP-05
 Branch: feat/b6-item-dates-and-map-url
 
@@ -38,8 +38,10 @@ SECURITY CHECKLIST (routes modified: POST/PATCH /api/trips/:tripId/items)
    text field on items, not a new FK) — the .notNull()-on-FK rule doesn't
    apply here. No new FK column was added.
 
-CI: (placeholder — updated once the PR is opened and scripts/ci-wait.sh
-confirms green; see the housekeeping commit that follows this one.)
+CI: scripts/ci-wait.sh pr 306 — PASS, all 18 checks green @ 5057a1c
+(Type Check, Biome, Backend/Frontend/Contract/E2E Tests, Static Analysis,
+Dependency Scan, Secret Scanning — each runs twice per the known accepted
+push+pull_request duplicate-trigger behaviour, CLAUDE.md).
 
 OPEN ISSUES / BLOCKERS
 - QUAL-17 (hand-rolled route-test DDL, not drift-safe) is NOT resolved by

--- a/jobs/COO/inbox/20260728_1520-BACKEND-b6-item-dates-map-url-complete.txt
+++ b/jobs/COO/inbox/20260728_1520-BACKEND-b6-item-dates-map-url-complete.txt
@@ -1,0 +1,70 @@
+BACKEND completion report
+Tracker: BUG-57, BRD-DP06, BUG-44, BRD-IT10 · GitHub issue #300 · PR: (see below)
+BRD: §5.5 IT-10/IT-11 · §5.x DP-06 · §5.16 WP-05
+Branch: feat/b6-item-dates-and-map-url
+
+WHAT WAS BUILT
+Fullstack (backend + frontend) brief, one file surface. IT-10: nullable
+`map_url` on the base `items` table per ADL-45 (implemented exactly as
+specified, not re-derived) — Zod-only validation, https://-only, no host
+allowlist, sanitiseUrl() extended (not forked), "View map" link with
+target=_blank/noopener/noreferrer. IT-11 + DP-06 implemented as one shared
+defaulting utility (dateDefaults.ts) per the brief's instruction. BUG-44:
+car rental pickup-location subtext added to ItemCard, mirroring the flight
+pattern.
+
+ACCEPTANCE CRITERIA
+- IT-11: item date fields default from trip start (fallback today when no
+  range) on create: PASS
+- IT-11: flight arrival defaults to/cascades from departure until hand-edited: PASS
+- IT-11: a hand-edited date persists through save and re-open: PASS
+- DP-06: first place on an empty trip inherits trip start/end: PASS
+- DP-06: a revisit (trip already has ≥1 place) never inherits: PASS
+- BUG-44: car rental pickup location renders as subtext under provider: PASS
+- IT-10: map_url nullable base-table column, additive migration only: PASS
+- IT-10: https://-only, no host allowlist, 2048 cap, Zod-only: PASS
+- IT-10: sanitiseUrl() extended (not forked), map_url passes ['https:']: PASS
+- IT-10: anchor has target=_blank rel="noopener noreferrer": PASS
+
+SECURITY CHECKLIST (routes modified: POST/PATCH /api/trips/:tripId/items)
+1. Auth middleware — requireAuth applied globally via app.use('/api/', requireAuth)
+   in server.ts (unchanged by this brief; both routes pre-existing, only the
+   body schema/repository call changed).
+2. Repository queries — itemRepository.create/update both scope by
+   eq(items.userId, userId) (update's WHERE; create verifies trip ownership
+   via assertWritable before insert) — unchanged pattern, map_url flows
+   through the same userId-scoped calls as notes/status.
+3. New user-data column — `map_url` does NOT reference a user (it's a plain
+   text field on items, not a new FK) — the .notNull()-on-FK rule doesn't
+   apply here. No new FK column was added.
+
+CI: PR not yet opened — opening next, will confirm gh pr checks green before
+this thread is fully done. (See note below — I ran out of remaining budget
+for this response to also complete the push/PR/CI-wait steps in the same
+turn; branch is fully committed and ready to push.)
+
+OPEN ISSUES / BLOCKERS
+- QUAL-17 (hand-rolled route-test DDL, not drift-safe) is NOT resolved by
+  this brief — I mechanically patched the 12 affected `items`-table files
+  to add `map_url TEXT,` so they keep passing, but the underlying "each
+  file hand-rolls its own copy" problem is untouched. Flagging so it isn't
+  mistaken for closed.
+- Design decision beyond the literal BRD text: I generalised hotel
+  check-out / car-rental drop-off to default from trip end_date (no
+  fallback), by symmetry with check-in/pickup defaulting from trip start —
+  the quoted success criteria only names flight-arrival cascading and the
+  generic "opens on trip start" behaviour explicitly. Recommend QA/PO
+  confirm this matches intent. Full reasoning in the park doc.
+- map_url write-path verification rests partly on route-level tests
+  (QUAL-17 caveat) but is independently confirmed via repository tests
+  (drift-safe, schema-derived) AND live contract tests against a running
+  `npm run dev:api` + real dev.db — not resting on the route tests alone.
+
+WHAT IS NOW UNBLOCKED
+- Frontend/QA can build/verify against a stable map_url + date-defaulting
+  contract; jobs/backend/tech/20260307-api-reference.md updated with the
+  map_url field in both POST/PATCH item bodies and the GET response shape.
+- BRD-IT10, BRD-DP06, BUG-57, BUG-44 all have a working implementation
+  ready for UAT once PR merges.
+
+Full detail: jobs/backend/park-docs/20260728-BACKEND-b6-park.txt

--- a/jobs/COO/inbox/20260728_1520-BACKEND-b6-item-dates-map-url-complete.txt
+++ b/jobs/COO/inbox/20260728_1520-BACKEND-b6-item-dates-map-url-complete.txt
@@ -38,10 +38,8 @@ SECURITY CHECKLIST (routes modified: POST/PATCH /api/trips/:tripId/items)
    text field on items, not a new FK) — the .notNull()-on-FK rule doesn't
    apply here. No new FK column was added.
 
-CI: PR not yet opened — opening next, will confirm gh pr checks green before
-this thread is fully done. (See note below — I ran out of remaining budget
-for this response to also complete the push/PR/CI-wait steps in the same
-turn; branch is fully committed and ready to push.)
+CI: (placeholder — updated once the PR is opened and scripts/ci-wait.sh
+confirms green; see the housekeeping commit that follows this one.)
 
 OPEN ISSUES / BLOCKERS
 - QUAL-17 (hand-rolled route-test DDL, not drift-safe) is NOT resolved by

--- a/jobs/backend/context/current.txt
+++ b/jobs/backend/context/current.txt
@@ -1,56 +1,48 @@
 BACKEND CONTEXT — 2026-07-28
 PROJECT: Travel Tracker
-CURRENT STATUS: B9 brief (QUAL-03 + QUAL-11), this thread.
-  1. QUAL-03/QUAL-11 (branch chore/b9-migration-driven-test-schema, issue #291):
-     - src/backend/repositories/__tests__/test-db.ts rewritten: no more
-       hand-written 21-table DDL. Now applies the real migrations
-       (src/backend/migrations/*.sql) via drizzle-orm's libsql migrator to a
-       template :memory: DB ONCE per module instance (Vitest isolate:true
-       default ⇒ effectively once per test file), snapshots the schema from
-       sqlite_master, and replays that cached snapshot into a fresh
-       :memory: DB per createTestDb() call via client.batch(). Exported API
-       (createTestDb, TestDb, TEST_USER_ID, OTHER_USER_ID, seedTestUser,
-       seedTrip, seedCountry, seedCity, seedCompanion) is unchanged — all 7
-       consumers needed no changes.
-     - This immediately surfaced real pre-existing drift: items.test.ts used
-       status: 'booked' in 8 places, which has never been valid against the
-       real chk_items_status CHECK constraint (schema.ts:497-500 —
-       consider/confirmed/completed/cancelled/next_time) and appears nowhere
-       in application code. Only the old hand-written DDL (no CHECK at all)
-       let it silently pass. Fixed by replacing with 'confirmed' — preserves
-       every test's actual intent (a non-default status for filter/update
-       assertions).
-     - src/backend/services/startup.service.ts: added
-       assertForeignKeysEnabled() — reads (never sets) PRAGMA foreign_keys on
-       the real application connection, throws if not exactly 1. No-op for
-       DB_TYPE=postgres. Wired into server.ts's startup() right after getDb().
-       Covered by new src/backend/services/__tests__/startup.service.test.ts
-       (3 tests: resolves at 1, throws when flipped OFF on a real connection,
-       no-ops for postgres).
-     - jobs/architect/tech/ADL-41-trip-place-identity.md §7.2.1: stamped
-       residual gap 1 IMPLEMENTED, citing this brief.
-     - Drift-detection demonstrated live: temporarily appended
-       `ALTER TABLE companions DROP COLUMN is_active;` to migrations/0012,
-       all 17 companions.test.ts tests failed, reverted via `git checkout --`,
-       re-ran green. See completion report for full detail.
-     - Backend suite: 583 passed (580 baseline + 3 new tests), 1 skipped.
-       Duration ~6.7-6.9s before and after — no material regression.
-     - Found but OUT OF SCOPE: 14 other test files (routes/__tests__/*,
-       services/__tests__/shading.*.test.ts) independently hand-roll the
-       SAME 21-table DDL rather than importing test-db.ts — the brief's "7
-       files consume test-db.ts" undercounts the total duplication. Same
-       staleness risk, not touched this thread; flagged to COO as a
-       follow-up-sized finding.
+CURRENT STATUS: B6 brief (BUG-57/IT-11, BRD-DP06, BUG-44, BRD-IT10), this thread.
+  1. Fullstack brief on branch feat/b6-item-dates-and-map-url (issue #300):
+     - IT-10/ADL-45 implemented exactly as specified: nullable
+       `map_url text` on the base `items` table (one additive migration,
+       0013_fantastic_vance_astro.sql), Zod `zMapUrl` (https:// only, 2048
+       cap, no host allowlist, no DB CHECK), sanitiseUrl() extended with an
+       optional allowedSchemes param (default preserves photo_album_ref
+       behaviour; map_url passes ['https:']), "View map" link on ItemCard
+       with target=_blank rel="noopener noreferrer".
+     - BUG-57/IT-11 + BRD-DP06 implemented as one shared defaulting
+       mechanism (src/frontend/utils/dateDefaults.ts — resolveDefaultDate /
+       resolveDefaultDateTime), per the brief's explicit instruction not to
+       write two mechanisms. Item date fields default from trip start/end
+       on create only; flight arrival live-cascades from departure until
+       hand-edited (touched-tracking); DP-06 fires only on the
+       empty-trip→first-place transition (isFirstPlace = trip.places.length
+       === 0, computed by the caller, model-agnostic per ADL-41).
+     - BUG-44: car_rental subtext (pickup_location) added to ItemCard,
+       mirroring the flight airline/flight-number subtext pattern.
+     - QUAL-17 caveat confirmed still live: 12 of 15 hand-rolled-DDL route
+       test files needed `map_url TEXT,` added manually to keep passing —
+       patched, but the underlying "not drift-safe" issue is untouched.
+       map_url write path also verified via repository tests (drift-safe)
+       and live contract tests (npm run dev:api + real dev.db) — not
+       resting on the route tests alone.
+     - Full verification: type:check:all clean; test:backend 598 passed/1
+       skipped (+15 new); test:frontend 167 passed (+13 new); test:contract
+       115 passed (+6 new, run against a live npm run dev:api).
+     - See jobs/backend/park-docs/20260728-BACKEND-b6-park.txt for full
+       implementation detail, including the checkout/dropoff generalisation
+       flagged for QA/PO confirmation (BRD success criteria only names
+       flight-arrival cascading and hotel/car-rental check-in/pickup
+       defaulting explicitly; check-out/drop-off defaulting from trip end
+       is my extension, reasonable but not literally spelled out).
 ACTIVE TASKS: None — PR to be opened this thread, awaiting CI + COO review/merge.
-PENDING MESSAGES TO COO: 20260728_[time]-BACKEND-b9-qual03-qual11-complete.txt (to send)
+PENDING MESSAGES TO COO: completion report in jobs/COO/inbox/ (this thread).
 OPEN ISSUES:
-  - 14 test files beyond test-db.ts's 7 consumers hand-roll their own copy of
-    the same 21-table DDL (routes/__tests__/*.test.ts,
-    services/__tests__/shading.trip-countries.test.ts,
-    services/__tests__/shading.user-scope.test.ts). Same drift risk as
-    QUAL-03 described, at larger scale. Sizing a fix: likely a bigger lift
-    than B9 (touches more files, some may have per-test seed helpers beyond
-    what test-db.ts exports) — recommend COO size as its own QUAL item rather
-    than folding into this brief's scope.
-LAST PARK DOC: jobs/backend/park-docs/20260728-BACKEND-b9-park.txt
-  (see also 20260723-BACKEND-ad07-ad08-park.txt for prior thread)
+  - QUAL-17 (hand-rolled route-test DDL not drift-safe) remains open —
+    this thread mechanically patched the 12 affected `items`-table files to
+    add `map_url`, it did not fix the underlying duplication. Same fix will
+    be needed again on the next items-table schema change until QUAL-17
+    itself is addressed.
+  - Checkout/dropoff date-default generalisation (see park doc) — flagged
+    for QA/PO confirmation, not blocking.
+LAST PARK DOC: jobs/backend/park-docs/20260728-BACKEND-b6-park.txt
+  (see also 20260728-BACKEND-b9-park.txt for prior thread)

--- a/jobs/backend/park-docs/20260728-BACKEND-b6-park.txt
+++ b/jobs/backend/park-docs/20260728-BACKEND-b6-park.txt
@@ -1,0 +1,204 @@
+PARK DOCUMENT — BACKEND — 2026-07-28
+BRIEF: B6 (Wave 1 sub-wave A) — BUG-57/IT-11, BRD-DP06, BUG-44, BRD-IT10
+BRANCH: feat/b6-item-dates-and-map-url
+GITHUB ISSUE: #300
+
+=== SCOPE ===
+Fullstack brief, one file surface (ItemForm.tsx, ItemCard.tsx + one additive
+migration), four bundled items:
+1. BUG-57/IT-11 — item date fields default from the trip's date range.
+2. BRD-DP06 — first place added to an empty trip inherits the trip's range.
+3. BUG-44 — car rental pickup location as subtext (mirrors flight pattern).
+4. BRD-IT10 — optional item map URL, per ADL-45 (design already decided,
+   implemented as specified, not re-derived).
+
+=== IT-10 / ADL-45 IMPLEMENTATION ===
+
+Implemented exactly per ADL-45 D1-D9:
+- schema.ts: `mapUrl: text('map_url')` added to the base `items` table
+  (schema.ts, after `notes`), nullable, no default, no CHECK.
+- Migration: `npm run db:generate` produced
+  src/backend/migrations/0013_fantastic_vance_astro.sql — single statement,
+  `ALTER TABLE items ADD map_url text` — matches D9 exactly (no table
+  recreation). Applied via `npm run db:migrate` against local dev.db.
+- validation/common.ts: `zMapUrl` added — trim, `.url()`, `.max(2048)`,
+  `.refine(startsWith('https://'))`, optional. No host allowlist (D4).
+- validation/items.schemas.ts: `map_url: zMapUrl` added to `itemBase` (feeds
+  CreateItemSchema) AND explicitly to `UpdateItemSchema` — UpdateItemSchema
+  does NOT spread itemBase (it hand-lists status/notes/...extensionFields),
+  so map_url needed adding to both call sites, not just itemBase, to
+  actually reach the PATCH schema. Documented inline with a comment so the
+  next reader doesn't assume the itemBase spread alone covers it.
+- routes/items-helper.ts (fetchItemsWithExtensions / flattenItem): mapUrl
+  added to the select projection, ItemRow interface, and the `base` object
+  in flattenItem (applies to all item types, same tier as `notes`). This is
+  shared by both routes/items.ts and routes/trips.ts's nested
+  GET /api/trips/:id response — no separate change needed in trips.ts.
+- repositories/items.ts: create()/update() both accept `mapUrl` in their
+  data param; create() inserts `data.mapUrl ?? null`; update() only touches
+  the column `if (data.mapUrl !== undefined)`, matching the existing
+  status/notes pattern (omitted field ⇒ untouched, not cleared — same
+  pre-existing app-wide limitation as `notes`, not something this brief
+  introduces or fixes).
+- routes/items.ts: POST passes `mapUrl: body.map_url ?? null`; PATCH passes
+  `mapUrl: body.map_url` through to the repository.
+- Frontend: types/api.ts Item.map_url: string | null (required field, all
+  existing Item test fixtures updated — see TEST FIXTURE FALLOUT below).
+  hooks/useItems.ts CreateItemData.map_url?: string | null (UpdateItemData
+  inherits it via the existing Partial<Omit<...>> type).
+- urlSanitiser.ts: sanitiseUrl() extended with an optional `allowedSchemes`
+  parameter (default `['https:', 'file:']`, preserves photo_album_ref
+  behaviour unchanged). Implementation changed from two `startsWith`
+  literals to `allowedSchemes.some(s => url.startsWith(`${s}//`))` — same
+  semantics, parameterised. Header comment updated (D7's explicit ask — the
+  old comment said "the only Phase 1 user-supplied URL field is
+  photo_album_ref", now false).
+- ItemCard.tsx: `sanitiseUrl(item.map_url, ['https:'])` renders a "View map"
+  link with `target="_blank" rel="noopener noreferrer"` (D8, mandatory) when
+  non-null. Placed near the notes rendering per ADL-45's pointer.
+- ItemForm.tsx: added a "Map URL" field (type="url") as a base field shown
+  for every item type, right before Notes. Included in buildPayload's
+  `base` object for both create and update.
+- security-spec.md SEC-12: updated to name `map_url` as a second example
+  URL field (ADL-45's stated non-blocking nice-to-have).
+
+=== IT-11 / DP-06 SHARED DEFAULTING LOGIC ===
+
+New file src/frontend/utils/dateDefaults.ts — one shared mechanism per the
+brief's explicit instruction ("IT-11 and DP-06 are one defaulting code
+path... implementing them as two separate mechanisms defeats the purpose").
+Two functions:
+- resolveDefaultDate(tripDate, fallbackToToday) — returns tripDate if set,
+  else todayIso() if fallbackToToday, else ''.
+- resolveDefaultDateTime(tripDate, fallbackToToday) — same, formatted as
+  `${date}T00:00` for `<input type="datetime-local">`, which silently
+  ignores a bare YYYY-MM-DD value (browsers require the full format to
+  register anything at all).
+
+Design decision beyond the literal success-criteria text (flagging this
+explicitly, not silently assumed): the BRD text only names two concrete
+behaviours — "opens the date picker on the trip's start date" (singular)
+and "flight arrival defaults to departure date". It says nothing about
+hotel check-out or car-rental drop-off. I generalised to a symmetric
+start/end model:
+  - "start" fields (check_in_date, departure_datetime, pickup_datetime)
+    default from trip start_date, falling back to today.
+  - "end" fields (check_out_date, dropoff_datetime) default from trip
+    end_date, no fallback (blank if trip has no end — currently
+    unreachable, see below).
+  - EXCEPTION: flight arrival_datetime does NOT default from trip end — it
+    live-cascades from departure_datetime instead (mirrors it on every
+    change), exactly as the BRD names, since arrival-hours-after-departure
+    is a different fact than trip-end-date. This is the one field with
+    "touched" tracking (arrivalTouched state) — once the user hand-edits
+    arrival, changing departure never overwrites it again. All other
+    fields need no touched-tracking: nothing else auto-mutates them after
+    mount, so a direct edit already persists (satisfies "changing either
+    date by hand persists that value through save and re-open").
+  - All defaulting is create-mode only (isEditing gate) — edit mode always
+    starts from existingItem's actual saved values, cascade disabled
+    (arrivalTouched initialises to true when editing).
+Please have QA/PO confirm this checkout/dropoff generalisation matches
+intent — it's a reasonable, coherent extension but not literally spelled
+out in the quoted success criteria.
+
+Finding (not fixed, out of scope, noted so nobody re-derives it as a bug):
+`trips.start_date`/`trips.end_date` are NOT NULL in schema.ts — every trip
+always has a date range today. IT-11's "adding an item to a trip with no
+date range set falls back to today with no error" branch is implemented
+(resolveDefaultDate's fallbackToToday=true path) but currently unreachable
+via the trips table as it stands. Implemented anyway per the stated success
+criteria; harmless if the constraint is ever relaxed.
+
+DP-06 wiring: AddPlaceFlow.tsx gained `tripStartDate`, `tripEndDate`,
+`isFirstPlace` props. `isFirstPlace` must be computed by the caller as
+`trip.places.length === 0` — both TripDetail.tsx and MobileTripDetailView.tsx
+now pass this. This is model-agnostic per the ADL-41 constraint in the brief
+("fires only on the empty-trip → first-place transition... stays correct
+under both models") — "empty trip" is well-defined whether or not the
+Wave-2 one-row-per-visit migration has landed. arrivedOn/departedOn's
+initial useState only applies the trip-range default when isFirstPlace is
+true; a revisit (trip already has ≥1 place) keeps the pre-existing blank
+default untouched.
+
+Props threaded through: TripItemsSection.tsx gained required
+tripStartDate/tripEndDate (passed to both its ItemForm instances);
+PlaceSection.tsx already had tripStartDate/tripEndDate (D-03 precedent) —
+just wired them into its two ItemForm instances, which previously received
+neither.
+
+=== BUG-44 ===
+
+Small, self-contained. ItemCard.tsx: car_rental block already existed as
+the card's bold header (`getItemLabel` returns `item.provider`) but had NO
+subtext line — added one showing `item.pickup_location` when set, directly
+mirroring the flight block's shape (bold header + muted subtext row below).
+
+=== TEST FIXTURE FALLOUT (map_url added to Item type) ===
+
+`Item.map_url: string | null` (no `?`) meant every hand-built Item test
+fixture without an `as Item` cast needed the field added or TypeScript
+would fail. Fixed 3 files: resolvePlaceDateRange.test.ts, PlaceSection.test.tsx,
+ReviewPanel.test.tsx (PostTripReview). TripItemsSection.test.ts's makeFlight()
+uses `as Item` so it wouldn't have failed type-check, but I added map_url
+there too for correctness/consistency. TripItemsSection.tsx's new required
+tripStartDate/tripEndDate props meant all 5 `render(<TripItemsSection .../>)`
+calls in its test needed the two new props — added `tripStartDate="2026-06-01"
+tripEndDate="2026-06-10"` throughout.
+
+=== QUAL-17 CAVEAT — HAND-ROLLED ROUTE-TEST DDL ===
+
+Confirmed QUAL-17's finding still holds: 12 of the 15 hand-rolled-DDL route
+test files (per the CLAUDE.md/brief caveat) create the `items` table and
+needed `map_url TEXT,` inserted manually (they don't derive from
+migrations — only repository tests do, since PR #292/B9). Verified via two
+independent probes matching the brief's negative-findings rule: (1) grep
+`CREATE TABLE` across src/backend found 16 files total; (2) reading
+test-db.ts confirmed it's the one exception (schema-derived via the real
+migrator, not hand-rolled — the "CREATE TABLE" hit there is a doc-comment
+reference, not literal DDL), giving exactly 15 hand-rolled files, matching
+QUAL-17's stated count. Of those 15, 12 create the `items` table (verified
+by grep for the literal `notes TEXT,` line, anchored to avoid false-positive
+matches on `post_visit_notes TEXT,`) and got `map_url TEXT,` inserted via a
+scripted, verified-unique-match replacement, confirmed by full backend
+suite going green after (598 tests, up from 583 baseline — 15 new: 4
+repository create/update tests + 11 zMapUrl validation tests). The other 3
+(cities.get-by-id.test.ts, companions.test.ts, map.test.ts) don't create an
+items table at all and needed no change.
+
+This is a mechanical fix to keep the existing hand-rolled-DDL tests
+truthful, NOT a resolution of QUAL-17 itself (the "not drift-safe" design
+flaw is untouched — still 12 files that will need the same manual fix on
+the next schema change). Flagging so QUAL-17 isn't mistakenly considered
+addressed by this brief.
+
+map_url write-path is verified at three independent layers, not just the
+route tests: (1) repository tests (drift-safe, schema-derived —
+items.test.ts, 4 new cases), (2) live contract tests against a running
+`npm run dev:api` + real dev.db (items.contract.test.ts, 6 new cases, all
+passed), (3) the hand-rolled-DDL route tests (patched as above, not
+drift-safe long-term per QUAL-17).
+
+=== VERIFICATION RUN ===
+
+- npm run type:check:all — clean.
+- npm run test:backend — 598 passed, 1 skipped (was 583 baseline; +15 new).
+- npm run test:frontend — 167 passed (was 154 baseline; +13 new: 9
+  dateDefaults.test.ts, 4 urlSanitiser.test.ts allowedSchemes cases).
+- npm run test:contract — 115 passed (was ~109; +6 items.contract.test.ts
+  map_url cases), run against `npm run dev:api` with BYPASS_AUTH=true and
+  OWNER_CLERK_ID=test_clerk_id in a throwaway .env.local (gitignored, not
+  committed — needed because this worktree had none; ADL-27's bypass-auth
+  owner derivation requires OWNER_CLERK_ID to match the hardcoded
+  'test_clerk_id' bypass value, confirmed by reading
+  src/backend/middleware/auth.ts:99-111).
+
+=== NOT DONE / FOLLOW-UPS ===
+
+- QUAL-18 (photo_album_ref has no server-side scheme validation,
+  sanitiseUrl() had zero call sites) — explicitly out of scope per ADL-45,
+  left alone. Note: sanitiseUrl() now DOES have a call site (ItemCard.tsx,
+  for map_url) — QUAL-18's "zero call sites" premise for photo_album_ref
+  itself is still true (unchanged), only map_url gained a caller.
+- The checkout/dropoff generalisation beyond the literal success-criteria
+  text (see above) — flagged for QA/PO confirmation, not blocking.

--- a/jobs/backend/tech/20260307-api-reference.md
+++ b/jobs/backend/tech/20260307-api-reference.md
@@ -752,6 +752,7 @@ List all items on a trip.
     "item_type": "restaurant",
     "status": "consider",
     "notes": "Try the tasting menu",
+    "map_url": null,
     "is_carried_forward": false,
     "carried_from_item_id": null,
     "created_at": "2026-03-07T14:32:00.000Z",
@@ -808,6 +809,7 @@ Base fields (all item types):
   "item_type": "restaurant",
   "status": "consider",
   "notes": "Try the tasting menu",
+  "map_url": "https://maps.google.com/?q=Le+Jules+Verne",
   "is_carried_forward": false,
   "carried_from_item_id": null
 }
@@ -819,6 +821,7 @@ Base fields (all item types):
 | `item_type` | string | **Yes** | One of: `flight`, `hotel`, `car_rental`, `restaurant`, `experience`, `note` |
 | `status` | string | No | Default: `"consider"`. See [Item Status Values](#item-status-values) |
 | `notes` | string \| null | No | Free-text notes |
+| `map_url` | string \| null | No | Optional map/directions link (IT-10, ADL-45). Must be a well-formed `https://` URL (no other scheme, no host allowlist), max 2048 chars. No DB-level check — enforced only by Zod (`zMapUrl`), rejects on write with `400`. |
 | `is_carried_forward` | boolean | No | Default: `false`. Must be `true` if `carried_from_item_id` is set |
 | `carried_from_item_id` | integer \| null | No | Source item ID if this is a carry-forward copy |
 
@@ -902,7 +905,8 @@ Base fields:
 ```json
 {
   "status": "completed",
-  "notes": "Updated notes"
+  "notes": "Updated notes",
+  "map_url": "https://maps.google.com/?q=Le+Jules+Verne"
 }
 ```
 

--- a/src/backend/db/schema.ts
+++ b/src/backend/db/schema.ts
@@ -462,6 +462,9 @@ export const items = sqliteTable(
     itemType: text('item_type').notNull(),
     status: text('status').notNull().default('consider'),
     notes: text('notes'), // General notes — applies to all item types (IT-04)
+    // Optional map/directions link — applies to all item types (IT-10, ADL-45 D1/D2).
+    // Nullable, no default, no DB length CHECK (Zod-only cap, ADL-45 D3).
+    mapUrl: text('map_url'),
     // Boolean flag — allows simple WHERE is_carried_forward = 1 queries
     isCarriedForward: integer('is_carried_forward').notNull().default(0),
     // Self-referential FK — preserves lineage to the source item (ADL-13)

--- a/src/backend/migrations/0013_fantastic_vance_astro.sql
+++ b/src/backend/migrations/0013_fantastic_vance_astro.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `items` ADD `map_url` text;

--- a/src/backend/migrations/meta/0013_snapshot.json
+++ b/src/backend/migrations/meta/0013_snapshot.json
@@ -1,0 +1,1877 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "567dab26-b9ee-4366-a05d-214ba440732a",
+  "prevId": "be265ee3-f9b1-44df-9cee-7e0108f3c82d",
+  "tables": {
+    "activities": {
+      "name": "activities",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "activities_name_unique": {
+          "name": "activities_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "chk_activities_is_active": {
+          "name": "chk_activities_is_active",
+          "value": "\"activities\".\"is_active\" IN (0, 1)"
+        }
+      }
+    },
+    "cities": {
+      "name": "cities",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "country_code": {
+          "name": "country_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "region_id": {
+          "name": "region_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "geocode_status": {
+          "name": "geocode_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "geocode_attempted_at": {
+          "name": "geocode_attempted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "idx_cities_country": {
+          "name": "idx_cities_country",
+          "columns": [
+            "country_code"
+          ],
+          "isUnique": false
+        },
+        "idx_cities_region": {
+          "name": "idx_cities_region",
+          "columns": [
+            "region_id"
+          ],
+          "isUnique": false
+        },
+        "idx_cities_geocode": {
+          "name": "idx_cities_geocode",
+          "columns": [
+            "geocode_status"
+          ],
+          "isUnique": false,
+          "where": "\"cities\".\"geocode_status\" = 'pending'"
+        },
+        "uniq_cities_name_country_ci": {
+          "name": "uniq_cities_name_country_ci",
+          "columns": [
+            "\"name\" COLLATE NOCASE",
+            "country_code"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "cities_country_code_countries_country_code_fk": {
+          "name": "cities_country_code_countries_country_code_fk",
+          "tableFrom": "cities",
+          "tableTo": "countries",
+          "columnsFrom": [
+            "country_code"
+          ],
+          "columnsTo": [
+            "country_code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "cities_region_id_regions_id_fk": {
+          "name": "cities_region_id_regions_id_fk",
+          "tableFrom": "cities",
+          "tableTo": "regions",
+          "columnsFrom": [
+            "region_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "chk_cities_geocode_status": {
+          "name": "chk_cities_geocode_status",
+          "value": "\"cities\".\"geocode_status\" IN ('pending', 'resolved')"
+        }
+      }
+    },
+    "companions": {
+      "name": "companions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "uniq_companions_user_name": {
+          "name": "uniq_companions_user_name",
+          "columns": [
+            "user_id",
+            "name"
+          ],
+          "isUnique": true
+        },
+        "idx_companions_user": {
+          "name": "idx_companions_user",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "companions_user_id_users_id_fk": {
+          "name": "companions_user_id_users_id_fk",
+          "tableFrom": "companions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "chk_companions_is_active": {
+          "name": "chk_companions_is_active",
+          "value": "\"companions\".\"is_active\" IN (0, 1)"
+        }
+      }
+    },
+    "countries": {
+      "name": "countries",
+      "columns": {
+        "country_code": {
+          "name": "country_code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "region_tier_enabled": {
+          "name": "region_tier_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "region_tier_label": {
+          "name": "region_tier_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "chk_countries_region_tier_enabled": {
+          "name": "chk_countries_region_tier_enabled",
+          "value": "\"countries\".\"region_tier_enabled\" IN (0, 1)"
+        }
+      }
+    },
+    "item_car_rentals": {
+      "name": "item_car_rentals",
+      "columns": {
+        "item_id": {
+          "name": "item_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pickup_location": {
+          "name": "pickup_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dropoff_location": {
+          "name": "dropoff_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pickup_datetime": {
+          "name": "pickup_datetime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dropoff_datetime": {
+          "name": "dropoff_datetime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "booking_reference": {
+          "name": "booking_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vehicle_class": {
+          "name": "vehicle_class",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "item_car_rentals_item_id_items_id_fk": {
+          "name": "item_car_rentals_item_id_items_id_fk",
+          "tableFrom": "item_car_rentals",
+          "tableTo": "items",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "item_experiences": {
+      "name": "item_experiences",
+      "columns": {
+        "item_id": {
+          "name": "item_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "post_visit_notes": {
+          "name": "post_visit_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_item_experiences_rating": {
+          "name": "idx_item_experiences_rating",
+          "columns": [
+            "rating"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "item_experiences_item_id_items_id_fk": {
+          "name": "item_experiences_item_id_items_id_fk",
+          "tableFrom": "item_experiences",
+          "tableTo": "items",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "chk_item_experiences_rating": {
+          "name": "chk_item_experiences_rating",
+          "value": "\"item_experiences\".\"rating\" IS NULL OR (\"item_experiences\".\"rating\" BETWEEN 1 AND 5)"
+        }
+      }
+    },
+    "item_flights": {
+      "name": "item_flights",
+      "columns": {
+        "item_id": {
+          "name": "item_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "airline": {
+          "name": "airline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "flight_number": {
+          "name": "flight_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "departure_airport": {
+          "name": "departure_airport",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "arrival_airport": {
+          "name": "arrival_airport",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "departure_datetime": {
+          "name": "departure_datetime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "arrival_datetime": {
+          "name": "arrival_datetime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "booking_reference": {
+          "name": "booking_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "seat": {
+          "name": "seat",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "item_flights_item_id_items_id_fk": {
+          "name": "item_flights_item_id_items_id_fk",
+          "tableFrom": "item_flights",
+          "tableTo": "items",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "item_hotels": {
+      "name": "item_hotels",
+      "columns": {
+        "item_id": {
+          "name": "item_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "property_name": {
+          "name": "property_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "check_in_date": {
+          "name": "check_in_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "check_out_date": {
+          "name": "check_out_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "booking_reference": {
+          "name": "booking_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "confirmation_number": {
+          "name": "confirmation_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "post_visit_notes": {
+          "name": "post_visit_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_item_hotels_rating": {
+          "name": "idx_item_hotels_rating",
+          "columns": [
+            "rating"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "item_hotels_item_id_items_id_fk": {
+          "name": "item_hotels_item_id_items_id_fk",
+          "tableFrom": "item_hotels",
+          "tableTo": "items",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "chk_item_hotels_rating": {
+          "name": "chk_item_hotels_rating",
+          "value": "\"item_hotels\".\"rating\" IS NULL OR (\"item_hotels\".\"rating\" BETWEEN 1 AND 5)"
+        }
+      }
+    },
+    "item_restaurants": {
+      "name": "item_restaurants",
+      "columns": {
+        "item_id": {
+          "name": "item_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "neighbourhood_area": {
+          "name": "neighbourhood_area",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cuisine_type": {
+          "name": "cuisine_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "post_visit_notes": {
+          "name": "post_visit_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_item_restaurants_rating": {
+          "name": "idx_item_restaurants_rating",
+          "columns": [
+            "rating"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "item_restaurants_item_id_items_id_fk": {
+          "name": "item_restaurants_item_id_items_id_fk",
+          "tableFrom": "item_restaurants",
+          "tableTo": "items",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "chk_item_restaurants_rating": {
+          "name": "chk_item_restaurants_rating",
+          "value": "\"item_restaurants\".\"rating\" IS NULL OR (\"item_restaurants\".\"rating\" BETWEEN 1 AND 5)"
+        }
+      }
+    },
+    "items": {
+      "name": "items",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "trip_id": {
+          "name": "trip_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "trip_place_id": {
+          "name": "trip_place_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "item_type": {
+          "name": "item_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'consider'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "map_url": {
+          "name": "map_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_carried_forward": {
+          "name": "is_carried_forward",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "carried_from_item_id": {
+          "name": "carried_from_item_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "idx_items_trip": {
+          "name": "idx_items_trip",
+          "columns": [
+            "trip_id"
+          ],
+          "isUnique": false
+        },
+        "idx_items_trip_place": {
+          "name": "idx_items_trip_place",
+          "columns": [
+            "trip_place_id"
+          ],
+          "isUnique": false
+        },
+        "idx_items_type": {
+          "name": "idx_items_type",
+          "columns": [
+            "item_type"
+          ],
+          "isUnique": false
+        },
+        "idx_items_status": {
+          "name": "idx_items_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "idx_items_carried": {
+          "name": "idx_items_carried",
+          "columns": [
+            "carried_from_item_id"
+          ],
+          "isUnique": false,
+          "where": "\"items\".\"carried_from_item_id\" IS NOT NULL"
+        },
+        "items_user_id_idx": {
+          "name": "items_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "items_trip_id_trips_id_fk": {
+          "name": "items_trip_id_trips_id_fk",
+          "tableFrom": "items",
+          "tableTo": "trips",
+          "columnsFrom": [
+            "trip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "items_trip_place_id_trip_places_id_fk": {
+          "name": "items_trip_place_id_trip_places_id_fk",
+          "tableFrom": "items",
+          "tableTo": "trip_places",
+          "columnsFrom": [
+            "trip_place_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "items_carried_from_item_id_items_id_fk": {
+          "name": "items_carried_from_item_id_items_id_fk",
+          "tableFrom": "items",
+          "tableTo": "items",
+          "columnsFrom": [
+            "carried_from_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "items_user_id_users_id_fk": {
+          "name": "items_user_id_users_id_fk",
+          "tableFrom": "items",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "chk_items_item_type": {
+          "name": "chk_items_item_type",
+          "value": "\"items\".\"item_type\" IN ('restaurant', 'hotel', 'flight', 'car_rental', 'experience', 'note')"
+        },
+        "chk_items_status": {
+          "name": "chk_items_status",
+          "value": "\"items\".\"status\" IN ('consider', 'confirmed', 'completed', 'cancelled', 'next_time')"
+        },
+        "chk_items_is_carried_forward": {
+          "name": "chk_items_is_carried_forward",
+          "value": "\"items\".\"is_carried_forward\" IN (0, 1)"
+        }
+      }
+    },
+    "map_shading_config": {
+      "name": "map_shading_config",
+      "columns": {
+        "state_key": {
+          "name": "state_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "color_hex": {
+          "name": "color_hex",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "idx_map_shading_user": {
+          "name": "idx_map_shading_user",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "map_shading_config_user_id_users_id_fk": {
+          "name": "map_shading_config_user_id_users_id_fk",
+          "tableFrom": "map_shading_config",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "map_shading_config_state_key_user_id_pk": {
+          "columns": [
+            "state_key",
+            "user_id"
+          ],
+          "name": "map_shading_config_state_key_user_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "chk_map_shading_state_key": {
+          "name": "chk_map_shading_state_key",
+          "value": "\"map_shading_config\".\"state_key\" IN ('active', 'planned', 'visited_once', 'visited_once_planning', 'visited_multiple', 'visited_multiple_planning')"
+        }
+      }
+    },
+    "regions": {
+      "name": "regions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "country_code": {
+          "name": "country_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "iso_3166_2": {
+          "name": "iso_3166_2",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "idx_regions_country": {
+          "name": "idx_regions_country",
+          "columns": [
+            "country_code"
+          ],
+          "isUnique": false
+        },
+        "uniq_regions_iso_3166_2": {
+          "name": "uniq_regions_iso_3166_2",
+          "columns": [
+            "iso_3166_2"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "regions_country_code_countries_country_code_fk": {
+          "name": "regions_country_code_countries_country_code_fk",
+          "tableFrom": "regions",
+          "tableTo": "countries",
+          "columnsFrom": [
+            "country_code"
+          ],
+          "columnsTo": [
+            "country_code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "trip_activities_map": {
+      "name": "trip_activities_map",
+      "columns": {
+        "trip_id": {
+          "name": "trip_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "activity_id": {
+          "name": "activity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "trip_activities_map_trip_id_trips_id_fk": {
+          "name": "trip_activities_map_trip_id_trips_id_fk",
+          "tableFrom": "trip_activities_map",
+          "tableTo": "trips",
+          "columnsFrom": [
+            "trip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "trip_activities_map_activity_id_activities_id_fk": {
+          "name": "trip_activities_map_activity_id_activities_id_fk",
+          "tableFrom": "trip_activities_map",
+          "tableTo": "activities",
+          "columnsFrom": [
+            "activity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "trip_activities_map_trip_id_activity_id_pk": {
+          "columns": [
+            "trip_id",
+            "activity_id"
+          ],
+          "name": "trip_activities_map_trip_id_activity_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "trip_categories": {
+      "name": "trip_categories",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "trip_categories_name_unique": {
+          "name": "trip_categories_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "chk_trip_categories_is_active": {
+          "name": "chk_trip_categories_is_active",
+          "value": "\"trip_categories\".\"is_active\" IN (0, 1)"
+        }
+      }
+    },
+    "trip_categories_map": {
+      "name": "trip_categories_map",
+      "columns": {
+        "trip_id": {
+          "name": "trip_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_tcm_category": {
+          "name": "idx_tcm_category",
+          "columns": [
+            "category_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "trip_categories_map_trip_id_trips_id_fk": {
+          "name": "trip_categories_map_trip_id_trips_id_fk",
+          "tableFrom": "trip_categories_map",
+          "tableTo": "trips",
+          "columnsFrom": [
+            "trip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "trip_categories_map_category_id_trip_categories_id_fk": {
+          "name": "trip_categories_map_category_id_trip_categories_id_fk",
+          "tableFrom": "trip_categories_map",
+          "tableTo": "trip_categories",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "trip_categories_map_trip_id_category_id_pk": {
+          "columns": [
+            "trip_id",
+            "category_id"
+          ],
+          "name": "trip_categories_map_trip_id_category_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "trip_companions_map": {
+      "name": "trip_companions_map",
+      "columns": {
+        "trip_id": {
+          "name": "trip_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "companion_id": {
+          "name": "companion_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_tcpm_companion": {
+          "name": "idx_tcpm_companion",
+          "columns": [
+            "companion_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "trip_companions_map_trip_id_trips_id_fk": {
+          "name": "trip_companions_map_trip_id_trips_id_fk",
+          "tableFrom": "trip_companions_map",
+          "tableTo": "trips",
+          "columnsFrom": [
+            "trip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "trip_companions_map_companion_id_companions_id_fk": {
+          "name": "trip_companions_map_companion_id_companions_id_fk",
+          "tableFrom": "trip_companions_map",
+          "tableTo": "companions",
+          "columnsFrom": [
+            "companion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "trip_companions_map_trip_id_companion_id_pk": {
+          "columns": [
+            "trip_id",
+            "companion_id"
+          ],
+          "name": "trip_companions_map_trip_id_companion_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "trip_countries": {
+      "name": "trip_countries",
+      "columns": {
+        "trip_id": {
+          "name": "trip_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "country_code": {
+          "name": "country_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "idx_trip_countries_country": {
+          "name": "idx_trip_countries_country",
+          "columns": [
+            "country_code"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "trip_countries_trip_id_trips_id_fk": {
+          "name": "trip_countries_trip_id_trips_id_fk",
+          "tableFrom": "trip_countries",
+          "tableTo": "trips",
+          "columnsFrom": [
+            "trip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "trip_countries_country_code_countries_country_code_fk": {
+          "name": "trip_countries_country_code_countries_country_code_fk",
+          "tableFrom": "trip_countries",
+          "tableTo": "countries",
+          "columnsFrom": [
+            "country_code"
+          ],
+          "columnsTo": [
+            "country_code"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "trip_countries_trip_id_country_code_pk": {
+          "columns": [
+            "trip_id",
+            "country_code"
+          ],
+          "name": "trip_countries_trip_id_country_code_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "trip_place_activities_map": {
+      "name": "trip_place_activities_map",
+      "columns": {
+        "trip_place_id": {
+          "name": "trip_place_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "activity_id": {
+          "name": "activity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "trip_place_activities_map_trip_place_id_trip_places_id_fk": {
+          "name": "trip_place_activities_map_trip_place_id_trip_places_id_fk",
+          "tableFrom": "trip_place_activities_map",
+          "tableTo": "trip_places",
+          "columnsFrom": [
+            "trip_place_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "trip_place_activities_map_activity_id_activities_id_fk": {
+          "name": "trip_place_activities_map_activity_id_activities_id_fk",
+          "tableFrom": "trip_place_activities_map",
+          "tableTo": "activities",
+          "columnsFrom": [
+            "activity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "trip_place_activities_map_trip_place_id_activity_id_pk": {
+          "columns": [
+            "trip_place_id",
+            "activity_id"
+          ],
+          "name": "trip_place_activities_map_trip_place_id_activity_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "trip_places": {
+      "name": "trip_places",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "trip_id": {
+          "name": "trip_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "city_id": {
+          "name": "city_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "arrived_on": {
+          "name": "arrived_on",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "departed_on": {
+          "name": "departed_on",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "uniq_trip_places_trip_city": {
+          "name": "uniq_trip_places_trip_city",
+          "columns": [
+            "trip_id",
+            "city_id"
+          ],
+          "isUnique": true
+        },
+        "idx_trip_places_trip": {
+          "name": "idx_trip_places_trip",
+          "columns": [
+            "trip_id"
+          ],
+          "isUnique": false
+        },
+        "idx_trip_places_city": {
+          "name": "idx_trip_places_city",
+          "columns": [
+            "city_id"
+          ],
+          "isUnique": false
+        },
+        "trip_places_user_id_idx": {
+          "name": "trip_places_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "trip_places_trip_id_trips_id_fk": {
+          "name": "trip_places_trip_id_trips_id_fk",
+          "tableFrom": "trip_places",
+          "tableTo": "trips",
+          "columnsFrom": [
+            "trip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "trip_places_city_id_cities_id_fk": {
+          "name": "trip_places_city_id_cities_id_fk",
+          "tableFrom": "trip_places",
+          "tableTo": "cities",
+          "columnsFrom": [
+            "city_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "trip_places_user_id_users_id_fk": {
+          "name": "trip_places_user_id_users_id_fk",
+          "tableFrom": "trip_places",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "trips": {
+      "name": "trips",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'planning'"
+        },
+        "photo_album_ref": {
+          "name": "photo_album_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "idx_trips_status": {
+          "name": "idx_trips_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "idx_trips_start_date": {
+          "name": "idx_trips_start_date",
+          "columns": [
+            "start_date"
+          ],
+          "isUnique": false
+        },
+        "idx_trips_end_date": {
+          "name": "idx_trips_end_date",
+          "columns": [
+            "end_date"
+          ],
+          "isUnique": false
+        },
+        "trips_user_id_idx": {
+          "name": "trips_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "trips_user_id_users_id_fk": {
+          "name": "trips_user_id_users_id_fk",
+          "tableFrom": "trips",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "chk_trips_status": {
+          "name": "chk_trips_status",
+          "value": "\"trips\".\"status\" IN ('planning', 'active', 'review_pending', 'locked')"
+        }
+      }
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "clerk_id": {
+          "name": "clerk_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_owner": {
+          "name": "is_owner",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_clerk_id_unique": {
+          "name": "users_clerk_id_unique",
+          "columns": [
+            "clerk_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {
+      "uniq_cities_name_country_ci": {
+        "columns": {
+          "\"name\" COLLATE NOCASE": {
+            "isExpression": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/backend/migrations/meta/_journal.json
+++ b/src/backend/migrations/meta/_journal.json
@@ -92,6 +92,13 @@
       "when": 1784853900836,
       "tag": "0012_grey_ultimates",
       "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "6",
+      "when": 1785250547092,
+      "tag": "0013_fantastic_vance_astro",
+      "breakpoints": true
     }
   ]
 }

--- a/src/backend/repositories/__tests__/items.test.ts
+++ b/src/backend/repositories/__tests__/items.test.ts
@@ -171,6 +171,30 @@ describe('itemRepository.create', () => {
     expect(item.notes).toBeNull();
   });
 
+  // IT-10 / ADL-45: base-table map_url field, applies to all item types.
+  it('sets map_url when provided', async () => {
+    const db = testDb!;
+    const trip = await seedTrip(db);
+
+    const item = await itemRepository.create(
+      TEST_USER_ID,
+      trip.id,
+      { itemType: 'hotel', mapUrl: 'https://maps.google.com/?q=Grand+Hotel' },
+      {},
+    );
+
+    expect(item.map_url).toBe('https://maps.google.com/?q=Grand+Hotel');
+  });
+
+  it('stores null map_url when not provided', async () => {
+    const db = testDb!;
+    const trip = await seedTrip(db);
+
+    const item = await itemRepository.create(TEST_USER_ID, trip.id, { itemType: 'note' }, {});
+
+    expect(item.map_url).toBeNull();
+  });
+
   it('assigns userId from the provided userId', async () => {
     const db = testDb!;
     const trip = await seedTrip(db);
@@ -405,6 +429,46 @@ describe('itemRepository.update', () => {
     );
 
     expect(result!.notes).toBe('Needs early check-in');
+  });
+
+  // IT-10 / ADL-45: base-table map_url field, updatable independently of extension fields.
+  it('updates map_url field', async () => {
+    const db = testDb!;
+    const trip = await seedTrip(db);
+    const item = await itemRepository.create(TEST_USER_ID, trip.id, { itemType: 'hotel' }, {});
+
+    const result = await itemRepository.update(
+      TEST_USER_ID,
+      trip.id,
+      item.id as number,
+      { mapUrl: 'https://maps.google.com/?q=Updated' },
+      {},
+      'hotel',
+    );
+
+    expect(result!.map_url).toBe('https://maps.google.com/?q=Updated');
+  });
+
+  it('leaves map_url unchanged when not provided in the update', async () => {
+    const db = testDb!;
+    const trip = await seedTrip(db);
+    const item = await itemRepository.create(
+      TEST_USER_ID,
+      trip.id,
+      { itemType: 'hotel', mapUrl: 'https://maps.google.com/?q=Original' },
+      {},
+    );
+
+    const result = await itemRepository.update(
+      TEST_USER_ID,
+      trip.id,
+      item.id as number,
+      { status: 'confirmed' },
+      {},
+      'hotel',
+    );
+
+    expect(result!.map_url).toBe('https://maps.google.com/?q=Original');
   });
 
   it('updates flight extension fields', async () => {

--- a/src/backend/repositories/items.ts
+++ b/src/backend/repositories/items.ts
@@ -115,6 +115,7 @@ export const itemRepository = {
       itemType: string;
       status?: string;
       notes?: string | null;
+      mapUrl?: string | null;
       isCarriedForward?: boolean;
       carriedFromItemId?: number | null;
     },
@@ -131,6 +132,7 @@ export const itemRepository = {
         itemType: data.itemType,
         status: data.status ?? 'consider',
         notes: data.notes ?? null,
+        mapUrl: data.mapUrl ?? null,
         isCarriedForward: data.isCarriedForward ? 1 : 0,
         carriedFromItemId: data.carriedFromItemId ?? null,
         userId,
@@ -159,6 +161,7 @@ export const itemRepository = {
     data: {
       status?: string;
       notes?: string | null;
+      mapUrl?: string | null;
     },
     extensionBody: Record<string, unknown>,
     itemType: string,
@@ -169,6 +172,7 @@ export const itemRepository = {
     const baseUpdates: Partial<typeof items.$inferInsert> = { updatedAt: now };
     if (data.status !== undefined) baseUpdates.status = data.status;
     if (data.notes !== undefined) baseUpdates.notes = data.notes;
+    if (data.mapUrl !== undefined) baseUpdates.mapUrl = data.mapUrl;
 
     await db
       .update(items)

--- a/src/backend/routes/__tests__/cities.carry-forward.test.ts
+++ b/src/backend/routes/__tests__/cities.carry-forward.test.ts
@@ -150,6 +150,7 @@ async function createTestDb() {
       item_type TEXT NOT NULL,
       status TEXT DEFAULT 'consider' NOT NULL,
       notes TEXT,
+      map_url TEXT,
       is_carried_forward INTEGER DEFAULT 0 NOT NULL,
       carried_from_item_id INTEGER,
       user_id TEXT,

--- a/src/backend/routes/__tests__/items.rating-sort-filter.test.ts
+++ b/src/backend/routes/__tests__/items.rating-sort-filter.test.ts
@@ -164,6 +164,7 @@ async function createTestDb() {
       item_type TEXT NOT NULL,
       status TEXT DEFAULT 'consider' NOT NULL,
       notes TEXT,
+      map_url TEXT,
       is_carried_forward INTEGER DEFAULT 0 NOT NULL,
       carried_from_item_id INTEGER,
       user_id TEXT,

--- a/src/backend/routes/__tests__/items.test.ts
+++ b/src/backend/routes/__tests__/items.test.ts
@@ -153,6 +153,7 @@ async function createTestDb() {
       item_type TEXT NOT NULL,
       status TEXT DEFAULT 'consider' NOT NULL,
       notes TEXT,
+      map_url TEXT,
       is_carried_forward INTEGER DEFAULT 0 NOT NULL,
       carried_from_item_id INTEGER,
       user_id TEXT,

--- a/src/backend/routes/__tests__/owner-access.test.ts
+++ b/src/backend/routes/__tests__/owner-access.test.ts
@@ -176,6 +176,7 @@ async function createTestDb() {
       item_type TEXT NOT NULL,
       status TEXT DEFAULT 'consider' NOT NULL,
       notes TEXT,
+      map_url TEXT,
       is_carried_forward INTEGER DEFAULT 0 NOT NULL,
       carried_from_item_id INTEGER,
       user_id TEXT,

--- a/src/backend/routes/__tests__/places.test.ts
+++ b/src/backend/routes/__tests__/places.test.ts
@@ -153,6 +153,7 @@ async function createTestDb() {
       item_type TEXT NOT NULL,
       status TEXT DEFAULT 'consider' NOT NULL,
       notes TEXT,
+      map_url TEXT,
       is_carried_forward INTEGER DEFAULT 0 NOT NULL,
       carried_from_item_id INTEGER,
       user_id TEXT,

--- a/src/backend/routes/__tests__/qa-backend-fixes.test.ts
+++ b/src/backend/routes/__tests__/qa-backend-fixes.test.ts
@@ -147,6 +147,7 @@ async function createTestDb() {
       item_type TEXT NOT NULL,
       status TEXT DEFAULT 'consider' NOT NULL,
       notes TEXT,
+      map_url TEXT,
       is_carried_forward INTEGER DEFAULT 0 NOT NULL,
       carried_from_item_id INTEGER,
       user_id TEXT,

--- a/src/backend/routes/__tests__/security.access-matrix.test.ts
+++ b/src/backend/routes/__tests__/security.access-matrix.test.ts
@@ -171,6 +171,7 @@ async function createTestDb() {
       item_type TEXT NOT NULL,
       status TEXT DEFAULT 'consider' NOT NULL,
       notes TEXT,
+      map_url TEXT,
       is_carried_forward INTEGER DEFAULT 0 NOT NULL,
       carried_from_item_id INTEGER,
       user_id TEXT,

--- a/src/backend/routes/__tests__/trip-countries.test.ts
+++ b/src/backend/routes/__tests__/trip-countries.test.ts
@@ -159,6 +159,7 @@ async function createTestDb() {
       item_type TEXT NOT NULL,
       status TEXT DEFAULT 'consider' NOT NULL,
       notes TEXT,
+      map_url TEXT,
       is_carried_forward INTEGER DEFAULT 0 NOT NULL,
       carried_from_item_id INTEGER,
       user_id TEXT,

--- a/src/backend/routes/__tests__/trips.crud.test.ts
+++ b/src/backend/routes/__tests__/trips.crud.test.ts
@@ -158,6 +158,7 @@ async function createTestDb() {
       item_type TEXT NOT NULL,
       status TEXT DEFAULT 'consider' NOT NULL,
       notes TEXT,
+      map_url TEXT,
       is_carried_forward INTEGER DEFAULT 0 NOT NULL,
       carried_from_item_id INTEGER,
       user_id TEXT,

--- a/src/backend/routes/__tests__/trips.delete.test.ts
+++ b/src/backend/routes/__tests__/trips.delete.test.ts
@@ -162,6 +162,7 @@ async function createTestDb() {
       item_type TEXT NOT NULL,
       status TEXT DEFAULT 'consider' NOT NULL,
       notes TEXT,
+      map_url TEXT,
       is_carried_forward INTEGER DEFAULT 0 NOT NULL,
       carried_from_item_id INTEGER,
       user_id TEXT,

--- a/src/backend/routes/items-helper.ts
+++ b/src/backend/routes/items-helper.ts
@@ -25,6 +25,7 @@ interface ItemRow {
   itemType: string;
   status: string;
   notes: string | null;
+  mapUrl: string | null;
   isCarriedForward: number;
   carriedFromItemId: number | null;
   createdAt: string;
@@ -97,6 +98,7 @@ export async function fetchItemsWithExtensions(
       itemType: items.itemType,
       status: items.status,
       notes: items.notes,
+      mapUrl: items.mapUrl,
       isCarriedForward: items.isCarriedForward,
       carriedFromItemId: items.carriedFromItemId,
       createdAt: items.createdAt,
@@ -172,6 +174,7 @@ function flattenItem(row: ItemRow): Record<string, unknown> {
     item_type: row.itemType,
     status: row.status,
     notes: row.notes,
+    map_url: row.mapUrl,
     is_carried_forward: row.isCarriedForward === 1,
     carried_from_item_id: row.carriedFromItemId,
     created_at: row.createdAt,

--- a/src/backend/routes/items.ts
+++ b/src/backend/routes/items.ts
@@ -90,6 +90,7 @@ itemsRouter.post(
         itemType: body.item_type,
         status: body.status ?? 'consider',
         notes: body.notes ?? null,
+        mapUrl: body.map_url ?? null,
         isCarriedForward: !!body.is_carried_forward,
         carriedFromItemId: body.carried_from_item_id ?? null,
       },
@@ -129,6 +130,7 @@ itemsRouter.patch(
       {
         status: body.status,
         notes: body.notes,
+        mapUrl: body.map_url,
       },
       body,
       existing.itemType,

--- a/src/backend/services/__tests__/shading.trip-countries.test.ts
+++ b/src/backend/services/__tests__/shading.trip-countries.test.ts
@@ -157,6 +157,7 @@ async function createTestDb() {
       item_type TEXT NOT NULL,
       status TEXT DEFAULT 'consider' NOT NULL,
       notes TEXT,
+      map_url TEXT,
       is_carried_forward INTEGER DEFAULT 0 NOT NULL,
       carried_from_item_id INTEGER,
       user_id TEXT,

--- a/src/backend/services/__tests__/shading.user-scope.test.ts
+++ b/src/backend/services/__tests__/shading.user-scope.test.ts
@@ -153,6 +153,7 @@ async function createTestDb() {
       item_type TEXT NOT NULL,
       status TEXT DEFAULT 'consider' NOT NULL,
       notes TEXT,
+      map_url TEXT,
       is_carried_forward INTEGER DEFAULT 0 NOT NULL,
       carried_from_item_id INTEGER,
       user_id TEXT,

--- a/src/backend/validation/__tests__/common.test.ts
+++ b/src/backend/validation/__tests__/common.test.ts
@@ -16,6 +16,7 @@ import {
   zIsoDate,
   zItemStatus,
   zItemType,
+  zMapUrl,
   zName,
   zOptionalString,
   zRating,
@@ -269,6 +270,63 @@ describe('zOptionalString', () => {
   });
   it('rejects a whitespace-only string', () => {
     fails(zOptionalString, '   ');
+  });
+});
+
+// ----------------------------------------------------------------
+// zMapUrl (IT-10, ADL-45)
+// ----------------------------------------------------------------
+
+describe('zMapUrl', () => {
+  it('accepts undefined (optional field)', () => {
+    expect(passes(zMapUrl, undefined)).toBeUndefined();
+  });
+
+  it('accepts a well-formed https:// URL', () => {
+    const url = 'https://maps.google.com/?q=Paris';
+    expect(passes(zMapUrl, url)).toBe(url);
+  });
+
+  it('accepts a non-Google https:// host (ADL-45 D4: no host allowlist)', () => {
+    const url = 'https://maps.apple.com/?q=Paris';
+    expect(passes(zMapUrl, url)).toBe(url);
+  });
+
+  it('trims surrounding whitespace', () => {
+    expect(passes(zMapUrl, '  https://maps.google.com/  ')).toBe('https://maps.google.com/');
+  });
+
+  it('rejects http:// (ADL-45 D5: https:// only)', () => {
+    fails(zMapUrl, 'http://maps.google.com/');
+  });
+
+  it('rejects file:// (ADL-45 D5: narrower than the frontend sanitiser default)', () => {
+    fails(zMapUrl, 'file:///Users/alice/map.html');
+  });
+
+  it('rejects javascript: scheme', () => {
+    fails(zMapUrl, 'javascript:alert(1)');
+  });
+
+  it('rejects an empty string', () => {
+    fails(zMapUrl, '');
+  });
+
+  it('rejects a malformed URL', () => {
+    fails(zMapUrl, 'not a url');
+  });
+
+  it('accepts a URL of exactly 2048 characters (ADL-45 D3)', () => {
+    const padding = 'a'.repeat(2048 - 'https://maps.google.com/?q='.length);
+    const url = `https://maps.google.com/?q=${padding}`;
+    expect(url.length).toBe(2048);
+    expect(passes(zMapUrl, url)).toBe(url);
+  });
+
+  it('rejects a URL longer than 2048 characters', () => {
+    const padding = 'a'.repeat(2048 - 'https://maps.google.com/?q='.length + 1);
+    const url = `https://maps.google.com/?q=${padding}`;
+    fails(zMapUrl, url);
   });
 });
 

--- a/src/backend/validation/common.ts
+++ b/src/backend/validation/common.ts
@@ -54,3 +54,20 @@ export const zOptionalString = z.string().trim().min(1).optional();
 
 /** Positive integer ID */
 export const zId = z.coerce.number().int().positive();
+
+/**
+ * Optional map/directions URL (IT-10, ADL-45).
+ * https:// only (narrower than the frontend sanitiseUrl()'s https:/file: default —
+ * ADL-45 D5, file:// is not a legitimate "get directions" link). No host allowlist
+ * (ADL-45 D4) — any well-formed https:// URL is accepted. Length capped at 2048
+ * chars, Zod-only, no DB CHECK (ADL-45 D3, matches the zName precedent).
+ */
+export const zMapUrl = z
+  .string()
+  .trim()
+  .url()
+  .max(2048, 'Map URL must be 2048 characters or fewer')
+  .refine((u) => u.startsWith('https://'), {
+    message: 'Map URL must use https://',
+  })
+  .optional();

--- a/src/backend/validation/items.schemas.ts
+++ b/src/backend/validation/items.schemas.ts
@@ -4,7 +4,7 @@
  */
 
 import { z } from 'zod';
-import { zItemStatus, zItemType, zOptionalString, zRating } from './common.js';
+import { zItemStatus, zItemType, zMapUrl, zOptionalString, zRating } from './common.js';
 
 /** Fields shared by all item types */
 const itemBase = {
@@ -12,6 +12,8 @@ const itemBase = {
   item_type: zItemType,
   status: zItemStatus.optional(),
   notes: zOptionalString,
+  // Optional map/directions link — base-table field, applies to all item types (IT-10, ADL-45).
+  map_url: zMapUrl,
   is_carried_forward: z.boolean().optional(),
   carried_from_item_id: z.number().int().positive().nullable().optional(),
 };
@@ -67,6 +69,9 @@ export const CreateItemSchema = z.object({ ...itemBase, ...extensionFields }).re
 export const UpdateItemSchema = z.object({
   status: zItemStatus.optional(),
   notes: zOptionalString,
+  // itemBase isn't spread here (trip_place_id/item_type/carry-forward fields aren't
+  // patchable) — map_url is added explicitly since it, like notes, is patchable (ADL-45).
+  map_url: zMapUrl,
   ...extensionFields,
 });
 

--- a/src/frontend/components/PostTripReview/__tests__/ReviewPanel.test.tsx
+++ b/src/frontend/components/PostTripReview/__tests__/ReviewPanel.test.tsx
@@ -70,6 +70,7 @@ function makeItem(overrides: Partial<Item> = {}): Item {
     item_type: 'restaurant',
     status: 'consider',
     notes: null,
+    map_url: null,
     name: 'Test Restaurant',
     neighbourhood_area: null,
     cuisine_type: null,

--- a/src/frontend/components/TripDetail/AddPlaceFlow.tsx
+++ b/src/frontend/components/TripDetail/AddPlaceFlow.tsx
@@ -21,12 +21,24 @@ import {
 import { useAddPlace } from '../../hooks/usePlaces';
 import { geocodeRetryQueue } from '../../services/geocodeRetryQueue';
 import type { City } from '../../types/api';
+import { resolveDefaultDate } from '../../utils/dateDefaults';
 import { CarryForwardModal } from '../CarryForward/CarryForwardModal';
 import { ErrorMessage } from '../shared/ErrorMessage';
 
 interface AddPlaceFlowProps {
   tripId: number;
   onClose: () => void;
+  /** Trip start date (YYYY-MM-DD) — inherited by the first place (BRD-DP06). */
+  tripStartDate: string;
+  /** Trip end date (YYYY-MM-DD) — inherited by the first place (BRD-DP06). */
+  tripEndDate: string;
+  /**
+   * True only on the empty-trip → first-place transition (ADL-41 constraint).
+   * Pass `trip.places.length === 0` from the caller — a revisit (trip already
+   * has at least one place) never inherits trip dates, regardless of model
+   * (works unchanged once ADL-41's one-row-per-visit migration lands, Wave 2).
+   */
+  isFirstPlace: boolean;
 }
 
 /** Debounce delay for city search (ms). */
@@ -36,7 +48,13 @@ const DEBOUNCE_MS = 300;
  * Renders the multi-step Add Place modal. Handles city search, city creation,
  * place creation (with optional dates), and triggering carry-forward when applicable.
  */
-export function AddPlaceFlow({ tripId, onClose }: AddPlaceFlowProps) {
+export function AddPlaceFlow({
+  tripId,
+  onClose,
+  tripStartDate,
+  tripEndDate,
+  isFirstPlace,
+}: AddPlaceFlowProps) {
   const [query, setQuery] = useState('');
   const [debouncedQuery, setDebouncedQuery] = useState('');
   const [showNewCityForm, setShowNewCityForm] = useState(false);
@@ -49,9 +67,18 @@ export function AddPlaceFlow({ tripId, onClose }: AddPlaceFlowProps) {
   const [addedCityId, setAddedCityId] = useState<number | null>(null);
   const [showCarryForward, setShowCarryForward] = useState(false);
 
-  // UX-02: optional date fields for place creation
-  const [arrivedOn, setArrivedOn] = useState('');
-  const [departedOn, setDepartedOn] = useState('');
+  // UX-02: optional date fields for place creation.
+  // BRD-DP06: the first place added to an empty trip inherits the trip's date
+  // range as a starting value — ADL-41 constraint: fires only on the
+  // empty-trip → first-place transition (isFirstPlace), never on a revisit.
+  // resolveDefaultDate's fallbackToToday=false means "no trip range to
+  // inherit" leaves these blank, same as before this brief.
+  const [arrivedOn, setArrivedOn] = useState(
+    isFirstPlace ? resolveDefaultDate(tripStartDate, false) : '',
+  );
+  const [departedOn, setDepartedOn] = useState(
+    isFirstPlace ? resolveDefaultDate(tripEndDate, false) : '',
+  );
   const [dateValidationError, setDateValidationError] = useState<string | null>(null);
   const [placeWarnings, setPlaceWarnings] = useState<string[]>([]);
 

--- a/src/frontend/components/TripDetail/ItemCard.tsx
+++ b/src/frontend/components/TripDetail/ItemCard.tsx
@@ -15,6 +15,7 @@ import { useState } from 'react';
 import { useDeleteItem } from '../../hooks/useItems';
 import type { Item } from '../../types/api';
 import { formatDate } from '../../utils/formatDate';
+import { sanitiseUrl } from '../../utils/urlSanitiser';
 import { ITEM_TYPE_ICONS, NoteIcon } from '../icons';
 import { ConfirmDialog } from '../shared/ConfirmDialog';
 import { RatingStars } from '../shared/RatingStars';
@@ -77,6 +78,11 @@ export function ItemCard({ item, tripId, isLocked, onEdit }: ItemCardProps) {
       item.item_type === 'experience') &&
     rating !== null;
 
+  // IT-10/ADL-45: https:// only (narrower than sanitiseUrl()'s https:/file: default —
+  // file:// is not a legitimate "get directions" link). Client-side re-validation —
+  // the server (zMapUrl) is authoritative; this is defense in depth only.
+  const mapHref = sanitiseUrl(item.map_url, ['https:']);
+
   // WP-02: icon lookup by item_type; falls back to the generic Note glyph for
   // any (currently impossible) unrecognised type rather than leaving a gap.
   const TypeIcon = ITEM_TYPE_ICONS[item.item_type] ?? NoteIcon;
@@ -121,6 +127,12 @@ export function ItemCard({ item, tripId, isLocked, onEdit }: ItemCardProps) {
               {item.departure_datetime ? ` · ${item.departure_datetime.slice(0, 10)}` : ''}
             </div>
           )}
+          {/* BUG-44: car rental pickup location as subtext, mirroring the flight pattern above */}
+          {item.item_type === 'car_rental' && item.pickup_location && (
+            <div className="mt-1 font-ui text-xs text-wp-ink-muted break-words">
+              {item.pickup_location}
+            </div>
+          )}
 
           {/* C5: rating stars (read-only) — must preserve */}
           {hasRating && (
@@ -133,6 +145,20 @@ export function ItemCard({ item, tripId, isLocked, onEdit }: ItemCardProps) {
             <div className="mt-1 font-ui text-xs text-wp-ink-muted italic break-words">
               {item.notes.slice(0, 100)}
               {item.notes.length > 100 ? '…' : ''}
+            </div>
+          )}
+
+          {/* IT-10/ADL-45: map/directions link — target=_blank + noopener noreferrer mandatory (D8) */}
+          {mapHref && (
+            <div className="mt-1">
+              <a
+                href={mapHref}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="font-ui text-xs text-wp-primary hover:underline"
+              >
+                View map
+              </a>
             </div>
           )}
         </div>

--- a/src/frontend/components/TripDetail/ItemForm.tsx
+++ b/src/frontend/components/TripDetail/ItemForm.tsx
@@ -16,6 +16,7 @@ import {
   useUpdateItem,
 } from '../../hooks/useItems';
 import type { Item, ItemStatus, ItemType } from '../../types/api';
+import { resolveDefaultDate, resolveDefaultDateTime } from '../../utils/dateDefaults';
 import { ITEM_TYPE_ICONS } from '../icons';
 import { ErrorMessage } from '../shared/ErrorMessage';
 import { RatingStars } from '../shared/RatingStars';
@@ -34,6 +35,13 @@ interface ItemFormProps {
    * tied to a specific city and don't make sense without a place.
    */
   allowedTypes?: ItemType[];
+  /**
+   * Trip start date (YYYY-MM-DD) — seeds new-item date field defaults
+   * (BUG-57/IT-11). Ignored in edit mode; existingItem's saved values win.
+   */
+  tripStartDate?: string;
+  /** Trip end date (YYYY-MM-DD) — seeds new-item "end" date field defaults (IT-11). */
+  tripEndDate?: string;
   /** Called when the modal should close. */
   onClose: () => void;
 }
@@ -116,6 +124,8 @@ export function ItemForm({
   tripPlaceId,
   existingItem,
   allowedTypes,
+  tripStartDate,
+  tripEndDate,
   onClose,
 }: ItemFormProps) {
   const isEditing = !!existingItem;
@@ -126,6 +136,7 @@ export function ItemForm({
   const [itemType, setItemType] = useState<ItemType | null>(existingItem?.item_type ?? null);
   const [status, setStatus] = useState<ItemStatus>(existingItem?.status ?? 'consider');
   const [notes, setNotes] = useState(existingItem?.notes ?? '');
+  const [mapUrl, setMapUrl] = useState(existingItem?.map_url ?? '');
   const [rating, setRating] = useState<number | null>(existingItem?.rating ?? null);
   const [postVisitNotes, setPostVisitNotes] = useState(existingItem?.post_visit_notes ?? '');
 
@@ -138,8 +149,16 @@ export function ItemForm({
   const [source, setSource] = useState(existingItem?.source ?? '');
   const [propertyName, setPropertyName] = useState(existingItem?.property_name ?? '');
   const [address, setAddress] = useState(existingItem?.address ?? '');
-  const [checkInDate, setCheckInDate] = useState(existingItem?.check_in_date ?? '');
-  const [checkOutDate, setCheckOutDate] = useState(existingItem?.check_out_date ?? '');
+  // BUG-57/IT-11: new items default date fields from the trip's date range
+  // rather than opening blank (which made native date pickers default to the
+  // current month regardless of the trip's actual dates). Edit mode is
+  // untouched — existingItem's saved values win, no re-defaulting.
+  const [checkInDate, setCheckInDate] = useState(
+    isEditing ? (existingItem?.check_in_date ?? '') : resolveDefaultDate(tripStartDate, true),
+  );
+  const [checkOutDate, setCheckOutDate] = useState(
+    isEditing ? (existingItem?.check_out_date ?? '') : resolveDefaultDate(tripEndDate, false),
+  );
   const [bookingReference, setBookingReference] = useState(existingItem?.booking_reference ?? '');
   const [confirmationNumber, setConfirmationNumber] = useState(
     existingItem?.confirmation_number ?? '',
@@ -149,16 +168,44 @@ export function ItemForm({
   const [departureAirport, setDepartureAirport] = useState(existingItem?.departure_airport ?? '');
   const [arrivalAirport, setArrivalAirport] = useState(existingItem?.arrival_airport ?? '');
   const [departureDatetime, setDepartureDatetime] = useState(
-    existingItem?.departure_datetime ?? '',
+    isEditing
+      ? (existingItem?.departure_datetime ?? '')
+      : resolveDefaultDateTime(tripStartDate, true),
   );
-  const [arrivalDatetime, setArrivalDatetime] = useState(existingItem?.arrival_datetime ?? '');
+  const [arrivalDatetime, setArrivalDatetime] = useState(
+    isEditing
+      ? (existingItem?.arrival_datetime ?? '')
+      : resolveDefaultDateTime(tripStartDate, true),
+  );
+  // Tracks whether the user has hand-edited arrival — once true, changing
+  // departure never overwrites it again (IT-11: "changing either date by
+  // hand persists that value through save and re-open"). Starts true in
+  // edit mode so opening an existing item never re-triggers the cascade.
+  const [arrivalTouched, setArrivalTouched] = useState(isEditing);
   const [seat, setSeat] = useState(existingItem?.seat ?? '');
   const [provider, setProvider] = useState(existingItem?.provider ?? '');
   const [pickupLocation, setPickupLocation] = useState(existingItem?.pickup_location ?? '');
   const [dropoffLocation, setDropoffLocation] = useState(existingItem?.dropoff_location ?? '');
-  const [pickupDatetime, setPickupDatetime] = useState(existingItem?.pickup_datetime ?? '');
-  const [dropoffDatetime, setDropoffDatetime] = useState(existingItem?.dropoff_datetime ?? '');
+  const [pickupDatetime, setPickupDatetime] = useState(
+    isEditing
+      ? (existingItem?.pickup_datetime ?? '')
+      : resolveDefaultDateTime(tripStartDate, true),
+  );
+  const [dropoffDatetime, setDropoffDatetime] = useState(
+    isEditing ? (existingItem?.dropoff_datetime ?? '') : resolveDefaultDateTime(tripEndDate, false),
+  );
   const [vehicleClass, setVehicleClass] = useState(existingItem?.vehicle_class ?? '');
+
+  // BUG-57/IT-11: entering a flight departure date populates arrival with the
+  // same value, but only until the user hand-edits arrival themselves.
+  const handleDepartureDatetimeChange = (v: string) => {
+    setDepartureDatetime(v);
+    if (!arrivalTouched) setArrivalDatetime(v);
+  };
+  const handleArrivalDatetimeChange = (v: string) => {
+    setArrivalTouched(true);
+    setArrivalDatetime(v);
+  };
 
   const createItem = useCreateItem();
   const updateItem = useUpdateItem();
@@ -177,7 +224,7 @@ export function ItemForm({
 
   const buildPayload = (): CreateItemData | UpdateItemData => {
     const n = (v: string) => v.trim() || undefined;
-    const base = { status, notes: n(notes) };
+    const base = { status, notes: n(notes), map_url: n(mapUrl) };
     const typeFields =
       itemType === 'restaurant'
         ? {
@@ -403,13 +450,13 @@ export function ItemForm({
                     <Field
                       label="Departure"
                       value={departureDatetime}
-                      onChange={setDepartureDatetime}
+                      onChange={handleDepartureDatetimeChange}
                       type="datetime-local"
                     />
                     <Field
                       label="Arrival"
                       value={arrivalDatetime}
-                      onChange={setArrivalDatetime}
+                      onChange={handleArrivalDatetimeChange}
                       type="datetime-local"
                     />
                   </div>
@@ -478,6 +525,15 @@ export function ItemForm({
                   </div>
                 </>
               )}
+
+              {/* Map URL — base field, all types (IT-10, ADL-45) */}
+              <Field
+                label="Map URL"
+                value={mapUrl}
+                onChange={setMapUrl}
+                type="url"
+                placeholder="https://maps.google.com/…"
+              />
 
               {/* Notes — all types */}
               <div className="mb-3.5">

--- a/src/frontend/components/TripDetail/ItemForm.tsx
+++ b/src/frontend/components/TripDetail/ItemForm.tsx
@@ -187,9 +187,7 @@ export function ItemForm({
   const [pickupLocation, setPickupLocation] = useState(existingItem?.pickup_location ?? '');
   const [dropoffLocation, setDropoffLocation] = useState(existingItem?.dropoff_location ?? '');
   const [pickupDatetime, setPickupDatetime] = useState(
-    isEditing
-      ? (existingItem?.pickup_datetime ?? '')
-      : resolveDefaultDateTime(tripStartDate, true),
+    isEditing ? (existingItem?.pickup_datetime ?? '') : resolveDefaultDateTime(tripStartDate, true),
   );
   const [dropoffDatetime, setDropoffDatetime] = useState(
     isEditing ? (existingItem?.dropoff_datetime ?? '') : resolveDefaultDateTime(tripEndDate, false),

--- a/src/frontend/components/TripDetail/MobileTripDetailView.tsx
+++ b/src/frontend/components/TripDetail/MobileTripDetailView.tsx
@@ -196,7 +196,12 @@ export function MobileTripDetailView({ trip, onBack }: MobileTripDetailViewProps
           {c.statusError && <ErrorMessage error={c.statusError} />}
 
           {/* Trip-level items (BUG-36/IT-01/C3) */}
-          <TripItemsSection tripId={trip.id} isLocked={c.isLocked} />
+          <TripItemsSection
+            tripId={trip.id}
+            isLocked={c.isLocked}
+            tripStartDate={trip.start_date}
+            tripEndDate={trip.end_date}
+          />
 
           {/* Places — sorted by arrived_on ascending, nulls last (UX-02 / ADL-24) */}
           <div className="mb-4">
@@ -235,7 +240,15 @@ export function MobileTripDetailView({ trip, onBack }: MobileTripDetailViewProps
 
       {/* Modals */}
       {c.showEdit && <TripForm existingTrip={trip} onClose={() => c.setShowEdit(false)} />}
-      {c.showAddPlace && <AddPlaceFlow tripId={trip.id} onClose={c.handleAddPlaceClose} />}
+      {c.showAddPlace && (
+        <AddPlaceFlow
+          tripId={trip.id}
+          onClose={c.handleAddPlaceClose}
+          tripStartDate={trip.start_date}
+          tripEndDate={trip.end_date}
+          isFirstPlace={trip.places.length === 0}
+        />
+      )}
 
       <ConfirmDialog
         isOpen={c.confirmLock}

--- a/src/frontend/components/TripDetail/PlaceSection.tsx
+++ b/src/frontend/components/TripDetail/PlaceSection.tsx
@@ -215,7 +215,15 @@ export function PlaceSection({
       </div>
 
       {/* Add item modal */}
-      {showAddItem && <ItemForm tripId={tripId} tripPlaceId={place.id} onClose={handleCloseForm} />}
+      {showAddItem && (
+        <ItemForm
+          tripId={tripId}
+          tripPlaceId={place.id}
+          tripStartDate={tripStartDate}
+          tripEndDate={tripEndDate}
+          onClose={handleCloseForm}
+        />
+      )}
 
       {/* Edit item modal */}
       {editingItem && (
@@ -223,6 +231,8 @@ export function PlaceSection({
           tripId={tripId}
           tripPlaceId={place.id}
           existingItem={editingItem}
+          tripStartDate={tripStartDate}
+          tripEndDate={tripEndDate}
           onClose={handleCloseForm}
         />
       )}

--- a/src/frontend/components/TripDetail/TripDetail.tsx
+++ b/src/frontend/components/TripDetail/TripDetail.tsx
@@ -186,7 +186,12 @@ export function TripDetail({ trip }: TripDetailProps) {
           {/* Trip-level items (BUG-36/IT-01/C3) — flights and car rentals that
               aren't tied to a specific place. Rendered above Places since
               transport typically bookends the trip. */}
-          <TripItemsSection tripId={trip.id} isLocked={c.isLocked} />
+          <TripItemsSection
+            tripId={trip.id}
+            isLocked={c.isLocked}
+            tripStartDate={trip.start_date}
+            tripEndDate={trip.end_date}
+          />
 
           {/* Places — sorted by arrived_on ascending, nulls last (UX-02 / ADL-24) */}
           <div className="mb-4">
@@ -226,7 +231,15 @@ export function TripDetail({ trip }: TripDetailProps) {
 
       {/* Modals */}
       {c.showEdit && <TripForm existingTrip={trip} onClose={() => c.setShowEdit(false)} />}
-      {c.showAddPlace && <AddPlaceFlow tripId={trip.id} onClose={c.handleAddPlaceClose} />}
+      {c.showAddPlace && (
+        <AddPlaceFlow
+          tripId={trip.id}
+          onClose={c.handleAddPlaceClose}
+          tripStartDate={trip.start_date}
+          tripEndDate={trip.end_date}
+          isFirstPlace={trip.places.length === 0}
+        />
+      )}
 
       <ConfirmDialog
         isOpen={c.confirmLock}

--- a/src/frontend/components/TripDetail/TripItemsSection.tsx
+++ b/src/frontend/components/TripDetail/TripItemsSection.tsx
@@ -33,6 +33,10 @@ interface TripItemsSectionProps {
   tripId: number;
   /** When true, all edit/delete/add controls are hidden. */
   isLocked: boolean;
+  /** Trip start date (YYYY-MM-DD) — seeds new-item date defaults (BUG-57/IT-11). */
+  tripStartDate: string;
+  /** Trip end date (YYYY-MM-DD) — seeds new-item "end" date defaults (IT-11). */
+  tripEndDate: string;
 }
 
 /** Item types offered at trip level — see module doc for rationale. */
@@ -45,7 +49,12 @@ const TRIP_LEVEL_ITEM_TYPES: ItemType[] = ['flight', 'car_rental'];
  * @param tripId - Parent trip ID for item queries/mutations.
  * @param isLocked - When true, hides all write controls.
  */
-export function TripItemsSection({ tripId, isLocked }: TripItemsSectionProps) {
+export function TripItemsSection({
+  tripId,
+  isLocked,
+  tripStartDate,
+  tripEndDate,
+}: TripItemsSectionProps) {
   const { data: items = [], isLoading, error } = useTripLevelItems(tripId);
   const [showAddItem, setShowAddItem] = useState(false);
   const [editingItem, setEditingItem] = useState<Item | null>(null);
@@ -108,6 +117,8 @@ export function TripItemsSection({ tripId, isLocked }: TripItemsSectionProps) {
           tripId={tripId}
           tripPlaceId={null}
           allowedTypes={TRIP_LEVEL_ITEM_TYPES}
+          tripStartDate={tripStartDate}
+          tripEndDate={tripEndDate}
           onClose={handleCloseForm}
         />
       )}
@@ -119,6 +130,8 @@ export function TripItemsSection({ tripId, isLocked }: TripItemsSectionProps) {
           tripPlaceId={null}
           existingItem={editingItem}
           allowedTypes={TRIP_LEVEL_ITEM_TYPES}
+          tripStartDate={tripStartDate}
+          tripEndDate={tripEndDate}
           onClose={handleCloseForm}
         />
       )}

--- a/src/frontend/components/TripDetail/__tests__/PlaceSection.test.tsx
+++ b/src/frontend/components/TripDetail/__tests__/PlaceSection.test.tsx
@@ -57,6 +57,7 @@ function makeItem(overrides: Partial<Item> = {}): Item {
     item_type: 'restaurant',
     status: 'consider',
     notes: null,
+    map_url: null,
     name: 'Test Restaurant',
     neighbourhood_area: null,
     cuisine_type: null,

--- a/src/frontend/components/TripDetail/__tests__/TripItemsSection.test.tsx
+++ b/src/frontend/components/TripDetail/__tests__/TripItemsSection.test.tsx
@@ -40,6 +40,7 @@ function makeFlight(overrides: Partial<Item> = {}): Item {
     item_type: 'flight',
     status: 'confirmed',
     notes: null,
+    map_url: null,
     is_carried_forward: false,
     carried_from_item_id: null,
     created_at: '2026-01-01T00:00:00Z',
@@ -66,7 +67,14 @@ describe('TripItemsSection', () => {
     mockUseUpdateItem.mockReturnValue(idleMutation);
     mockUseDeleteItem.mockReturnValue(idleMutation);
 
-    render(<TripItemsSection tripId={1} isLocked={false} />);
+    render(
+      <TripItemsSection
+        tripId={1}
+        isLocked={false}
+        tripStartDate="2026-06-01"
+        tripEndDate="2026-06-10"
+      />,
+    );
 
     expect(screen.getByText('LHR → JFK')).toBeInTheDocument();
     expect(screen.getByText('Trip Items')).toBeInTheDocument();
@@ -78,7 +86,14 @@ describe('TripItemsSection', () => {
     mockUseUpdateItem.mockReturnValue(idleMutation);
     mockUseDeleteItem.mockReturnValue(idleMutation);
 
-    render(<TripItemsSection tripId={1} isLocked={false} />);
+    render(
+      <TripItemsSection
+        tripId={1}
+        isLocked={false}
+        tripStartDate="2026-06-01"
+        tripEndDate="2026-06-10"
+      />,
+    );
 
     expect(screen.getByText(/No trip-level items yet/)).toBeInTheDocument();
   });
@@ -89,7 +104,14 @@ describe('TripItemsSection', () => {
     mockUseUpdateItem.mockReturnValue(idleMutation);
     mockUseDeleteItem.mockReturnValue(idleMutation);
 
-    render(<TripItemsSection tripId={1} isLocked={false} />);
+    render(
+      <TripItemsSection
+        tripId={1}
+        isLocked={false}
+        tripStartDate="2026-06-01"
+        tripEndDate="2026-06-10"
+      />,
+    );
     await userEvent.click(screen.getByText('+ Add Trip Item'));
 
     expect(screen.getByText('Flight')).toBeInTheDocument();
@@ -110,7 +132,14 @@ describe('TripItemsSection', () => {
     mockUseUpdateItem.mockReturnValue(idleMutation);
     mockUseDeleteItem.mockReturnValue(idleMutation);
 
-    render(<TripItemsSection tripId={1} isLocked={true} />);
+    render(
+      <TripItemsSection
+        tripId={1}
+        isLocked={true}
+        tripStartDate="2026-06-01"
+        tripEndDate="2026-06-10"
+      />,
+    );
 
     expect(screen.queryByText('+ Add Trip Item')).not.toBeInTheDocument();
   });
@@ -121,7 +150,14 @@ describe('TripItemsSection', () => {
     mockUseUpdateItem.mockReturnValue(idleMutation);
     mockUseDeleteItem.mockReturnValue(idleMutation);
 
-    const { container } = render(<TripItemsSection tripId={1} isLocked={true} />);
+    const { container } = render(
+      <TripItemsSection
+        tripId={1}
+        isLocked={true}
+        tripStartDate="2026-06-01"
+        tripEndDate="2026-06-10"
+      />,
+    );
 
     expect(container).toBeEmptyDOMElement();
   });

--- a/src/frontend/hooks/useItems.ts
+++ b/src/frontend/hooks/useItems.ts
@@ -13,6 +13,8 @@ export interface CreateItemData {
   item_type: ItemType;
   status?: ItemStatus;
   notes?: string | null;
+  /** Optional map/directions link (IT-10, ADL-45). https:// only. */
+  map_url?: string | null;
   // Restaurant
   name?: string | null;
   neighbourhood_area?: string | null;

--- a/src/frontend/types/api.ts
+++ b/src/frontend/types/api.ts
@@ -116,6 +116,8 @@ export interface Item {
   item_type: ItemType;
   status: ItemStatus;
   notes: string | null;
+  /** Optional map/directions link (IT-10, ADL-45). https:// only, null if unset. */
+  map_url: string | null;
   is_carried_forward: boolean;
   carried_from_item_id: number | null;
   created_at: string;

--- a/src/frontend/utils/__tests__/dateDefaults.test.ts
+++ b/src/frontend/utils/__tests__/dateDefaults.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Unit tests for the shared trip-date defaulting logic (BUG-57/IT-11, BRD-DP06).
+ *
+ * Pure functions; no mocks needed.
+ *
+ * Source: src/frontend/utils/dateDefaults.ts
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { resolveDefaultDate, resolveDefaultDateTime, todayIso } from '../dateDefaults.js';
+
+describe('todayIso()', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns the current local date as YYYY-MM-DD', () => {
+    vi.setSystemTime(new Date(2026, 5, 15, 10, 30)); // June 15 2026, local time
+    expect(todayIso()).toBe('2026-06-15');
+  });
+
+  it('zero-pads single-digit months and days', () => {
+    vi.setSystemTime(new Date(2026, 0, 5, 10, 30)); // Jan 5 2026
+    expect(todayIso()).toBe('2026-01-05');
+  });
+});
+
+describe('resolveDefaultDate()', () => {
+  it('returns the trip date when set', () => {
+    expect(resolveDefaultDate('2026-06-01', true)).toBe('2026-06-01');
+    expect(resolveDefaultDate('2026-06-01', false)).toBe('2026-06-01');
+  });
+
+  it('IT-11: falls back to today when unset and fallbackToToday is true', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 5, 15));
+    expect(resolveDefaultDate(null, true)).toBe('2026-06-15');
+    expect(resolveDefaultDate(undefined, true)).toBe('2026-06-15');
+    vi.useRealTimers();
+  });
+
+  it('BRD-DP06: returns empty string when unset and fallbackToToday is false', () => {
+    expect(resolveDefaultDate(null, false)).toBe('');
+    expect(resolveDefaultDate(undefined, false)).toBe('');
+  });
+
+  it('treats an empty string trip date as unset', () => {
+    expect(resolveDefaultDate('', false)).toBe('');
+  });
+});
+
+describe('resolveDefaultDateTime()', () => {
+  it('anchors to midnight on the resolved day when a trip date is set', () => {
+    expect(resolveDefaultDateTime('2026-06-01', true)).toBe('2026-06-01T00:00');
+  });
+
+  it('falls back to today at midnight when unset and fallbackToToday is true', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 5, 15));
+    expect(resolveDefaultDateTime(null, true)).toBe('2026-06-15T00:00');
+    vi.useRealTimers();
+  });
+
+  it('returns empty string when unset and fallbackToToday is false', () => {
+    expect(resolveDefaultDateTime(null, false)).toBe('');
+  });
+});

--- a/src/frontend/utils/__tests__/resolvePlaceDateRange.test.ts
+++ b/src/frontend/utils/__tests__/resolvePlaceDateRange.test.ts
@@ -12,6 +12,7 @@ function hotelItem(checkIn: string, checkOut: string): Item {
     item_type: 'hotel',
     status: 'confirmed',
     notes: null,
+    map_url: null,
     is_carried_forward: false,
     carried_from_item_id: null,
     created_at: '2025-01-01',

--- a/src/frontend/utils/__tests__/urlSanitiser.test.ts
+++ b/src/frontend/utils/__tests__/urlSanitiser.test.ts
@@ -81,4 +81,29 @@ describe('sanitiseUrl()', () => {
   it('returns null for an empty string', () => {
     expect(sanitiseUrl('')).toBeNull();
   });
+
+  // ----------------------------------------------------------------
+  // allowedSchemes parameter (ADL-45 D7 — item.map_url uses ['https:'])
+  // ----------------------------------------------------------------
+
+  describe('with an explicit allowedSchemes list', () => {
+    it('accepts https:// when allowedSchemes is ["https:"]', () => {
+      const url = 'https://maps.google.com/?q=Paris';
+      expect(sanitiseUrl(url, ['https:'])).toBe(url);
+    });
+
+    it('rejects file:// when allowedSchemes is ["https:"] (ADL-45 D5)', () => {
+      expect(sanitiseUrl('file:///Users/alice/map.html', ['https:'])).toBeNull();
+    });
+
+    it('still rejects javascript: regardless of allowedSchemes', () => {
+      expect(sanitiseUrl('javascript:alert(1)', ['https:'])).toBeNull();
+    });
+
+    it('defaults to https:/file: when allowedSchemes is omitted (back-compat)', () => {
+      expect(sanitiseUrl('file:///Users/alice/Photos/japan')).toBe(
+        'file:///Users/alice/Photos/japan',
+      );
+    });
+  });
 });

--- a/src/frontend/utils/dateDefaults.ts
+++ b/src/frontend/utils/dateDefaults.ts
@@ -1,0 +1,62 @@
+/**
+ * Shared trip-date defaulting logic — BUG-57/BRD IT-11 and BRD-DP06.
+ *
+ * IT-11 ("adding an item to a trip whose range does not include today opens
+ * the date picker on the trip's start date") and DP-06 ("the first place
+ * added to a trip inherits the trip's date range") are the same underlying
+ * rule: read the trip's start/end date and use it as a starting value the
+ * user can freely override. One function, so the two call sites (ItemForm,
+ * AddPlaceFlow) cannot drift out of sync the way two independently-written
+ * defaulting mechanisms would (see B6 brief / GitHub issue #300).
+ *
+ * `trips.start_date`/`trips.end_date` are NOT NULL at the schema level
+ * (src/backend/db/schema.ts) — every trip always has a date range today, so
+ * the "no date range set" branch below is currently unreachable in practice.
+ * It is implemented anyway because IT-11's stated success criteria requires
+ * it and this stays correct if that constraint is ever relaxed.
+ */
+
+/** Returns today's date as YYYY-MM-DD (local calendar day, not UTC). */
+export function todayIso(): string {
+  const d = new Date();
+  const yyyy = d.getFullYear();
+  const mm = String(d.getMonth() + 1).padStart(2, '0');
+  const dd = String(d.getDate()).padStart(2, '0');
+  return `${yyyy}-${mm}-${dd}`;
+}
+
+/**
+ * Resolves a default date (YYYY-MM-DD) from one end of a trip's date range.
+ *
+ * @param tripDate - The trip's start_date or end_date, or falsy if unset.
+ * @param fallbackToToday - IT-11: item date fields fall back to today when
+ *   the trip has no range set. DP-06 passes `false` — a place with no trip
+ *   range to inherit simply has no default (existing blank-field behaviour),
+ *   it never falls back to today.
+ * @returns A YYYY-MM-DD date string, or `''` when there is nothing to default to.
+ */
+export function resolveDefaultDate(
+  tripDate: string | null | undefined,
+  fallbackToToday: boolean,
+): string {
+  if (tripDate) return tripDate;
+  return fallbackToToday ? todayIso() : '';
+}
+
+/**
+ * Resolves a default `datetime-local` input value (YYYY-MM-DDTHH:mm) from a
+ * trip date. `<input type="datetime-local">` requires the full format to
+ * register a value at all — a bare YYYY-MM-DD is silently ignored by the
+ * browser — so item date/time fields (flight departure, car rental pickup)
+ * anchor to midnight on the resolved day; this is enough to satisfy IT-11's
+ * "opens the date picker on the trip's start date" (the calendar view lands
+ * on the right day), even though the time itself is a placeholder the user
+ * is expected to fill in precisely.
+ */
+export function resolveDefaultDateTime(
+  tripDate: string | null | undefined,
+  fallbackToToday: boolean,
+): string {
+  const date = resolveDefaultDate(tripDate, fallbackToToday);
+  return date ? `${date}T00:00` : '';
+}

--- a/src/frontend/utils/urlSanitiser.ts
+++ b/src/frontend/utils/urlSanitiser.ts
@@ -1,25 +1,39 @@
 /**
  * URL sanitiser — SEC-12 compliance.
  *
- * Only https:// and file:// schemes are permitted when rendering user-supplied
- * URLs as anchor tags. Any other scheme (javascript:, data:, vbscript:, etc.)
- * is rejected and this function returns null, signalling the caller to render
- * the value as plain text rather than as a link.
+ * By default, only https:// and file:// schemes are permitted when rendering
+ * user-supplied URLs as anchor tags. Any other scheme (javascript:, data:,
+ * vbscript:, etc.) is rejected and this function returns null, signalling the
+ * caller to render the value as plain text rather than as a link.
  *
- * The only Phase 1 user-supplied URL field is trip.photo_album_ref.
- * Call sanitiseUrl() wherever that field is rendered as an <a href>.
+ * Two Phase 1 user-supplied URL fields use this: trip.photo_album_ref (default
+ * https:/file: scheme set) and item.map_url (ADL-45 — https:// only, narrower;
+ * file:// is not a legitimate "get directions" link). Call sanitiseUrl()
+ * wherever either field is rendered as an <a href>, passing an explicit
+ * allowedSchemes list to narrow beyond the default (ADL-45 D7 — one function,
+ * parameterised, rather than a second sanitiser that can drift out of sync).
  */
+
+/** Default allowed schemes — preserves pre-ADL-45 behaviour for photo_album_ref. */
+const DEFAULT_ALLOWED_SCHEMES = ['https:', 'file:'];
 
 /**
  * Validates a user-supplied URL and returns it if the scheme is safe,
  * or null if the scheme is not permitted or the value is falsy.
  *
  * @param url - The raw URL string from the API response (may be null).
+ * @param allowedSchemes - Schemes to accept (default `['https:', 'file:']`).
+ *   Pass `['https:']` for fields that should reject `file://` (ADL-45 D5).
  * @returns The original URL if safe, null otherwise.
  */
-export function sanitiseUrl(url: string | null | undefined): string | null {
+export function sanitiseUrl(
+  url: string | null | undefined,
+  allowedSchemes: string[] = DEFAULT_ALLOWED_SCHEMES,
+): string | null {
   if (!url) return null;
-  if (url.startsWith('https://') || url.startsWith('file://')) return url;
-  // All other schemes (javascript:, data:, vbscript:, http://, etc.) are rejected.
-  return null;
+  // startsWith on the literal scheme prefix (not new URL().protocol) — scheme
+  // confusion tricks like `https:/\evil` are a redirect/parsing concern, not a
+  // script-execution one, so this remains correct for SEC-12's actual threat
+  // model (rejecting javascript:/data:/vbscript:). See ADL-45 D6/D7.
+  return allowedSchemes.some((scheme) => url.startsWith(`${scheme}//`)) ? url : null;
 }

--- a/tests/contract/items.contract.test.ts
+++ b/tests/contract/items.contract.test.ts
@@ -158,6 +158,43 @@ describe('POST /api/trips/:tripId/items — note type', () => {
     expect(res.body).toHaveProperty('error');
   });
 
+  // IT-10 / ADL-45
+  it('201 — creates an item with a map_url', async () => {
+    const res = await api
+      .post(`/api/trips/${tripId}/items`)
+      .send({ item_type: 'note', map_url: 'https://maps.google.com/?q=Test' })
+      .expect(201);
+
+    expect(res.body.map_url).toBe('https://maps.google.com/?q=Test');
+  });
+
+  it('201 — map_url is null when not provided', async () => {
+    const res = await api
+      .post(`/api/trips/${tripId}/items`)
+      .send({ item_type: 'note' })
+      .expect(201);
+
+    expect(res.body.map_url).toBeNull();
+  });
+
+  it('400 — rejects a non-https map_url (ADL-45 D5)', async () => {
+    const res = await api
+      .post(`/api/trips/${tripId}/items`)
+      .send({ item_type: 'note', map_url: 'http://maps.google.com/?q=Test' })
+      .expect(400);
+
+    expect(res.body).toHaveProperty('error');
+  });
+
+  it('400 — rejects a javascript: map_url', async () => {
+    const res = await api
+      .post(`/api/trips/${tripId}/items`)
+      .send({ item_type: 'note', map_url: 'javascript:alert(1)' })
+      .expect(400);
+
+    expect(res.body).toHaveProperty('error');
+  });
+
   it('403 — POST rejected when trip is locked', async () => {
     const lockedTrip = await createTestTrip({ name: '[TEST] Locked trip for items POST' });
     await lockTrip(lockedTrip.id);
@@ -299,6 +336,25 @@ describe('PATCH /api/trips/:tripId/items/:itemId', () => {
       .expect(200);
 
     expect(res.body.notes).toBe('Updated note text');
+  });
+
+  // IT-10 / ADL-45
+  it('200 — updates item map_url', async () => {
+    const res = await api
+      .patch(`/api/trips/${tripId}/items/${itemId}`)
+      .send({ map_url: 'https://maps.google.com/?q=Updated' })
+      .expect(200);
+
+    expect(res.body.map_url).toBe('https://maps.google.com/?q=Updated');
+  });
+
+  it('400 — rejects a non-https map_url on update', async () => {
+    const res = await api
+      .patch(`/api/trips/${tripId}/items/${itemId}`)
+      .send({ map_url: 'file:///etc/passwd' })
+      .expect(400);
+
+    expect(res.body).toHaveProperty('error');
   });
 
   it('400 — invalid status value on update', async () => {


### PR DESCRIPTION
Closes #300

BRD §5.5 IT-10, IT-11 · §5.x DP-06 · §5.16 WP-05

## Summary
Fullstack brief (backend + frontend), one file surface, four bundled items per COO brief B6:

- **BUG-57 / BRD IT-11** — item date fields default from the trip's date range on create (falls back to today when the trip has no range); flight arrival live-cascades from departure until hand-edited; a hand-edited date persists through save/reopen.
- **BRD-DP06** — the first place added to an *empty* trip inherits the trip's date range (ADL-41 constraint: fires only on the empty-trip → first-place transition, never on a revisit). Implemented as one shared defaulting mechanism with IT-11 (`src/frontend/utils/dateDefaults.ts`), per the brief's explicit instruction not to write two mechanisms.
- **BUG-44** — car rental pickup location renders as subtext under the provider, mirroring the existing flight subtext pattern.
- **BRD-IT10** — optional item `map_url`, implemented exactly per ADL-45 (design already decided, not re-derived): nullable base-table column, one additive migration, Zod-only `https://`-only validation with no host allowlist, `sanitiseUrl()` extended (not forked) with an optional scheme list, mandatory `target="_blank" rel="noopener noreferrer"` on render.

## Security checklist (routes modified: POST/PATCH /api/trips/:tripId/items)
1. **Auth middleware** — `requireAuth` applied globally via `app.use('/api/', requireAuth)` in `server.ts` (unchanged by this brief).
2. **Repository queries** — `itemRepository.create`/`update` both scope by `eq(items.userId, userId)`; `map_url` flows through the same userId-scoped calls as `notes`/`status`.
3. **New user-data column** — `map_url` is a plain text field, not a new FK referencing a user — the `.notNull()`-on-FK rule doesn't apply.

## QUAL-17 caveat
Route-level tests hand-roll their own copy of the 21-table DDL (not drift-safe). 12 of the 15 affected files create an `items` table and needed `map_url TEXT,` added manually to keep passing — this is a mechanical patch, **not** a resolution of QUAL-17 itself. `map_url`'s write path is independently verified via repository tests (drift-safe, schema-derived) and live contract tests (`npm run dev:api` + real `dev.db`), not resting on the route tests alone.

## Verification
- `npm run type:check:all` — clean
- `npm run test:backend` — 599 passed, 1 skipped
- `npm run test:frontend` — 169 passed
- `npm run test:contract` — 115 passed (run against a live `npm run dev:api`)
- `npm run check` (Biome) — clean

## Open for QA/PO confirmation (non-blocking)
Hotel check-out / car-rental drop-off default from trip `end_date` (no fallback) by symmetry with check-in/pickup defaulting from trip start — the quoted BRD success criteria only names flight-arrival cascading and the generic "opens on trip start" behaviour explicitly. Full reasoning in `jobs/backend/park-docs/20260728-BACKEND-b6-park.txt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)