### PR TITLE
fix(BUG-51): invalidate the trips query cache on companion mutations (#305)

### DIFF
--- a/_project/tracker.json
+++ b/_project/tracker.json
@@ -2004,7 +2004,7 @@
       "priority": "P1",
       "brdRefs": [],
       "phase": 6,
-      "notes": "Found 2026-07-21 UAT, logged only — not yet briefed. Renaming a companion in the admin panel updated correctly on one trip automatically, but a second trip (companion role 'partner', renamed to Aisling) kept showing the old value until that trip was opened, edited, and saved. Suggests inconsistent propagation/derivation of companion name depending on how the trip stores/displays the reference — data-integrity concern, needs investigation."
+      "notes": "Found 2026-07-21 UAT, logged only — not yet briefed. Renaming a companion in the admin panel updated correctly on one trip automatically, but a second trip (companion role 'partner', renamed to Aisling) kept showing the old value until that trip was opened, edited, and saved. Suggests inconsistent propagation/derivation of companion name depending on how the trip stores/displays the reference — data-integrity concern, needs investigation. Root cause investigated and split: backend confirmed correct (issue #299, PR #302 — tripRepository.getAssociations() always LEFT JOINs companions.name live, no denormalised copy). Frontend fix (issue #305): useCreateCompanion/useUpdateCompanion/useDeleteCompanion in src/frontend/hooks/useAdmin.ts invalidated only ['admin','companions'], never ['trips'], so a fresh 5-minute-staleTime trips query kept serving the stale name. Fixed by cross-invalidating ['trips'] in all three mutations, matching the existing ['map','shading'] precedent at useAdmin.ts:237. Status left 'pending' — COO flips to 'done' at merge."
     },
     {
       "id": "BUG-52",

--- a/jobs/COO/inbox/20260728_0834-FRONTEND-bug51-trips-cache-invalidation-complete.txt
+++ b/jobs/COO/inbox/20260728_0834-FRONTEND-bug51-trips-cache-invalidation-complete.txt
@@ -1,0 +1,44 @@
+BUG-51 (P1) · GitHub #305 · PR #308 · BRD: no BRD requirement ID (data-integrity
+bug fix, tracker entry pre-existing, no new requirement) · Branch:
+fix/bug51-trips-cache-invalidation
+
+WHAT WAS BUILT
+useCreateCompanion, useUpdateCompanion and useDeleteCompanion in
+src/frontend/hooks/useAdmin.ts now cross-invalidate ['trips'] alongside the
+existing ['admin','companions'] invalidation, mirroring the ['map','shading']
+precedent already in the same file (useUpdateCountry). Fixes stale companion
+names surviving on trips whose ['trips'] query was still within the 5-minute
+staleTime at rename/create/deactivate time.
+
+ACCEPTANCE CRITERIA (from GitHub #305)
+- Renaming a companion updates that companion's name on every trip
+  referencing it, no trip write, no manual refresh: PASS (fix invalidates
+  ['trips'] on the update mutation)
+- Creating and deactivating a companion behave the same way: PASS (same fix
+  applied to useCreateCompanion and useDeleteCompanion)
+- Frontend test asserts each of the three mutations invalidates both
+  ['admin','companions'] and ['trips']: PASS (3/3 new tests in
+  src/frontend/hooks/__tests__/useAdmin.companions.test.tsx)
+- No backend change: PASS (only src/frontend/hooks/useAdmin.ts touched,
+  plus the new test file and tracker.json notes)
+
+CI: gh pr checks 308 — all 18 checks green (scripts/ci-wait.sh pr 308 -> PASS)
+
+OPEN ISSUES / BLOCKERS
+None blocking. Two scope-discipline judgment calls flagged for COO, not
+decided unilaterally (see park doc for detail):
+  1. tracker.json BUG-51 "owner" field left as "backend" even though the
+     fix landed in frontend — reassignment felt like a taxonomy call above
+     this brief's scope.
+  2. BUG-51's brdRefs is empty; DP-03 ("trip detail header shows... the
+     names of companions on the trip") is the closest BRD home if COO wants
+     to backfill the cross-reference — not done here, not compelled by the
+     brief.
+Not audited: whether the non-companion mutations in useAdmin.ts (categories/
+activities/countries) have their own staleness gaps — out of scope, only
+skimmed for shape, not independently verified.
+
+WHAT IS NOW UNBLOCKED
+BUG-51 is ready for COO review/merge via /coo-merge-and-close. Once merged,
+this closes the P1 data-integrity bug that #302 (backend half) left open.
+No other work depends on this branch.

--- a/jobs/frontend/context/current.txt
+++ b/jobs/frontend/context/current.txt
@@ -1,3 +1,54 @@
+FRONTEND CONTEXT — as of 2026-07-28 (BUG-51 trips cache invalidation)
+
+STATUS: fix/bug51-trips-cache-invalidation branch, GitHub issue #305, tracker
+  BUG-51 (P1). Follow-up to the B3 backend investigation (issue #299, PR
+  #302), which closed out only the backend half. Root cause was already
+  established and NOT re-investigated here (per the brief and the
+  negative-findings rule — the backend LEFT JOIN / no-denormalised-copy
+  claim was already double-probed in #302 and re-verified by the COO): the
+  bug is frontend cache invalidation. useCreateCompanion, useUpdateCompanion
+  and useDeleteCompanion in src/frontend/hooks/useAdmin.ts invalidated only
+  ['admin','companions'], never ['trips'], against the global 5-minute
+  staleTime at main.tsx:32.
+
+  Fix: added `qc.invalidateQueries({ queryKey: ['trips'] })` alongside the
+  existing invalidation in all three companion mutations, mirroring the
+  existing ['map','shading'] cross-invalidation precedent at useAdmin.ts:237
+  (useUpdateCountry). Three lines of source change, no refactor, no other
+  mutations touched — scope held exactly to the brief.
+
+  New test file src/frontend/hooks/__tests__/useAdmin.companions.test.tsx
+  (3 tests, modeled on the existing useGeocodeRetryQueue.test.tsx pattern —
+  mocked apiClient, real QueryClient per test, spy on
+  qc.invalidateQueries) asserts each of the three mutations invalidates
+  BOTH ['admin','companions'] and ['trips'] on success.
+
+  tracker.json: BUG-51 notes appended with the root-cause split (#299/#302
+  backend, #305 frontend) and this fix summary, per the mandatory GitHub
+  issue <-> tracker cross-referencing rule. Status left "pending" — COO
+  flips to "done" at merge, same pattern as the BUG-62 entry above.
+
+  VERIFICATION: npm run check (biome, clean), npm run type:check:all
+  (clean), npm run test:backend (584 passed / 1 skipped, unaffected — no
+  backend files touched), npm run test:frontend (161 passed, includes the
+  3 new BUG-51 tests), npm run status:check (STATUS.md in sync). See
+  completion report for PR number and CI status.
+
+  KEY FILE LOCATIONS (changed this thread)
+    src/frontend/hooks/useAdmin.ts (3-line invalidation fix x3 mutations)
+    src/frontend/hooks/__tests__/useAdmin.companions.test.tsx (new, 3 tests)
+    _project/tracker.json (BUG-51 notes)
+
+  NEXT STEPS (when resumed)
+    COO: review PR (branch fix/bug51-trips-cache-invalidation), merge via
+    /coo-merge-and-close when CI is green, flip BUG-51 status to "done".
+
+========================================================================
+PRIOR THREAD, SAME DAY — BUG-62 / brief B2 (PR #303, merged into main before
+this thread branched). Retained in full below per the newest-first pattern
+already established in this file's history.
+========================================================================
+
 FRONTEND CONTEXT — as of 2026-07-28 (BUG-62 per-tab admin gating, B2 backlog-clearance)
 
 STATUS: fix/bug62-admin-per-tab-gating branch, GitHub issue #298, Wave 1 sub-wave A

--- a/jobs/frontend/park-docs/20260728-FRONTEND-bug51-trips-cache-invalidation-park.txt
+++ b/jobs/frontend/park-docs/20260728-FRONTEND-bug51-trips-cache-invalidation-park.txt
@@ -1,0 +1,129 @@
+FRONTEND PARK DOC — BUG-51 trips cache invalidation
+Date: 2026-07-28
+Branch: fix/bug51-trips-cache-invalidation
+GitHub issue: #305 (follow-up to #299 / PR #302)
+Tracker: BUG-51 (P1, data integrity)
+
+SCOPE
+  Small, tightly-scoped follow-up brief. Backend half of BUG-51 was already
+  closed by PR #302 (issue #299) — that PR established the root cause and
+  added a backend regression test proving tripRepository.getAssociations()
+  always LEFT JOINs companions.name live, with no denormalised copy anywhere
+  in the schema or migrations. Two independent probes in #302, re-verified
+  by the COO. This brief explicitly did NOT re-investigate that finding —
+  instructed not to, and had no reason to doubt it.
+
+  This thread closes the frontend half: useCreateCompanion,
+  useUpdateCompanion and useDeleteCompanion in
+  src/frontend/hooks/useAdmin.ts invalidated only ['admin','companions'] on
+  success, never ['trips']. Against the global 5-minute staleTime configured
+  at src/frontend/main.tsx:32, any trip whose ['trips'] query was still
+  fresh at companion-rename time kept serving the stale name until
+  something else forced a refetch — which is exactly the originally
+  reported symptom, including why opening the affected trip didn't fix it
+  but saving it did (useUpdateTrip already invalidates ['trips']).
+
+ROOT CAUSE — NOT RE-INVESTIGATED
+  Per the brief and CLAUDE.md's negative-findings rule, the "backend has no
+  denormalised copy" claim was already established by two independent
+  probes in #302 and re-verified by the COO before this brief was written.
+  I did not re-probe it. I did independently confirm the frontend half of
+  the claim by reading src/frontend/hooks/useAdmin.ts directly (all three
+  companion mutations, lines ~150-182 before the fix) and
+  src/frontend/main.tsx:32 (staleTime: 5 * 60 * 1000) myself — this is a
+  positive finding (the missing invalidation is directly visible in the
+  diff), not a negative one, so it doesn't need the two-probe treatment.
+
+FIX
+  src/frontend/hooks/useAdmin.ts: added
+    void qc.invalidateQueries({ queryKey: ['trips'] });
+  immediately after the existing
+    void qc.invalidateQueries({ queryKey: ['admin', 'companions'] });
+  in useCreateCompanion, useUpdateCompanion, and useDeleteCompanion (the
+  brief's "useDeactivateCompanion" refers to this function — the actual
+  export name in the file is useDeleteCompanion, a soft-delete via
+  apiDelete('/api/companions/:id'); confirmed this is the only
+  deactivation-shaped companion mutation in the file, so no ambiguity).
+  Each site got a one-line comment pointing at BUG-51 and the LEFT JOIN
+  root cause for future readers.
+
+  Pattern mirrors the existing precedent already in the same file at
+  useUpdateCountry (useAdmin.ts:237), which cross-invalidates
+  ['map','shading'] from a countries mutation for the same reason (a
+  derived/joined view elsewhere in the app needs a nudge that this
+  mutation's write affects it too).
+
+  No backend change. No other mutations in useAdmin.ts touched. No
+  refactor of the file — this was flagged explicitly in the brief as
+  three-lines-plus-test scope, and that's what shipped.
+
+TEST
+  New file src/frontend/hooks/__tests__/useAdmin.companions.test.tsx (3
+  tests), modeled directly on the existing
+  src/frontend/hooks/__tests__/useGeocodeRetryQueue.test.tsx pattern (the
+  only other hooks-directory test in the repo): apiClient mocked via
+  vi.mock with the real ApiError class spread through, each test gets its
+  own QueryClient + QueryClientProvider wrapper via a local
+  renderWithClient() helper, and asserts on a vi.spyOn(qc,
+  'invalidateQueries') call list rather than inspecting cache state
+  indirectly. Each of the three tests mutates, waits for isSuccess, then
+  asserts invalidateSpy was called with both { queryKey: ['admin',
+  'companions'] } and { queryKey: ['trips'] }.
+
+  This satisfies the brief's explicit success criterion: "A frontend test
+  asserts each of the three mutations invalidates both ['admin',
+  'companions'] and ['trips']."
+
+VERIFICATION
+  npm run check (biome, clean — 180 files, no fixes needed)
+  npm run type:check:all (frontend + backend, clean)
+  npm run test:backend (584 passed / 1 skipped — unaffected, no backend
+    files touched by this change)
+  npm run test:frontend (161 passed — includes the 3 new BUG-51 tests;
+    baseline was 156 before BUG-62/#303 merged in ahead of this branch,
+    which added its own tests, so 161 = that new baseline + 3 mine + 2
+    net from unrelated file changes; exact accounting not re-derived,
+    the important fact is 161/161 green, 0 failed)
+  npm run status:check (STATUS.md in sync, no regeneration needed)
+  Full /pre-push checklist run before pushing — see completion report for
+  outcome and PR/CI status.
+
+  Not run: manual browser/Clerk check (same sandbox limitation as every
+  prior Frontend thread — no real Clerk publishable key, firewall doesn't
+  reach Clerk's hosted sign-in) and Playwright e2e (not required by this
+  brief's success criteria, and the fix is a two-line cache-key addition
+  covered directly and completely by the new unit tests — running the full
+  e2e suite for a change this narrow would not add confidence beyond what
+  the unit tests already establish).
+
+SCOPE DISCIPLINE — WHAT WAS DELIBERATELY NOT DONE
+  Did not refactor useAdmin.ts's shared CRUD-factory-shaped duplication
+  (categories/activities/companions each hand-roll near-identical
+  create/update/delete hooks) even though it was directly visible while
+  making this edit — out of scope per the brief, not touched.
+  Did not touch categories, activities, or countries mutations.
+  Did not add e2e coverage beyond what the brief's success criteria state.
+  Did not change the tracker entry's "owner" field (left as "backend" even
+  though the fix landed in frontend) or its brdRefs (empty, unchanged) —
+  reassigning ownership or backfilling a BRD cross-reference (DP-03 is the
+  closest candidate: "trip detail header shows... the names of companions
+  on the trip") felt like tracker-taxonomy judgment calls above this
+  brief's scope, not a compelled part of the fix. Flagging both to COO
+  below rather than deciding unilaterally.
+
+FINDINGS TO FLAG (not fixed, per brief's "report it, don't fix it")
+  None found beyond the two scope-discipline notes above. No BRD/API
+  contract mismatch encountered. No other cache-invalidation gaps noticed
+  in useAdmin.ts's non-companion mutations during this read, but that was
+  not audited exhaustively — only the three companion mutations named in
+  the brief were reviewed line-by-line; the categories/activities/
+  countries mutations were skimmed for the same shape as prior art, not
+  independently audited for their own possible staleness bugs.
+
+NEXT STEPS (when resumed)
+  COO: review PR (branch fix/bug51-trips-cache-invalidation, see completion
+  report for PR # and CI status), merge via /coo-merge-and-close, flip
+  BUG-51 status to "done" in tracker.json at merge time. Consider (COO's
+  call, not blocking): whether BUG-51's brdRefs should point at DP-03, and
+  whether "owner" should flip to "frontend" now that the fix landed there —
+  both left as-is in this thread, noted above.

--- a/src/frontend/hooks/__tests__/useAdmin.companions.test.tsx
+++ b/src/frontend/hooks/__tests__/useAdmin.companions.test.tsx
@@ -1,0 +1,110 @@
+/**
+ * Tests for BUG-51: companion mutations must invalidate the ['trips'] query
+ * cache, not just ['admin', 'companions'].
+ *
+ * Root cause (established in #302, not re-litigated here): trips embed the
+ * companion's name via a live LEFT JOIN, not a denormalised copy. Against
+ * the global 5-minute staleTime (src/frontend/main.tsx:32), a trip whose
+ * ['trips'] query was still fresh at rename time kept serving the stale
+ * companion name until something else forced a refetch.
+ *
+ * These tests assert each of useCreateCompanion, useUpdateCompanion and
+ * useDeleteCompanion invalidates BOTH ['admin', 'companions'] and ['trips']
+ * on success.
+ */
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { apiDelete, apiPatch, apiPost } from '../../utils/apiClient';
+import { useCreateCompanion, useDeleteCompanion, useUpdateCompanion } from '../useAdmin';
+
+vi.mock('../../utils/apiClient', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../utils/apiClient')>();
+  return {
+    ...actual,
+    apiGet: vi.fn(),
+    apiPost: vi.fn(),
+    apiPatch: vi.fn(),
+    apiDelete: vi.fn(),
+  };
+});
+
+/** Renders the hook with its own QueryClient and returns both. */
+function renderWithClient<T>(useHook: () => T) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const localWrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+  );
+  const result = renderHook(useHook, { wrapper: localWrapper });
+  return { ...result, qc };
+}
+
+describe('BUG-51: companion mutations invalidate both admin.companions and trips', () => {
+  beforeEach(() => {
+    vi.mocked(apiPost).mockReset();
+    vi.mocked(apiPatch).mockReset();
+    vi.mocked(apiDelete).mockReset();
+  });
+
+  it('useCreateCompanion invalidates both query keys on success', async () => {
+    vi.mocked(apiPost).mockResolvedValue({
+      id: 1,
+      name: 'Alex',
+      is_active: 1,
+      created_at: '',
+      updated_at: '',
+    });
+
+    const { result, qc } = renderWithClient(useCreateCompanion);
+    const invalidateSpy = vi.spyOn(qc, 'invalidateQueries');
+
+    result.current.mutate('Alex');
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['admin', 'companions'] });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['trips'] });
+  });
+
+  it('useUpdateCompanion invalidates both query keys on success', async () => {
+    vi.mocked(apiPatch).mockResolvedValue({
+      id: 1,
+      name: 'Alexandra',
+      is_active: 1,
+      created_at: '',
+      updated_at: '',
+    });
+
+    const { result, qc } = renderWithClient(useUpdateCompanion);
+    const invalidateSpy = vi.spyOn(qc, 'invalidateQueries');
+
+    result.current.mutate({ id: 1, data: { name: 'Alexandra' } });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['admin', 'companions'] });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['trips'] });
+  });
+
+  it('useDeleteCompanion invalidates both query keys on success', async () => {
+    vi.mocked(apiDelete).mockResolvedValue(undefined);
+
+    const { result, qc } = renderWithClient(useDeleteCompanion);
+    const invalidateSpy = vi.spyOn(qc, 'invalidateQueries');
+
+    result.current.mutate(1);
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['admin', 'companions'] });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['trips'] });
+  });
+});

--- a/src/frontend/hooks/useAdmin.ts
+++ b/src/frontend/hooks/useAdmin.ts
@@ -154,6 +154,10 @@ export function useCreateCompanion() {
     mutationFn: (name: string) => apiPost<Companion>('/api/companions', { name }),
     onSuccess: () => {
       void qc.invalidateQueries({ queryKey: ['admin', 'companions'] });
+      // BUG-51: trips embed the companion's name via a live LEFT JOIN, not a
+      // denormalised copy — a fresh ['trips'] query would keep serving the
+      // pre-mutation name until something else forced a refetch.
+      void qc.invalidateQueries({ queryKey: ['trips'] });
     },
   });
 }
@@ -166,6 +170,9 @@ export function useUpdateCompanion() {
       apiPatch<Companion>(`/api/companions/${id}`, data),
     onSuccess: () => {
       void qc.invalidateQueries({ queryKey: ['admin', 'companions'] });
+      // BUG-51: see useCreateCompanion — a companion rename must invalidate
+      // every trip referencing it, not just the admin companions list.
+      void qc.invalidateQueries({ queryKey: ['trips'] });
     },
   });
 }
@@ -177,6 +184,9 @@ export function useDeleteCompanion() {
     mutationFn: (id: number) => apiDelete(`/api/companions/${id}`),
     onSuccess: () => {
       void qc.invalidateQueries({ queryKey: ['admin', 'companions'] });
+      // BUG-51: see useCreateCompanion — deactivation must also refresh trips
+      // that reference this companion.
+      void qc.invalidateQueries({ queryKey: ['trips'] });
     },
   });
 }


### PR DESCRIPTION
Closes #305

## Summary
Follow-up to the B3 backend investigation (issue #299, PR #302), which closed only the backend half of BUG-51. The backend is correct (already double-probed and re-verified by the COO): `tripRepository.getAssociations()` always `LEFT JOIN`s `companions.name` live — no denormalised copy exists anywhere.

The bug was frontend cache invalidation: `useCreateCompanion`, `useUpdateCompanion` and `useDeleteCompanion` in `src/frontend/hooks/useAdmin.ts` invalidated only `['admin','companions']`, never `['trips']`. Against the global 5-minute `staleTime` (`src/frontend/main.tsx:32`), any trip whose `['trips']` query was still fresh at companion-rename time kept serving the stale companion name until something else forced a refetch.

## Fix
Added `qc.invalidateQueries({ queryKey: ['trips'] })` alongside the existing invalidation in all three companion mutations, mirroring the existing `['map','shading']` cross-invalidation precedent already in the same file (`useUpdateCountry`, `useAdmin.ts:237`). Three lines of source change across three functions, no refactor, no other mutations touched.

## Test plan
- [x] New `src/frontend/hooks/__tests__/useAdmin.companions.test.tsx` (3 tests) asserts each of the three mutations invalidates both `['admin','companions']` and `['trips']`
- [x] `npm run check` — clean
- [x] `npm run type:check:all` — clean
- [x] `npm run test:backend` — 584 passed / 1 skipped (unaffected, no backend files touched)
- [x] `npm run test:frontend` — 161 passed (includes the 3 new tests)
- [x] `npm run status:check` — STATUS.md in sync

No backend change. BRD: no new requirement ID (tracker BUG-51, P1, data integrity — pre-existing entry, notes updated with this fix's cross-reference).

🤖 Generated with [Claude Code](https://claude.com/claude-code)