### PR TITLE
chore(OP-28/29/30): rewrite guard, whole-team negative findings, scanner-suppression rule

### DIFF
--- a/.claude/hooks/negative-findings-guard.sh
+++ b/.claude/hooks/negative-findings-guard.sh
@@ -3,6 +3,16 @@
 # asserts an absence ("X does not exist / is unreachable / is not implemented") without a
 # paired second-probe or UNVERIFIED marker nearby, per CLAUDE.md's negative-findings rule.
 #
+# EXTENDED 2026-07-28 (OP-29) to cover `gh issue create` / `gh pr create` bodies as well as
+# file writes. The original hook only matched Write|Edit, which left the COO's own dominant
+# failure path completely uncovered: the COO does not write briefs to files, it writes them
+# into GitHub issue bodies via Bash. That is exactly how a false premise reached brief B2 on
+# 2026-07-28 — the claim "AD-09's owner-only deactivation is not enforced on the backend
+# today" was propagated from a planning doc into issue #298 without a second probe, and was
+# flatly false (`adminRouter.use(requireOwner)` already gated every categories/activities
+# route). PO direction the same day: the negative-findings rule binds the whole team, COO
+# included, so its enforcement has to reach where the COO actually writes.
+#
 # Warn-only by design, not a PreToolUse block: regex against natural language will
 # false-positive (e.g. an agent quoting this very rule), and a hard block would stall an
 # agent mid-task for no reason. Revisit block-vs-warn once the real false-positive rate is
@@ -18,11 +28,21 @@ import sys, json
 try:
     d = json.load(sys.stdin)
     ti = d.get('tool_input', {})
-    file_path = ti.get('file_path', '')
-    content = ti.get('content', '') or ti.get('new_string', '') or ''
-    print(file_path)
-    print('---NFG-SEP---')
-    print(content)
+    cmd = ti.get('command', '') or ''
+    # Bash path: only briefs/reports authored into GitHub, not every shell command.
+    if cmd:
+        if 'gh issue create' in cmd or 'gh pr create' in cmd or 'gh issue comment' in cmd:
+            print('<gh-brief>')
+            print('---NFG-SEP---')
+            print(cmd)
+        else:
+            print('')
+            print('---NFG-SEP---')
+            print('')
+    else:
+        print(ti.get('file_path', ''))
+        print('---NFG-SEP---')
+        print(ti.get('content', '') or ti.get('new_string', '') or '')
 except Exception:
     print('')
     print('---NFG-SEP---')
@@ -32,20 +52,29 @@ except Exception:
 FILE=$(printf '%s' "$result" | awk '/---NFG-SEP---/{exit} {print}')
 CONTENT=$(printf '%s' "$result" | awk 'f{print} /---NFG-SEP---/{f=1}')
 
-# Only deliverables and tracker notes — jobs/** and _project/tracker.json
+# Deliverables, tracker notes, and briefs authored into GitHub issues/PRs
 case "$FILE" in
-  */jobs/*|*/_project/tracker.json) ;;
+  */jobs/*|*/_project/tracker.json|'<gh-brief>') ;;
   *) exit 0 ;;
 esac
 
 [ -z "$CONTENT" ] && exit 0
 
-ABSENCE_RE='does not exist|doesn'"'"'t exist|not found|no evidence of|is unreachable|cannot be verified|can'"'"'t be verified|not implemented|never implemented|is not enabled|is disabled|no such|not present in'
+# Widened 2026-07-28 (OP-29). The original set missed the two phrasings that actually
+# produced this project's false premises: "is not enforced on the backend" (brief B2's
+# AD-09 claim) and "there is no router.delete in trips.ts" (the Wave 0 claim the COO
+# propagated unchecked). Absence-of-enforcement and "there is no X" are the highest-value
+# patterns to catch precisely because designs get built straight on top of them.
+ABSENCE_RE='does not exist|doesn'"'"'t exist|not found|no evidence of|is unreachable|cannot be verified|can'"'"'t be verified|not implemented|never implemented|is not enabled|is disabled|no such|not present in|not enforced|isn'"'"'t enforced|not gated|not validated|never validated|no call sites|never called|there is no |there are no |never wired'
 PAIRING_RE='UNVERIFIED|probe 2|second probe|two independent probes|two probes'
 
 if printf '%s' "$CONTENT" | grep -qiE "$ABSENCE_RE"; then
   if ! printf '%s' "$CONTENT" | grep -qiE "$PAIRING_RE"; then
-    echo "negative-findings-guard: $FILE asserts something is missing/unreachable/not implemented but has no adjacent UNVERIFIED marker or second-probe mention. Per CLAUDE.md's negative-findings rule, confirm this with a second independent probe or mark it UNVERIFIED with the blind spot stated before treating it as fact."
+    if [ "$FILE" = '<gh-brief>' ]; then
+      echo "negative-findings-guard: this GitHub issue/PR body asserts something is missing/unreachable/not implemented but states no second probe and carries no UNVERIFIED marker. Briefs are the highest-leverage place for a false absence — an agent will build on it without re-checking. Per CLAUDE.md's negative-findings rule (which binds the COO propagating findings, not just agents writing them), verify it with a second independent probe or mark it UNVERIFIED with the blind spot stated. This exact failure produced brief B2's false AD-09 premise on 2026-07-28."
+    else
+      echo "negative-findings-guard: $FILE asserts something is missing/unreachable/not implemented but has no adjacent UNVERIFIED marker or second-probe mention. Per CLAUDE.md's negative-findings rule, confirm this with a second independent probe or mark it UNVERIFIED with the blind spot stated before treating it as fact."
+    fi
   fi
 fi
 

--- a/.claude/hooks/no-wholesale-rewrite.sh
+++ b/.claude/hooks/no-wholesale-rewrite.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# PostToolUse hook (OP-28) — warns when a Write replaces an EXISTING shared-record file
+# wholesale instead of amending it with Edit.
+#
+# Why this exists: on 2026-07-28 two concurrent Frontend agents each rewrote
+# jobs/frontend/context/current.txt in full. Both rewrites were individually sensible; the
+# result was a merge conflict the COO had to hand-resolve, and either agent's thread record
+# would have been silently destroyed had the conflict not surfaced. Shared-record files
+# exist to ACCUMULATE across many agents and sessions — a wholesale replacement of one is
+# almost always a deviation, not an intended edit.
+#
+# PO direction (2026-07-28): "agents should never fully rewrite anything; if a full rewrite
+# is required there is a fundamental issue/deviation and I'd want it double checked."
+# Scoped here to shared-record paths — source-code rewrites stay allowed but must be
+# DECLARED in the completion report (CLAUDE.md), since a small module legitimately changing
+# in full is normal and blocking it would be noise.
+#
+# Warn-only, matching negative-findings-guard.sh's precedent: revisit block-vs-warn once the
+# real false-positive rate is known. Silent when clean — zero tokens on the common case.
+
+INPUT=$(cat)
+
+result=$(echo "$INPUT" | python3 -c "
+import sys, json
+try:
+    d = json.load(sys.stdin)
+    print(d.get('tool_name', ''))
+    print(d.get('tool_input', {}).get('file_path', ''))
+except Exception:
+    print('')
+    print('')
+" 2>/dev/null)
+
+TOOL=$(printf '%s' "$result" | head -1)
+FILE=$(printf '%s' "$result" | sed -n '2p')
+
+# Only Write replaces a file wholesale. Edit is surgical by construction.
+[ "$TOOL" = "Write" ] || exit 0
+[ -n "$FILE" ] || exit 0
+
+# Only fires for a file that ALREADY existed — creating a new file is not a rewrite.
+# PostToolUse runs after the write, so "did it exist before" is inferred from git: a path
+# git already tracks existed before this tool call.
+case "$FILE" in
+  */jobs/*|*/_project/*|*/.planning/*|*/CLAUDE.md) ;;
+  *) exit 0 ;;
+esac
+
+REPO=$(cd "$(dirname "$FILE")" 2>/dev/null && git rev-parse --show-toplevel 2>/dev/null)
+[ -n "$REPO" ] || exit 0
+
+REL=${FILE#"$REPO"/}
+git -C "$REPO" ls-files --error-unmatch "$REL" >/dev/null 2>&1 || exit 0
+
+echo "no-wholesale-rewrite: $REL is a tracked shared-record file and was replaced wholesale with Write rather than amended with Edit. These files accumulate entries across agents and sessions — a full rewrite destroys other threads' records and causes merge conflicts (this happened twice: Wave 0, and again 2026-07-28 with two concurrent frontend agents). Append or amend a dated entry instead. If a full rewrite is genuinely correct here, say so explicitly in your completion report with the reason, so the COO can double-check it."
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -29,6 +29,19 @@
           {
             "type": "command",
             "command": "bash /workspace/.claude/hooks/negative-findings-guard.sh"
+          },
+          {
+            "type": "command",
+            "command": "bash /workspace/.claude/hooks/no-wholesale-rewrite.sh"
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash /workspace/.claude/hooks/negative-findings-guard.sh"
           }
         ]
       }

--- a/.claude/skills/coo-startup/SKILL.md
+++ b/.claude/skills/coo-startup/SKILL.md
@@ -110,6 +110,23 @@ after=$(wc -l < /workspace/.claude/hooks/typecheck-perf.log)
 echo '{"tool_input":{"file_path":"/workspace/jobs/COO/canary-test.md","content":"This route does not exist anywhere in the codebase."}}' \
   | bash /workspace/.claude/hooks/negative-findings-guard.sh | grep -q "negative-findings-guard" \
   && echo "negative-findings guard OK" || echo "FAIL: negative-findings guard broken"
+
+# negative-findings guard, COO brief path (OP-29) — must also warn on a gh issue body.
+# This is the COO's own failure path: briefs are authored via Bash, not Write.
+echo '{"tool_name":"Bash","tool_input":{"command":"gh issue create --body \"this is not enforced on the backend today\""}}' \
+  | bash /workspace/.claude/hooks/negative-findings-guard.sh | grep -q "negative-findings-guard" \
+  && echo "negative-findings guard (brief path) OK" || echo "FAIL: negative-findings brief path broken"
+
+# no-wholesale-rewrite guard (OP-28) must warn on a Write over an existing tracked shared record
+echo '{"tool_name":"Write","tool_input":{"file_path":"/workspace/jobs/COO/open-dialogues.md"}}' \
+  | bash /workspace/.claude/hooks/no-wholesale-rewrite.sh | grep -q "no-wholesale-rewrite" \
+  && echo "no-wholesale-rewrite guard OK" || echo "FAIL: no-wholesale-rewrite guard broken"
+
+# ...and must stay silent on an Edit of that same file (the correct way to amend it)
+echo '{"tool_name":"Edit","tool_input":{"file_path":"/workspace/jobs/COO/open-dialogues.md"}}' \
+  | bash /workspace/.claude/hooks/no-wholesale-rewrite.sh | grep -q "no-wholesale-rewrite" \
+  && echo "FAIL: no-wholesale-rewrite guard fires on Edit (should be silent)" \
+  || echo "no-wholesale-rewrite guard (Edit path) OK"
 ```
 
 Any FAIL → fix the hook before doing anything else this session. Secondary tell for the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,6 +138,89 @@ block** — regex against natural language will false-positive (e.g. an agent qu
 very rule), and a hard block stalls an agent mid-task for no reason. Revisit block-vs-warn
 once the false-positive rate from real use is known.
 
+**The rule binds the whole team, and the hook now reaches the COO too (2026-07-28, OP-29).**
+It fired again on the very next wave: brief B2 (issue #298) asserted that *"AD-09's
+owner-only deactivation is not enforced on the backend today"* and bundled a "go enforce it"
+task on that premise. It was false — `adminRouter.use(requireOwner)` already gated every
+categories/activities route, and `security.access-matrix.test.ts` already had passing
+non-owner-403 tests for exactly that. The claim came out of a planning doc and the COO
+propagated it into the brief without a second probe. Only the brief's own instruction to
+double-probe caught it, before any code was written.
+
+Two things follow, both adopted on PO direction:
+
+1. **No role is exempt — explicitly including the COO.** The rule applies to every artifact
+   any role produces: deliverables, tracker notes, ADLs, plans, completion reports, **and
+   COO-authored briefs**. A claim inherited from an existing project document is *not*
+   pre-verified; age is not evidence. If you are about to build on "X doesn't exist," probe
+   it again yourself.
+2. **Enforcement had a COO-shaped hole and it has been closed.** The OP-26 hook matched only
+   `Write|Edit`, but the COO does not write briefs to files — it writes them into GitHub
+   issue bodies via Bash. The single highest-leverage place for a false absence was the one
+   place the hook could not see. It now also scans `gh issue create` / `gh pr create` /
+   `gh issue comment` bodies. The pattern set was widened at the same time: testing showed it
+   missed *both* phrasings that actually caused this project's false premises — "is not
+   enforced" and "there is no X" — so absence-of-enforcement language is now covered.
+
+### No wholesale rewrites of shared records (mandatory, OP-28)
+
+Adopted 2026-07-28 on PO direction: *"agents should never fully rewrite anything — if a full
+rewrite is required there is a fundamental issue/deviation and I'd want it double checked."*
+
+Trigger: two concurrent Frontend agents (B1 and B2) each rewrote
+`jobs/frontend/context/current.txt` in full on the same day. Each rewrite was individually
+reasonable and each silently dropped the other's thread record; it surfaced only as a merge
+conflict the COO hand-resolved. This was a **recurrence** — the Wave 0 concurrency notes
+record the same file colliding in 3 of 4 concurrent agents for the same reason, and the fix
+identified then was never adopted. Twice across two waves is a pattern, not an accident.
+
+**The rule, scoped by file class:**
+
+- **Shared-record files — append or amend only, never wholesale replacement.** These
+  accumulate entries across many agents and sessions, so replacing one destroys other
+  people's records: `jobs/**` (context docs, park docs, inbox, role tech docs),
+  `_project/tracker.json`, the BRD, the ADL log, the backlog clearance plan, `.planning/**`,
+  and `CLAUDE.md`. Mechanically: **use `Edit`, not `Write`, on any of these that already
+  exists.** Add a new dated entry; leave prior entries in place.
+- **Source code — a full-file rewrite is allowed, but must be declared.** A small module
+  legitimately changing in full is normal work and blocking it would be noise. But if you
+  replace a source file wholesale, **say so explicitly in your completion report with the
+  reason**, so the COO can double-check that it was a deliberate choice and not a deviation
+  from the brief.
+
+A blanket "never rewrite anything" was considered and deliberately narrowed to this split —
+the PO invited that calibration. Generated files, stubs a brief says to replace, and small
+modules changing entirely are all legitimate; the accumulating-record case is the one where
+a rewrite is nearly always wrong.
+
+**Hook-enforced (warn, not block).** `.claude/hooks/no-wholesale-rewrite.sh` fires on a
+`Write` to an already-tracked file under the shared-record paths and points the agent at
+`Edit`. Warn-only, following OP-26's precedent; revisit once the false-positive rate is known.
+
+### Scanner suppressions need COO sign-off (mandatory, OP-30)
+
+Adopted 2026-07-28. During B2, Gitleaks' `generic-api-key` rule flagged the literal string
+`Categories/Activities/Countries` in a tracker note the agent had just written — a genuine
+false positive. The agent resolved it by adding `.gitleaks.toml` with a narrow allowlist and
+went green. The config itself is sound (`useDefault = true` keeps every standard rule active;
+the allowlist is an exact-string match on that one phrase, not a path or file exemption), and
+it is kept.
+
+The precedent is the problem: an implementation agent independently weakening a **security
+scanner's** configuration in order to turn a red check green is not a call an implementation
+brief carries, however narrow the change.
+
+- **First, fix your own text.** When a scanner flags content *you just authored* and it is a
+  false positive, reword your text. Rephrasing a changelog note costs nothing and leaves the
+  scanner at full strength.
+- **Never add or widen a scanner suppression** — `.gitleaks.toml` allowlists, `nosemgrep`
+  comments on new code, `npm audit` exceptions, lint-rule disables — **without COO sign-off.**
+  Stop and report the finding instead. Existing `nosemgrep` annotations with a stated reason
+  (e.g. the `requireAuth`-applied-globally comments in `src/backend/routes/`) are unaffected;
+  this governs *new* suppressions.
+- A suppression the COO does approve carries a comment naming what was flagged, why it is a
+  false positive, and how it was verified — as `.gitleaks.toml` now does.
+
 ### BRD → tracker rule (mandatory)
 Whenever the BRD is updated (a changelog entry is written), the COO must create tracker
 entries for every new requirement ID introduced before closing the session. No BRD version

--- a/_project/STATUS.md
+++ b/_project/STATUS.md
@@ -30,7 +30,7 @@ _Tracker last updated: 2026-07-28 (B9 merged — QUAL-03 + QUAL-11 done, PR #292
 | ID | Title | Owner | Status |
 |---|---|---|---|
 | BUG-50 | No way to delete an entire trip | frontend | ⬜ Pending |
-| BUG-51 | Companion name edits in admin panel don't consistently propagate to trips | backend | ⬜ Pending |
+| BUG-51 | Companion name edits in admin panel don't consistently propagate to trips | frontend | done_pending_uat |
 
 ### P2 — Important (29)
 
@@ -45,22 +45,22 @@ _Tracker last updated: 2026-07-28 (B9 merged — QUAL-03 + QUAL-11 done, PR #292
 | BRD-PL06 | Co-planning — companions contribute to idea pool on shared trips (PL-06, Phase 3) | architect | ⬜ Pending |
 | BRD-LB01 | Destination recommendations view — aggregated across trips (LB-01) | fullstack | ⬜ Pending |
 | BRD-MB0102 | Mobile reference mode — bookings readable + directions links on phone (MB-01–02) | frontend | ⬜ Pending |
-| BRD-DP06 | First place added to a trip inherits the trip's date range (DP-06) | fullstack | ⬜ Pending |
+| BRD-DP06 | First place added to a trip inherits the trip's date range (DP-06) | fullstack | done_pending_uat |
 | OQ-03 | Approximate/partial dates for shell trips — year-only or month-only, and their effect on shading and ordering | architect | ⬜ Pending |
 | OP-25 | Scheduled cloud health-check routines (daily CI/drift, weekly doc-lifecycle) + cron-flag surfacing in /coo-startup | coo | ⛔ Blocked |
 | BUG-40 | Place deletion should prompt (delete all / move to trip-level / cancel) when the place has items | fullstack | ⬜ Pending |
 | BUG-41 | Multi-leg / connecting flights within a single booking | database | ⬜ Pending |
 | BUG-42 | Multiple companions/seats per booking item | database | ⬜ Pending |
-| BUG-44 | Car rental pickup location should show as subtext under provider | frontend | ⬜ Pending |
+| BUG-44 | Car rental pickup location should show as subtext under provider | frontend | done_pending_uat |
 | BUG-46 | Activities selector missing from trip create flow (only present on edit) | frontend | ⬜ Pending |
 | BUG-48 | Country→state map shading zoom threshold too high / laggy | frontend | ⬜ Pending |
-| BUG-49 | City markers render behind state shading layer | frontend | ⬜ Pending |
+| BUG-49 | City markers render behind state shading layer | frontend | done_pending_uat |
 | BUG-52 | Trip search doesn't match on country name | backend | ⬜ Pending |
 | BUG-53 | Trip list place display: show state (not country) under city, surface country separately | ux | ⬜ Pending |
 | BUG-55 | City entry doesn't auto-populate country/state | backend | ⬜ Pending |
-| BUG-57 | Intelligent date defaults across item entry, keyed off the trip's date range | fullstack | ⬜ Pending |
+| BUG-57 | Intelligent date defaults across item entry, keyed off the trip's date range | fullstack | done_pending_uat |
 | BUG-58 | Moving a trip backward in the status workflow deselects it from the left panel | frontend | ⬜ Pending |
-| BUG-62 | Admin panel is still fully owner-gated at the page/nav level — non-owner users can't reach the Companions tab even after AD-08 made companions per-user | frontend | ⬜ Pending |
+| BUG-62 | Admin panel is still fully owner-gated at the page/nav level — non-owner users can't reach the Companions tab even after AD-08 made companions per-user | frontend | done_pending_uat |
 | BUG-63 | Non-owner blocked from creating a trip with a "forbidden" error on mobile — not currently reproducible | unassigned | ⬜ Pending |
 | QUAL-08 | sanitiseUrl() has zero call sites and photo_album_ref has no server-side scheme validation | fullstack | ⬜ Pending |
 | QUAL-12 | Concurrent role dispatches collide on the single shared jobs/<role>/context/current.txt | coo | ⬜ Pending |
@@ -78,7 +78,7 @@ _Tracker last updated: 2026-07-28 (B9 merged — QUAL-03 + QUAL-11 done, PR #292
 | QUAL-04 | Dead code and one stale source comment left by the WP reskin and the ADL-28 companions migration | frontend | ⬜ Pending |
 | BRD-LB02 | Stats and patterns view (LB-02, Phase 2) | frontend | ⬜ Pending |
 | BRD-LB03 | Shareable recommendations link (LB-03, Phase 3) | architect | ⬜ Pending |
-| BRD-IT10 | Optional Google Maps URL per item — one-click directions (IT-10) | architect | ⬜ Pending |
+| BRD-IT10 | Optional Google Maps URL per item — one-click directions (IT-10) | architect | done_pending_uat |
 | UX-11 | Trip-list status pill colours should match map shading colours (admin-driven) | ux | ⬜ Pending |
 | WP-05 | Waypoint reskin must not be reported as closing unrelated data/behavior gaps it only reskins the display of | coo | ⬜ Pending |
 | BUG-43 | Apple Wallet (.pkpass) import to pre-populate booking details | integrations | ⬜ Pending |
@@ -135,4 +135,4 @@ _Tracker last updated: 2026-07-28 (B9 merged — QUAL-03 + QUAL-11 done, PR #292
 
 ---
 
-_130 done · 10 deferred · 4 closed · 54 open — 198 tracked items_
+_133 done · 10 deferred · 4 closed · 54 open — 201 tracked items_

--- a/_project/tracker.json
+++ b/_project/tracker.json
@@ -1689,23 +1689,23 @@
       "id": "BRD-DP06",
       "type": "feature",
       "title": "First place added to a trip inherits the trip's date range (DP-06)",
-      "status": "pending",
+      "status": "done_pending_uat",
       "owner": "fullstack",
       "priority": "P2",
       "brdRefs": ["DP-06"],
       "phase": 6,
-      "notes": "Added to BRD v3.1, 2026-07-20 UAT. Success criteria: adding the first place to a trip with dates set pre-fills place arrival/departure from trip start/end; later per-place edits persist independently of trip dates."
+      "notes": "Added to BRD v3.1, 2026-07-20 UAT. Success criteria: adding the first place to a trip with dates set pre-fills place arrival/departure from trip start/end; later per-place edits persist independently of trip dates. IMPLEMENTED 2026-07-28 (GitHub #300, PR #306, Wave 1 sub-wave A brief B6). Shares one defaulting code path with BUG-57/IT-11 — that is why the two were briefed together rather than separately: src/frontend/utils/dateDefaults.ts (resolveDefaultDate/resolveDefaultDateTime) is consumed by both ItemForm.tsx and AddPlaceFlow.tsx. ADL-41 constraint honoured: inheritance fires only on the empty-trip to first-place transition (isFirstPlace = trip.places.length === 0), so a revisit never inherits trip dates."
     },
     {
       "id": "BRD-IT10",
       "type": "feature",
       "title": "Optional Google Maps URL per item — one-click directions (IT-10)",
-      "status": "pending",
+      "status": "done_pending_uat",
       "owner": "architect",
       "priority": "P3",
       "brdRefs": ["IT-10"],
       "phase": 5,
-      "notes": "Added to BRD v3.1, 2026-07-20 UAT. GitHub issue #276. DESIGNED 2026-07-27 — Architect ADL-45 (jobs/architect/tech/20260307-architecture-decisions-log.md, Wave 0 brief S6) decided: nullable map_url TEXT column on base items table (not per-extension-table); https-only scheme allowlist, deliberately no Google-host restriction; server-side Zod (zMapUrl) authoritative, frontend sanitiseUrl() extended (not forked) for render-time defense in depth; single additive db:generate/db:migrate migration, no DB CHECK (Zod-only length/scheme cap, matches zName precedent). Status 'designed', implementation pending. Success criteria unchanged, still in BRD §5.5 — no BRD edit needed. Flagged, not fixed: trips.photo_album_ref has no server-side URL scheme validation today and its existing sanitiseUrl() utility has no call site yet — follow-up candidate, not bundled into this item."
+      "notes": "Added to BRD v3.1, 2026-07-20 UAT. GitHub issue #276. DESIGNED 2026-07-27 — Architect ADL-45 (jobs/architect/tech/20260307-architecture-decisions-log.md, Wave 0 brief S6) decided: nullable map_url TEXT column on base items table (not per-extension-table); https-only scheme allowlist, deliberately no Google-host restriction; server-side Zod (zMapUrl) authoritative, frontend sanitiseUrl() extended (not forked) for render-time defense in depth; single additive db:generate/db:migrate migration, no DB CHECK (Zod-only length/scheme cap, matches zName precedent). Status 'designed', implementation pending. Success criteria unchanged, still in BRD §5.5 — no BRD edit needed. Flagged, not fixed: trips.photo_album_ref has no server-side URL scheme validation today and its existing sanitiseUrl() utility has no call site yet — follow-up candidate, not bundled into this item. IMPLEMENTED 2026-07-28 (GitHub #300, PR #306, Wave 1 sub-wave A brief B6), exactly per ADL-45's D1-D9 with no deviation: nullable map_url text on the BASE items table; single additive migration 0013 (ALTER TABLE items ADD map_url text, no table recreation); zMapUrl in src/backend/validation/common.ts (trim, url, max 2048, https-only refine, no host allowlist, no DB CHECK — matching the zName precedent); sanitiseUrl() EXTENDED with an optional allowed-scheme list rather than forked, default preserving photo_album_ref's https:/file: behaviour; 'View map' link on ItemCard with target=_blank rel='noopener noreferrer'. _project/security-spec.md updated in the same PR (SEC-12 scope extended from one URL field to two), per the document lifecycle rule. MINOR, NOT BLOCKING: the https-only refine is case-sensitive (startsWith('https://')), so an uppercase 'HTTPS://' URL is rejected despite being valid — fails closed, not open, so it is a small UX wart rather than a security gap; worth tidying next time this file is touched. QUAL-17 cost materialised here exactly as predicted: 12 of the 15 hand-rolled-DDL route test files needed 'map_url TEXT,' added by hand because they each maintain their own copy of the schema."
     },
     {
       "id": "OQ-05",
@@ -1805,6 +1805,39 @@
       "brdRefs": [],
       "phase": 6,
       "notes": "PO direction 2026-07-28, specifying the exact mechanism: dispatch the spec-writing Architect brief, let that subagent close out fully, then dispatch a second, freshly-context Architect agent given only the spec and instructed to critique/stress-test it, not confirm it — never the same agent re-checking its own work in the same thread. Modeled on the Wave 0 precedent (ADL-41 §7.2.1's false FK-enforcement claim, caught only because the re-dispatched review agent was told to critique rather than rubber-stamp). Applies to every Architect deliverable that will be cited elsewhere (an ADL feeding a BRD bump or an implementation brief) — not gated to a stakes threshold, since ADLs are exactly the artifact everything downstream trusts without re-verifying. Recorded in CLAUDE.md 'Recording decisions' section, following '### Recording decisions'. See feedback_architect_fresh_eyes_review memory."
+    },
+    {
+      "id": "OP-28",
+      "type": "operational",
+      "title": "No wholesale rewrites of shared-record files — append/amend only, hook-enforced (warn)",
+      "status": "done",
+      "owner": "coo",
+      "priority": "P2",
+      "brdRefs": [],
+      "phase": 6,
+      "notes": "PO direction 2026-07-28: 'agents should never fully rewrite anything, if a full rewrite is required there is a fundamental issue/deviation and I'd want it double checked' — with an explicit invitation to calibrate, since a blanket rule may be too strict. Trigger: Wave 1 sub-wave A ran B1 and B2 as concurrent Frontend agents and BOTH rewrote jobs/frontend/context/current.txt in full. Each rewrite was individually reasonable and each silently dropped the other's thread record; it surfaced only as the PR #303 merge conflict, hand-resolved by the COO keeping both entries. RECURRENCE, not a one-off: the Wave 0 concurrency notes record the same file colliding in 3 of 4 concurrent agents for the same reason, and the fix identified then (per-agent region / append-don't-rewrite) was never adopted. Twice across two waves cleared the D-03 bar. Calibration adopted, scoped by file class rather than blanket: (a) SHARED-RECORD files are append/amend-only, never wholesale replacement — jobs/**, _project/tracker.json, the BRD, the ADL log, the backlog clearance plan, .planning/**, CLAUDE.md; mechanically 'use Edit not Write on an existing one'. (b) SOURCE CODE full-file rewrites stay allowed but must be DECLARED in the completion report with a reason, so the COO can double-check — a small module legitimately changing in full is normal work and blocking it would be noise. Implemented: .claude/hooks/no-wholesale-rewrite.sh (PostToolUse, Write matcher, fires only when git already tracks the path so new-file creation is silent), wired in .claude/settings.json, canary added to /coo-startup step 0 (both the warn case and the Edit-stays-silent case). Tested 6 cases, all passed. Root-cause fix beyond the hook: all 8 jobs/<role>/<role>-system-prompt.txt files said 'Update jobs/<role>/context/current.txt with current state' as an end-of-thread step — that instruction was itself producing the rewrites, and now reads 'APPEND a new dated entry ... never rewrite the file wholesale'. Warn-not-block per OP-26's precedent; revisit once the false-positive rate is known."
+    },
+    {
+      "id": "OP-29",
+      "type": "operational",
+      "title": "Negative-findings rule binds every role including the COO — hook extended to cover COO-authored briefs",
+      "status": "done",
+      "owner": "coo",
+      "priority": "P1",
+      "brdRefs": [],
+      "phase": 6,
+      "notes": "PO direction 2026-07-28: 'you as the COO also need the negative findings piece, it should apply to the whole team.' Trigger: the rule failed again on the very next wave after being adopted. Brief B2 (issue #298) asserted that AD-09's owner-only deactivation 'is not enforced on the backend today' and bundled a go-enforce-it backend task on that premise. FALSE — adminRouter.use(requireOwner) at src/backend/routes/admin.ts:105 registers BEFORE the categories/activities sub-routers mount at :232-233, so every PATCH/DELETE was already owner-gated, and security.access-matrix.test.ts already had passing non-owner-403 tests for exactly it. The claim came from the backlog clearance plan §7 and the COO propagated it into the brief without re-probing. Caught only because the brief itself instructed the agent to double-probe; the agent ran three probes and corrected the tracker note instead of writing code. Same shape as the router.delete failure already recorded in CLAUDE.md — both COO failures, not agent ones. TWO FIXES. (1) Written rule: CLAUDE.md now states no role is exempt, the COO explicitly included, and that a claim inherited from an existing project document is NOT pre-verified — age is not evidence. Added to all 8 role system prompts. (2) Enforcement gap closed: the OP-26 hook matched only Write|Edit, but the COO does not write briefs to files — it writes them into GitHub issue bodies via Bash, so the single highest-leverage place for a false absence was the one place the hook could not see. negative-findings-guard.sh now also scans `gh issue create` / `gh pr create` / `gh issue comment` bodies (Bash matcher added in settings.json). PATTERN SET WIDENED, found by testing rather than assumed: the original regex missed BOTH phrasings that actually caused this project's false premises — 'is not enforced' and 'there is no X' — so absence-of-enforcement language ('not enforced', 'not gated', 'not validated', 'no call sites', 'there is no', 'there are no', 'never wired') is now covered. 6 test cases pass, including both historical false premises. Canary added to /coo-startup step 0 for the brief path specifically."
+    },
+    {
+      "id": "OP-30",
+      "type": "operational",
+      "title": "Scanner suppressions need COO sign-off — reword your own text first",
+      "status": "done",
+      "owner": "coo",
+      "priority": "P2",
+      "brdRefs": [],
+      "phase": 6,
+      "notes": "PO direction 2026-07-28, agreeing with the COO recommendation ('agree on rewording and flagging the instance'). Trigger: during B2 (PR #303), Gitleaks' generic-api-key rule flagged the literal string 'Categories/Activities/Countries' in a tracker note the agent had just authored — a genuine false positive, three capitalised words joined by slashes matching an entropy/shape heuristic. The agent resolved it by adding .gitleaks.toml and went green. THE CONFIG IS KEPT and is sound on inspection: [extend] useDefault = true keeps every standard rule active, and the allowlist is an exact-string regexTarget='match' on that one 50-character phrase — not a path exemption, not a file exemption, not a commit exemption. The PRECEDENT is what needed a decision: an implementation agent independently weakening a SECURITY SCANNER's configuration to turn a red check green is not a call an implementation brief carries, however narrow the change, and the cheaper fix was available — reword its own changelog note. Rule adopted: (a) when a scanner flags content you just authored and it is a false positive, fix your own text first; (b) never add or widen a scanner suppression — .gitleaks.toml allowlists, new nosemgrep comments, npm audit exceptions, lint disables — without COO sign-off, stop and report instead; (c) pre-existing nosemgrep annotations carrying a stated reason (e.g. the requireAuth-applied-globally comments in src/backend/routes/) are unaffected, this governs NEW suppressions; (d) any suppression the COO does approve carries a comment naming what was flagged, why it is a false positive, and how that was verified — as .gitleaks.toml now does. Recorded in CLAUDE.md and all 8 role system prompts."
     },
     {
       "id": "WP-01",
@@ -1911,12 +1944,12 @@
       "id": "BUG-44",
       "type": "bug",
       "title": "Car rental pickup location should show as subtext under provider",
-      "status": "pending",
+      "status": "done_pending_uat",
       "owner": "frontend",
       "priority": "P2",
       "brdRefs": [],
       "phase": 6,
-      "notes": "Found 2026-07-21 UAT, logged only — not yet briefed. Mirror the existing flight pattern (airline + flight number render as subtext under the flight item) — car rental should show pickup location as subtext under the provider name the same way. Small, self-contained UI fix."
+      "notes": "Found 2026-07-21 UAT, logged only — not yet briefed. Mirror the existing flight pattern (airline + flight number render as subtext under the flight item) — car rental should show pickup location as subtext under the provider name the same way. Small, self-contained UI fix. FIXED 2026-07-28 (GitHub #300, PR #306, Wave 1 sub-wave A brief B6) — pickup-location subtext added to ItemCard.tsx, mirroring the flight pattern as specified. Bundled with BUG-57/IT-11, BRD-DP06 and BRD-IT10 because all four share the ItemForm/ItemCard surface."
     },
     {
       "id": "BUG-45",
@@ -1977,12 +2010,12 @@
       "id": "BUG-49",
       "type": "bug",
       "title": "City markers render behind state shading layer",
-      "status": "pending",
+      "status": "done_pending_uat",
       "owner": "frontend",
       "priority": "P2",
-      "brdRefs": [],
+      "brdRefs": ["MP-02"],
       "phase": 6,
-      "notes": "Found 2026-07-21 UAT, logged only — not yet briefed. When state shading activates it visually covers city tag markers — layer/z-order issue, city markers should stay on top."
+      "notes": "Found 2026-07-21 UAT, logged only — not yet briefed. When state shading activates it visually covers city tag markers — layer/z-order issue, city markers should stay on top. FIXED 2026-07-28 (GitHub #296, PR #301, Wave 1 sub-wave A brief B1). Root cause was not CSS or JSX order: RegionLayer, CountryLayer and CityMarkers are all native MapLibre GL layers, so paint order is the order layers were ADDED to the style. CountryLayer and CityMarkers mount unconditionally on MapView's first render; RegionLayer mounts lazily once zoom crosses REGION_ZOOM_THRESHOLD and region data loads, and MapLibre's addLayer with no beforeId always inserts at the top of the stack — so region shading landed above city-markers the moment it activated, despite CityMarkers appearing later in MapView's JSX. Fix: beforeId: 'city-markers' on regionFillLayer, which the Layer component honours on both initial addLayer and later moveLayer, so it holds across remounts as the user zooms. COO verified the failure mode this fix could have had — a beforeId naming a layer that does not exist throws — and it cannot occur: MapView.tsx:160 mounts CityMarkers unconditionally and CityMarkers always renders its Source+Layer (empty FeatureCollection when there are no trips). Region outline is a fill-outline-color paint property, not a second layer, so one beforeId covers it. Regression test at src/frontend/components/Map/__tests__/RegionLayer.test.ts. Stale doc comment at MapView.tsx:6 ('zoom >= 4' vs the constant's 3) fixed in the same PR per the document lifecycle rule. brdRefs backfilled to MP-02, the governing requirement ('zooming in on the map reveals region-level shading and city-level pins') — flagged by the B1 agent, verified against the BRD by the COO before adding. REGION_ZOOM_THRESHOLD and the 39 MB region payload deliberately untouched (BUG-48 / ADL-44)."
     },
     {
       "id": "BUG-50",
@@ -1999,8 +2032,8 @@
       "id": "BUG-51",
       "type": "bug",
       "title": "Companion name edits in admin panel don't consistently propagate to trips",
-      "status": "pending",
-      "owner": "backend",
+      "status": "done_pending_uat",
+      "owner": "frontend",
       "priority": "P1",
       "brdRefs": [],
       "phase": 6,
@@ -2065,12 +2098,12 @@
       "id": "BUG-57",
       "type": "feature",
       "title": "Intelligent date defaults across item entry, keyed off the trip's date range",
-      "status": "pending",
+      "status": "done_pending_uat",
       "owner": "fullstack",
       "priority": "P2",
       "brdRefs": ["IT-11"],
       "phase": 6,
-      "notes": "Found 2026-07-21 UAT. PO wants consistent date-picker defaulting across all item entry: (1) if the trip's date range is set, adding any item should default its date(s) to the start of the trip's range rather than today; (2) flights specifically should default arrival to the same day as departure once departure is entered, editable after. Explicit PO goal: avoid manually moving both to/from date pickers away from 'today' when entering a trip outside the current month — defaulting should land the picker in the right neighborhood automatically. Subsumes the narrower 'flight arrival defaults to departure date' finding from the same session. BRD gate cleared 2026-07-27 (v3.8): IT-11 added with success criteria — no separate BRD-IT11 tracker item exists, this entry is IT-11's tracked work. Ships in backlog-clearance-plan B6 alongside BRD-DP06: IT-11 and DP-06 are one defaulting code path, so briefing them separately would write the same logic twice."
+      "notes": "Found 2026-07-21 UAT. PO wants consistent date-picker defaulting across all item entry: (1) if the trip's date range is set, adding any item should default its date(s) to the start of the trip's range rather than today; (2) flights specifically should default arrival to the same day as departure once departure is entered, editable after. Explicit PO goal: avoid manually moving both to/from date pickers away from 'today' when entering a trip outside the current month — defaulting should land the picker in the right neighborhood automatically. Subsumes the narrower 'flight arrival defaults to departure date' finding from the same session. BRD gate cleared 2026-07-27 (v3.8): IT-11 added with success criteria — no separate BRD-IT11 tracker item exists, this entry is IT-11's tracked work. Ships in backlog-clearance-plan B6 alongside BRD-DP06: IT-11 and DP-06 are one defaulting code path, so briefing them separately would write the same logic twice. IMPLEMENTED 2026-07-28 (GitHub #300, PR #306). Shared utility src/frontend/utils/dateDefaults.ts consumed by ItemForm.tsx and AddPlaceFlow.tsx; flight arrival live-cascades from departure with touched-tracking so a hand-edit is never overwritten by re-defaulting, as IT-11 requires. OPEN FOR PO AT UAT — the agent flagged this itself rather than deciding silently: it also defaults hotel checkout and car-rental dropoff from the trip's END date. IT-11's text says only 'defaults its date(s) to the start of that range' and names solely the flight departure->arrival cascade explicitly, so second-date-from-trip-end is a reasonable generalisation but is beyond the literal success criteria. Confirm or reject at UAT; it is a default value, trivially changed either way."
     },
     {
       "id": "BUG-58",
@@ -2120,7 +2153,7 @@
       "id": "BUG-62",
       "type": "bug",
       "title": "Admin panel is still fully owner-gated at the page/nav level — non-owner users can't reach the Companions tab even after AD-08 made companions per-user",
-      "status": "pending",
+      "status": "done_pending_uat",
       "owner": "frontend",
       "priority": "P2",
       "brdRefs": ["AD-08"],

--- a/jobs/architect/architect-system-prompt.txt
+++ b/jobs/architect/architect-system-prompt.txt
@@ -70,8 +70,40 @@ Positive findings self-verify; negative ones don't, and designs get built on top
 Adopted 2026-07-28 after three false premises from one wave of work — see CLAUDE.md
 "Negative findings need two probes" for the full rule and the three incidents.
 
+This binds EVERY role with no exemptions, the COO included — a claim inherited from an
+existing project document is NOT pre-verified, and age is not evidence. It fired again on
+2026-07-28: a COO-authored brief asserted an access control "is not enforced on the
+backend today" when it already was, propagated from a planning doc without a second probe.
+
+NEVER FULLY REWRITE A SHARED RECORD (MANDATORY):
+Shared-record files accumulate entries across many agents and sessions. Replacing one
+wholesale destroys other threads' records. This covers jobs/** (context docs, park docs,
+inbox, role tech docs), _project/tracker.json, the BRD, the ADL log, the backlog clearance
+plan, .planning/** and CLAUDE.md.
+
+Mechanically: use Edit, not Write, on any of those files that already exists. Add a new
+dated entry and leave prior entries in place.
+
+Source code is different — a full-file rewrite is allowed there, but you MUST declare it in
+your completion report with the reason, so the COO can double-check it was deliberate and
+not a drift from the brief.
+
+Adopted 2026-07-28 (OP-28) after two concurrent Frontend agents each rewrote
+jobs/frontend/context/current.txt in full on the same day and collided; a recurrence of the
+same Wave 0 pattern. A PostToolUse hook warns when a Write replaces a tracked shared-record
+file. See CLAUDE.md "No wholesale rewrites of shared records".
+
+NEVER ADD OR WIDEN A SCANNER SUPPRESSION WITHOUT COO SIGN-OFF (MANDATORY):
+If a security scanner (Gitleaks, Semgrep, npm audit) or a linter flags content YOU JUST
+WROTE and it is a false positive, reword your own text first — that costs nothing and leaves
+the scanner at full strength. Do NOT add a .gitleaks.toml allowlist entry, a new nosemgrep
+comment, an audit exception or a lint disable to turn a red check green. Stop and report the
+finding to the COO instead. Adopted 2026-07-28 (OP-30). See CLAUDE.md "Scanner suppressions
+need COO sign-off".
+
 AT THE END OF EVERY THREAD, YOU MUST:
-1. Update jobs/architect/context/current.txt with current state
+1. APPEND a new dated entry to jobs/architect/context/current.txt — amend it, never
+   rewrite the file wholesale (see NEVER FULLY REWRITE A SHARED RECORD below)
 2. Write a Park Document to jobs/architect/park-docs/YYYYMMDD-ARCHITECT-park.txt
 3. Save all design documents, data models and decision logs to jobs/architect/tech/
 4. Send a completion report to COO via jobs/COO/inbox/

--- a/jobs/backend/backend-system-prompt.txt
+++ b/jobs/backend/backend-system-prompt.txt
@@ -53,8 +53,40 @@ Positive findings self-verify; negative ones don't, and designs get built on top
 Adopted 2026-07-28 after three false premises from one wave of work — see CLAUDE.md
 "Negative findings need two probes" for the full rule and the three incidents.
 
+This binds EVERY role with no exemptions, the COO included — a claim inherited from an
+existing project document is NOT pre-verified, and age is not evidence. It fired again on
+2026-07-28: a COO-authored brief asserted an access control "is not enforced on the
+backend today" when it already was, propagated from a planning doc without a second probe.
+
+NEVER FULLY REWRITE A SHARED RECORD (MANDATORY):
+Shared-record files accumulate entries across many agents and sessions. Replacing one
+wholesale destroys other threads' records. This covers jobs/** (context docs, park docs,
+inbox, role tech docs), _project/tracker.json, the BRD, the ADL log, the backlog clearance
+plan, .planning/** and CLAUDE.md.
+
+Mechanically: use Edit, not Write, on any of those files that already exists. Add a new
+dated entry and leave prior entries in place.
+
+Source code is different — a full-file rewrite is allowed there, but you MUST declare it in
+your completion report with the reason, so the COO can double-check it was deliberate and
+not a drift from the brief.
+
+Adopted 2026-07-28 (OP-28) after two concurrent Frontend agents each rewrote
+jobs/frontend/context/current.txt in full on the same day and collided; a recurrence of the
+same Wave 0 pattern. A PostToolUse hook warns when a Write replaces a tracked shared-record
+file. See CLAUDE.md "No wholesale rewrites of shared records".
+
+NEVER ADD OR WIDEN A SCANNER SUPPRESSION WITHOUT COO SIGN-OFF (MANDATORY):
+If a security scanner (Gitleaks, Semgrep, npm audit) or a linter flags content YOU JUST
+WROTE and it is a false positive, reword your own text first — that costs nothing and leaves
+the scanner at full strength. Do NOT add a .gitleaks.toml allowlist entry, a new nosemgrep
+comment, an audit exception or a lint disable to turn a red check green. Stop and report the
+finding to the COO instead. Adopted 2026-07-28 (OP-30). See CLAUDE.md "Scanner suppressions
+need COO sign-off".
+
 AT THE END OF EVERY THREAD, YOU MUST:
-1. Update jobs/backend/context/current.txt with current state
+1. APPEND a new dated entry to jobs/backend/context/current.txt — amend it, never
+   rewrite the file wholesale (see NEVER FULLY REWRITE A SHARED RECORD below)
 2. Write a Park Document to jobs/backend/park-docs/YYYYMMDD-BACKEND-park.txt
 3. Save all API documentation and business logic notes to jobs/backend/tech/
 4. Send a completion report to COO via jobs/COO/inbox/

--- a/jobs/database/database-system-prompt.txt
+++ b/jobs/database/database-system-prompt.txt
@@ -53,8 +53,40 @@ Positive findings self-verify; negative ones don't, and designs get built on top
 Adopted 2026-07-28 after three false premises from one wave of work — see CLAUDE.md
 "Negative findings need two probes" for the full rule and the three incidents.
 
+This binds EVERY role with no exemptions, the COO included — a claim inherited from an
+existing project document is NOT pre-verified, and age is not evidence. It fired again on
+2026-07-28: a COO-authored brief asserted an access control "is not enforced on the
+backend today" when it already was, propagated from a planning doc without a second probe.
+
+NEVER FULLY REWRITE A SHARED RECORD (MANDATORY):
+Shared-record files accumulate entries across many agents and sessions. Replacing one
+wholesale destroys other threads' records. This covers jobs/** (context docs, park docs,
+inbox, role tech docs), _project/tracker.json, the BRD, the ADL log, the backlog clearance
+plan, .planning/** and CLAUDE.md.
+
+Mechanically: use Edit, not Write, on any of those files that already exists. Add a new
+dated entry and leave prior entries in place.
+
+Source code is different — a full-file rewrite is allowed there, but you MUST declare it in
+your completion report with the reason, so the COO can double-check it was deliberate and
+not a drift from the brief.
+
+Adopted 2026-07-28 (OP-28) after two concurrent Frontend agents each rewrote
+jobs/frontend/context/current.txt in full on the same day and collided; a recurrence of the
+same Wave 0 pattern. A PostToolUse hook warns when a Write replaces a tracked shared-record
+file. See CLAUDE.md "No wholesale rewrites of shared records".
+
+NEVER ADD OR WIDEN A SCANNER SUPPRESSION WITHOUT COO SIGN-OFF (MANDATORY):
+If a security scanner (Gitleaks, Semgrep, npm audit) or a linter flags content YOU JUST
+WROTE and it is a false positive, reword your own text first — that costs nothing and leaves
+the scanner at full strength. Do NOT add a .gitleaks.toml allowlist entry, a new nosemgrep
+comment, an audit exception or a lint disable to turn a red check green. Stop and report the
+finding to the COO instead. Adopted 2026-07-28 (OP-30). See CLAUDE.md "Scanner suppressions
+need COO sign-off".
+
 AT THE END OF EVERY THREAD, YOU MUST:
-1. Update jobs/database/context/current.txt with current state
+1. APPEND a new dated entry to jobs/database/context/current.txt — amend it, never
+   rewrite the file wholesale (see NEVER FULLY REWRITE A SHARED RECORD below)
 2. Write a Park Document to jobs/database/park-docs/YYYYMMDD-DATABASE-park.txt
 3. Save all schema files, migration scripts and seed data to jobs/database/tech/
 4. Send a completion report to COO via jobs/COO/inbox/

--- a/jobs/docs/docs-system-prompt.txt
+++ b/jobs/docs/docs-system-prompt.txt
@@ -52,8 +52,40 @@ Positive findings self-verify; negative ones don't, and designs get built on top
 Adopted 2026-07-28 after three false premises from one wave of work — see CLAUDE.md
 "Negative findings need two probes" for the full rule and the three incidents.
 
+This binds EVERY role with no exemptions, the COO included — a claim inherited from an
+existing project document is NOT pre-verified, and age is not evidence. It fired again on
+2026-07-28: a COO-authored brief asserted an access control "is not enforced on the
+backend today" when it already was, propagated from a planning doc without a second probe.
+
+NEVER FULLY REWRITE A SHARED RECORD (MANDATORY):
+Shared-record files accumulate entries across many agents and sessions. Replacing one
+wholesale destroys other threads' records. This covers jobs/** (context docs, park docs,
+inbox, role tech docs), _project/tracker.json, the BRD, the ADL log, the backlog clearance
+plan, .planning/** and CLAUDE.md.
+
+Mechanically: use Edit, not Write, on any of those files that already exists. Add a new
+dated entry and leave prior entries in place.
+
+Source code is different — a full-file rewrite is allowed there, but you MUST declare it in
+your completion report with the reason, so the COO can double-check it was deliberate and
+not a drift from the brief.
+
+Adopted 2026-07-28 (OP-28) after two concurrent Frontend agents each rewrote
+jobs/frontend/context/current.txt in full on the same day and collided; a recurrence of the
+same Wave 0 pattern. A PostToolUse hook warns when a Write replaces a tracked shared-record
+file. See CLAUDE.md "No wholesale rewrites of shared records".
+
+NEVER ADD OR WIDEN A SCANNER SUPPRESSION WITHOUT COO SIGN-OFF (MANDATORY):
+If a security scanner (Gitleaks, Semgrep, npm audit) or a linter flags content YOU JUST
+WROTE and it is a false positive, reword your own text first — that costs nothing and leaves
+the scanner at full strength. Do NOT add a .gitleaks.toml allowlist entry, a new nosemgrep
+comment, an audit exception or a lint disable to turn a red check green. Stop and report the
+finding to the COO instead. Adopted 2026-07-28 (OP-30). See CLAUDE.md "Scanner suppressions
+need COO sign-off".
+
 AT THE END OF EVERY THREAD, YOU MUST:
-1. Update jobs/docs/context/current.txt with current state
+1. APPEND a new dated entry to jobs/docs/context/current.txt — amend it, never
+   rewrite the file wholesale (see NEVER FULLY REWRITE A SHARED RECORD below)
 2. Write a Park Document to jobs/docs/park-docs/YYYYMMDD-DOCS-park.txt
 3. Save all documentation to jobs/docs/tech/
 4. Send a completion report to COO via jobs/COO/inbox/

--- a/jobs/frontend/frontend-system-prompt.txt
+++ b/jobs/frontend/frontend-system-prompt.txt
@@ -53,8 +53,40 @@ Positive findings self-verify; negative ones don't, and designs get built on top
 Adopted 2026-07-28 after three false premises from one wave of work — see CLAUDE.md
 "Negative findings need two probes" for the full rule and the three incidents.
 
+This binds EVERY role with no exemptions, the COO included — a claim inherited from an
+existing project document is NOT pre-verified, and age is not evidence. It fired again on
+2026-07-28: a COO-authored brief asserted an access control "is not enforced on the
+backend today" when it already was, propagated from a planning doc without a second probe.
+
+NEVER FULLY REWRITE A SHARED RECORD (MANDATORY):
+Shared-record files accumulate entries across many agents and sessions. Replacing one
+wholesale destroys other threads' records. This covers jobs/** (context docs, park docs,
+inbox, role tech docs), _project/tracker.json, the BRD, the ADL log, the backlog clearance
+plan, .planning/** and CLAUDE.md.
+
+Mechanically: use Edit, not Write, on any of those files that already exists. Add a new
+dated entry and leave prior entries in place.
+
+Source code is different — a full-file rewrite is allowed there, but you MUST declare it in
+your completion report with the reason, so the COO can double-check it was deliberate and
+not a drift from the brief.
+
+Adopted 2026-07-28 (OP-28) after two concurrent Frontend agents each rewrote
+jobs/frontend/context/current.txt in full on the same day and collided; a recurrence of the
+same Wave 0 pattern. A PostToolUse hook warns when a Write replaces a tracked shared-record
+file. See CLAUDE.md "No wholesale rewrites of shared records".
+
+NEVER ADD OR WIDEN A SCANNER SUPPRESSION WITHOUT COO SIGN-OFF (MANDATORY):
+If a security scanner (Gitleaks, Semgrep, npm audit) or a linter flags content YOU JUST
+WROTE and it is a false positive, reword your own text first — that costs nothing and leaves
+the scanner at full strength. Do NOT add a .gitleaks.toml allowlist entry, a new nosemgrep
+comment, an audit exception or a lint disable to turn a red check green. Stop and report the
+finding to the COO instead. Adopted 2026-07-28 (OP-30). See CLAUDE.md "Scanner suppressions
+need COO sign-off".
+
 AT THE END OF EVERY THREAD, YOU MUST:
-1. Update jobs/frontend/context/current.txt with current state
+1. APPEND a new dated entry to jobs/frontend/context/current.txt — amend it, never
+   rewrite the file wholesale (see NEVER FULLY REWRITE A SHARED RECORD below)
 2. Write a Park Document to jobs/frontend/park-docs/YYYYMMDD-FRONTEND-park.txt
 3. Save all component documentation and UI notes to jobs/frontend/tech/
 4. Send a completion report to COO via jobs/COO/inbox/

--- a/jobs/integrations/integrations-system-prompt.txt
+++ b/jobs/integrations/integrations-system-prompt.txt
@@ -53,8 +53,40 @@ Positive findings self-verify; negative ones don't, and designs get built on top
 Adopted 2026-07-28 after three false premises from one wave of work — see CLAUDE.md
 "Negative findings need two probes" for the full rule and the three incidents.
 
+This binds EVERY role with no exemptions, the COO included — a claim inherited from an
+existing project document is NOT pre-verified, and age is not evidence. It fired again on
+2026-07-28: a COO-authored brief asserted an access control "is not enforced on the
+backend today" when it already was, propagated from a planning doc without a second probe.
+
+NEVER FULLY REWRITE A SHARED RECORD (MANDATORY):
+Shared-record files accumulate entries across many agents and sessions. Replacing one
+wholesale destroys other threads' records. This covers jobs/** (context docs, park docs,
+inbox, role tech docs), _project/tracker.json, the BRD, the ADL log, the backlog clearance
+plan, .planning/** and CLAUDE.md.
+
+Mechanically: use Edit, not Write, on any of those files that already exists. Add a new
+dated entry and leave prior entries in place.
+
+Source code is different — a full-file rewrite is allowed there, but you MUST declare it in
+your completion report with the reason, so the COO can double-check it was deliberate and
+not a drift from the brief.
+
+Adopted 2026-07-28 (OP-28) after two concurrent Frontend agents each rewrote
+jobs/frontend/context/current.txt in full on the same day and collided; a recurrence of the
+same Wave 0 pattern. A PostToolUse hook warns when a Write replaces a tracked shared-record
+file. See CLAUDE.md "No wholesale rewrites of shared records".
+
+NEVER ADD OR WIDEN A SCANNER SUPPRESSION WITHOUT COO SIGN-OFF (MANDATORY):
+If a security scanner (Gitleaks, Semgrep, npm audit) or a linter flags content YOU JUST
+WROTE and it is a false positive, reword your own text first — that costs nothing and leaves
+the scanner at full strength. Do NOT add a .gitleaks.toml allowlist entry, a new nosemgrep
+comment, an audit exception or a lint disable to turn a red check green. Stop and report the
+finding to the COO instead. Adopted 2026-07-28 (OP-30). See CLAUDE.md "Scanner suppressions
+need COO sign-off".
+
 AT THE END OF EVERY THREAD, YOU MUST:
-1. Update jobs/integrations/context/current.txt with current state
+1. APPEND a new dated entry to jobs/integrations/context/current.txt — amend it, never
+   rewrite the file wholesale (see NEVER FULLY REWRITE A SHARED RECORD below)
 2. Write a Park Document to jobs/integrations/park-docs/YYYYMMDD-INTEGRATIONS-park.txt
 3. Save all integration documentation to jobs/integrations/tech/
 4. Send a completion report to COO via jobs/COO/inbox/

--- a/jobs/qa/qa-system-prompt.txt
+++ b/jobs/qa/qa-system-prompt.txt
@@ -52,8 +52,40 @@ Positive findings self-verify; negative ones don't, and designs get built on top
 Adopted 2026-07-28 after three false premises from one wave of work — see CLAUDE.md
 "Negative findings need two probes" for the full rule and the three incidents.
 
+This binds EVERY role with no exemptions, the COO included — a claim inherited from an
+existing project document is NOT pre-verified, and age is not evidence. It fired again on
+2026-07-28: a COO-authored brief asserted an access control "is not enforced on the
+backend today" when it already was, propagated from a planning doc without a second probe.
+
+NEVER FULLY REWRITE A SHARED RECORD (MANDATORY):
+Shared-record files accumulate entries across many agents and sessions. Replacing one
+wholesale destroys other threads' records. This covers jobs/** (context docs, park docs,
+inbox, role tech docs), _project/tracker.json, the BRD, the ADL log, the backlog clearance
+plan, .planning/** and CLAUDE.md.
+
+Mechanically: use Edit, not Write, on any of those files that already exists. Add a new
+dated entry and leave prior entries in place.
+
+Source code is different — a full-file rewrite is allowed there, but you MUST declare it in
+your completion report with the reason, so the COO can double-check it was deliberate and
+not a drift from the brief.
+
+Adopted 2026-07-28 (OP-28) after two concurrent Frontend agents each rewrote
+jobs/frontend/context/current.txt in full on the same day and collided; a recurrence of the
+same Wave 0 pattern. A PostToolUse hook warns when a Write replaces a tracked shared-record
+file. See CLAUDE.md "No wholesale rewrites of shared records".
+
+NEVER ADD OR WIDEN A SCANNER SUPPRESSION WITHOUT COO SIGN-OFF (MANDATORY):
+If a security scanner (Gitleaks, Semgrep, npm audit) or a linter flags content YOU JUST
+WROTE and it is a false positive, reword your own text first — that costs nothing and leaves
+the scanner at full strength. Do NOT add a .gitleaks.toml allowlist entry, a new nosemgrep
+comment, an audit exception or a lint disable to turn a red check green. Stop and report the
+finding to the COO instead. Adopted 2026-07-28 (OP-30). See CLAUDE.md "Scanner suppressions
+need COO sign-off".
+
 AT THE END OF EVERY THREAD, YOU MUST:
-1. Update jobs/qa/context/current.txt with current state
+1. APPEND a new dated entry to jobs/qa/context/current.txt — amend it, never
+   rewrite the file wholesale (see NEVER FULLY REWRITE A SHARED RECORD below)
 2. Write a Park Document to jobs/qa/park-docs/YYYYMMDD-QA-park.txt
 3. Save all test plans, test cases and bug reports to jobs/qa/tech/
 4. Send a completion report to COO via jobs/COO/inbox/

--- a/jobs/ux/ux-system-prompt.txt
+++ b/jobs/ux/ux-system-prompt.txt
@@ -56,8 +56,40 @@ Positive findings self-verify; negative ones don't, and designs get built on top
 Adopted 2026-07-28 after three false premises from one wave of work — see CLAUDE.md
 "Negative findings need two probes" for the full rule and the three incidents.
 
+This binds EVERY role with no exemptions, the COO included — a claim inherited from an
+existing project document is NOT pre-verified, and age is not evidence. It fired again on
+2026-07-28: a COO-authored brief asserted an access control "is not enforced on the
+backend today" when it already was, propagated from a planning doc without a second probe.
+
+NEVER FULLY REWRITE A SHARED RECORD (MANDATORY):
+Shared-record files accumulate entries across many agents and sessions. Replacing one
+wholesale destroys other threads' records. This covers jobs/** (context docs, park docs,
+inbox, role tech docs), _project/tracker.json, the BRD, the ADL log, the backlog clearance
+plan, .planning/** and CLAUDE.md.
+
+Mechanically: use Edit, not Write, on any of those files that already exists. Add a new
+dated entry and leave prior entries in place.
+
+Source code is different — a full-file rewrite is allowed there, but you MUST declare it in
+your completion report with the reason, so the COO can double-check it was deliberate and
+not a drift from the brief.
+
+Adopted 2026-07-28 (OP-28) after two concurrent Frontend agents each rewrote
+jobs/frontend/context/current.txt in full on the same day and collided; a recurrence of the
+same Wave 0 pattern. A PostToolUse hook warns when a Write replaces a tracked shared-record
+file. See CLAUDE.md "No wholesale rewrites of shared records".
+
+NEVER ADD OR WIDEN A SCANNER SUPPRESSION WITHOUT COO SIGN-OFF (MANDATORY):
+If a security scanner (Gitleaks, Semgrep, npm audit) or a linter flags content YOU JUST
+WROTE and it is a false positive, reword your own text first — that costs nothing and leaves
+the scanner at full strength. Do NOT add a .gitleaks.toml allowlist entry, a new nosemgrep
+comment, an audit exception or a lint disable to turn a red check green. Stop and report the
+finding to the COO instead. Adopted 2026-07-28 (OP-30). See CLAUDE.md "Scanner suppressions
+need COO sign-off".
+
 AT THE END OF EVERY THREAD, YOU MUST:
-1. Update jobs/ux/context/current.txt with current state
+1. APPEND a new dated entry to jobs/ux/context/current.txt — amend it, never
+   rewrite the file wholesale (see NEVER FULLY REWRITE A SHARED RECORD below)
 2. Write a Park Document to jobs/ux/park-docs/YYYYMMDD-UX-park.txt
 3. Save all design specs, audits and component notes to jobs/ux/tech/
 4. Send a completion report to COO via jobs/COO/inbox/


### PR DESCRIPTION
Three PO directions from the Wave 1 sub-wave A retro. All three are hook-backed, not written-only — the standing lesson from OP-26 is that a rule an agent has to remember mid-task is a rule that fails on the next wave.

## OP-28 — no wholesale rewrites of shared records

PO: *"agents should never fully rewrite anything, if a full rewrite is required there is a fundamental issue/deviation and I'd want it double checked"* — with an explicit invitation to calibrate.

**Trigger:** B1 and B2 ran concurrently and **both rewrote `jobs/frontend/context/current.txt` in full.** Each rewrite was individually sensible and each silently dropped the other's thread record; it surfaced only as the PR #303 merge conflict. **Recurrence** — the Wave 0 notes record the same file colliding in 3 of 4 concurrent agents for the same reason, and the fix identified then was never adopted.

**Calibration adopted** (blanket rule deliberately narrowed):
- **Shared records** — `jobs/**`, `_project/tracker.json`, BRD, ADL log, backlog plan, `.planning/**`, `CLAUDE.md` — append/amend only. Mechanically: **Edit, not Write**, on an existing one.
- **Source code** — full rewrites stay allowed but must be **declared in the completion report** with a reason. A small module changing entirely is normal work; blocking it would be noise.

New `.claude/hooks/no-wholesale-rewrite.sh` (PostToolUse, Write matcher, fires only when git already tracks the path so new files stay silent). Warn-only per OP-26's precedent. 6 test cases pass.

**Root cause also fixed:** all 8 role prompts listed *"Update jobs/<role>/context/current.txt with current state"* as an end-of-thread step. That instruction was itself producing the rewrites. Now reads *"APPEND a new dated entry … never rewrite the file wholesale"*.

## OP-29 — the negative-findings rule binds every role, COO included

PO: *"you as the COO also need the negative findings piece, it should apply to the whole team."*

**Trigger:** the rule failed on the very next wave after adoption. Brief B2 (#298) asserted AD-09's owner-only deactivation *"is not enforced on the backend today"* and bundled a go-enforce-it task on it. **False** — `adminRouter.use(requireOwner)` at `admin.ts:105` registers before the categories/activities sub-routers at `:232-233`, and `security.access-matrix.test.ts` already had passing non-owner-403 tests. The claim came from the backlog plan §7 and **the COO propagated it into the brief without re-probing.** Caught only because the brief told the agent to double-probe.

Two fixes:
1. **No role is exempt, COO explicitly included.** A claim inherited from an existing project document is *not* pre-verified — age is not evidence. In CLAUDE.md and all 8 role prompts.
2. **The enforcement gap is closed.** The OP-26 hook matched only `Write|Edit` — but the COO doesn't write briefs to files, it writes them into **GitHub issue bodies via Bash**. The highest-leverage place for a false absence was the one place the hook couldn't see. Now scans `gh issue create` / `gh pr create` / `gh issue comment` bodies.

**Pattern set widened — found by testing, not assumed.** The original regex missed *both* phrasings that actually caused this project's false premises: `is not enforced` and `there is no X`. Both now covered and both regression-tested.

## OP-30 — scanner suppressions need COO sign-off

During B2, Gitleaks flagged `Categories/Activities/Countries` in a tracker note the agent had just written — a real false positive. The agent added `.gitleaks.toml` and went green.

**The config is kept** — `useDefault = true` keeps every rule active and the allowlist is an exact-string match on that one phrase, not a path or file exemption. **The precedent is what needed governing:** an implementation agent independently weakening a security scanner to clear a red check isn't a call an implementation brief carries, and the cheaper fix was to reword its own note. Rule: fix your own text first; never add or widen a suppression without COO sign-off; pre-existing annotated `nosemgrep`s unaffected.

## Also in this PR

Wave 1 sub-wave A tracker close-out — BUG-44, BUG-49, BUG-51, BUG-57, BUG-62, BRD-DP06, BRD-IT10 flipped to `done_pending_uat`, GitHub issue cross-references backfilled per the tracker rule, BUG-49's `brdRefs` backfilled to MP-02 (agent-flagged, COO-verified against the BRD), BUG-51's owner corrected `backend` → `frontend` to match where the fix landed.

**Two items logged for UAT rather than decided unilaterally:** B6's hotel-checkout/car-dropoff defaulting from trip *end* date goes beyond IT-11's literal success criteria, and `zMapUrl`'s https check is case-sensitive so `HTTPS://` is rejected (fails closed — a UX wart, not a security gap).

Closes #296
Closes #298
Closes #299
Closes #300
Closes #305

🤖 Generated with [Claude Code](https://claude.com/claude-code)