### PR TITLE
chore(OP-32): defect taxonomy + deployment shakedown, and the parity gap behind BUG-55

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,6 +87,65 @@ will hit confusing missing-module errors that look like a worktree-isolation bug
 aren't. Run `npm install` inside the worktree before anything else that needs
 `node_modules`, same as a fresh clone would.
 
+### Classify a defect before briefing it: regression, deployment, or gap (mandatory, OP-32)
+
+Adopted 2026-07-28 on PO direction, after BUG-55 was briefed as a missing feature when the
+feature was fully built and the real fault was a CSP misconfiguration.
+
+**Every defect is one of three classes, and the class determines the first action:**
+
+| Class | Meaning | First action | Implies |
+|---|---|---|---|
+| **Regression** | It worked before; code changed and broke it | Find *what broke it* — git history over the failing path | A **missing test**, always. The fix is incomplete without one |
+| **Deployment/config** | The code is correct; the environment, build, or config is wrong | Do **not** touch application logic. Diff the environments | An **environment-parity gap** (see below) |
+| **Gap / enhancement** | It was never built | Build it | A BRD home and success criteria are required first |
+
+Getting the class wrong invalidates the entire brief. BUG-55 was briefed as a gap; it was a
+deployment defect, and the brief would have had an agent rebuild working code — then "verify"
+it against a local environment where it already worked.
+
+**The rules:**
+
+1. **Classify before briefing, and state the class in the brief.** An unclassified item is
+   not dispatchable.
+2. **"It used to work" is decisive evidence and must be asked for.** It converts a gap into a
+   regression or a deployment defect instantly. The PO logging UAT feedback is not expected to
+   classify it — *the COO must ask* when the tracker note doesn't say.
+3. **A tracker note guessing at cause is not a classification.** BUG-55's note said *"likely
+   the geocode/lookup path isn't wired"* — an unverified single-probe absence claim (see the
+   negative-findings rule below) that sat for a week and was disproved by one grep. Re-probe
+   before inheriting it into a brief.
+4. **Never widen the class silently.** If a fix turns out to span two classes, say so and
+   re-scope rather than absorbing it.
+
+### Deployment shakedown before UAT (mandatory, OP-32)
+
+UAT run against a build nobody has verified produces **false product bugs** — defects logged
+against the product that are really environment faults. This has now cost the project twice:
+the BRD-NF09 deploy shakedown (D-06) and BUG-55.
+
+**Before a UAT round on deployed code, run a deployment shakedown** confirming the deployed
+build behaves like `main`: the app loads, the browser console and network tab are clean, and
+each externally-dependent surface is exercised once. Anything failing there is a **deployment
+defect**, logged as such — not as a product bug.
+
+**Environment parity is the durable half of this.** A shakedown catches instances; parity
+closes classes. The standing rule:
+
+> **Enumerate every way the test environment differs from production, and treat each
+> difference as an untested surface.** Any defect class that lives inside a difference is
+> invisible to CI by construction — no amount of test-writing inside the wrong environment
+> finds it.
+
+The known differences are tracked as **QUAL-18** (single-origin E2E topology), **QUAL-19**
+(CSP allowlist contract test) and **QUAL-20** (post-deploy smoke check). The worked example,
+kept because it explains the shape better than the rule does: production serves the frontend
+document from Express with helmet's CSP applied (`src/backend/server.ts:233`, gated on
+`NODE_ENV=production`), but E2E serves it from `vite preview` on a *different port*
+(`playwright.config.ts` `webServer`), so the document under test carries **no CSP header at
+all**. Every `connect-src` violation is therefore unobservable in CI. The test suite was not
+weak — the environment could not express the failure.
+
 ### Negative findings need two probes (mandatory)
 Adopted 2026-07-28 after three confidently-stated false premises came out of one wave of
 Architect work (Wave 0), each caught only because someone later re-ran the probe:

--- a/_project/STATUS.md
+++ b/_project/STATUS.md
@@ -17,7 +17,7 @@ _Tracker last updated: 2026-07-28 (B9 merged — QUAL-03 + QUAL-11 done, PR #292
 | PHASE-5 | Integrations — Notification Engine | ⬜ Pending |
 | PHASE-6 | v3 Planning-First Delivery | ⬜ Pending |
 
-## Open work (55)
+## Open work (58)
 
 ### P0 — Blockers (1)
 
@@ -25,14 +25,15 @@ _Tracker last updated: 2026-07-28 (B9 merged — QUAL-03 + QUAL-11 done, PR #292
 |---|---|---|---|
 | FEAT-IT | Item Logging | frontend | ◐ Partial |
 
-### P1 — Critical (2)
+### P1 — Critical (3)
 
 | ID | Title | Owner | Status |
 |---|---|---|---|
 | BUG-50 | No way to delete an entire trip | frontend | ⬜ Pending |
 | BUG-51 | Companion name edits in admin panel don't consistently propagate to trips | frontend | done_pending_uat |
+| QUAL-18 | E2E serves the frontend from vite preview, not Express — so no CSP header is ever under test | qa | ⬜ Pending |
 
-### P2 — Important (29)
+### P2 — Important (31)
 
 | ID | Title | Owner | Status |
 |---|---|---|---|
@@ -57,7 +58,7 @@ _Tracker last updated: 2026-07-28 (B9 merged — QUAL-03 + QUAL-11 done, PR #292
 | BUG-49 | City markers render behind state shading layer | frontend | done_pending_uat |
 | BUG-52 | Trip search doesn't match on country name | backend | ⬜ Pending |
 | BUG-53 | Trip list place display: show state (not country) under city, surface country separately | ux | ⬜ Pending |
-| BUG-55 | City entry doesn't auto-populate country/state | backend | ⬜ Pending |
+| BUG-55 | City entry doesn't auto-populate country/state — CSP blocks the Nominatim call (deployment defect) | architect | ⬜ Pending |
 | BUG-57 | Intelligent date defaults across item entry, keyed off the trip's date range | fullstack | done_pending_uat |
 | BUG-58 | Moving a trip backward in the status workflow deselects it from the left panel | frontend | ⬜ Pending |
 | BUG-62 | Admin panel is still fully owner-gated at the page/nav level — non-owner users can't reach the Companions tab even after AD-08 made companions per-user | frontend | done_pending_uat |
@@ -65,6 +66,8 @@ _Tracker last updated: 2026-07-28 (B9 merged — QUAL-03 + QUAL-11 done, PR #292
 | QUAL-08 | sanitiseUrl() has zero call sites and photo_album_ref has no server-side scheme validation | fullstack | ⬜ Pending |
 | QUAL-12 | Concurrent role dispatches collide on the single shared jobs/<role>/context/current.txt | coo | ⬜ Pending |
 | QUAL-17 | 15 further backend test files hand-roll the same 21-table DDL that QUAL-03 just removed from test-db.ts | backend | ⬜ Pending |
+| QUAL-19 | No test asserts that external origins the frontend fetches are present in the CSP allowlist | backend | ⬜ Pending |
+| QUAL-20 | No post-deploy smoke check — nothing verifies the deployed build behaves like main | qa | ⬜ Pending |
 
 ### P3 — Minor (23)
 
@@ -102,7 +105,7 @@ _Tracker last updated: 2026-07-28 (B9 merged — QUAL-03 + QUAL-11 done, PR #292
 | requirement | `███████████████████░` 32/33 | 32 | 1 | 6 |
 | bug | `███████████████░░░░░` 44/58 | 44 | 14 | 4 |
 | task | `████████████████████` 9/9 | 9 | 0 | 0 |
-| chore | `██████████░░░░░░░░░░` 11/23 | 11 | 12 | 1 |
+| chore | `█████████░░░░░░░░░░░` 12/27 | 12 | 15 | 1 |
 
 <details>
 <summary>Deferred (10)</summary>
@@ -136,4 +139,4 @@ _Tracker last updated: 2026-07-28 (B9 merged — QUAL-03 + QUAL-11 done, PR #292
 
 ---
 
-_133 done · 10 deferred · 4 closed · 55 open — 202 tracked items_
+_134 done · 10 deferred · 4 closed · 58 open — 206 tracked items_

--- a/_project/tracker.json
+++ b/_project/tracker.json
@@ -2086,9 +2086,9 @@
     {
       "id": "BUG-55",
       "type": "bug",
-      "title": "City entry doesn't auto-populate country/state",
+      "title": "City entry doesn't auto-populate country/state — CSP blocks the Nominatim call (deployment defect)",
       "status": "pending",
-      "owner": "backend",
+      "owner": "architect",
       "priority": "P2",
       "brdRefs": ["GE-15"],
       "phase": 6,
@@ -2329,6 +2329,50 @@
       "brdRefs": [],
       "phase": 6,
       "notes": "Found 2026-07-28 by the B9 agent (issue #291, PR #292) while doing QUAL-03, and independently re-counted by the COO before logging. QUAL-03 made src/backend/repositories/__tests__/test-db.ts migration-derived, but 15 OTHER test files never used test-db.ts at all — they each hand-write the same 21-table DDL inline: 13 under src/backend/routes/__tests__/ (cities.get-by-id, companions, places, items.rating-sort-filter, qa-backend-fixes, items, trips.crud, owner-access, map, trip-countries, trips.delete, cities.carry-forward, security.access-matrix) and 2 under src/backend/services/__tests__/ (shading.trip-countries, shading.user-scope). COUNT CORRECTION: the agent's report said 14 (12 routes + 2 services); the actual figure is 15 (13 + 2), verified by 'grep -rl \"CREATE TABLE\" src/backend' minus test-db.ts and the 6 migration .sql files. Cited because the sizing matters. CONSEQUENCE — this narrows what B9 actually unblocked: REPOSITORY tests are now drift-safe, ROUTE tests are not, so the B9 report's claim that 'every other Wave 1 backend brief's tests are now trustworthy' is true only of the repository layer. Any Wave 1 backend brief whose verification rests on route tests is still verifying against a hand-maintained schema copy. The exposure is the same one QUAL-03 described and is 15x larger by file count. Note the concrete evidence this class of bug is real and not theoretical: QUAL-03's fix immediately surfaced 8 uses of an item status ('booked') that has never been valid against chk_items_status, silently green for the life of that file because the hand-written DDL carried no CHECK constraint. Success criteria: the 15 files derive their schema from the same migration-driven helper as test-db.ts; no hand-written CREATE TABLE remains in any backend test file; a deliberate migration change is detectable by route-level tests as well as repository tests; backend suite stays green with no material runtime regression."
+    },
+    {
+      "id": "QUAL-18",
+      "type": "chore",
+      "title": "E2E serves the frontend from vite preview, not Express — so no CSP header is ever under test",
+      "status": "pending",
+      "owner": "qa",
+      "priority": "P1",
+      "brdRefs": [],
+      "phase": 6,
+      "notes": "Found 2026-07-28 while root-causing BUG-55, on the PO's question 'should we be mirroring staging/production more closely for these tests?'. THE ANSWER IS YES AND THIS IS THE SPECIFIC GAP. Two independent probes: (1) playwright.config.ts webServer runs the frontend as 'vite preview --port 5173' with baseURL http://localhost:5173, while the backend runs separately on :3001; (2) src/backend/server.ts:233 mounts express.static(DIST_DIR) gated on NODE_ENV=production AND dist/ existing. So PRODUCTION is single-origin — Express serves the frontend document with helmet's CSP applied to it — while E2E is TWO-origin, and the document under test is served by vite preview, which sets no CSP header at all. Consequence: every Content-Security-Policy violation, including the connect-src omission that caused BUG-55, is UNOBSERVABLE in CI by construction. This is not a weak test suite; the test environment cannot express the failure. Fix: make the E2E webServer serve the built frontend through Express in production mode (single origin, helmet applied), matching prod topology. Note CI also sets GEOCODING_ENABLED=false, a second layer of the same blind spot. Success criteria: the E2E suite loads the app from the same Express process that applies helmet; a deliberately-removed connect-src origin causes an E2E failure rather than passing silently; the suite stays green and does not materially slow down."
+    },
+    {
+      "id": "QUAL-19",
+      "type": "chore",
+      "title": "No test asserts that external origins the frontend fetches are present in the CSP allowlist",
+      "status": "pending",
+      "owner": "backend",
+      "priority": "P2",
+      "brdRefs": [],
+      "phase": 6,
+      "notes": "Companion to QUAL-18, from the same BUG-55 root-cause pass 2026-07-28. QUAL-18 closes the class at runtime; this closes it statically and far more cheaply. The defect shape: src/frontend/hooks/useCities.ts:14 fetches https://nominatim.openstreetmap.org from the BROWSER, but that origin is absent from helmet's connectSrc at src/backend/server.ts:128-130 — nothing anywhere asserts the two lists agree. Proposed: a unit test that enumerates external origins referenced in frontend source and asserts each appears in the CSP directive that governs it (connectSrc for fetch/XHR, imgSrc for images, scriptSrc for scripts). No network, no browser, runs in milliseconds. ALSO IN SCOPE, same file, found in the same probe: useCities.ts:47 sets a 'User-Agent' header on a browser fetch(), which is a FORBIDDEN HEADER NAME — browsers silently drop it, so the app is anonymous against Nominatim's usage policy and exposed to throttling. Together these two facts argue the Nominatim call belongs behind a backend proxy route rather than a widened CSP allowlist; that is a SEC-01 decision and needs the Architect pass tracked on BUG-55, not an implementation brief. Success criteria: adding a frontend fetch to an un-allowlisted origin fails a test; the test names the offending origin and the directive it belongs in."
+    },
+    {
+      "id": "QUAL-20",
+      "type": "chore",
+      "title": "No post-deploy smoke check — nothing verifies the deployed build behaves like main",
+      "status": "pending",
+      "owner": "qa",
+      "priority": "P2",
+      "brdRefs": [],
+      "phase": 6,
+      "notes": "Third of the three environment-parity items from the BUG-55 root-cause pass 2026-07-28; implements the mechanical half of OP-32's deployment-shakedown rule. Today a green CI run says the code is correct in CI's environment, and nothing at all says the DEPLOYED artifact works — which is exactly the gap BUG-55 and the BRD-NF09 shakedown (open-dialogues D-06) both fell into. Proposed: a smoke check against the deployed URL after a staging deploy — app loads, no console errors, no CSP violations, each externally-dependent surface exercised once. IMPORTANT CONSTRAINT AND WHY THIS IS NOT BLOCKED: this devcontainer's firewall cannot reach the app's public Railway domain (D-06, still-open request), but a GitHub Action runner has no such restriction — so this belongs in CI, not in a COO-run script, and D-06 does not gate it. Deliberately scoped as a smoke check, not a full E2E run against prod: it answers 'is the deployed thing broken' cheaply and often. Success criteria: a staging deploy that serves a CSP-broken or otherwise non-functional build fails the check; a healthy deploy passes without manual steps; the failure output names what broke."
+    },
+    {
+      "id": "OP-32",
+      "type": "chore",
+      "title": "Defect taxonomy (regression / deployment / gap) + deployment shakedown before UAT",
+      "status": "done",
+      "owner": "coo",
+      "priority": "P1",
+      "brdRefs": [],
+      "phase": 6,
+      "notes": "Adopted 2026-07-28 on PO direction ('adopt now'), recorded in CLAUDE.md. Trigger: BUG-55 was briefed as a missing feature when the feature was fully built and the fault was a CSP misconfiguration — the brief would have had an agent rebuild working code and then verify it in an environment where it already worked. The PO's framing: 'this time is on me as I labelled them all UAT feedback' — the COO's assessment is that labelling was NOT the primary failure. BUG-55's tracker note had asserted 'likely the geocode/lookup path isn't wired' since 2026-07-21, an unverified single-probe absence claim that the existing negative-findings rule already covered and that one grep disproves. The rule existed; it was not applied. Two parts adopted: (1) a three-class defect taxonomy where the class determines the first action, with 'it used to work' called out as decisive evidence the COO must ASK for rather than expect the PO to volunteer; (2) a deployment shakedown before any UAT round on deployed code, plus the standing environment-parity principle — enumerate every difference between the test environment and production and treat each as an untested surface. Adopted immediately rather than logged to open-dialogues per the D-03 precedent because, unlike D-03, this has two independent incidents behind it (BRD-NF09 / D-06 and BUG-55) and a demonstrated cost. Mechanical follow-through tracked as QUAL-18/19/20."
     },
     {
       "id": "DEP-04",


### PR DESCRIPTION
PO direction 2026-07-28: *"adopt now."* Two rules into CLAUDE.md, three tracked follow-ups.

### Trigger
BUG-55 was briefed as a missing feature. The feature was **fully built** — `AddPlaceFlow.tsx:183-208` auto-populates country *and* region. The fault was a CSP misconfiguration. The brief would have had an agent rebuild working code, then "verify" it in an environment where it already worked.

### 1. Defect taxonomy — regression / deployment-config / gap
The class determines the first action (*find what broke it* / *don't touch the code* / *build it*), so getting it wrong invalidates the whole brief. **"It used to work" is decisive evidence, and the COO must ask for it** rather than expect the PO to volunteer it.

### 2. Deployment shakedown before UAT
UAT against an unverified build produces false product bugs. Twice now: BRD-NF09 (D-06) and BUG-55. Plus the durable half — **enumerate every difference between the test environment and production and treat each as an untested surface.**

### On fault
The PO offered that mislabelling UAT feedback as bugs was the cause. It was not the primary one. BUG-55's tracker note asserted *"likely the geocode/lookup path isn't wired"* from 2026-07-21 — an unverified single-probe absence claim already covered by the negative-findings rule, disproved by one grep. **The rule existed and was not applied.**

### The parity gap, now tracked
| ID | Finding |
|---|---|
| **QUAL-18** (P1) | Production is single-origin — Express serves the frontend document with helmet's CSP applied (`server.ts:233`). E2E is **two-origin**: `vite preview` serves the document on :5173 with **no CSP header at all**. Every `connect-src` violation is unobservable in CI *by construction*. The suite isn't weak; the environment cannot express the failure. |
| **QUAL-19** | Nothing asserts that origins the frontend fetches appear in the CSP allowlist. A static test would catch this in milliseconds. Also covers `useCities.ts:47` setting a `User-Agent` header on a browser `fetch()` — a forbidden header name, silently dropped. |
| **QUAL-20** | No post-deploy smoke check. Belongs in **CI**, where D-06's firewall limitation doesn't apply. |

### BUG-55 reclassified
Owner `backend` → `architect`, pulled from brief B4. Backend proxy vs. widened CSP allowlist is a SEC-01 call, so it needs an Architect pass rather than an implementation brief.

Docs + tracker only; no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)