### PR TITLE
fix: red main — TripDetail tests broke on the B7 + B8 combination

### DIFF
--- a/src/frontend/components/TripDetail/__tests__/MobileTripDetailView.test.tsx
+++ b/src/frontend/components/TripDetail/__tests__/MobileTripDetailView.test.tsx
@@ -29,10 +29,18 @@ vi.mock('../../../utils/apiClient', async (importOriginal) => {
   return { ...actual, apiPatch: vi.fn(), apiDelete: vi.fn() };
 });
 
-vi.mock('../../../hooks/useItems', () => ({
-  useTripLevelItems: () => ({ data: [], isLoading: false, error: null }),
-  useDeleteItem: () => ({ mutateAsync: vi.fn(), isPending: false, error: null }),
-}));
+// Partial mock via importOriginal — see the same mock in TripDetail.test.tsx for
+// the full rationale. This file renders PlaceSection too (MobileTripDetailView.tsx:254),
+// so it carries the identical hazard; it survives today only because no test here
+// mounts a place, which would stop being true the moment one did.
+vi.mock('../../../hooks/useItems', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../hooks/useItems')>();
+  return {
+    ...actual,
+    useTripLevelItems: () => ({ data: [], isLoading: false, error: null }),
+    useDeleteItem: () => ({ mutateAsync: vi.fn(), isPending: false, error: null }),
+  };
+});
 
 vi.mock('../../../hooks/usePlaces', () => ({
   useRemovePlace: () => ({ mutate: vi.fn(), isPending: false, error: null, reset: vi.fn() }),

--- a/src/frontend/components/TripDetail/__tests__/TripDetail.test.tsx
+++ b/src/frontend/components/TripDetail/__tests__/TripDetail.test.tsx
@@ -27,6 +27,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type { ReactNode } from 'react';
+import { MemoryRouter } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Item, TripDetail as TripDetailType, TripPlace } from '../../../types/api';
 import { apiDelete, apiPatch } from '../../../utils/apiClient';
@@ -44,10 +45,20 @@ vi.mock('../../../utils/apiClient', async (importOriginal) => {
   return { ...actual, apiPatch: vi.fn(), apiDelete: vi.fn() };
 });
 
-vi.mock('../../../hooks/useItems', () => ({
-  useTripLevelItems: () => ({ data: [], isLoading: false, error: null }),
-  useDeleteItem: () => ({ mutateAsync: vi.fn(), isPending: false, error: null }),
-}));
+// Partial mock via importOriginal, NOT a total replacement. TripDetail renders
+// PlaceSection, which consumes other exports of this module (e.g. B8's
+// DEFAULT_RATING_SORT_FILTER / applyRatingSortFilter for IT-08). A total mock
+// silently drops those, and the failure surfaces as an unrelated render crash
+// inside PlaceSection rather than as a missing mock — which is exactly how this
+// broke main: B7 and B8 were each green alone and red once merged together.
+vi.mock('../../../hooks/useItems', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../hooks/useItems')>();
+  return {
+    ...actual,
+    useTripLevelItems: () => ({ data: [], isLoading: false, error: null }),
+    useDeleteItem: () => ({ mutateAsync: vi.fn(), isPending: false, error: null }),
+  };
+});
 
 vi.mock('../../../hooks/usePlaces', () => ({
   useRemovePlace: () => ({ mutate: vi.fn(), isPending: false, error: null, reset: vi.fn() }),
@@ -136,8 +147,14 @@ function makeTrip(overrides: Partial<TripDetailType> = {}): TripDetailType {
 
 function renderTrip(trip: TripDetailType) {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  // MemoryRouter is required because TripDetail renders PlaceSection, which
+  // links each city to /cities/:id (IT-09). Router context is not optional
+  // scaffolding here — without it react-router throws on a null context and
+  // the failure reads as an unrelated destructuring error.
   const wrapper = ({ children }: { children: ReactNode }) => (
-    <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+    <MemoryRouter>
+      <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+    </MemoryRouter>
   );
   return render(<TripDetail trip={trip} />, { wrapper });
 }


### PR DESCRIPTION
**Main is red** on `a9d5689` (B7's merge) — Frontend Tests failing. Fixing immediately per CLAUDE.md; red main is never left unowned.

### This is BUG-24's shape, and worth noting
**Both PRs were 18/18 green.** B8 (#318) and B7 (#319) had no textual conflict and each was correct alone. They break only in combination — B7's CI ran against a base that predated B8. A green PR does not guarantee a green main.

### Mechanism, in the order it surfaced

1. **Total mock dropped a new export.** B7's `TripDetail.test.tsx` used a *total* `vi.mock` of `hooks/useItems`, listing only the two exports that existed when B7 branched. B8 then added `DEFAULT_RATING_SORT_FILTER`, which `PlaceSection` consumes — absent under a total mock, so `PlaceSection` threw on render.
   → switched to a **partial mock via `importOriginal`**, which inherits new exports rather than silently dropping them.

2. **Restoring the real module exposed a second layer.** With `PlaceSection` actually mounting, B8's new per-city `Link` to `/cities/:id` (IT-09) needs router context. The test rendered with only `QueryClientProvider`, so react-router threw on a null context — surfacing as an opaque *"Cannot destructure property 'basename'"*.
   → wrapped the render in **`MemoryRouter`**.

### Fixed preventively as well
`MobileTripDetailView.test.tsx` carries the **identical total-mock pattern** and renders `PlaceSection` (`MobileTripDetailView.tsx:254`). It passes today only because no test there mounts a place — it would break the moment one did. Same fix applied.

### Verification
`test:frontend` 212/212 · `test:backend` 599 passed / 1 skipped · `check` clean · `type:check:all` clean · `status:check` in sync.

Test-only change; no production code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)