### PR TITLE
test(ADL-46): ATDD red acceptance tests — access matrix, D13 find-or-create, GE-16 containment

### DIFF
--- a/jobs/COO/inbox/20260731_1950-QA-adl46-atdd-red-tests-complete.txt
+++ b/jobs/COO/inbox/20260731_1950-QA-adl46-atdd-red-tests-complete.txt
@@ -1,0 +1,75 @@
+QA COMPLETION REPORT — ADL-46 ATDD trial (RED acceptance tests)
+
+Tracker: BUG-63 / ADL-46 / open-dialogues D-17 (ATDD trial)
+GitHub PR: #<see gh pr create output below> — targets release/adl46-access-model (NOT main)
+BRD: ADL-46 §7/§8/§4.2.1/§4.4 (SE-01/SE-03/AD-09/GE-16)
+Branch: test/adl46-atdd
+
+WHAT WAS TESTED
+  Authored independent RED acceptance tests against the ADL-46 spec, before
+  the Backend stage implements it. New file
+  src/backend/routes/__tests__/adl46-access-model.test.ts, 32 assertions
+  across three groups (access matrix / D13 find-or-create / GE-16
+  containment), plus a one-line unskip of the §8.1 coverage-hole regression
+  in security.access-matrix.test.ts. No production code touched.
+
+PASS/FAIL PER GROUP (counts = new assertions; "already-green" = deliberate
+regression guards/anchors, not misses — see tech/ doc for the full table)
+  Group A (access matrix, 12): 8 red-for-the-right-reason, 4 already-green
+  Group B (D13 find-or-create, 6): 4 red-for-the-right-reason, 2 already-green
+  Group C (GE-16 containment, 6 incl. 1 bonus): 2 red-for-the-right-reason, 4 already-green
+
+  Total: 14/32 red-for-the-right-reason (clean assertion mismatches, zero
+  exceptions, zero DB errors — confirmed not blocked by the DB-stage
+  breakage). 0 blocked. Full suite baseline: 34 pre-existing DB-stage
+  failures (trips.test.ts, lock-matrix.test.ts, owner-access.test.ts,
+  qa-backend-fixes.test.ts) untouched, not mine.
+
+JUDGEMENT CALLS FLAGGED (ATDD trial ask)
+  1. Group B tests run as OWNER not non-owner — isolates D13's find-or-create
+     correctness from D4's access-model change, since POST /api/cities is
+     still requireOwner on this branch and a non-owner would fail at the
+     auth gate before reaching the logic under test. B6 is the explicit
+     non-owner exception per ADL-46 §8 row 4.
+  2. B4 (ambiguous no-region, two existing regioned rows) — ADL-46 states
+     this case has "no safe automatic answer" and defers the mechanism to
+     D14, without committing to a status code/response shape at this
+     route's contract level. Encoded only the two invariants the spec text
+     commits to (no silent pick, no duplicate) rather than presuming one.
+  3. The §8-row-6/OP-27-P2 test (non-owner POST hits another user's pending
+     row) isn't in the brief's explicit bullet list; added to Group C as a
+     labeled bonus since it sits at the find-or-create/containment seam.
+
+BUG FOUND: spec gap in ADL-46's own change inventory (severity: process, not
+a code defect)
+  owner-access.test.ts's HC-06 block (lines 168-190: "POST /api/cities → 403
+  for non-owner" / "→ 201 for owner") directly contradicts the ADL-46 D4 end
+  state, and is NOT in ADL-46 §8.2's list of what breaks in that file — §8.2
+  only credits the file's HC-04/categories block. Same file §8.2 already
+  lists, incomplete inventory of what breaks within it. Verified via the
+  same grep §8.2 itself describes running. Not fixed by me (out of scope,
+  "don't touch existing assertions" + it's genuinely Backend's edit to make
+  under §8's authority-transfer framing) — flagging so the S1 Backend brief
+  inherits a complete list and doesn't hit an unauthorised red check
+  (OP-30 precedent: an implementation agent facing a red security test its
+  brief didn't authorise it to touch). Full writeup:
+  jobs/qa/tech/20260731-adl46-atdd-red-tests.md
+
+CI
+  npm run check            → clean
+  npm run type:check:all   → 20 pre-existing errors, zero new from my changes
+  npm run test:backend     → 48 failed / 586 passed; 14 mine (by design), 34
+                              pre-existing (not mine, not fixed, per brief)
+  npm run test:frontend    → 228/228 passed, untouched
+  npm run status:check     → up to date
+  gh pr checks: red CI on this PR is expected and is the acceptance
+  criterion for the trial, not a defect — confirm via scripts/ci-wait.sh once
+  the PR is open; do not chase these red per the brief.
+
+OPEN ISSUES / BLOCKERS
+  None for this thread. For the next stage: Backend inherits this test file
+  plus the §8.2 file list PLUS the owner-access.test.ts HC-06 gap above as
+  its definition-of-done.
+
+Full detail: jobs/qa/tech/20260731-adl46-atdd-red-tests.md
+Park doc: jobs/qa/park-docs/20260731-QA-park.txt

--- a/jobs/qa/context/current.txt
+++ b/jobs/qa/context/current.txt
@@ -133,3 +133,41 @@ NEXT STEPS (for incoming QA)
   4. When all fixes verified:
        → Issue QA sign-off memo to COO
        → Request PO frontend UAT pass with script from qa-report-2026-03-20.md Part 6
+
+================================================================================
+2026-07-31 — ADL-46 ATDD TRIAL (RED ACCEPTANCE TESTS, PRE-IMPLEMENTATION)
+================================================================================
+
+  Branch: test/adl46-atdd (off origin/release/adl46-access-model — the
+  integration branch; Database stage already landed there, migrations
+  0014/0015, no route code yet).
+
+  Authored 32 new RED assertions in a new file,
+  src/backend/routes/__tests__/adl46-access-model.test.ts, encoding ADL-46's
+  end-state access matrix (§7/§8), D13 find-or-create invariants (§4.2.1),
+  and GE-16 pending/resolved city containment (§4.4) — BEFORE Backend
+  implements any of it. Also unskipped the §8.1 coverage-hole regression in
+  security.access-matrix.test.ts:457 (guard present since BUG-22, assertion
+  had silently never run).
+
+  Result: 14/32 new assertions red-for-the-right-reason (clean assertion
+  mismatches, zero exceptions); 18/32 already green (fail-closed guards +
+  vacuous-until-implemented anchors, included deliberately — must stay true
+  post-implementation). Did not touch the 34 pre-existing DB-stage failures
+  in trips.test.ts / lock-matrix.test.ts / owner-access.test.ts /
+  qa-backend-fixes.test.ts (out of scope, Backend's job).
+
+  SPEC GAP FOUND: owner-access.test.ts's HC-06 block (non-owner POST
+  /api/cities → 403) directly contradicts the ADL-46 end state and is
+  missing from ADL-46 §8.2's inventory of what breaks in that file (§8.2
+  only credits the HC-04/categories block). Flagged, not fixed — see
+  jobs/qa/tech/20260731-adl46-atdd-red-tests.md for the full writeup.
+
+  Full detail: jobs/qa/tech/20260731-adl46-atdd-red-tests.md
+  Park doc: jobs/qa/park-docs/20260731-QA-park.txt
+  PR: opened against release/adl46-access-model (NOT main) — red CI expected
+  and is the acceptance criterion, not a defect. COO merges.
+
+  NEXT: Backend stage (S1-S4) implements against this file as part of its
+  definition-of-done, including the owner-access.test.ts HC-06 gap this
+  thread surfaced.

--- a/jobs/qa/park-docs/20260731-QA-park.txt
+++ b/jobs/qa/park-docs/20260731-QA-park.txt
@@ -1,0 +1,122 @@
+QA PARK DOCUMENT — 2026-07-31
+PROJECT: Travel Tracker
+THREAD: ADL-46 ATDD trial — RED acceptance tests (access matrix, D13, GE-16)
+
+---
+
+WORK COMPLETED THIS THREAD
+
+Authored independent RED acceptance tests against the ADL-46 spec
+(jobs/architect/tech/ADL-46-non-owner-access-model.md) BEFORE the Backend
+stage implements it, per the ATDD trial (open-dialogues D-17). This is the
+executable definition-of-done the Backend brief will be built and judged
+against. Did NOT implement any production code. Did NOT make anything green
+by design — red is the correct, expected outcome of this thread.
+
+Branch: test/adl46-atdd, off origin/release/adl46-access-model (the
+integration branch the Database stage already landed on — migrations
+0014/0015, no route code yet).
+
+Full detail: jobs/qa/tech/20260731-adl46-atdd-red-tests.md
+Completion report: jobs/COO/inbox/
+
+---
+
+FILES CHANGED
+
+New:
+  src/backend/routes/__tests__/adl46-access-model.test.ts (32 new assertions,
+    Group A/B/C per the brief)
+
+Edited (one line + comment, declared):
+  src/backend/routes/__tests__/security.access-matrix.test.ts — unskipped the
+    §8.1 coverage-hole regression (PATCH /api/cities/:id → 403 for non-owner).
+    Verified safe: 63/63 pass in that file after the change.
+
+Not touched (out of scope for this pass, Backend's job per §8/§8.2):
+  owner-access.test.ts, qa-backend-fixes.test.ts, tests/contract/places.contract.test.ts
+
+---
+
+RED BASELINE (see tech/ doc for the full per-test table)
+
+My new file: 14 failed / 18 passed (32 total). Every one of the 14 failures is
+a clean assertion mismatch (wrong status/body/row-count) — zero exceptions,
+zero DB errors. All 14 are red-for-the-right-reason, none blocked by the
+DB-stage breakage (my fixtures set userId explicitly on every
+trip_categories/activities insert).
+
+Pre-existing DB-stage breakage, confirmed NOT mine: 34 failures across
+trips.test.ts, lock-matrix.test.ts, owner-access.test.ts,
+qa-backend-fixes.test.ts — all NOT NULL constraint failures on
+trip_categories.user_id / activities.user_id, or downstream type errors from
+the same cause. Left untouched per the brief ("do not try to fix them").
+
+Some of my new assertions are already green today (fail-closed regression
+guards, the §8.1 unskip, and a few containment/find-or-create anchors that
+are vacuously true because the relevant mechanism doesn't exist yet at all).
+Each is commented in the test file and tabulated in the tech/ doc — included
+deliberately, not mistakenly, because they must STAY true after Backend
+implements this.
+
+---
+
+JUDGEMENT CALLS FLAGGED (see tech/ doc §"Judgement calls" for full reasoning)
+
+1. Group B (D13 find-or-create) tests run as OWNER, not non-owner, to isolate
+   D13's correctness from D4's access-model change — POST /api/cities is
+   still requireOwner on this branch, so a non-owner caller would fail at the
+   auth gate before ever reaching the find-or-create logic.
+2. B4 (ambiguous no-region case) — ADL-46 explicitly declines to specify a
+   status code/response shape for this case, deferring the mechanism to D14.
+   Encoded only the two invariants the spec's text commits to (no silent
+   pick, no duplicate) rather than presuming one.
+3. The §8-row-6/OP-27-P2 cross-user-pending-city test isn't in the brief's
+   explicit bullet list; added as a labeled "bonus" in Group C since it sits
+   at the seam between find-or-create and containment.
+
+---
+
+SPEC GAP FOUND (trial success condition)
+
+owner-access.test.ts's HC-06 block (lines 168-190, "POST /api/cities → 403
+for non-owner" / "→ 201 for owner") directly contradicts the ADL-46 end state
+and is NOT among the breaking assertions ADL-46 §8.2 credits to that file —
+§8.2 only names that file's HC-04 (categories) block as breaking. Same route,
+same scenario §8 row 3 already names as changing 403→201, in a file §8.2
+already lists — just an incomplete inventory of what breaks within it. Full
+writeup with the verification grep in tech/20260731-adl46-atdd-red-tests.md.
+Not fixed by me (out of scope, "don't touch existing assertions") — flagged
+so the Backend brief for S1 inherits a complete list rather than an
+incomplete one and doesn't hit an unauthorised red check (OP-30 precedent).
+
+---
+
+CI / VERIFICATION
+
+npm run check            → clean (biome --write applied to my new file once)
+npm run type:check:all   → 20 pre-existing errors, zero new from my changes
+npm run test:backend     → 48 failed / 586 passed; 14 of the 48 are mine (red
+                            by design), 34 pre-existing (not mine)
+npm run test:frontend    → 228 passed (228), untouched
+npm run status:check     → STATUS.md up to date
+
+PR opened against release/adl46-access-model (not main). CI on that PR is
+expected to be red — this is the acceptance criterion for the trial, not a
+defect. Did not merge (COO's job).
+
+---
+
+NEXT STEPS FOR WHOEVER PICKS THIS UP
+
+1. Backend stage (S1-S4 per ADL-46 §9) implements against this test file as
+   part of its definition-of-done, alongside the §8/§8.2 edits to the four
+   existing files (now five, including owner-access.test.ts's HC-06 block —
+   see spec gap above).
+2. Once Backend lands, re-run adl46-access-model.test.ts — every assertion
+   should go green, including the ones flagged "already green" here (they
+   must stay green, i.e. become genuine regression guards rather than
+   vacuous passes).
+3. The B4 ambiguous-no-region assertion may need tightening once Backend
+   picks a concrete mechanism (see judgement call #2) — loosen or tighten to
+   match rather than leaving it permissively worded forever.

--- a/jobs/qa/tech/20260731-adl46-atdd-red-tests.md
+++ b/jobs/qa/tech/20260731-adl46-atdd-red-tests.md
@@ -1,0 +1,176 @@
+# ADL-46 ATDD trial — RED acceptance tests (2026-07-31)
+
+**Tracker:** BUG-63 / ADL-46 / open-dialogues D-17 (ATDD trial)
+**Branch:** `test/adl46-atdd` (off `release/adl46-access-model`)
+**PR:** targets `release/adl46-access-model`, NOT main
+**Spec:** `jobs/architect/tech/ADL-46-non-owner-access-model.md` §7, §8, §8.1, §8.2, §4.2.1, §4.4
+
+## What this is
+
+Independent RED acceptance tests written against the ADL-46 spec before the Backend
+stage implements it. Not a bug report — the integration branch is DB-stage-only so
+far (migrations 0014/0015 landed, no route code). Red is the correct, expected
+outcome, both from the pre-existing DB-stage breakage and from these new tests.
+
+## New file
+
+`src/backend/routes/__tests__/adl46-access-model.test.ts` — 32 new assertions across
+three describe blocks (Group A/B/C), following the house style (mocked `getDb`,
+`requireAuth`, `resolveCity`, shading service) of `security.access-matrix.test.ts`.
+
+## Edit to an existing file
+
+`src/backend/routes/__tests__/security.access-matrix.test.ts:457` — removed
+`.skip` from `PATCH /api/cities/1 → 403 (BUG-22...)` per ADL-46 §8.1, which names
+this as a live coverage hole (guard present since BUG-22 merged, assertion never
+ran). Reworded the surrounding comment to explain why. One-line source edit,
+declared here per CLAUDE.md's "source code — full-file rewrite must be declared"
+rule (this isn't a full-file rewrite, but flagging the edit for the same reason:
+transparency on any change to an existing security test). Verified this test now
+passes (63/63 in the file, no regressions) — the guard genuinely is present today.
+
+## Red baseline, by group
+
+Ran three times: (1) the new file alone, (2) alongside `security.access-matrix.test.ts`
++ `owner-access.test.ts`, (3) the full `npm run test:backend` suite, to separate my
+red from the DB-stage's pre-existing red.
+
+**Full-suite baseline (before my change):** 34 pre-existing failures across
+`trips.test.ts` (6), `lock-matrix.test.ts` (21), `owner-access.test.ts` (1),
+`qa-backend-fixes.test.ts` (6) — all `NOT NULL constraint failed: trip_categories.user_id`
+/ `activities.user_id` or downstream type errors, i.e. exactly the DB-stage
+breakage the brief described. None of these are mine; I did not touch them.
+
+**My new file — 14 failed / 18 passed (32 total). Every failure is a clean assertion
+mismatch (wrong status code, wrong body field, wrong row count) — zero exceptions,
+zero DB errors, zero unhandled rejections.** All 14 are red-for-the-right-reason.
+None are blocked by the DB-stage breakage — my fixtures seed `userId` explicitly on
+every `trip_categories`/`activities` insert, sidestepping the NOT NULL issue that
+blocks the pre-existing suites.
+
+### Group A — access matrix (12 assertions, 8 red / 4 already-passing-as-designed)
+| Test | Result | Why |
+|---|---|---|
+| GET /api/categories → 200 own list | RED (404) | route doesn't exist yet (S3) |
+| GET /api/activities → 200 own list | RED (404) | route doesn't exist yet (S3) |
+| category isolation A absent from B | RED (404) | same |
+| activity isolation A absent from B | RED (404) | same |
+| POST /api/trips cross-user category_id → 400 | RED (got 201) | `replaceAssociations` validates only companions today |
+| PATCH /api/trips/:id cross-user category_id → 400 | RED (got 200) | same |
+| place-level activity cross-user → 400 (F1c) | RED (got 201) | `places.ts` POST has no ownership check on `activity_id` at all |
+| POST /api/cities non-owner → 201 | RED (got 403) | `requireOwner` still gates the route (D4/S1 not landed) |
+| 8× fail-closed admin/country 403 rows | GREEN (already) | `requireOwner` untouched by the DB stage — regression guard, must stay green |
+| §8.1 unskip (PATCH cities non-owner → 403) | GREEN (already) | guard present since BUG-22; the point was it wasn't running |
+| GET /api/categories → 401 | GREEN (already) | global `requireAuth` fires before routing regardless of route existence |
+| GET /api/activities → 401 | GREEN (already) | same |
+
+### Group B — D13 find-or-create (6 assertions, 4 red / 2 already-passing-as-designed)
+Run as **owner** (judgement call, see report) except B6 which is explicitly a
+non-owner case per ADL-46 §8 row 4.
+| Test | Result | Why |
+|---|---|---|
+| B1 exact match, row count unchanged | GREEN (already) | today's 2-column lookup happens to still work when there's exactly one row |
+| B2 wildcard upgrade (adopt region) | RED (`region_id` stayed null) | today's code explicitly never overwrites region_id on a find |
+| B3 same name, different region both allowed | RED (got 200, same row) | today's lookup ignores region entirely — collapses Springfield IL/MO into one row |
+| B4 ambiguous no-region, 2 existing rows | RED (silently returned the IL row) | no disambiguation logic exists |
+| B5 exactly-one-match, no region → return it | GREEN (already) | no-regression anchor, holds under both old and new lookup |
+| B6 non-owner different casing → 200 | RED (got 403) | D4 access gate not open yet |
+
+### Group C — containment / GE-16 (5 base + 1 bonus, 2 red / 3 already-passing-as-designed + 1 red)
+| Test | Result | Why |
+|---|---|---|
+| C1 pending visible to creator, not to other | RED (visible to both) | no containment clause exists in `GET /api/cities` yet |
+| C2 resolved visible to all | GREEN (already) | vacuously true — no containment exists to hide it |
+| C3 NULL-creator pending visible to all (F3) | GREEN (already) | vacuously true today; becomes a REAL regression guard once containment lands — this is the exact defect OP-27's review caught in the ADL's first draft |
+| C4 GET /:id carries no containment | GREEN (already) | vacuously true; must stay true — explicit "do not add containment here" guard |
+| bonus: B's POST hits A's pending row, no dup | RED (got 403) | POST still owner-gated (D4 not landed) |
+
+## Judgement calls flagged (ATDD trial success condition)
+
+1. **Group B caller identity (owner, not non-owner).** POST /api/cities is still
+   `requireOwner` on this branch. Testing D13's find-or-create logic as a
+   non-owner would fail every case at the auth gate before reaching the logic
+   under test, conflating D13's correctness with D4's access-model change into
+   one failure mode. I ran Group B as owner (who already has access today) to
+   isolate the two concerns — each red failure maps to exactly one causal gap.
+   D13's own text never depends on caller identity. The exception is B6, which
+   ADL-46 §8 explicitly lists as a non-owner case (row 4) and is written as such.
+
+2. **B4's assertion shape (ambiguous no-region case).** ADL-46 §4.2.1 states
+   plainly that this case has "no safe automatic answer" and is "a disambiguation
+   prompt, not a guess," explicitly deferring the mechanism to D14 (§4.3.2),
+   which is itself a frontend-facing candidate-list flow, not a route-level
+   contract. The spec does not commit to a status code or response shape for
+   `POST /api/cities` in this case. I encoded only the two invariants the text
+   does commit to — no silent pick of an existing row, no duplication of either
+   existing row — rather than presuming a specific status code (409? a new
+   `pending` row? something else?). Flagging this because a Backend implementer
+   reading only §4.2.1 has the same gap I did.
+
+3. **Where to place the §8-row-6 / OP-27-P2 test.** Not explicitly named in the
+   brief's Group A/B/C bullet lists, but ADL-46 §8 calls it out by name as
+   "nowhere stated" before the ADL, and it sits exactly at the seam between
+   Group B (find-or-create) and Group C (containment) — it is find-or-create's
+   pass-1 lookup deliberately staying creator-unscoped so a pending row can be
+   picked back up by its own future POSTs (and, per OP-27 P2, by a second
+   user's POST too). Added it to Group C as a labeled "bonus" rather than
+   silently folding it into an existing test, so its provenance is traceable.
+
+## A genuine spec gap I found (the trial's explicit success condition)
+
+**`owner-access.test.ts`'s HC-06 block (lines 168-190) directly contradicts the
+ADL-46 end state and is not in §8.2's enumerated "four files that break."**
+
+§8.2 lists `owner-access.test.ts` as one of the three files (besides
+`security.access-matrix.test.ts`) that break at S3, and gives its breaking line
+numbers as `:129,137` (non-owner 403) and `:147,155` (owner 200/201) — both in
+the **HC-04 categories block**. But the same file's **HC-06 block**, a few lines
+below, independently asserts:
+
+```
+it('POST /api/cities → 403 for non-owner', ...)   // owner-access.test.ts:169
+it('POST /api/cities → 201 for owner', ...)        // owner-access.test.ts:180
+```
+
+This is the exact same route/scenario §8 row 3 of the main table names as
+changing from `403` to `201` for a non-owner (D4/S1) — but §8.2's "grep -rln
+for the route strings ... returns exactly these four files" inventory only
+credits this file's *categories* assertions as breaking, not its *cities*
+assertions. Verified independently: I ran the grep ADL-46 §8.2 describes
+(`grep -rln` for `/api/cities` across `src/` and `tests/`) and it does surface
+this file — the omission is in what the ADL says will break within the file it
+already lists, not a missed file.
+
+Practical consequence: when the Backend brief opens `POST /api/cities` to
+non-owners (S1), this existing, currently-passing assertion
+(`owner-access.test.ts:169`, "non-owner → 403") will start failing — and
+nothing in ADL-46's own change inventory told the implementer to expect or
+authorise that. Under OP-30's precedent (an implementation agent should not
+face a red security-relevant check its brief didn't authorise it to touch), the
+Backend brief for S1 should explicitly list `owner-access.test.ts:168-178` (the
+non-owner-403 half of HC-06) as a fourth thing that changes, alongside HC-04.
+I have not touched this test myself — out of scope for this ATDD pass, and it's
+one of the "must not weaken/delete existing assertions" files — but flagging it
+now, before Backend inherits an incomplete inventory.
+
+## Verification run
+
+```
+npx vitest run src/backend/routes/__tests__/adl46-access-model.test.ts
+  → 14 failed | 18 passed (32)  — zero exceptions, all clean assertion mismatches
+
+npx vitest run src/backend/routes/__tests__/security.access-matrix.test.ts
+  → 63 passed (63)  — unskip verified safe, no regressions
+
+npm run test:backend (full suite)
+  → 5 files failed | 25 passed (30); 48 failed | 586 passed (634)
+  → failures: trips.test.ts, lock-matrix.test.ts, owner-access.test.ts,
+    qa-backend-fixes.test.ts (all pre-existing DB-stage breakage, untouched)
+    + adl46-access-model.test.ts (mine, 14/32, all red-for-the-right-reason)
+
+npm run check            → clean (1 formatting nit in my new file, biome --write applied)
+npm run type:check:all   → 20 pre-existing errors, all in files I did not touch;
+                            zero new errors from my file or my one-line edit
+npm run test:frontend    → 228 passed (228), untouched
+npm run status:check     → STATUS.md up to date
+```

--- a/src/backend/routes/__tests__/adl46-access-model.test.ts
+++ b/src/backend/routes/__tests__/adl46-access-model.test.ts
@@ -1,0 +1,712 @@
+/**
+ * ADL-46 — Per-user access model: ATDD acceptance tests (QA, pre-implementation)
+ *
+ * Source of truth: jobs/architect/tech/ADL-46-non-owner-access-model.md
+ *   §7   — revised access matrix
+ *   §8   — security.access-matrix.test.ts assertions that must change (S1-S3)
+ *   §8.1 — stale skip / coverage-hole regression (PATCH /api/cities/:id → 403)
+ *   §8.2 — the other three files that break at S3 (not edited here — Backend's job)
+ *   §4.2.1 (D13) — find-or-create three-step lookup, wildcard upgrade, ambiguity
+ *   §4.4 (D5/GE-16) — pending vs resolved city containment
+ *
+ * THIS FILE IS DELIBERATELY RED. It is written BEFORE the Backend stage (S1-S4)
+ * lands on this integration branch, and encodes the END-STATE behaviour ADL-46
+ * specifies. Red here is the correct, expected outcome — these are the executable
+ * definition-of-done the Backend brief is built against, not a report of a bug in
+ * today's code.
+ *
+ * A handful of assertions below are edge/regression guards that are ALREADY GREEN
+ * today (e.g. GET /api/cities/:id already carries no containment because no
+ * containment exists yet at all). Each such case is commented at the point of the
+ * assertion — they are included deliberately because they must STAY true after
+ * Backend implements this, not because they are red now.
+ *
+ * Caller-identity note (judgement call — see QA completion report): Group B (D13)
+ * tests run as the OWNER, not a non-owner. POST /api/cities is still requireOwner
+ * on this branch (D4/S1 has not landed), so a non-owner caller would fail at the
+ * auth gate before ever reaching the find-or-create logic under test, conflating
+ * D13's correctness with D4's access-model change. Running Group B as owner
+ * isolates the two concerns; D13's own text is caller-identity-agnostic. The one
+ * exception is B6, which is explicitly listed in ADL-46 §8 row 4 as a non-owner
+ * case and is written as such on purpose.
+ */
+
+import { and, eq } from 'drizzle-orm';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as schema from '../../db/schema.js';
+import { createTestDb, type TestDb } from '../../repositories/__tests__/test-db.js';
+
+// ----------------------------------------------------------------
+// Test user constants
+// ----------------------------------------------------------------
+
+const USER_A_ID = 'user-a-00000000-0000-0000-0000-000000000000'; // owner, isOwner=1
+const USER_B_ID = 'user-b-00000000-0000-0000-0000-000000000000'; // non-owner, isOwner=0
+
+// ----------------------------------------------------------------
+// Module-level mock control variables
+// ----------------------------------------------------------------
+
+let testDb: TestDb | null = null;
+let mockIsOwner = 1;
+let mockUserId = USER_A_ID;
+let mockAuthEnabled = true;
+
+// ----------------------------------------------------------------
+// Module mocks — must be declared before any imports that use them
+// ----------------------------------------------------------------
+
+vi.mock('../../db/index.js', async (importOriginal) => {
+  const real = await importOriginal<typeof import('../../db/index.js')>();
+  return {
+    ...real,
+    getDb: () => {
+      if (!testDb) throw new Error('[TEST] testDb not initialised');
+      return testDb;
+    },
+  };
+});
+
+vi.mock('../../middleware/auth.js', () => ({
+  requireAuth: (
+    req: import('express').Request,
+    res: import('express').Response,
+    next: import('express').NextFunction,
+  ) => {
+    if (!mockAuthEnabled) {
+      res.status(401).json({ error: 'Unauthorized' });
+      return;
+    }
+    (req as import('express').Request & { user?: unknown }).user = {
+      id: mockUserId,
+      clerkId: mockUserId === USER_A_ID ? 'clerk_user_a' : 'clerk_user_b',
+      email: mockUserId === USER_A_ID ? 'usera@example.com' : 'userb@example.com',
+      isOwner: mockIsOwner,
+    };
+    next();
+  },
+}));
+
+// resolveCity is a no-op in this suite — none of these tests depend on the
+// geocoder actually resolving anything (that is S2's proxy work), only on the
+// find-or-create / containment logic around it.
+vi.mock('../../services/geocoding.service.js', () => ({
+  resolveCity: async () => undefined,
+}));
+
+vi.mock('../../services/shading.service.js', () => ({
+  getAllCountryShading: async () => [],
+  getCountryShading: async () => null,
+  getRegionShading: async () => [],
+  invalidateConfigCache: () => undefined,
+}));
+
+const { default: app } = await import('../../server-test-app.js');
+const supertest = (await import('supertest')).default;
+
+// ----------------------------------------------------------------
+// Seed helpers
+// ----------------------------------------------------------------
+
+async function seedUser(
+  db: TestDb,
+  userId: string,
+  clerkId: string,
+  email: string,
+  isOwner: number,
+) {
+  const now = Date.now();
+  await db
+    .insert(schema.users)
+    .values({
+      id: userId,
+      clerkId,
+      email,
+      isOwner,
+      createdAt: new Date(now),
+      updatedAt: new Date(now),
+    })
+    .onConflictDoNothing();
+}
+
+async function seedCountry(
+  db: TestDb,
+  countryCode = 'US',
+  name = 'United States',
+  regionTierEnabled = 0,
+) {
+  await db
+    .insert(schema.countries)
+    .values({ countryCode, name, regionTierEnabled })
+    .onConflictDoNothing();
+}
+
+async function seedRegion(db: TestDb, countryCode: string, name: string, iso: string) {
+  const inserted = await db
+    .insert(schema.regions)
+    .values({ countryCode, name, iso3166_2: iso })
+    .returning({ id: schema.regions.id });
+  return inserted[0].id;
+}
+
+async function seedTrip(db: TestDb, userId: string): Promise<number> {
+  const now = new Date().toISOString();
+  const inserted = await db
+    .insert(schema.trips)
+    .values({
+      name: 'Test Trip',
+      startDate: '2026-01-01',
+      endDate: '2026-01-10',
+      status: 'planning',
+      userId,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .returning({ id: schema.trips.id });
+  return inserted[0].id;
+}
+
+async function seedCity(
+  db: TestDb,
+  overrides: Partial<typeof schema.cities.$inferInsert> & { countryCode: string; name: string },
+) {
+  const inserted = await db.insert(schema.cities).values(overrides).returning();
+  return inserted[0];
+}
+
+async function seedPlace(db: TestDb, tripId: number, cityId: number, userId: string) {
+  const inserted = await db
+    .insert(schema.tripPlaces)
+    .values({ tripId, cityId, userId })
+    .returning({ id: schema.tripPlaces.id });
+  return inserted[0].id;
+}
+
+async function seedCategory(db: TestDb, userId: string, name: string) {
+  const inserted = await db
+    .insert(schema.tripCategories)
+    .values({ userId, name })
+    .returning({ id: schema.tripCategories.id });
+  return inserted[0].id;
+}
+
+async function seedActivity(db: TestDb, userId: string, name: string) {
+  const inserted = await db
+    .insert(schema.activities)
+    .values({ userId, name })
+    .returning({ id: schema.activities.id });
+  return inserted[0].id;
+}
+
+async function cityCountByNameCountry(db: TestDb, name: string, countryCode: string) {
+  const rows = await db
+    .select({ id: schema.cities.id })
+    .from(schema.cities)
+    .where(and(eq(schema.cities.countryCode, countryCode), eq(schema.cities.name, name)));
+  return rows.length;
+}
+
+// ----------------------------------------------------------------
+// Setup / teardown
+// ----------------------------------------------------------------
+
+beforeEach(async () => {
+  testDb = await createTestDb();
+  mockAuthEnabled = true;
+  mockIsOwner = 1;
+  mockUserId = USER_A_ID;
+});
+
+afterEach(() => {
+  testDb = null;
+  mockAuthEnabled = true;
+  mockIsOwner = 1;
+  mockUserId = USER_A_ID;
+});
+
+// ================================================================
+// GROUP A — Access matrix (ADL-46 §7 / §8 end-state, S1+S3)
+// ================================================================
+
+describe('ADL-46 Group A — access matrix', () => {
+  describe('Per-user category/activity routes (S3) — GET /api/categories, /api/activities', () => {
+    it("GET /api/categories → 200 with the caller's own list", async () => {
+      await seedUser(testDb!, USER_A_ID, 'clerk_user_a', 'usera@example.com', 1);
+      await seedCategory(testDb!, USER_A_ID, 'Ski Trip');
+
+      const res = await supertest(app).get('/api/categories');
+      expect(res.status).toBe(200);
+      expect(Array.isArray(res.body)).toBe(true);
+      expect(res.body).toEqual(
+        expect.arrayContaining([expect.objectContaining({ name: 'Ski Trip' })]),
+      );
+    });
+
+    it("GET /api/activities → 200 with the caller's own list", async () => {
+      await seedUser(testDb!, USER_A_ID, 'clerk_user_a', 'usera@example.com', 1);
+      await seedActivity(testDb!, USER_A_ID, 'Skiing');
+
+      const res = await supertest(app).get('/api/activities');
+      expect(res.status).toBe(200);
+      expect(Array.isArray(res.body)).toBe(true);
+      expect(res.body).toEqual(
+        expect.arrayContaining([expect.objectContaining({ name: 'Skiing' })]),
+      );
+    });
+
+    it("per-user isolation (AD-09): user A's custom category is absent from user B's list", async () => {
+      await seedUser(testDb!, USER_A_ID, 'clerk_user_a', 'usera@example.com', 1);
+      await seedUser(testDb!, USER_B_ID, 'clerk_user_b', 'userb@example.com', 0);
+      await seedCategory(testDb!, USER_A_ID, 'Owner-Only Category');
+
+      mockIsOwner = 0;
+      mockUserId = USER_B_ID;
+      const res = await supertest(app).get('/api/categories');
+      expect(res.status).toBe(200);
+      expect(res.body).not.toEqual(
+        expect.arrayContaining([expect.objectContaining({ name: 'Owner-Only Category' })]),
+      );
+    });
+
+    it("per-user isolation (AD-09): user A's custom activity is absent from user B's list", async () => {
+      await seedUser(testDb!, USER_A_ID, 'clerk_user_a', 'usera@example.com', 1);
+      await seedUser(testDb!, USER_B_ID, 'clerk_user_b', 'userb@example.com', 0);
+      await seedActivity(testDb!, USER_A_ID, 'Owner-Only Activity');
+
+      mockIsOwner = 0;
+      mockUserId = USER_B_ID;
+      const res = await supertest(app).get('/api/activities');
+      expect(res.status).toBe(200);
+      expect(res.body).not.toEqual(
+        expect.arrayContaining([expect.objectContaining({ name: 'Owner-Only Activity' })]),
+      );
+    });
+  });
+
+  describe('Cross-user association writes are rejected (ADL-46 §3.3 / F1)', () => {
+    it("POST /api/trips with another user's category_id → 400", async () => {
+      await seedUser(testDb!, USER_A_ID, 'clerk_user_a', 'usera@example.com', 1);
+      await seedUser(testDb!, USER_B_ID, 'clerk_user_b', 'userb@example.com', 0);
+      const categoryAId = await seedCategory(testDb!, USER_A_ID, "A's Category");
+
+      mockIsOwner = 0;
+      mockUserId = USER_B_ID;
+      const res = await supertest(app)
+        .post('/api/trips')
+        .send({
+          name: 'B Trip',
+          start_date: '2026-02-01',
+          end_date: '2026-02-05',
+          category_ids: [categoryAId],
+        });
+      expect(res.status).toBe(400);
+    });
+
+    it("PATCH /api/trips/:id with another user's category_id → 400", async () => {
+      await seedUser(testDb!, USER_A_ID, 'clerk_user_a', 'usera@example.com', 1);
+      await seedUser(testDb!, USER_B_ID, 'clerk_user_b', 'userb@example.com', 0);
+      const categoryAId = await seedCategory(testDb!, USER_A_ID, "A's Category");
+      const tripBId = await seedTrip(testDb!, USER_B_ID);
+
+      mockIsOwner = 0;
+      mockUserId = USER_B_ID;
+      const res = await supertest(app)
+        .patch(`/api/trips/${tripBId}`)
+        .send({ category_ids: [categoryAId] });
+      expect(res.status).toBe(400);
+    });
+
+    // F1(c) — the place-level write path. ADL-46 §3.3 names this as the half of
+    // F1 that survives the disposable-data constraint: replaceAssociations gets
+    // ownership validation for trip-level category/activity ids, but the
+    // place-level activities route (places.ts POST /:placeId/activities) has no
+    // equivalent check at all today. Without this assertion nothing in CI
+    // catches that hole.
+    it("POST /api/trips/:t/places/:p/activities with another user's activity_id → 400", async () => {
+      await seedUser(testDb!, USER_A_ID, 'clerk_user_a', 'usera@example.com', 1);
+      await seedUser(testDb!, USER_B_ID, 'clerk_user_b', 'userb@example.com', 0);
+      await seedCountry(testDb!, 'US', 'United States', 0);
+      const activityAId = await seedActivity(testDb!, USER_A_ID, "A's Activity");
+      const tripBId = await seedTrip(testDb!, USER_B_ID);
+      const city = await seedCity(testDb!, { countryCode: 'US', name: 'Testville' });
+      const placeId = await seedPlace(testDb!, tripBId, city.id, USER_B_ID);
+
+      mockIsOwner = 0;
+      mockUserId = USER_B_ID;
+      const res = await supertest(app)
+        .post(`/api/trips/${tripBId}/places/${placeId}/activities`)
+        .send({ activity_id: activityAId });
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe('City creation opens to non-owner (D4)', () => {
+    it('POST /api/cities as a non-owner → 201 for a genuinely new city', async () => {
+      await seedUser(testDb!, USER_B_ID, 'clerk_user_b', 'userb@example.com', 0);
+      await seedCountry(testDb!, 'US', 'United States', 0);
+
+      mockIsOwner = 0;
+      mockUserId = USER_B_ID;
+      const res = await supertest(app)
+        .post('/api/cities')
+        .send({ name: 'Non-Owner City', country_code: 'US' });
+      expect(res.status).toBe(201);
+      expect(res.body).toMatchObject({ name: 'Non-Owner City', country_code: 'US' });
+    });
+  });
+
+  // ==============================================================
+  // Fail-closed regression guard — these rows must stay 403 through this whole
+  // release. ADL-46 §8: "a careless 'open the admin router' fix" is exactly the
+  // failure this section exists to catch. All of these are ALREADY GREEN today
+  // (requireOwner still gates the admin router) and MUST remain green after S3 —
+  // adminRouter.use(requireOwner) is router-level middleware, so a non-owner
+  // still hits it even once the categories/activities sub-router mounts are
+  // removed (ADL-46 §8.2 "verified counterpoint"). Included here as an explicit
+  // acceptance criterion, not because it is expected to go red.
+  // ==============================================================
+  describe('Fail-closed: admin CRUD and country/region writes stay 403 for non-owner', () => {
+    beforeEach(async () => {
+      mockIsOwner = 0;
+      mockUserId = USER_B_ID;
+      await seedUser(testDb!, USER_B_ID, 'clerk_user_b', 'userb@example.com', 0);
+      await seedCountry(testDb!, 'US', 'United States', 0);
+    });
+
+    it('GET /api/admin/categories → 403', async () => {
+      const res = await supertest(app).get('/api/admin/categories');
+      expect(res.status).toBe(403);
+    });
+    it('POST /api/admin/categories → 403', async () => {
+      const res = await supertest(app).post('/api/admin/categories').send({ name: 'X' });
+      expect(res.status).toBe(403);
+    });
+    it('PATCH /api/admin/categories/1 → 403', async () => {
+      const res = await supertest(app).patch('/api/admin/categories/1').send({ name: 'X' });
+      expect(res.status).toBe(403);
+    });
+    it('DELETE /api/admin/categories/1 → 403', async () => {
+      const res = await supertest(app).delete('/api/admin/categories/1');
+      expect(res.status).toBe(403);
+    });
+    it('GET /api/admin/activities → 403', async () => {
+      const res = await supertest(app).get('/api/admin/activities');
+      expect(res.status).toBe(403);
+    });
+    it('POST /api/admin/activities → 403', async () => {
+      const res = await supertest(app).post('/api/admin/activities').send({ name: 'X' });
+      expect(res.status).toBe(403);
+    });
+    it('PATCH /api/admin/activities/1 → 403', async () => {
+      const res = await supertest(app).patch('/api/admin/activities/1').send({ name: 'X' });
+      expect(res.status).toBe(403);
+    });
+    it('DELETE /api/admin/activities/1 → 403', async () => {
+      const res = await supertest(app).delete('/api/admin/activities/1');
+      expect(res.status).toBe(403);
+    });
+    it('PATCH /api/admin/countries/US → 403 (city curation stays owner-only)', async () => {
+      const res = await supertest(app).patch('/api/admin/countries/US').send({});
+      expect(res.status).toBe(403);
+    });
+    it('POST /api/admin/countries/US/regions → 403', async () => {
+      const res = await supertest(app).post('/api/admin/countries/US/regions').send({});
+      expect(res.status).toBe(403);
+    });
+  });
+
+  // ==============================================================
+  // §8.1 — coverage-hole regression: PATCH /api/cities/:id → 403 for a non-owner.
+  // Corresponding skip in security.access-matrix.test.ts:457 is removed as part
+  // of this same PR (declared in the QA completion report). ALREADY GREEN today
+  // (BUG-22's requireOwner guard is present and unrelated to this integration
+  // branch's DB-stage changes) — the point of this test is that it was silently
+  // NOT RUNNING, not that the behaviour is missing. City curation staying
+  // owner-only is the premise D4 relies on to make city CREATION safe to open.
+  // ==============================================================
+  it('§8.1: PATCH /api/cities/1 → 403 for a non-owner (city curation stays owner-only)', async () => {
+    await seedUser(testDb!, USER_B_ID, 'clerk_user_b', 'userb@example.com', 0);
+    mockIsOwner = 0;
+    mockUserId = USER_B_ID;
+    const res = await supertest(app).patch('/api/cities/1').send({ region_id: null });
+    expect(res.status).toBe(403);
+    expect(res.body).toMatchObject({ error: 'Forbidden' });
+  });
+
+  describe('Part A parity — 401 unauthenticated on the newly-opened routes', () => {
+    beforeEach(() => {
+      mockAuthEnabled = false;
+    });
+
+    it('GET /api/categories → 401', async () => {
+      const res = await supertest(app).get('/api/categories');
+      expect(res.status).toBe(401);
+    });
+
+    it('GET /api/activities → 401', async () => {
+      const res = await supertest(app).get('/api/activities');
+      expect(res.status).toBe(401);
+    });
+    // POST /api/cities → 401 is already covered by the existing Part A suite
+    // (security.access-matrix.test.ts:223) and is intentionally not duplicated.
+  });
+});
+
+// ================================================================
+// GROUP B — D13 find-or-create invariants (ADL-46 §4.2.1)
+// ================================================================
+
+describe('ADL-46 Group B — D13 find-or-create invariants (POST /api/cities)', () => {
+  beforeEach(async () => {
+    // Owner caller throughout (except B6) — see file header for why.
+    mockIsOwner = 1;
+    mockUserId = USER_A_ID;
+    await seedUser(testDb!, USER_A_ID, 'clerk_user_a', 'usera@example.com', 1);
+    // Region-tier country with three US-style regions for the Denver/Springfield
+    // examples ADL-46 §4.2.1 itself uses.
+    await seedCountry(testDb!, 'US', 'United States', 1);
+  });
+
+  it('B1 — exact match: repeating (name, country, region) returns the existing row (200), row count unchanged', async () => {
+    const coId = await seedRegion(testDb!, 'US', 'Colorado', 'US-CO');
+
+    const first = await supertest(app)
+      .post('/api/cities')
+      .send({ name: 'Denver', country_code: 'US', region_id: coId });
+    expect(first.status).toBe(201);
+
+    const second = await supertest(app)
+      .post('/api/cities')
+      .send({ name: 'Denver', country_code: 'US', region_id: coId });
+    expect(second.status).toBe(200);
+    expect(second.body.id).toBe(first.body.id);
+
+    expect(await cityCountByNameCountry(testDb!, 'Denver', 'US')).toBe(1);
+  });
+
+  it('B2 — wildcard upgrade: a region-less existing row is ADOPTED (region set), not duplicated', async () => {
+    const coId = await seedRegion(testDb!, 'US', 'Colorado', 'US-CO');
+    // Pre-existing region-less Denver, as if it predates regions being resolved.
+    const existing = await seedCity(testDb!, { countryCode: 'US', name: 'Denver', regionId: null });
+
+    const res = await supertest(app)
+      .post('/api/cities')
+      .send({ name: 'Denver', country_code: 'US', region_id: coId });
+
+    // D13 step 2: adopt the existing row — same id, region_id now set to the
+    // request's region. Current code returns the existing row unchanged
+    // (region_id still null) because it deliberately never overwrites region_id
+    // on a find — that "deliberate" behaviour is exactly what D13 changes.
+    expect(res.status).toBe(200);
+    expect(res.body.id).toBe(existing.id);
+    expect(res.body.region_id).toBe(coId);
+
+    expect(await cityCountByNameCountry(testDb!, 'Denver', 'US')).toBe(1);
+  });
+
+  it('B3 — same name, different region are both allowed (Springfield IL vs MO)', async () => {
+    const ilId = await seedRegion(testDb!, 'US', 'Illinois', 'US-IL');
+    const moId = await seedRegion(testDb!, 'US', 'Missouri', 'US-MO');
+
+    const first = await supertest(app)
+      .post('/api/cities')
+      .send({ name: 'Springfield', country_code: 'US', region_id: ilId });
+    expect(first.status).toBe(201);
+
+    const second = await supertest(app)
+      .post('/api/cities')
+      .send({ name: 'Springfield', country_code: 'US', region_id: moId });
+    expect(second.status).toBe(201);
+    expect(second.body.id).not.toBe(first.body.id);
+
+    expect(await cityCountByNameCountry(testDb!, 'Springfield', 'US')).toBe(2);
+  });
+
+  it('B4 — ambiguous no-region request does not silently pick one of two existing regioned rows, and does not duplicate either', async () => {
+    const ilId = await seedRegion(testDb!, 'US', 'Illinois', 'US-IL');
+    const moId = await seedRegion(testDb!, 'US', 'Missouri', 'US-MO');
+    const il = await seedCity(testDb!, { countryCode: 'US', name: 'Springfield', regionId: ilId });
+    const mo = await seedCity(testDb!, { countryCode: 'US', name: 'Springfield', regionId: moId });
+
+    const res = await supertest(app)
+      .post('/api/cities')
+      .send({ name: 'Springfield', country_code: 'US' }); // no region_id
+
+    // Judgement call (flagged in QA report): ADL-46 states this case explicitly
+    // has "no safe automatic answer" and must not guess, but does not prescribe
+    // an exact status code or response shape — it says the mechanism is shared
+    // with D14 (§4.3.2), which is a frontend-facing candidate list, not specified
+    // at this route's contract level. So this test asserts only the two
+    // invariants D13's own text commits to, not a specific status code:
+    //   (a) it must not silently return either existing regioned row as if it
+    //       were an unambiguous exact match;
+    //   (b) it must not duplicate either existing row.
+    if (res.status === 200) {
+      expect([il.id, mo.id]).not.toContain(res.body.id);
+    }
+    const ilRows = await testDb!
+      .select({ id: schema.cities.id })
+      .from(schema.cities)
+      .where(eq(schema.cities.regionId, ilId));
+    const moRows = await testDb!
+      .select({ id: schema.cities.id })
+      .from(schema.cities)
+      .where(eq(schema.cities.regionId, moId));
+    expect(ilRows).toHaveLength(1);
+    expect(moRows).toHaveLength(1);
+  });
+
+  it('B5 — exactly one row matches name+country with no region requested → returns it (no regression)', async () => {
+    // Non-region-tier country — mirrors "today's behaviour, unchanged" per D13.
+    await seedCountry(testDb!, 'JP', 'Japan', 0);
+    const existing = await seedCity(testDb!, { countryCode: 'JP', name: 'Tokyo' });
+
+    const res = await supertest(app)
+      .post('/api/cities')
+      .send({ name: 'Tokyo', country_code: 'JP' });
+    expect(res.status).toBe(200);
+    expect(res.body.id).toBe(existing.id);
+    expect(await cityCountByNameCountry(testDb!, 'Tokyo', 'JP')).toBe(1);
+  });
+
+  // §8 row 4 — what makes city creation safe rather than merely permitted.
+  // Explicitly the non-owner case (unlike B1-B5), per ADL-46 §8's own listing.
+  it('B6 — POST with an existing name in different casing, as a non-owner → 200, row count unchanged', async () => {
+    await seedUser(testDb!, USER_B_ID, 'clerk_user_b', 'userb@example.com', 0);
+    await seedCountry(testDb!, 'GB', 'United Kingdom', 0);
+    const existing = await seedCity(testDb!, { countryCode: 'GB', name: 'Glasgow' });
+
+    mockIsOwner = 0;
+    mockUserId = USER_B_ID;
+    const res = await supertest(app)
+      .post('/api/cities')
+      .send({ name: 'GLASGOW', country_code: 'GB' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.id).toBe(existing.id);
+    expect(await cityCountByNameCountry(testDb!, 'Glasgow', 'GB')).toBe(1);
+  });
+});
+
+// ================================================================
+// GROUP C — Containment / GE-16 (ADL-46 §4.4)
+// ================================================================
+
+describe('ADL-46 Group C — pending vs resolved city containment (GE-16)', () => {
+  beforeEach(async () => {
+    await seedUser(testDb!, USER_A_ID, 'clerk_user_a', 'usera@example.com', 1);
+    await seedUser(testDb!, USER_B_ID, 'clerk_user_b', 'userb@example.com', 0);
+    await seedCountry(testDb!, 'US', 'United States', 0);
+  });
+
+  it("C1 — a pending city is visible in its creator's search but absent from another user's search", async () => {
+    await seedCity(testDb!, {
+      countryCode: 'US',
+      name: 'Nowheresville',
+      geocodeStatus: 'pending',
+      createdByUserId: USER_A_ID,
+    });
+
+    mockIsOwner = 1;
+    mockUserId = USER_A_ID;
+    const asCreator = await supertest(app).get('/api/cities').query({ q: 'Nowheres' });
+    expect(asCreator.status).toBe(200);
+    expect(asCreator.body).toEqual(
+      expect.arrayContaining([expect.objectContaining({ name: 'Nowheresville' })]),
+    );
+
+    mockIsOwner = 0;
+    mockUserId = USER_B_ID;
+    const asOther = await supertest(app).get('/api/cities').query({ q: 'Nowheres' });
+    expect(asOther.status).toBe(200);
+    expect(asOther.body).not.toEqual(
+      expect.arrayContaining([expect.objectContaining({ name: 'Nowheresville' })]),
+    );
+  });
+
+  it("C2 — a resolved city is visible in every user's search (already-satisfied anchor — must stay true)", async () => {
+    await seedCity(testDb!, {
+      countryCode: 'US',
+      name: 'Resolvedton',
+      geocodeStatus: 'resolved',
+      createdByUserId: USER_A_ID,
+    });
+
+    mockIsOwner = 0;
+    mockUserId = USER_B_ID;
+    const res = await supertest(app).get('/api/cities').query({ q: 'Resolvedton' });
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(
+      expect.arrayContaining([expect.objectContaining({ name: 'Resolvedton' })]),
+    );
+  });
+
+  // F3 regression test (OP-27 review). A NULL creator must be treated as global,
+  // not as "belongs to nobody, so it's invisible to everybody" — the exact defect
+  // the first ADL-46 draft's query had before the IS NULL branch was added. CI
+  // runs GEOCODING_ENABLED=false so every freshly-created city via the API is
+  // pending; the fixture below seeds directly with createdByUserId left
+  // unset (NULL) so the NULL-creator branch is genuinely exercised rather than
+  // accidentally satisfied by "everything is pending" alone.
+  it("C3 — a pending city with created_by_user_id IS NULL is visible in every user's search", async () => {
+    await seedCity(testDb!, {
+      countryCode: 'US',
+      name: 'Orphantown',
+      geocodeStatus: 'pending',
+      // createdByUserId intentionally omitted → NULL
+    });
+
+    mockIsOwner = 0;
+    mockUserId = USER_B_ID;
+    const res = await supertest(app).get('/api/cities').query({ q: 'Orphantown' });
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(
+      expect.arrayContaining([expect.objectContaining({ name: 'Orphantown' })]),
+    );
+  });
+
+  it('C4 — GET /api/cities/:id carries no containment: returns the row regardless of creator/status (already-satisfied anchor — must stay true)', async () => {
+    const city = await seedCity(testDb!, {
+      countryCode: 'US',
+      name: 'PrivatePending',
+      geocodeStatus: 'pending',
+      createdByUserId: USER_A_ID,
+    });
+
+    mockIsOwner = 0;
+    mockUserId = USER_B_ID;
+    const res = await supertest(app).get(`/api/cities/${city.id}`);
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ id: city.id, name: 'PrivatePending' });
+  });
+
+  // Bonus coverage beyond the brief's explicit list — ADL-46 §8 row 6 / OP-27
+  // review P2, named in the spec as "nowhere stated" before this ADL. Flagged in
+  // the QA report as extra coverage added because it is directly adjacent to C1
+  // and is exactly the kind of interaction a narrower reading of the brief could
+  // miss: search-invisibility and POST-return-visibility of a pending row are
+  // two different code paths, and this is the only place they meet.
+  it("bonus — user B posting a name matching user A's PENDING city gets A's row back (200), not a new row, even though B cannot see it in search", async () => {
+    const pending = await seedCity(testDb!, {
+      countryCode: 'US',
+      name: 'SharedPending',
+      geocodeStatus: 'pending',
+      createdByUserId: USER_A_ID,
+    });
+
+    mockIsOwner = 0;
+    mockUserId = USER_B_ID;
+    const res = await supertest(app)
+      .post('/api/cities')
+      .send({ name: 'SharedPending', country_code: 'US' });
+
+    // Today this 403s outright (POST /api/cities is still owner-only) — red for
+    // the D4 reason, not the containment reason, but it is the same assertion
+    // that will need to hold once D4 lands, so it belongs here rather than in
+    // Group A: once POST is open, correctness depends on pass 1 of find-or-create
+    // being creator-unscoped (per ADL-46 §8 row 6), which is Group C's concern.
+    expect(res.status).toBe(200);
+    expect(res.body.id).toBe(pending.id);
+    expect(await cityCountByNameCountry(testDb!, 'SharedPending', 'US')).toBe(1);
+  });
+});

--- a/src/backend/routes/__tests__/security.access-matrix.test.ts
+++ b/src/backend/routes/__tests__/security.access-matrix.test.ts
@@ -450,11 +450,15 @@ describe('Part B — Non-owner authenticated user receives 403 on owner-only rou
     expect(res.body).toMatchObject({ error: 'Forbidden' });
   });
 
-  // PATCH /api/cities/:id — BUG-22 (GitHub issue #91) is being fixed concurrently.
-  // requireOwner is missing on PATCH /api/cities/:id in current main.
-  // This test is skipped until fix/bug22-cities-patch-owner is merged.
-  // Once BUG-22 merges, remove the .skip and the test should pass (returns 403).
-  it.skip('PATCH /api/cities/1 → 403 (BUG-22: requireOwner missing on PATCH /api/cities/:id — unskip after BUG-22 merge)', async () => {
+  // PATCH /api/cities/:id — BUG-22 (GitHub issue #91) merged and the requireOwner
+  // guard has been present ever since (src/backend/routes/cities.ts:225), but this
+  // assertion stayed skipped and unrun the whole time (ADL-46 §8.1 — a live
+  // security-coverage hole found en route to the ADL-46 spec, not introduced by
+  // it). Unskipped here as part of the ADL-46 QA ATDD pass: city curation staying
+  // owner-only is the premise D4 relies on to make city CREATION safe to open to
+  // non-owners, so the one assertion protecting that premise should not be the
+  // one silently switched off.
+  it('PATCH /api/cities/1 → 403 (ADL-46 §8.1: unskipped — coverage hole, guard already present)', async () => {
     const res = await supertest(app).patch('/api/cities/1').send({ region_id: null });
     expect(res.status).toBe(403);
     expect(res.body).toMatchObject({ error: 'Forbidden' });


### PR DESCRIPTION
## Summary

ATDD-first trial (open-dialogues D-17): independent RED acceptance tests authored
against the ADL-46 spec **before** the Backend stage implements it. These are the
executable definition-of-done for the S1-S4 Backend brief, not a bug report.

Targets `release/adl46-access-model` (the integration branch), not `main`, per
ADL-47's expand/contract discipline — the Database stage has already landed
schema/migrations here (0014/0015) with no route code yet, so this branch is
red by design (ADL-46 §9).

**Red CI on this PR is expected and is the acceptance criterion, not a defect.**

## What's here

- New: `src/backend/routes/__tests__/adl46-access-model.test.ts` — 32 assertions,
  three groups per ADL-46:
  - **Group A** (§7/§8 end-state access matrix): per-user categories/activities
    routes + isolation, cross-user `category_id`/`activity_id` → 400 (incl. the
    F1(c) place-level write path), non-owner city creation → 201, fail-closed
    403 regression guards, 401 parity for the newly-opened routes.
  - **Group B** (§4.2.1 D13 find-or-create): exact match, wildcard upgrade,
    same-name-different-region, ambiguous no-region, single-match anchor,
    non-owner different-casing (§8 row 4).
  - **Group C** (§4.4/GE-16 containment): pending visible to creator only,
    resolved visible to all, NULL-creator pending visible to all (F3
    regression), by-id fetch carries no containment, plus a bonus test for
    §8 row 6 / OP-27 P2.
- Edited: `security.access-matrix.test.ts` — unskipped the §8.1 coverage-hole
  regression (`PATCH /api/cities/:id → 403` for non-owner). Verified safe:
  63/63 pass in that file after the change.

## Red baseline (see `jobs/qa/tech/20260731-adl46-atdd-red-tests.md` for the full table)

- New file: **14 failed / 18 passed** (32 total). Every failure is a clean
  assertion mismatch — zero exceptions, zero DB errors, not blocked by the
  DB-stage breakage.
- Pre-existing DB-stage breakage (34 failures across `trips.test.ts`,
  `lock-matrix.test.ts`, `owner-access.test.ts`, `qa-backend-fixes.test.ts`):
  confirmed **not mine**, left untouched per the brief.

## Spec gap found (flagged, not fixed — Backend's call)

`owner-access.test.ts`'s HC-06 block (`POST /api/cities → 403` for non-owner)
directly contradicts the ADL-46 D4 end state and is **not** in ADL-46 §8.2's
inventory of what breaks in that file (§8.2 only credits the HC-04/categories
block). Full writeup in the tech doc.

## Test plan

- [x] `npm run check` clean
- [x] `npm run type:check:all` — zero new errors from this change
- [x] `npm run test:backend` — 14/32 new assertions red-for-the-right-reason,
      confirmed not blocked; pre-existing 34 failures untouched
- [x] `npm run test:frontend` — 228/228, untouched
- [x] `npm run status:check` — up to date
- [ ] Backend stage (S1-S4) implements against this file; every assertion
      (including the ones already green today as regression guards) should
      hold post-implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)