### PR TITLE
feat(ADL-46): backend stage — S1/S2 + backend half of S3/S4 (BRD-GE16)

### DIFF
--- a/src/backend/db/reset-staging.ts
+++ b/src/backend/db/reset-staging.ts
@@ -60,9 +60,10 @@ import { config } from 'dotenv';
 
 config({ path: '.env.local' });
 
+import { activityRepository } from '../repositories/activities.js';
+import { tripCategoryRepository } from '../repositories/tripCategories.js';
 import { getDb } from './index.js';
 import {
-  activities,
   companions,
   itemCarRentals,
   itemExperiences,
@@ -72,7 +73,6 @@ import {
   items,
   mapShadingConfig,
   tripActivitiesMap,
-  tripCategories,
   tripCategoriesMap,
   tripCompanionsMap,
   tripCountries,
@@ -81,7 +81,6 @@ import {
   trips,
   users,
 } from './schema.js';
-import { ACTIVITIES, TRIP_CATEGORIES } from './seed-data.js';
 
 // Ordered child-before-parent. Every entry here must appear before anything
 // it references via a FK. Update this list if the schema grows new tables
@@ -165,21 +164,23 @@ async function main(): Promise<void> {
     console.log(`  ✓ cleared ${name}`);
   }
 
-  // Reseed global admin/reference lists immediately rather than waiting on
-  // the next Railway restart's idempotent startup seed. Safe to repeat —
-  // onConflictDoNothing. companions and map_shading_config are NOT reseeded
-  // here (ADL-28) — they are per-user now and self-heal on next access.
-  await db
-    .insert(tripCategories)
-    .values([...TRIP_CATEGORIES])
-    .onConflictDoNothing();
-  await db
-    .insert(activities)
-    .values([...ACTIVITIES])
-    .onConflictDoNothing();
+  // Reseed per-user admin lists immediately rather than waiting on the next
+  // Railway restart's idempotent startup reconciliation. Safe to repeat —
+  // ensureSeeded/onConflictDoNothing. ADL-46 (AD-09, D3): trip_categories and
+  // activities are per-user now, so the reseed is per-user; if the users table
+  // was cleared this is a no-op and lists self-heal on next sign-in + access.
+  // companions and map_shading_config are NOT reseeded here (ADL-28) — they are
+  // per-user and self-heal on next access.
+  const remainingUsers = await db.select({ id: users.id }).from(users);
+  for (const u of remainingUsers) {
+    await tripCategoryRepository.ensureSeeded(u.id);
+    await activityRepository.ensureSeeded(u.id);
+  }
 
   console.log('\n[RESET] Complete. Trip/user data (incl. per-user companions and');
-  console.log('[RESET] map_shading_config) cleared; global admin lists re-seeded.');
+  console.log(
+    `[RESET] map_shading_config) cleared; per-user admin lists re-seeded for ${remainingUsers.length} user(s).`,
+  );
   console.log('[RESET] countries/regions/cities were left untouched (see module docstring).');
 }
 

--- a/src/backend/db/seed.ts
+++ b/src/backend/db/seed.ts
@@ -19,38 +19,34 @@ import { config } from 'dotenv';
 
 config({ path: '.env.local' });
 
+import { activityRepository } from '../repositories/activities.js';
+import { tripCategoryRepository } from '../repositories/tripCategories.js';
 import { getDb } from './index.js';
-import { activities, tripCategories } from './schema.js';
-import { ACTIVITIES, TRIP_CATEGORIES } from './seed-data.js';
+import { users } from './schema.js';
 
 /**
- * Seeds all default admin list tables.
- * Each insert uses onConflictDoNothing() — safe to repeat without side effects.
+ * Seeds default per-user admin lists for every existing user.
+ * Each per-user seed uses onConflictDoNothing() — safe to repeat.
  *
- * ADL-28 (AD-07/AD-08): companions and map_shading_config are no longer
- * global-seeded here. Both tables are now per-user (userId NOT NULL FK).
- * companions has no default list post-migration (users build their own from
- * an empty list); map_shading_config is lazily seeded per-user on first
- * access to the shading config endpoint (shadingConfigRepository.seedDefaults,
- * ADL-28 repository section — Backend brief, not yet implemented). Only
- * trip_categories and activities remain global seeded defaults (AD-09,
- * unaffected by this ADL).
+ * ADL-46 (AD-09, D3): trip_categories and activities are per-user now
+ * (userId NOT NULL FK) — there is no global default list to seed. This script
+ * back-fills the default categories/activities for every existing user; new
+ * users are lazily seeded on first access (repositories' ensureSeeded).
+ *
+ * ADL-28 (AD-07/AD-08): companions and map_shading_config are likewise per-user;
+ * companions have no default list post-migration, and map_shading_config is
+ * lazily seeded per-user on first access to the shading config endpoint.
  */
 async function seed(): Promise<void> {
   console.log('[SEED] Starting seed...\n');
   const db = getDb();
 
-  await db
-    .insert(tripCategories)
-    .values([...TRIP_CATEGORIES])
-    .onConflictDoNothing();
-  console.log(`✓ trip_categories seeded (${TRIP_CATEGORIES.length} rows attempted)`);
-
-  await db
-    .insert(activities)
-    .values([...ACTIVITIES])
-    .onConflictDoNothing();
-  console.log(`✓ activities seeded (${ACTIVITIES.length} rows attempted)`);
+  const allUsers = await db.select({ id: users.id }).from(users);
+  for (const u of allUsers) {
+    await tripCategoryRepository.ensureSeeded(u.id);
+    await activityRepository.ensureSeeded(u.id);
+  }
+  console.log(`✓ per-user categories/activities seeded for ${allUsers.length} user(s)`);
 
   console.log('\n[SEED] Complete.');
 }

--- a/src/backend/repositories/__tests__/trips.test.ts
+++ b/src/backend/repositories/__tests__/trips.test.ts
@@ -116,8 +116,8 @@ describe('tripRepository.findAll', () => {
     const [cat, otherCat] = await db
       .insert(schema.tripCategories)
       .values([
-        { name: 'Adventure', isActive: 1 },
-        { name: 'Relaxation', isActive: 1 },
+        { userId: TEST_USER_ID, name: 'Adventure', isActive: 1 },
+        { userId: TEST_USER_ID, name: 'Relaxation', isActive: 1 },
       ])
       .returning();
     await db.insert(schema.tripCategoriesMap).values({ tripId: trip.id, categoryId: cat.id });
@@ -143,8 +143,8 @@ describe('tripRepository.findAll', () => {
     const [act, otherAct] = await db
       .insert(schema.activities)
       .values([
-        { name: 'Hiking', isActive: 1 },
-        { name: 'Museums', isActive: 1 },
+        { userId: TEST_USER_ID, name: 'Hiking', isActive: 1 },
+        { userId: TEST_USER_ID, name: 'Museums', isActive: 1 },
       ])
       .returning();
     await db.insert(schema.tripActivitiesMap).values({ tripId: trip.id, activityId: act.id });
@@ -405,7 +405,7 @@ describe('tripRepository.getAssociations', () => {
     const trip = await seedTrip(db);
     const [cat] = await db
       .insert(schema.tripCategories)
-      .values({ name: 'Beach', isActive: 1 })
+      .values({ userId: TEST_USER_ID, name: 'Beach', isActive: 1 })
       .returning();
     await db.insert(schema.tripCategoriesMap).values({ tripId: trip.id, categoryId: cat.id });
 
@@ -478,7 +478,7 @@ describe('tripRepository.replaceAssociations', () => {
     const trip = await seedTrip(db);
     const [cat] = await db
       .insert(schema.tripCategories)
-      .values({ name: 'Mountains', isActive: 1 })
+      .values({ userId: TEST_USER_ID, name: 'Mountains', isActive: 1 })
       .returning();
 
     await tripRepository.replaceAssociations(TEST_USER_ID, trip.id, [cat.id]);
@@ -493,7 +493,7 @@ describe('tripRepository.replaceAssociations', () => {
     const trip = await seedTrip(db);
     const [cat] = await db
       .insert(schema.tripCategories)
-      .values({ name: 'City', isActive: 1 })
+      .values({ userId: TEST_USER_ID, name: 'City', isActive: 1 })
       .returning();
     await db.insert(schema.tripCategoriesMap).values({ tripId: trip.id, categoryId: cat.id });
 
@@ -508,7 +508,7 @@ describe('tripRepository.replaceAssociations', () => {
     const trip = await seedTrip(db);
     const [cat] = await db
       .insert(schema.tripCategories)
-      .values({ name: 'Desert', isActive: 1 })
+      .values({ userId: TEST_USER_ID, name: 'Desert', isActive: 1 })
       .returning();
     await db.insert(schema.tripCategoriesMap).values({ tripId: trip.id, categoryId: cat.id });
 

--- a/src/backend/repositories/activities.ts
+++ b/src/backend/repositories/activities.ts
@@ -1,0 +1,148 @@
+/**
+ * Travel Tracker — Activities Repository
+ *
+ * ADL-46 (AD-09, D3): activities are per-user, following ADL-28's companions
+ * pattern verbatim. Every function scopes to userId — no user's activity row
+ * is ever returned or mutated unless the userId matches. Per ADL-18, all
+ * user-scoped queries go through a repository.
+ *
+ * Lazy seed (ADL-46 §3.2.1): a user's default activities are seeded on first
+ * access (read OR write) via ensureSeeded, counting ALL rows (not active), so
+ * a brand-new user whose first action is a POST still receives the defaults,
+ * and a user who deactivates everything is not re-seeded. onConflictDoNothing
+ * on the (user_id, name) unique index makes concurrent first-requests safe.
+ */
+
+import { and, asc, eq, inArray } from 'drizzle-orm';
+import { activities, getDb } from '../db/index.js';
+import type { Activity } from '../db/schema.js';
+import { ACTIVITIES } from '../db/seed-data.js';
+
+export const activityRepository = {
+  /**
+   * Seeds the default activities for userId. Uses onConflictDoNothing on the
+   * (user_id, name) unique index — idempotent and safe under concurrency.
+   */
+  async seedDefaults(userId: string): Promise<void> {
+    const db = getDb();
+    const now = new Date().toISOString();
+    await db
+      .insert(activities)
+      .values(ACTIVITIES.map((a) => ({ userId, name: a.name, createdAt: now, updatedAt: now })))
+      .onConflictDoNothing();
+  },
+
+  /**
+   * Lazy-seed trigger (ADL-46 §3.2.1): if userId has NO rows at all (active or
+   * inactive), seed the defaults. Counting all rows — not active — means a user
+   * who deactivated every entry is not re-seeded. Called before every read and
+   * write handler so a first-action POST still receives the defaults.
+   */
+  async ensureSeeded(userId: string): Promise<void> {
+    const db = getDb();
+    const rows = await db
+      .select({ id: activities.id })
+      .from(activities)
+      .where(eq(activities.userId, userId))
+      .limit(1);
+    if (!rows.length) {
+      await activityRepository.seedDefaults(userId);
+    }
+  },
+
+  /** Returns all activities owned by userId (active + inactive), name ascending. */
+  async findAll(userId: string): Promise<Activity[]> {
+    const db = getDb();
+    return db
+      .select()
+      .from(activities)
+      .where(eq(activities.userId, userId))
+      .orderBy(asc(activities.name));
+  },
+
+  /** Returns only active activities for userId, name ascending. */
+  async findActive(userId: string): Promise<Activity[]> {
+    const db = getDb();
+    return db
+      .select()
+      .from(activities)
+      .where(and(eq(activities.userId, userId), eq(activities.isActive, 1)))
+      .orderBy(asc(activities.name));
+  },
+
+  /** Returns a single activity by id, only if owned by userId. */
+  async findById(userId: string, id: number): Promise<Activity | null> {
+    const db = getDb();
+    const rows = await db
+      .select()
+      .from(activities)
+      .where(and(eq(activities.id, id), eq(activities.userId, userId)))
+      .limit(1);
+    return rows[0] ?? null;
+  },
+
+  /** Creates a new activity for userId. */
+  async create(userId: string, name: string): Promise<Activity> {
+    const db = getDb();
+    const now = new Date().toISOString();
+    const inserted = await db
+      .insert(activities)
+      .values({ userId, name, createdAt: now, updatedAt: now })
+      .returning();
+    return inserted[0];
+  },
+
+  /**
+   * Updates name and/or is_active for an activity owned by userId.
+   * Returns null if the activity does not exist or is not owned by userId.
+   */
+  async update(
+    userId: string,
+    id: number,
+    data: { name?: string; isActive?: number },
+  ): Promise<Activity | null> {
+    const db = getDb();
+    const now = new Date().toISOString();
+    const updates: Partial<typeof activities.$inferInsert> = { updatedAt: now };
+    if (data.name !== undefined) updates.name = data.name;
+    if (data.isActive !== undefined) updates.isActive = data.isActive;
+
+    const updated = await db
+      .update(activities)
+      .set(updates)
+      .where(and(eq(activities.id, id), eq(activities.userId, userId)))
+      .returning();
+    return updated[0] ?? null;
+  },
+
+  /**
+   * Soft-deletes (sets is_active = 0) an activity owned by userId.
+   * Returns null if the activity does not exist or is not owned by userId.
+   */
+  async deactivate(userId: string, id: number): Promise<Activity | null> {
+    return activityRepository.update(userId, id, { isActive: 0 });
+  },
+
+  /**
+   * Validates that all activityIds belong to userId.
+   * Returns the subset of activityIds that are invalid — i.e. belong to a
+   * different user, or do not exist at all. An empty return means every ID
+   * is valid.
+   *
+   * ADL-46 §3.3 / F1: the sole cross-user guard for both trip_activities_map
+   * (trip-level, via tripRepository.replaceAssociations) and
+   * trip_place_activities_map (place-level, via the places router). SQLite
+   * cannot enforce activities.user_id === owner at the schema level, so this
+   * application-layer check is load-bearing on BOTH write paths.
+   */
+  async validateOwnership(userId: string, activityIds: number[]): Promise<number[]> {
+    if (!activityIds.length) return [];
+    const db = getDb();
+    const rows = await db
+      .select({ id: activities.id })
+      .from(activities)
+      .where(and(eq(activities.userId, userId), inArray(activities.id, activityIds)));
+    const validIds = new Set(rows.map((r) => r.id));
+    return activityIds.filter((id) => !validIds.has(id));
+  },
+};

--- a/src/backend/repositories/places.ts
+++ b/src/backend/repositories/places.ts
@@ -215,6 +215,7 @@ export const placeRepository = {
     placeId: number,
     arrivedOn?: string | null,
     departedOn?: string | null,
+    cityId?: number,
   ): Promise<TripPlace> {
     await this.assertWritable(userId, tripId);
 
@@ -231,6 +232,12 @@ export const placeRepository = {
     const updates: Partial<typeof tripPlaces.$inferInsert> = { updatedAt: now };
     if (arrivedOn !== undefined) updates.arrivedOn = arrivedOn;
     if (departedOn !== undefined) updates.departedOn = departedOn;
+    // ADL-46 D11 (§4.4.2): re-point a place to a different city — the escape
+    // hatch for a mistyped/wrong city. The correction happens at the PLACE level
+    // (place ownership already checked), never by writing to a shared city row.
+    // Items and place-level activity tags hang off trip_place_id, which does not
+    // change, so re-pointing preserves them (unlike delete-and-re-add).
+    if (cityId !== undefined) updates.cityId = cityId;
 
     const updated = await db
       .update(tripPlaces)

--- a/src/backend/repositories/tripCategories.ts
+++ b/src/backend/repositories/tripCategories.ts
@@ -1,0 +1,150 @@
+/**
+ * Travel Tracker — Trip Categories Repository
+ *
+ * ADL-46 (AD-09, D3): trip categories are per-user, following ADL-28's
+ * companions pattern verbatim. Every function scopes to userId — no user's
+ * category row is ever returned or mutated unless the userId matches. Per
+ * ADL-18, all user-scoped queries go through a repository.
+ *
+ * Lazy seed (ADL-46 §3.2.1): a user's default categories are seeded on first
+ * access (read OR write) via ensureSeeded, counting ALL rows (not active), so
+ * a brand-new user whose first action is a POST still receives the defaults,
+ * and a user who deactivates everything is not re-seeded. onConflictDoNothing
+ * on the (user_id, name) unique index makes concurrent first-requests safe.
+ */
+
+import { and, asc, eq, inArray } from 'drizzle-orm';
+import { getDb, tripCategories } from '../db/index.js';
+import type { TripCategory } from '../db/schema.js';
+import { TRIP_CATEGORIES } from '../db/seed-data.js';
+
+export const tripCategoryRepository = {
+  /**
+   * Seeds the default categories for userId. Uses onConflictDoNothing on the
+   * (user_id, name) unique index — idempotent and safe under concurrency.
+   */
+  async seedDefaults(userId: string): Promise<void> {
+    const db = getDb();
+    const now = new Date().toISOString();
+    await db
+      .insert(tripCategories)
+      .values(
+        TRIP_CATEGORIES.map((c) => ({ userId, name: c.name, createdAt: now, updatedAt: now })),
+      )
+      .onConflictDoNothing();
+  },
+
+  /**
+   * Lazy-seed trigger (ADL-46 §3.2.1): if userId has NO rows at all (active or
+   * inactive), seed the defaults. Counting all rows — not active — means a user
+   * who deactivated every entry is not re-seeded. Called before every read and
+   * write handler so a first-action POST still receives the defaults.
+   */
+  async ensureSeeded(userId: string): Promise<void> {
+    const db = getDb();
+    const rows = await db
+      .select({ id: tripCategories.id })
+      .from(tripCategories)
+      .where(eq(tripCategories.userId, userId))
+      .limit(1);
+    if (!rows.length) {
+      await tripCategoryRepository.seedDefaults(userId);
+    }
+  },
+
+  /** Returns all categories owned by userId (active + inactive), name ascending. */
+  async findAll(userId: string): Promise<TripCategory[]> {
+    const db = getDb();
+    return db
+      .select()
+      .from(tripCategories)
+      .where(eq(tripCategories.userId, userId))
+      .orderBy(asc(tripCategories.name));
+  },
+
+  /** Returns only active categories for userId, name ascending. */
+  async findActive(userId: string): Promise<TripCategory[]> {
+    const db = getDb();
+    return db
+      .select()
+      .from(tripCategories)
+      .where(and(eq(tripCategories.userId, userId), eq(tripCategories.isActive, 1)))
+      .orderBy(asc(tripCategories.name));
+  },
+
+  /** Returns a single category by id, only if owned by userId. */
+  async findById(userId: string, id: number): Promise<TripCategory | null> {
+    const db = getDb();
+    const rows = await db
+      .select()
+      .from(tripCategories)
+      .where(and(eq(tripCategories.id, id), eq(tripCategories.userId, userId)))
+      .limit(1);
+    return rows[0] ?? null;
+  },
+
+  /** Creates a new category for userId. */
+  async create(userId: string, name: string): Promise<TripCategory> {
+    const db = getDb();
+    const now = new Date().toISOString();
+    const inserted = await db
+      .insert(tripCategories)
+      .values({ userId, name, createdAt: now, updatedAt: now })
+      .returning();
+    return inserted[0];
+  },
+
+  /**
+   * Updates name and/or is_active for a category owned by userId.
+   * Returns null if the category does not exist or is not owned by userId.
+   */
+  async update(
+    userId: string,
+    id: number,
+    data: { name?: string; isActive?: number },
+  ): Promise<TripCategory | null> {
+    const db = getDb();
+    const now = new Date().toISOString();
+    const updates: Partial<typeof tripCategories.$inferInsert> = { updatedAt: now };
+    if (data.name !== undefined) updates.name = data.name;
+    if (data.isActive !== undefined) updates.isActive = data.isActive;
+
+    const updated = await db
+      .update(tripCategories)
+      .set(updates)
+      .where(and(eq(tripCategories.id, id), eq(tripCategories.userId, userId)))
+      .returning();
+    return updated[0] ?? null;
+  },
+
+  /**
+   * Soft-deletes (sets is_active = 0) a category owned by userId.
+   * Returns null if the category does not exist or is not owned by userId.
+   */
+  async deactivate(userId: string, id: number): Promise<TripCategory | null> {
+    return tripCategoryRepository.update(userId, id, { isActive: 0 });
+  },
+
+  /**
+   * Validates that all categoryIds belong to userId.
+   * Returns the subset of categoryIds that are invalid — i.e. belong to a
+   * different user, or do not exist at all. An empty return means every ID
+   * is valid.
+   *
+   * ADL-46 §3.3 / F1: once categories are per-user, a trip may reference a
+   * category belonging to a different user. SQLite cannot enforce
+   * trip_categories.user_id === trips.user_id at the schema level, so this
+   * application-layer check is load-bearing (tripRepository.replaceAssociations
+   * calls it before inserting into trip_categories_map).
+   */
+  async validateOwnership(userId: string, categoryIds: number[]): Promise<number[]> {
+    if (!categoryIds.length) return [];
+    const db = getDb();
+    const rows = await db
+      .select({ id: tripCategories.id })
+      .from(tripCategories)
+      .where(and(eq(tripCategories.userId, userId), inArray(tripCategories.id, categoryIds)));
+    const validIds = new Set(rows.map((r) => r.id));
+    return categoryIds.filter((id) => !validIds.has(id));
+  },
+};

--- a/src/backend/repositories/trips.ts
+++ b/src/backend/repositories/trips.ts
@@ -25,7 +25,9 @@ import {
 } from '../db/index.js';
 import type { Trip } from '../db/schema.js';
 import { NotFoundError, ValidationError } from '../errors.js';
+import { activityRepository } from './activities.js';
 import { companionRepository } from './companions.js';
+import { tripCategoryRepository } from './tripCategories.js';
 
 // ----------------------------------------------------------------
 // Types
@@ -232,11 +234,14 @@ export const tripRepository = {
    * Replaces all M2M associations for a trip (delete + reinsert).
    * Pass undefined for a collection to leave it unchanged.
    *
-   * ADL-28 R4: companionIds are validated against userId before insert —
-   * companions.user_id must match the trip's user_id, and SQLite cannot
-   * enforce that cross-table invariant at the schema level. Any companionId
-   * that does not belong to userId throws ValidationError (400, not 404 —
-   * the companion may genuinely exist, just under a different user).
+   * ADL-28 R4 / ADL-46 §3.3 (F1): categoryIds, companionIds and activityIds are
+   * each validated against userId before insert — the referenced row's user_id
+   * must match the trip's user_id, and SQLite cannot enforce that cross-table
+   * invariant at the schema level (the junction FK targets the id column, which
+   * has no user dimension). Any id that does not belong to userId throws
+   * ValidationError (400, not 404 — the row may genuinely exist, just under a
+   * different user). Once categories and activities became per-user (ADL-46 D3)
+   * they carry exactly the cross-user hazard companions already had.
    */
   async replaceAssociations(
     userId: string,
@@ -247,11 +252,29 @@ export const tripRepository = {
   ): Promise<void> {
     const db = getDb();
 
+    if (categoryIds?.length) {
+      const invalidIds = await tripCategoryRepository.validateOwnership(userId, categoryIds);
+      if (invalidIds.length) {
+        throw new ValidationError(
+          `Category ID(s) not found or not owned by user: ${invalidIds.join(', ')}`,
+        );
+      }
+    }
+
     if (companionIds?.length) {
       const invalidIds = await companionRepository.validateOwnership(userId, companionIds);
       if (invalidIds.length) {
         throw new ValidationError(
           `Companion ID(s) not found or not owned by user: ${invalidIds.join(', ')}`,
+        );
+      }
+    }
+
+    if (activityIds?.length) {
+      const invalidIds = await activityRepository.validateOwnership(userId, activityIds);
+      if (invalidIds.length) {
+        throw new ValidationError(
+          `Activity ID(s) not found or not owned by user: ${invalidIds.join(', ')}`,
         );
       }
     }

--- a/src/backend/routes/__tests__/cities-find-or-create.test.ts
+++ b/src/backend/routes/__tests__/cities-find-or-create.test.ts
@@ -1,0 +1,207 @@
+/**
+ * ADL-46 D13 (§4.2.1) — backend-owned find-or-create regression tests.
+ *
+ * These complement (do NOT duplicate or touch) QA's frozen acceptance spec
+ * adl46-access-model.test.ts. Focus: the REVERSE single-match case §4.2.1
+ * flagged as the trap — a no-region POST against a region-tier country that
+ * holds exactly one *regioned* row of that (name, country) must return that
+ * row, not insert a duplicate. It regressed once because step 1 keys on
+ * COALESCE(region_id,0) and a regioned row never has key 0.
+ */
+
+import { and, eq } from 'drizzle-orm';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as schema from '../../db/schema.js';
+import { createTestDb, type TestDb } from '../../repositories/__tests__/test-db.js';
+
+const USER_ID = 'user-d13-0000-0000-0000-000000000000';
+
+let testDb: TestDb | null = null;
+
+vi.mock('../../db/index.js', async (importOriginal) => {
+  const real = await importOriginal<typeof import('../../db/index.js')>();
+  return {
+    ...real,
+    getDb: () => {
+      if (!testDb) throw new Error('[TEST] testDb not initialised');
+      return testDb;
+    },
+  };
+});
+
+vi.mock('../../middleware/auth.js', () => ({
+  requireAuth: (
+    req: import('express').Request,
+    _res: import('express').Response,
+    next: import('express').NextFunction,
+  ) => {
+    (req as import('express').Request & { user?: unknown }).user = {
+      id: USER_ID,
+      clerkId: 'clerk_d13',
+      email: 'd13@example.com',
+      isOwner: 0,
+    };
+    next();
+  },
+}));
+
+// No geocoder in this suite — resolve-then-create degrades to pending, so the
+// find-or-create logic is what is under test (mirrors the CI GEOCODING_ENABLED=false path).
+vi.mock('../../services/geocoding.service.js', () => ({
+  resolveCity: async () => undefined,
+  resolveCityName: async () => ({ status: 'disabled', candidates: [] }),
+}));
+
+vi.mock('../../services/shading.service.js', () => ({
+  getAllCountryShading: async () => [],
+  getCountryShading: async () => null,
+  getRegionShading: async () => [],
+  invalidateConfigCache: () => undefined,
+}));
+
+const { default: app } = await import('../../server-test-app.js');
+const supertest = (await import('supertest')).default;
+
+async function seedUser(db: TestDb) {
+  const now = new Date();
+  await db
+    .insert(schema.users)
+    .values({
+      id: USER_ID,
+      clerkId: 'clerk_d13',
+      email: 'd13@example.com',
+      isOwner: 0,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .onConflictDoNothing();
+}
+
+async function seedRegionTierCountry(db: TestDb) {
+  await db
+    .insert(schema.countries)
+    .values({ countryCode: 'US', name: 'United States', regionTierEnabled: 1 })
+    .onConflictDoNothing();
+}
+
+async function seedRegion(db: TestDb, name: string, iso: string): Promise<number> {
+  const [r] = await db
+    .insert(schema.regions)
+    .values({ countryCode: 'US', name, iso3166_2: iso })
+    .returning({ id: schema.regions.id });
+  return r.id;
+}
+
+async function cityCount(db: TestDb, name: string): Promise<number> {
+  const rows = await db
+    .select({ id: schema.cities.id })
+    .from(schema.cities)
+    .where(and(eq(schema.cities.countryCode, 'US'), eq(schema.cities.name, name)));
+  return rows.length;
+}
+
+beforeEach(async () => {
+  testDb = await createTestDb();
+  await seedUser(testDb);
+  await seedRegionTierCountry(testDb);
+});
+
+afterEach(() => {
+  testDb = null;
+});
+
+describe('ADL-46 D13 — reverse single-match (region-tier country, no region requested)', () => {
+  it('exactly one existing REGIONED row → returns it, no duplicate (§4.2.1 no-regression case)', async () => {
+    const db = testDb!;
+    const ilId = await seedRegion(db, 'Illinois', 'US-IL');
+    const [existing] = await db
+      .insert(schema.cities)
+      .values({ name: 'Springfield', countryCode: 'US', regionId: ilId, geocodeStatus: 'pending' })
+      .returning();
+
+    // No region_id in the request — the case the old (name, country) unique
+    // index used to match. Must NOT insert a second region-less Springfield.
+    const res = await supertest(app)
+      .post('/api/cities')
+      .send({ name: 'Springfield', country_code: 'US' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.id).toBe(existing.id);
+    expect(res.body.region_id).toBe(ilId); // returned unchanged, not blanked
+    expect(await cityCount(db, 'Springfield')).toBe(1);
+  });
+
+  it('two existing regioned rows (IL + MO), no region requested → does NOT silently pick one, does NOT duplicate either', async () => {
+    const db = testDb!;
+    const ilId = await seedRegion(db, 'Illinois', 'US-IL');
+    const moId = await seedRegion(db, 'Missouri', 'US-MO');
+    const [il] = await db
+      .insert(schema.cities)
+      .values({ name: 'Springfield', countryCode: 'US', regionId: ilId, geocodeStatus: 'pending' })
+      .returning();
+    const [mo] = await db
+      .insert(schema.cities)
+      .values({ name: 'Springfield', countryCode: 'US', regionId: moId, geocodeStatus: 'pending' })
+      .returning();
+
+    const res = await supertest(app)
+      .post('/api/cities')
+      .send({ name: 'Springfield', country_code: 'US' });
+
+    // Ambiguous → the two existing regioned rows must be untouched, and neither
+    // is returned as an unambiguous exact match.
+    if (res.status === 200) {
+      expect([il.id, mo.id]).not.toContain(res.body.id);
+    }
+    const ilRows = await db
+      .select({ id: schema.cities.id })
+      .from(schema.cities)
+      .where(eq(schema.cities.regionId, ilId));
+    const moRows = await db
+      .select({ id: schema.cities.id })
+      .from(schema.cities)
+      .where(eq(schema.cities.regionId, moId));
+    expect(ilRows).toHaveLength(1);
+    expect(moRows).toHaveLength(1);
+  });
+
+  it('has-region path unchanged: a region-bearing request still wildcard-upgrades a region-less row', async () => {
+    const db = testDb!;
+    const coId = await seedRegion(db, 'Colorado', 'US-CO');
+    const [existing] = await db
+      .insert(schema.cities)
+      .values({ name: 'Denver', countryCode: 'US', regionId: null, geocodeStatus: 'pending' })
+      .returning();
+
+    const res = await supertest(app)
+      .post('/api/cities')
+      .send({ name: 'Denver', country_code: 'US', region_id: coId });
+
+    // Step 2 wildcard-upgrade: same row, region now set — NOT the reverse branch.
+    expect(res.status).toBe(200);
+    expect(res.body.id).toBe(existing.id);
+    expect(res.body.region_id).toBe(coId);
+    expect(await cityCount(db, 'Denver')).toBe(1);
+  });
+
+  it('has-region path unchanged: a region-bearing request does NOT collapse onto a different-region row', async () => {
+    const db = testDb!;
+    const ilId = await seedRegion(db, 'Illinois', 'US-IL');
+    const moId = await seedRegion(db, 'Missouri', 'US-MO');
+    const [il] = await db
+      .insert(schema.cities)
+      .values({ name: 'Springfield', countryCode: 'US', regionId: ilId, geocodeStatus: 'pending' })
+      .returning();
+
+    // Request Springfield in MO while only the IL row exists → must create a new
+    // row, not return the IL one (the reverse single-match branch must NOT run).
+    const res = await supertest(app)
+      .post('/api/cities')
+      .send({ name: 'Springfield', country_code: 'US', region_id: moId });
+
+    expect(res.status).toBe(201);
+    expect(res.body.id).not.toBe(il.id);
+    expect(res.body.region_id).toBe(moId);
+    expect(await cityCount(db, 'Springfield')).toBe(2);
+  });
+});

--- a/src/backend/routes/__tests__/lock-matrix.test.ts
+++ b/src/backend/routes/__tests__/lock-matrix.test.ts
@@ -108,8 +108,14 @@ async function seedLockedTripFixture(
     .values({ name: 'Berlin', countryCode: 'DE', geocodeStatus: 'resolved' })
     .returning();
 
-  const [hiking] = await db.insert(schema.activities).values({ name: 'Hiking' }).returning();
-  const [museums] = await db.insert(schema.activities).values({ name: 'Museums' }).returning();
+  const [hiking] = await db
+    .insert(schema.activities)
+    .values({ userId: TEST_USER_ID, name: 'Hiking' })
+    .returning();
+  const [museums] = await db
+    .insert(schema.activities)
+    .values({ userId: TEST_USER_ID, name: 'Museums' })
+    .returning();
 
   const [trip] = await db
     .insert(schema.trips)

--- a/src/backend/routes/__tests__/owner-access.test.ts
+++ b/src/backend/routes/__tests__/owner-access.test.ts
@@ -143,38 +143,47 @@ describe('HC-04: Non-owner authenticated user receives 403 on admin routes', () 
   });
 });
 
-describe('HC-04: Owner user receives 200/201 on admin routes', () => {
-  it('GET /api/admin/categories → 200 for owner', async () => {
+// ADL-46 (AD-09, D3, §8.2): categories/activities are per-user now and moved
+// out of /api/admin/* to /api/categories + /api/activities (requireAuth only).
+// The owner-side "→ 200/201 on admin routes" assertions are re-pointed at the
+// new paths — owner and non-owner alike get 200/201 on their OWN lists; the
+// non-owner 403 assertions above stay (they now hit router-level requireOwner
+// before the removed routes resolve — §8.2 verified counterpoint).
+describe('HC-04: Users receive 200/201 on their own per-user category routes (ADL-46)', () => {
+  it('GET /api/categories → 200 for owner (own list)', async () => {
     mockIsOwner = 1;
     await seedTestUser(testDb!, 1);
-    const res = await supertest(app).get('/api/admin/categories');
+    const res = await supertest(app).get('/api/categories');
     expect(res.status).toBe(200);
     expect(Array.isArray(res.body)).toBe(true);
   });
 
-  it('POST /api/admin/categories → 201 for owner', async () => {
+  it('POST /api/categories → 201 for owner (own list)', async () => {
     mockIsOwner = 1;
     await seedTestUser(testDb!, 1);
-    const res = await supertest(app).post('/api/admin/categories').send({ name: 'Owner Category' });
+    const res = await supertest(app).post('/api/categories').send({ name: 'Owner Category' });
     expect(res.status).toBe(201);
     expect(res.body).toMatchObject({ name: 'Owner Category' });
   });
 });
 
 // ================================================================
-// HC-06: POST /api/cities requires owner
+// HC-06: POST /api/cities — creation opened to any authenticated user
+// (ADL-46 D4/§8.2, amended 2026-07-31). City CREATION is no longer owner-only;
+// city CURATION (PATCH /api/cities/:id) stays owner-only. The old "requires
+// owner" contract is inverted here under the spec's authority.
 // ================================================================
 
-describe('HC-06: POST /api/cities requires owner', () => {
-  it('POST /api/cities → 403 for non-owner', async () => {
+describe('HC-06: POST /api/cities is open to any authenticated user (ADL-46 D4)', () => {
+  it('POST /api/cities → 201 for non-owner (creation opened)', async () => {
     mockIsOwner = 0;
     await seedTestUser(testDb!, 0);
     await seedCountry(testDb!);
     const res = await supertest(app)
       .post('/api/cities')
       .send({ name: 'New City', country_code: 'US' });
-    expect(res.status).toBe(403);
-    expect(res.body).toMatchObject({ error: 'Forbidden' });
+    expect(res.status).toBe(201);
+    expect(res.body).toMatchObject({ name: 'New City', country_code: 'US' });
   });
 
   it('POST /api/cities → 201 for owner', async () => {

--- a/src/backend/routes/__tests__/place-repoint.test.ts
+++ b/src/backend/routes/__tests__/place-repoint.test.ts
@@ -1,0 +1,197 @@
+/**
+ * ADL-46 D11 (§4.4.2) — the city-correction path. PATCH /api/trips/:t/places/:p
+ * with city_id re-points a place to a different city, and because items and
+ * place-level activity tags hang off trip_place_id (which does not change),
+ * re-pointing preserves them — unlike delete-and-re-add.
+ */
+
+import { eq } from 'drizzle-orm';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as schema from '../../db/schema.js';
+import { createTestDb, type TestDb } from '../../repositories/__tests__/test-db.js';
+
+const USER_ID = 'user-d11-0000-0000-0000-000000000000';
+
+let testDb: TestDb | null = null;
+
+vi.mock('../../db/index.js', async (importOriginal) => {
+  const real = await importOriginal<typeof import('../../db/index.js')>();
+  return {
+    ...real,
+    getDb: () => {
+      if (!testDb) throw new Error('[TEST] testDb not initialised');
+      return testDb;
+    },
+  };
+});
+
+vi.mock('../../middleware/auth.js', () => ({
+  requireAuth: (
+    req: import('express').Request,
+    _res: import('express').Response,
+    next: import('express').NextFunction,
+  ) => {
+    (req as import('express').Request & { user?: unknown }).user = {
+      id: USER_ID,
+      clerkId: 'clerk_d11',
+      email: 'd11@example.com',
+      isOwner: 0,
+    };
+    next();
+  },
+}));
+
+vi.mock('../../services/geocoding.service.js', () => ({
+  resolveCity: async () => undefined,
+  resolveCityName: async () => ({ status: 'disabled', candidates: [] }),
+}));
+
+vi.mock('../../services/shading.service.js', () => ({
+  getAllCountryShading: async () => [],
+  getCountryShading: async () => null,
+  getRegionShading: async () => [],
+  invalidateConfigCache: () => undefined,
+}));
+
+const { default: app } = await import('../../server-test-app.js');
+const supertest = (await import('supertest')).default;
+
+beforeEach(async () => {
+  testDb = await createTestDb();
+  const now = new Date();
+  await testDb
+    .insert(schema.users)
+    .values({
+      id: USER_ID,
+      clerkId: 'clerk_d11',
+      email: 'd11@example.com',
+      isOwner: 0,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .onConflictDoNothing();
+  await testDb
+    .insert(schema.countries)
+    .values({ countryCode: 'US', name: 'United States', regionTierEnabled: 0 })
+    .onConflictDoNothing();
+});
+
+afterEach(() => {
+  testDb = null;
+});
+
+describe('ADL-46 D11 — re-pointing a place preserves its items and activity tags', () => {
+  it('PATCH place with a corrected city_id keeps the same trip_place_id, items and activities', async () => {
+    const db = testDb!;
+
+    // Two cities — a typo'd one and the correct one.
+    const [wrong] = await db
+      .insert(schema.cities)
+      .values({
+        name: 'Denvr',
+        countryCode: 'US',
+        geocodeStatus: 'pending',
+        createdByUserId: USER_ID,
+      })
+      .returning();
+    const [right] = await db
+      .insert(schema.cities)
+      .values({ name: 'Denver', countryCode: 'US', geocodeStatus: 'resolved' })
+      .returning();
+
+    const nowIso = new Date().toISOString();
+    const [trip] = await db
+      .insert(schema.trips)
+      .values({
+        name: 'Trip',
+        startDate: '2026-01-01',
+        endDate: '2026-01-10',
+        status: 'planning',
+        userId: USER_ID,
+        createdAt: nowIso,
+        updatedAt: nowIso,
+      })
+      .returning();
+    const [place] = await db
+      .insert(schema.tripPlaces)
+      .values({ tripId: trip.id, cityId: wrong.id, userId: USER_ID })
+      .returning();
+
+    // An item and a place-level activity tag hang off this trip_place.
+    const [act] = await db
+      .insert(schema.activities)
+      .values({ userId: USER_ID, name: 'Skiing' })
+      .returning();
+    await db
+      .insert(schema.tripPlaceActivitiesMap)
+      .values({ tripPlaceId: place.id, activityId: act.id });
+    const [item] = await db
+      .insert(schema.items)
+      .values({
+        tripId: trip.id,
+        tripPlaceId: place.id,
+        itemType: 'note',
+        status: 'consider',
+        userId: USER_ID,
+        createdAt: nowIso,
+        updatedAt: nowIso,
+      })
+      .returning();
+
+    // Correct the city.
+    const res = await supertest(app)
+      .patch(`/api/trips/${trip.id}/places/${place.id}`)
+      .send({ city_id: right.id });
+    expect(res.status).toBe(200);
+    expect(res.body.id).toBe(place.id); // same trip_place_id
+    expect(res.body.city_id).toBe(right.id); // re-pointed
+
+    // Item still attached to the same place.
+    const [itemAfter] = await db.select().from(schema.items).where(eq(schema.items.id, item.id));
+    expect(itemAfter.tripPlaceId).toBe(place.id);
+
+    // Activity tag preserved.
+    const tags = await db
+      .select()
+      .from(schema.tripPlaceActivitiesMap)
+      .where(eq(schema.tripPlaceActivitiesMap.tripPlaceId, place.id));
+    expect(tags).toHaveLength(1);
+    expect(tags[0].activityId).toBe(act.id);
+  });
+
+  it('PATCH place with a non-existent city_id → 404, place unchanged', async () => {
+    const db = testDb!;
+    const [city] = await db
+      .insert(schema.cities)
+      .values({ name: 'Denver', countryCode: 'US', geocodeStatus: 'resolved' })
+      .returning();
+    const nowIso = new Date().toISOString();
+    const [trip] = await db
+      .insert(schema.trips)
+      .values({
+        name: 'Trip',
+        startDate: '2026-01-01',
+        endDate: '2026-01-10',
+        status: 'planning',
+        userId: USER_ID,
+        createdAt: nowIso,
+        updatedAt: nowIso,
+      })
+      .returning();
+    const [place] = await db
+      .insert(schema.tripPlaces)
+      .values({ tripId: trip.id, cityId: city.id, userId: USER_ID })
+      .returning();
+
+    const res = await supertest(app)
+      .patch(`/api/trips/${trip.id}/places/${place.id}`)
+      .send({ city_id: 999999 });
+    expect(res.status).toBe(404);
+
+    const [after] = await db
+      .select()
+      .from(schema.tripPlaces)
+      .where(eq(schema.tripPlaces.id, place.id));
+    expect(after.cityId).toBe(city.id); // unchanged
+  });
+});

--- a/src/backend/routes/__tests__/qa-backend-fixes.test.ts
+++ b/src/backend/routes/__tests__/qa-backend-fixes.test.ts
@@ -198,25 +198,33 @@ describe('BUG-A: PATCH /api/trips/:id — effective date validation', () => {
 // BUG-B: Admin list endpoints return snake_case (#26)
 // ----------------------------------------------------------------
 
-describe('BUG-B: Admin list endpoints — snake_case serialization', () => {
+// ADL-46 (AD-09, D3, §8.2): categories/activities are per-user now and moved to
+// /api/categories + /api/activities (requireAuth only, userId-scoped). The
+// snake_case / /active-filter / soft-delete contracts are unchanged and must
+// still hold per-user. Fixtures now carry userId and seed the caller so the FK
+// to users.id holds; because a pre-existing row makes ensureSeeded a no-op, the
+// per-user default lazy seed does not perturb the fixed-count assertions.
+describe('BUG-B: Per-user category/activity endpoints — snake_case serialization (ADL-46)', () => {
   beforeEach(async () => {
     testDb = await createTestDb();
+    await seedTestUser(testDb);
   });
 
   afterEach(() => {
     testDb = null;
   });
 
-  it('GET /api/admin/categories returns is_active, not isActive', async () => {
+  it('GET /api/categories returns is_active, not isActive', async () => {
     const db = testDb!;
     await db.insert(schema.tripCategories).values({
+      userId: TEST_USER_ID,
       name: 'Beach',
       isActive: 1,
       createdAt: new Date().toISOString(),
       updatedAt: new Date().toISOString(),
     });
 
-    const res = await supertest(app).get('/api/admin/categories').expect(200);
+    const res = await supertest(app).get('/api/categories').expect(200);
 
     expect(res.body).toHaveLength(1);
     const item = res.body[0];
@@ -225,15 +233,15 @@ describe('BUG-B: Admin list endpoints — snake_case serialization', () => {
     expect(item.is_active).toBe(true);
   });
 
-  it('GET /api/admin/categories/active returns snake_case and only active items', async () => {
+  it('GET /api/categories/active returns snake_case and only active items', async () => {
     const db = testDb!;
     const now = new Date().toISOString();
     await db.insert(schema.tripCategories).values([
-      { name: 'Active Cat', isActive: 1, createdAt: now, updatedAt: now },
-      { name: 'Inactive Cat', isActive: 0, createdAt: now, updatedAt: now },
+      { userId: TEST_USER_ID, name: 'Active Cat', isActive: 1, createdAt: now, updatedAt: now },
+      { userId: TEST_USER_ID, name: 'Inactive Cat', isActive: 0, createdAt: now, updatedAt: now },
     ]);
 
-    const res = await supertest(app).get('/api/admin/categories/active').expect(200);
+    const res = await supertest(app).get('/api/categories/active').expect(200);
 
     expect(res.body).toHaveLength(1);
     expect(res.body[0].name).toBe('Active Cat');
@@ -241,10 +249,12 @@ describe('BUG-B: Admin list endpoints — snake_case serialization', () => {
     expect(res.body[0].is_active).toBe(true);
   });
 
-  it('POST /api/admin/activities returns snake_case', async () => {
+  it('POST /api/activities returns snake_case', async () => {
+    // A name NOT in the seeded defaults (ACTIVITIES) so the per-user lazy seed
+    // that fires on first write does not collide with it.
     const res = await supertest(app)
-      .post('/api/admin/activities')
-      .send({ name: 'Hiking' })
+      .post('/api/activities')
+      .send({ name: 'Paragliding' })
       .expect(201);
 
     expect(res.body).toHaveProperty('is_active');
@@ -281,12 +291,13 @@ describe('BUG-B: Admin list endpoints — snake_case serialization', () => {
     expect(res.body.name).toBe('Alicia');
   });
 
-  it('DELETE /api/admin/categories/:id (soft-delete) returns snake_case', async () => {
+  it('DELETE /api/categories/:id (soft-delete) returns snake_case', async () => {
     const db = testDb!;
     const now = new Date().toISOString();
     const [inserted] = await db
       .insert(schema.tripCategories)
       .values({
+        userId: TEST_USER_ID,
         name: 'TempCat',
         isActive: 1,
         createdAt: now,
@@ -294,7 +305,7 @@ describe('BUG-B: Admin list endpoints — snake_case serialization', () => {
       })
       .returning();
 
-    const res = await supertest(app).delete(`/api/admin/categories/${inserted.id}`).expect(200);
+    const res = await supertest(app).delete(`/api/categories/${inserted.id}`).expect(200);
 
     expect(res.body).toHaveProperty('is_active');
     expect(res.body.is_active).toBe(false);
@@ -513,6 +524,7 @@ describe('SEC-03: DELETE place activity — ownership check', () => {
     const [act] = await db
       .insert(schema.activities)
       .values({
+        userId: OTHER_USER_ID,
         name: 'Hiking',
         isActive: 1,
         createdAt: now,
@@ -552,6 +564,7 @@ describe('SEC-03: DELETE place activity — ownership check', () => {
     const [act] = await db
       .insert(schema.activities)
       .values({
+        userId: TEST_USER_ID,
         name: 'Swimming',
         isActive: 1,
         createdAt: now,

--- a/src/backend/routes/__tests__/security.access-matrix.test.ts
+++ b/src/backend/routes/__tests__/security.access-matrix.test.ts
@@ -440,14 +440,20 @@ describe('Part B — Non-owner authenticated user receives 403 on owner-only rou
     expect(res.body).toMatchObject({ error: 'Forbidden' });
   });
 
-  // Cities — owner-only routes
-  it('POST /api/cities → 403', async () => {
+  // Cities — CREATION is no longer owner-only (ADL-46 D4/§8 row 3). City
+  // create-on-demand is available to any authenticated user; curation (PATCH,
+  // below) stays owner-only. A non-owner POST now creates a city → 201, not 403.
+  // The full find-or-create / containment behaviour is covered by the ADL-46
+  // acceptance suite (adl46-access-model.test.ts Group A/B); this assertion just
+  // confirms the access gate flipped from owner-only to requireAuth here in the
+  // access matrix.
+  it('POST /api/cities → 201 for a non-owner (ADL-46 D4: creation opened)', async () => {
     await seedCountry(testDb!);
     const res = await supertest(app)
       .post('/api/cities')
       .send({ name: 'Test City', country_code: 'US' });
-    expect(res.status).toBe(403);
-    expect(res.body).toMatchObject({ error: 'Forbidden' });
+    expect(res.status).toBe(201);
+    expect(res.body).toMatchObject({ name: 'Test City', country_code: 'US' });
   });
 
   // PATCH /api/cities/:id — BUG-22 (GitHub issue #91) merged and the requireOwner

--- a/src/backend/routes/activities.ts
+++ b/src/backend/routes/activities.ts
@@ -1,0 +1,137 @@
+/**
+ * Travel Tracker — Activities Router
+ *
+ * ADL-46 (AD-09, D3): activities are per-user, not an admin resource — they
+ * moved out of /api/admin/* entirely (the structural error behind BUG-63) to
+ * /api/activities, exactly as ADL-28 moved companions to /api/companions.
+ * requireAuth (applied globally via app.use('/api/', requireAuth) in server.ts)
+ * is the only gate — every handler is scoped to req.user!.id via
+ * activityRepository. Soft-delete only (is_active = 0) — never hard-delete
+ * (AD-06). Defaults are lazily seeded per-user on first access (read or write).
+ */
+
+import { Router } from 'express';
+import { ConflictError, NotFoundError, ValidationError } from '../errors.js';
+import { asyncHandler } from '../middleware/error-handler.js';
+import { validateBody } from '../middleware/validate.js';
+import { activityRepository } from '../repositories/activities.js';
+import { CreateAdminItemSchema, UpdateAdminItemSchema } from '../validation/admin.schemas.js';
+
+export const activitiesRouter = Router();
+
+/** Serialize a raw Drizzle activity row to snake_case API shape. */
+function serializeActivity(row: {
+  id: number;
+  name: string;
+  isActive: number;
+  createdAt: string;
+  updatedAt: string;
+}) {
+  return {
+    id: row.id,
+    name: row.name,
+    is_active: row.isActive === 1,
+    created_at: row.createdAt,
+    updated_at: row.updatedAt,
+  };
+}
+
+// ----------------------------------------------------------------
+// GET /api/activities — all (active + inactive) owned by the caller
+// ----------------------------------------------------------------
+// nosemgrep: travel-tracker.express-route-no-auth -- reason: requireAuth applied globally via app.use('/api/', requireAuth) in server.ts
+activitiesRouter.get(
+  '/',
+  asyncHandler(async (req, res) => {
+    const userId = req.user!.id;
+    await activityRepository.ensureSeeded(userId);
+    const rows = await activityRepository.findAll(userId);
+    res.json(rows.map(serializeActivity));
+  }),
+);
+
+// ----------------------------------------------------------------
+// GET /api/activities/active — active only, owned by the caller
+// ----------------------------------------------------------------
+// nosemgrep: travel-tracker.express-route-no-auth -- reason: requireAuth applied globally via app.use('/api/', requireAuth) in server.ts
+activitiesRouter.get(
+  '/active',
+  asyncHandler(async (req, res) => {
+    const userId = req.user!.id;
+    await activityRepository.ensureSeeded(userId);
+    const rows = await activityRepository.findActive(userId);
+    res.json(rows.map(serializeActivity));
+  }),
+);
+
+// ----------------------------------------------------------------
+// POST /api/activities — create, owned by the caller
+// ----------------------------------------------------------------
+// nosemgrep: travel-tracker.express-route-no-auth -- reason: requireAuth applied globally via app.use('/api/', requireAuth) in server.ts
+activitiesRouter.post(
+  '/',
+  validateBody(CreateAdminItemSchema),
+  asyncHandler(async (req, res) => {
+    const userId = req.user!.id;
+    const { name } = req.body;
+
+    // Seed defaults first so a user whose very first action is a POST still
+    // receives the default list alongside their custom entry (ADL-46 §3.2.1).
+    await activityRepository.ensureSeeded(userId);
+
+    // uniq_activities_user_name is scoped to (user_id, name) — two different
+    // users may each have a 'Skiing' activity without conflict.
+    const existing = await activityRepository.findAll(userId);
+    if (existing.some((a) => a.name === name)) {
+      throw new ConflictError(`Activity '${name}' already exists`);
+    }
+
+    const created = await activityRepository.create(userId, name);
+    res.status(201).json(serializeActivity(created));
+  }),
+);
+
+// ----------------------------------------------------------------
+// PATCH /api/activities/:id — update name or is_active, owned by the caller
+// ----------------------------------------------------------------
+// nosemgrep: travel-tracker.express-route-no-auth -- reason: requireAuth applied globally via app.use('/api/', requireAuth) in server.ts
+activitiesRouter.patch(
+  '/:id',
+  validateBody(UpdateAdminItemSchema),
+  asyncHandler(async (req, res) => {
+    const userId = req.user!.id;
+    const id = parseInt(String(req.params.id), 10);
+    if (Number.isNaN(id)) throw new NotFoundError('Activity');
+
+    const { name, is_active } = req.body;
+    const updated = await activityRepository.update(userId, id, {
+      name,
+      isActive: is_active !== undefined ? (is_active ? 1 : 0) : undefined,
+    });
+    if (!updated) throw new NotFoundError('Activity');
+
+    res.json(serializeActivity(updated));
+  }),
+);
+
+// ----------------------------------------------------------------
+// DELETE /api/activities/:id — soft-delete, owned by the caller
+// ----------------------------------------------------------------
+// nosemgrep: travel-tracker.express-route-no-auth -- reason: requireAuth applied globally via app.use('/api/', requireAuth) in server.ts
+activitiesRouter.delete(
+  '/:id',
+  asyncHandler(async (req, res) => {
+    const userId = req.user!.id;
+    const id = parseInt(String(req.params.id), 10);
+    if (Number.isNaN(id)) throw new NotFoundError('Activity');
+
+    const existing = await activityRepository.findById(userId, id);
+    if (!existing) throw new NotFoundError('Activity');
+    if (existing.isActive === 0) {
+      throw new ValidationError('Activity is already inactive');
+    }
+
+    const updated = await activityRepository.deactivate(userId, id);
+    res.json(serializeActivity(updated!));
+  }),
+);

--- a/src/backend/routes/admin.ts
+++ b/src/backend/routes/admin.ts
@@ -1,8 +1,8 @@
 /**
  * Travel Tracker — Admin Router
  *
- * Manages admin list tables (categories, activities) and country/region config.
- * All admin list items use soft-delete (is_active = 0) — never hard-delete (AD-06).
+ * Manages instance-administration config: country region-tier config and region CRUD.
+ * These are the tier-3 (instance administration) operations from ADL-46 D1.
  *
  * Auth model (BUG-61 / ADL-38): the router is owner-gated by default via a router-level
  * requireOwner guard, EXCEPT the two global reference-data GET routes (countries + regions),
@@ -12,19 +12,28 @@
  * ADL-28 (AD-08): companions used to be registered here (`/api/admin/companions`) but are
  * no longer an admin/owner-only resource — they moved to their own router at
  * `/api/companions` (requireAuth only, userId-scoped). See routes/companions.ts.
+ *
+ * ADL-46 (AD-09, D3): trip categories and activities followed the same path — they were
+ * per-user (tier 2), not instance administration, and a tier-2 resource on an owner-gated
+ * admin router was the structural error behind BUG-63. They moved to their own routers at
+ * `/api/categories` and `/api/activities` (requireAuth only, userId-scoped, lazily seeded).
+ * See routes/categories.ts and routes/activities.ts. The old admin-list CRUD factory that
+ * served both from here has been removed, NOT left as scaffolding (ADL-46 §9.1 / §9.3).
+ * Note: `GET/POST/PATCH/DELETE /api/admin/categories` (and /activities) still return 403 for
+ * a non-owner — router-level requireOwner runs before any route resolves, so a non-owner hits
+ * the guard and gets 403; an owner now gets 404 (the routes no longer exist). This is the
+ * fail-closed behaviour asserted by the access-matrix suite (ADL-46 §8.2 verified counterpoint).
  */
 
 import { and, eq } from 'drizzle-orm';
 import { Router } from 'express';
-import { activities, countries, getDb, regions, tripCategories } from '../db/index.js';
-import { ConflictError, NotFoundError, ValidationError } from '../errors.js';
+import { countries, getDb, regions } from '../db/index.js';
+import { NotFoundError, ValidationError } from '../errors.js';
 import { asyncHandler } from '../middleware/error-handler.js';
 import { requireOwner } from '../middleware/requireOwner.js';
 import { validateBody } from '../middleware/validate.js';
 import {
-  CreateAdminItemSchema,
   CreateRegionSchema,
-  UpdateAdminItemSchema,
   UpdateCountrySchema,
   UpdateRegionSchema,
 } from '../validation/admin.schemas.js';
@@ -104,135 +113,13 @@ adminRouter.get(
 // The read/write split above (BUG-61 / ADL-38) is the sole, deliberate exception.
 adminRouter.use(requireOwner);
 
-// ----------------------------------------------------------------
-// Admin list CRUD factory
-// Generates identical CRUD for categories and activities.
-// (Companions used this same factory pre-ADL-28 — see routes/companions.ts
-// for its non-owner-gated, userId-scoped replacement.)
-// ----------------------------------------------------------------
-
-type AdminTable = typeof tripCategories | typeof activities;
-
-/** Serialize a raw Drizzle admin list row to snake_case API shape. */
-function serializeAdminItem(row: {
-  id: number;
-  name: string;
-  isActive: number;
-  createdAt: string;
-  updatedAt: string;
-}) {
-  return {
-    id: row.id,
-    name: row.name,
-    is_active: row.isActive === 1,
-    created_at: row.createdAt,
-    updated_at: row.updatedAt,
-  };
-}
-
-function createAdminListRouter(table: AdminTable, resourceName: string): Router {
-  const router = Router();
-
-  // GET / — all (active + inactive)
-  router.get(
-    '/',
-    asyncHandler(async (_req, res) => {
-      const db = getDb();
-      const rows = await db.select().from(table);
-      res.json(rows.map(serializeAdminItem));
-    }),
-  );
-
-  // GET /active — active only
-  router.get(
-    '/active',
-    asyncHandler(async (_req, res) => {
-      const db = getDb();
-      const rows = await db.select().from(table).where(eq(table.isActive, 1));
-      res.json(rows.map(serializeAdminItem));
-    }),
-  );
-
-  // POST / — create
-  router.post(
-    '/',
-    validateBody(CreateAdminItemSchema),
-    asyncHandler(async (req, res) => {
-      const { name } = req.body;
-      const db = getDb();
-
-      // Check uniqueness (table has UNIQUE constraint — catch the DB error too)
-      const existing = await db
-        .select({ id: table.id })
-        .from(table)
-        .where(eq(table.name, name))
-        .limit(1);
-      if (existing.length) throw new ConflictError(`${resourceName} '${name}' already exists`);
-
-      const now = new Date().toISOString();
-      const inserted = await db
-        .insert(table)
-        .values({ name, createdAt: now, updatedAt: now })
-        .returning();
-      res.status(201).json(serializeAdminItem(inserted[0]));
-    }),
-  );
-
-  // PATCH /:id — update name or is_active
-  router.patch(
-    '/:id',
-    validateBody(UpdateAdminItemSchema),
-    asyncHandler(async (req, res) => {
-      const id = parseInt(String(req.params.id), 10);
-      if (Number.isNaN(id)) throw new NotFoundError(resourceName);
-
-      const db = getDb();
-      const existing = await db.select().from(table).where(eq(table.id, id)).limit(1);
-      if (!existing.length) throw new NotFoundError(resourceName);
-
-      const { name, is_active } = req.body;
-      const now = new Date().toISOString();
-      const updates: Record<string, unknown> = { updatedAt: now };
-      if (name !== undefined) updates.name = name;
-      if (is_active !== undefined) updates.isActive = is_active ? 1 : 0;
-
-      const updated = await db.update(table).set(updates).where(eq(table.id, id)).returning();
-      res.json(serializeAdminItem(updated[0]));
-    }),
-  );
-
-  // DELETE /:id — soft-delete
-  router.delete(
-    '/:id',
-    asyncHandler(async (req, res) => {
-      const id = parseInt(String(req.params.id), 10);
-      if (Number.isNaN(id)) throw new NotFoundError(resourceName);
-
-      const db = getDb();
-      const existing = await db.select().from(table).where(eq(table.id, id)).limit(1);
-      if (!existing.length) throw new NotFoundError(resourceName);
-      if (existing[0].isActive === 0) {
-        throw new ValidationError(`${resourceName} is already inactive`);
-      }
-
-      const now = new Date().toISOString();
-      const updated = await db
-        .update(table)
-        .set({ isActive: 0, updatedAt: now })
-        .where(eq(table.id, id))
-        .returning();
-      res.json(serializeAdminItem(updated[0]));
-    }),
-  );
-
-  return router;
-}
-
-// Register admin list routers
-adminRouter.use('/categories', createAdminListRouter(tripCategories, 'Category'));
-adminRouter.use('/activities', createAdminListRouter(activities, 'Activity'));
-// Companions intentionally NOT registered here — ADL-28 (AD-08) moved them to
-// their own router at /api/companions (requireAuth only, userId-scoped).
+// Categories and activities are intentionally NOT registered here.
+// ADL-46 (AD-09, D3): they are per-user (tier 2) resources and moved to their
+// own routers at /api/categories and /api/activities (requireAuth only,
+// userId-scoped). Companions moved the same way under ADL-28 (AD-08). The old
+// admin-list CRUD factory that served categories/activities from here was
+// removed as part of this same release — no scaffolding left behind
+// (ADL-46 §9.1 ordering constraint 1, §9.3).
 
 // ----------------------------------------------------------------
 // Country admin — WRITES (owner-only; below the requireOwner guard).

--- a/src/backend/routes/categories.ts
+++ b/src/backend/routes/categories.ts
@@ -1,0 +1,137 @@
+/**
+ * Travel Tracker — Categories Router
+ *
+ * ADL-46 (AD-09, D3): trip categories are per-user, not an admin resource —
+ * they moved out of /api/admin/* entirely (the structural error behind BUG-63)
+ * to /api/categories, exactly as ADL-28 moved companions to /api/companions.
+ * requireAuth (applied globally via app.use('/api/', requireAuth) in server.ts)
+ * is the only gate — every handler is scoped to req.user!.id via
+ * tripCategoryRepository. Soft-delete only (is_active = 0) — never hard-delete
+ * (AD-06). Defaults are lazily seeded per-user on first access (read or write).
+ */
+
+import { Router } from 'express';
+import { ConflictError, NotFoundError, ValidationError } from '../errors.js';
+import { asyncHandler } from '../middleware/error-handler.js';
+import { validateBody } from '../middleware/validate.js';
+import { tripCategoryRepository } from '../repositories/tripCategories.js';
+import { CreateAdminItemSchema, UpdateAdminItemSchema } from '../validation/admin.schemas.js';
+
+export const categoriesRouter = Router();
+
+/** Serialize a raw Drizzle category row to snake_case API shape. */
+function serializeCategory(row: {
+  id: number;
+  name: string;
+  isActive: number;
+  createdAt: string;
+  updatedAt: string;
+}) {
+  return {
+    id: row.id,
+    name: row.name,
+    is_active: row.isActive === 1,
+    created_at: row.createdAt,
+    updated_at: row.updatedAt,
+  };
+}
+
+// ----------------------------------------------------------------
+// GET /api/categories — all (active + inactive) owned by the caller
+// ----------------------------------------------------------------
+// nosemgrep: travel-tracker.express-route-no-auth -- reason: requireAuth applied globally via app.use('/api/', requireAuth) in server.ts
+categoriesRouter.get(
+  '/',
+  asyncHandler(async (req, res) => {
+    const userId = req.user!.id;
+    await tripCategoryRepository.ensureSeeded(userId);
+    const rows = await tripCategoryRepository.findAll(userId);
+    res.json(rows.map(serializeCategory));
+  }),
+);
+
+// ----------------------------------------------------------------
+// GET /api/categories/active — active only, owned by the caller
+// ----------------------------------------------------------------
+// nosemgrep: travel-tracker.express-route-no-auth -- reason: requireAuth applied globally via app.use('/api/', requireAuth) in server.ts
+categoriesRouter.get(
+  '/active',
+  asyncHandler(async (req, res) => {
+    const userId = req.user!.id;
+    await tripCategoryRepository.ensureSeeded(userId);
+    const rows = await tripCategoryRepository.findActive(userId);
+    res.json(rows.map(serializeCategory));
+  }),
+);
+
+// ----------------------------------------------------------------
+// POST /api/categories — create, owned by the caller
+// ----------------------------------------------------------------
+// nosemgrep: travel-tracker.express-route-no-auth -- reason: requireAuth applied globally via app.use('/api/', requireAuth) in server.ts
+categoriesRouter.post(
+  '/',
+  validateBody(CreateAdminItemSchema),
+  asyncHandler(async (req, res) => {
+    const userId = req.user!.id;
+    const { name } = req.body;
+
+    // Seed defaults first so a user whose very first action is a POST still
+    // receives the default list alongside their custom entry (ADL-46 §3.2.1).
+    await tripCategoryRepository.ensureSeeded(userId);
+
+    // uniq_trip_categories_user_name is scoped to (user_id, name) — two
+    // different users may each have a 'Ski Trip' category without conflict.
+    const existing = await tripCategoryRepository.findAll(userId);
+    if (existing.some((c) => c.name === name)) {
+      throw new ConflictError(`Category '${name}' already exists`);
+    }
+
+    const created = await tripCategoryRepository.create(userId, name);
+    res.status(201).json(serializeCategory(created));
+  }),
+);
+
+// ----------------------------------------------------------------
+// PATCH /api/categories/:id — update name or is_active, owned by the caller
+// ----------------------------------------------------------------
+// nosemgrep: travel-tracker.express-route-no-auth -- reason: requireAuth applied globally via app.use('/api/', requireAuth) in server.ts
+categoriesRouter.patch(
+  '/:id',
+  validateBody(UpdateAdminItemSchema),
+  asyncHandler(async (req, res) => {
+    const userId = req.user!.id;
+    const id = parseInt(String(req.params.id), 10);
+    if (Number.isNaN(id)) throw new NotFoundError('Category');
+
+    const { name, is_active } = req.body;
+    const updated = await tripCategoryRepository.update(userId, id, {
+      name,
+      isActive: is_active !== undefined ? (is_active ? 1 : 0) : undefined,
+    });
+    if (!updated) throw new NotFoundError('Category');
+
+    res.json(serializeCategory(updated));
+  }),
+);
+
+// ----------------------------------------------------------------
+// DELETE /api/categories/:id — soft-delete, owned by the caller
+// ----------------------------------------------------------------
+// nosemgrep: travel-tracker.express-route-no-auth -- reason: requireAuth applied globally via app.use('/api/', requireAuth) in server.ts
+categoriesRouter.delete(
+  '/:id',
+  asyncHandler(async (req, res) => {
+    const userId = req.user!.id;
+    const id = parseInt(String(req.params.id), 10);
+    if (Number.isNaN(id)) throw new NotFoundError('Category');
+
+    const existing = await tripCategoryRepository.findById(userId, id);
+    if (!existing) throw new NotFoundError('Category');
+    if (existing.isActive === 0) {
+      throw new ValidationError('Category is already inactive');
+    }
+
+    const updated = await tripCategoryRepository.deactivate(userId, id);
+    res.json(serializeCategory(updated!));
+  }),
+);

--- a/src/backend/routes/cities.ts
+++ b/src/backend/routes/cities.ts
@@ -5,7 +5,7 @@
  * Geocoding is attempted immediately on city creation; failures are silent (GE-12).
  */
 
-import { and, asc, desc, eq, inArray, like, notInArray, sql } from 'drizzle-orm';
+import { and, asc, desc, eq, inArray, isNull, like, notInArray, or, sql } from 'drizzle-orm';
 import { Router } from 'express';
 import {
   cities,
@@ -23,7 +23,7 @@ import { NotFoundError, ValidationError } from '../errors.js';
 import { asyncHandler } from '../middleware/error-handler.js';
 import { requireOwner } from '../middleware/requireOwner.js';
 import { validateBody, validateQuery } from '../middleware/validate.js';
-import { resolveCity } from '../services/geocoding.service.js';
+import { resolveCity, resolveCityName } from '../services/geocoding.service.js';
 import {
   CityItemsQuerySchema,
   CreateCitySchema,
@@ -41,11 +41,27 @@ citiesRouter.get(
   validateQuery(SearchCitiesQuerySchema),
   asyncHandler(async (req, res) => {
     const { q, country_code } = req.query as { q: string; country_code?: string };
+    const userId = req.user!.id;
 
     const db = getDb();
 
     const conditions = [like(cities.name, `%${q}%`)];
     if (country_code) conditions.push(eq(cities.countryCode, country_code));
+
+    // ADL-46 GE-16 / D5 containment (§4.4): a 'pending' city is visible only in
+    // its creator's own searches; it becomes globally visible once 'resolved'.
+    // The IS NULL branch (F3) is load-bearing and permanent, not a legacy
+    // artefact — ON DELETE SET NULL regenerates a NULL creator on every user
+    // deletion, so a row that is pending AND has no known creator must be global
+    // (seeded, pre-column, or creator-since-deleted), never invisible-to-everyone.
+    // 'unresolvable' rows are NOT globally visible — they were never resolved, so
+    // they stay creator-scoped (or global when the creator is NULL) exactly like
+    // 'pending'. Only 'resolved' promotes a row to the shared catalogue.
+    const containment = or(
+      eq(cities.geocodeStatus, 'resolved'),
+      eq(cities.createdByUserId, userId),
+      isNull(cities.createdByUserId),
+    );
 
     const results = await db
       .select({
@@ -58,40 +74,127 @@ citiesRouter.get(
         geocode_status: cities.geocodeStatus,
       })
       .from(cities)
-      .where(and(...conditions))
+      .where(and(...conditions, containment))
       .orderBy(cities.name);
 
     res.json(results);
   }),
 );
 
+/** Serialize a city row to the snake_case API shape. */
+function serializeCity(row: {
+  id: number;
+  name: string;
+  countryCode: string;
+  regionId: number | null;
+  latitude: number | null;
+  longitude: number | null;
+  geocodeStatus: string;
+}) {
+  return {
+    id: row.id,
+    name: row.name,
+    country_code: row.countryCode,
+    region_id: row.regionId,
+    latitude: row.latitude,
+    longitude: row.longitude,
+    geocode_status: row.geocodeStatus,
+  };
+}
+
+/**
+ * ADL-46 D13 (§4.2.1) — the three-step find-or-create, steps 1 & 2. Returns an
+ * existing (or wildcard-upgraded) city row for (name, countryCode, regionId), or
+ * null if a genuine insert is needed. NOT creator-scoped: the unique index is
+ * global, so pass 1 must be able to return another user's pending row (OP-27 P2 /
+ * §8 row 6) rather than colliding with the index on insert.
+ *
+ *   Step 1 — exact match on (name COLLATE NOCASE, country_code, COALESCE(region_id,0)),
+ *            mirroring uniq_cities_name_country_region_ci exactly.
+ *   Step 2 — WILDCARD UPGRADE: if the request carries a region and step 1 missed,
+ *            adopt a region-less row of the same name+country by SETTING its
+ *            region_id. A region-less row is an under-specified record, not a
+ *            different city — specialising it prevents the duplicate that naively
+ *            adding `AND COALESCE(region_id,0)=…` would create (the BUG-33 class).
+ *
+ * The reverse ambiguity (no region requested, ≥2 same-name rows exist) is left to
+ * the caller: it falls through to null here and the caller creates a 'pending'
+ * row rather than guessing which region the user meant (§4.2.1 / D14).
+ */
+async function findOrUpgradeCity(
+  db: ReturnType<typeof getDb>,
+  name: string,
+  countryCode: string,
+  regionId: number | null,
+) {
+  const regionKey = regionId ?? 0;
+
+  // Step 1 — exact match on the composite identity key.
+  const exact = await db
+    .select()
+    .from(cities)
+    .where(
+      and(
+        eq(cities.countryCode, countryCode),
+        sql`${cities.name} = ${name} COLLATE NOCASE`,
+        sql`COALESCE(${cities.regionId}, 0) = ${regionKey}`,
+      ),
+    )
+    .limit(1);
+  if (exact.length) return exact[0];
+
+  // Step 2 — wildcard upgrade (only when the request carries a region).
+  if (regionId != null) {
+    const regionless = await db
+      .select()
+      .from(cities)
+      .where(
+        and(
+          eq(cities.countryCode, countryCode),
+          sql`${cities.name} = ${name} COLLATE NOCASE`,
+          isNull(cities.regionId),
+        ),
+      )
+      .limit(1);
+    if (regionless.length) {
+      const now = new Date().toISOString();
+      const upgraded = await db
+        .update(cities)
+        .set({ regionId, updatedAt: now })
+        .where(eq(cities.id, regionless[0].id))
+        .returning();
+      return upgraded[0];
+    }
+  }
+
+  return null;
+}
+
 // ----------------------------------------------------------------
 // POST /api/cities
-// ADL-27 / HC-06: owner-only (city creation pollutes the global seed)
+// ADL-46 D4/D5/GE-16: city CREATION is a constrained, service-validated
+// create-on-demand available to ANY authenticated user (requireAuth only) —
+// NOT owner-only. City CURATION (PATCH) stays owner-only (tier 1 write split,
+// §4.1). The old `requireOwner` gate conflated the two.
 //
-// BUG-33: find-or-create. GE-14 says the frontend should search before
-// offering "add new city", but that's a UX nicety, not a guarantee — a
-// case-mismatched query, a stale search-results list, or a double-submit
-// can all reach this route for a city that already exists. This handler
-// is the last line of defense against duplicate `cities` rows: it looks
-// up an existing (name, country_code) match case-insensitively before
-// ever inserting, and only inserts when genuinely not found.
+// Resolve-then-create (§4.3): the row is built from the geocoder's CANONICAL
+// response where one is available, so 'Denverr' / 'denver co' / 'DEN' converge
+// onto one row rather than only exact case-folds. D12 (§4.3.1): the lookup is
+// CONSTRAINED by the user's already-validated country (and region where given)
+// and may NEVER override them; unresolvable / offline / ambiguous input still
+// creates a 'pending' row from the user's text (GE-12 — creation never depends
+// on the geocoder), creator-private until it resolves (§4.4 containment).
 //
-// Migration 0010 (companion DB brief, merged) added
-// uniq_cities_name_country_ci — UNIQUE(name COLLATE NOCASE, country_code).
-// The lookup below matches that collation exactly (COLLATE NOCASE, not a
-// generic lower()) so it always finds the same row the DB constraint would
-// otherwise reject a duplicate of — verified empirically that SQLite/libSQL's
-// COLLATE NOCASE and lower() agree on every case (both are ASCII-only folds;
-// non-ASCII/diacritic variants are an accepted, documented limitation of the
-// index itself, not something this lookup needs to compensate for).
+// D13 (§4.2.1): identity is (name, country_code, COALESCE(region_id,0)); the
+// three-step find-or-create (findOrUpgradeCity + the reverse-ambiguity branch)
+// is what keeps this from re-opening BUG-33 by silently creating duplicates.
 // ----------------------------------------------------------------
 citiesRouter.post(
   '/',
-  requireOwner,
   validateBody(CreateCitySchema),
   asyncHandler(async (req, res) => {
     const { name, country_code, region_id } = req.body;
+    const userId = req.user!.id;
     const db = getDb();
 
     // Verify country exists
@@ -104,49 +207,82 @@ citiesRouter.post(
 
     const { regionTierEnabled } = countryRows[0];
 
-    // Correction 2: region_id is OPTIONAL even when region_tier_enabled = 1
-    // But region_id MUST be NULL when region_tier_enabled = 0
+    // region_id is OPTIONAL when region_tier_enabled = 1, but MUST be NULL when 0.
     if (regionTierEnabled === 0 && region_id != null) {
       throw new ValidationError('region_id must not be provided for countries without region tier');
     }
 
-    // If region_id is provided, verify it belongs to the country
+    // If region_id is provided, verify it belongs to the country and capture its
+    // ISO code so the geocoder lookup can be disambiguated by region (D12 step 2).
+    let regionIso: string | null = null;
     if (region_id != null) {
       const regionRows = await db
-        .select({ id: regions.id })
+        .select({ id: regions.id, iso: regions.iso3166_2 })
         .from(regions)
         .where(and(eq(regions.id, region_id), eq(regions.countryCode, country_code)))
         .limit(1);
       if (!regionRows.length) throw new NotFoundError('Region');
+      regionIso = regionRows[0].iso;
     }
 
-    // BUG-33: find-or-create — look up an existing city by (name, country_code),
-    // matching name COLLATE NOCASE to mirror uniq_cities_name_country_ci exactly.
-    // `name` arrives already whitespace-trimmed by CreateCitySchema (zod .trim()).
-    const existingRows = await db
-      .select()
-      .from(cities)
-      .where(
-        and(eq(cities.countryCode, country_code), sql`${cities.name} = ${name} COLLATE NOCASE`),
-      )
-      .limit(1);
-
-    if (existingRows.length) {
-      // Existing city found — return it as-is (200, not 201: no row was created).
-      // Deliberately does NOT overwrite region_id from the request; that's PATCH's job.
-      const existing = existingRows[0];
-      res.status(200).json({
-        id: existing.id,
-        name: existing.name,
-        country_code: existing.countryCode,
-        region_id: existing.regionId,
-        latitude: existing.latitude,
-        longitude: existing.longitude,
-        geocode_status: existing.geocodeStatus,
-      });
+    // Pass 1 (§4.3 step 2) — find-or-create against the user's submitted name.
+    const found1 = await findOrUpgradeCity(db, name, country_code, region_id ?? null);
+    if (found1) {
+      res.status(200).json(serializeCity(found1));
       return;
     }
 
+    // Resolve-then-create (§4.3 step 3) — resolve BEFORE inserting so the row is
+    // built from the canonical response. GEOCODING_ENABLED=false / offline /
+    // recoverable errors return 'disabled' → fall through to the pending insert.
+    // GE-12: city creation must NEVER depend on the geocoder — any failure in the
+    // resolve step degrades to a 'pending' row rather than failing the request.
+    let resolution: Awaited<ReturnType<typeof resolveCityName>>;
+    try {
+      resolution = await resolveCityName(name, country_code, { regionIso });
+    } catch {
+      resolution = { status: 'disabled', candidates: [] };
+    }
+
+    if (resolution.status === 'ok' && resolution.best) {
+      const canonicalName = resolution.best.name?.trim() || name;
+
+      // Pass 2 (§4.3 step 4a) — find-or-create against the CANONICAL name. This
+      // is the step that does the real convergence work and is easy to omit.
+      const found2 = await findOrUpgradeCity(db, canonicalName, country_code, region_id ?? null);
+      if (found2) {
+        res.status(200).json(serializeCity(found2));
+        return;
+      }
+
+      // Step 4b — INSERT from the canonical response. D12 rule 3: NEVER overwrite
+      // the user-supplied country_code / region_id with the lookup's — the user
+      // has ground truth about where they went; the lookup supplies only coords
+      // and the canonical name.
+      const now = new Date().toISOString();
+      const inserted = await db
+        .insert(cities)
+        .values({
+          name: canonicalName,
+          countryCode: country_code,
+          regionId: region_id ?? null,
+          latitude: resolution.best.latitude,
+          longitude: resolution.best.longitude,
+          geocodeStatus: 'resolved',
+          createdByUserId: userId,
+          createdAt: now,
+          updatedAt: now,
+        })
+        .returning();
+      res.status(201).json(serializeCity(inserted[0]));
+      return;
+    }
+
+    // Step 4c — unresolved / ambiguous / disabled: create a 'pending' row from the
+    // user's own text. Creator-private until it resolves (§4.4). Ambiguity never
+    // blocks creation (GE-12); the frontend's D14 candidate flow disambiguates
+    // via the region selector, after which a re-submit with a region hits the
+    // wildcard-upgrade path above.
     const now = new Date().toISOString();
     const inserted = await db
       .insert(cities)
@@ -155,6 +291,7 @@ citiesRouter.post(
         countryCode: country_code,
         regionId: region_id ?? null,
         geocodeStatus: 'pending',
+        createdByUserId: userId,
         createdAt: now,
         updatedAt: now,
       })
@@ -162,25 +299,15 @@ citiesRouter.post(
 
     const city = inserted[0];
 
-    // Attempt geocoding immediately (fire-and-forget — GE-12)
-    // resolveCity handles offline gracefully — never throws
+    // Fire-and-forget the queue re-resolution so a legitimate city created while
+    // the geocoder was unreachable is promoted to 'resolved' (and globally
+    // visible) on its own (GE-12 / §4.4). Never throws.
     resolveCity(city.id).catch(() => {
-      // Already handled internally — defensive catch
+      /* handled internally — defensive catch */
     });
 
-    // Re-fetch to get updated geocode status (may have resolved synchronously in fast environments)
     const fresh = await db.select().from(cities).where(eq(cities.id, city.id)).limit(1);
-    const result = fresh[0] ?? city;
-
-    res.status(201).json({
-      id: result.id,
-      name: result.name,
-      country_code: result.countryCode,
-      region_id: result.regionId,
-      latitude: result.latitude,
-      longitude: result.longitude,
-      geocode_status: result.geocodeStatus,
-    });
+    res.status(201).json(serializeCity(fresh[0] ?? city));
   }),
 );
 

--- a/src/backend/routes/cities.ts
+++ b/src/backend/routes/cities.ts
@@ -117,9 +117,19 @@ function serializeCity(row: {
  *            different city — specialising it prevents the duplicate that naively
  *            adding `AND COALESCE(region_id,0)=…` would create (the BUG-33 class).
  *
- * The reverse ambiguity (no region requested, ≥2 same-name rows exist) is left to
- * the caller: it falls through to null here and the caller creates a 'pending'
- * row rather than guessing which region the user meant (§4.2.1 / D14).
+ *   Step 2b (reverse, NO region requested) — collapse to (name, country_code)
+ *            regardless of region. This is the "today's behaviour" case the old
+ *            `(name, country_code)` unique index enforced, which §4.2.1 requires
+ *            we preserve:
+ *              • exactly ONE row matches → return it (single-match, NO regression);
+ *              • TWO OR MORE match → return null; the caller creates a 'pending'
+ *                row and leaves D14 disambiguation to the frontend, rather than
+ *                silently picking one (§4.2.1 / D14, QA B4).
+ *            Without this, a region-tier country holding exactly one *regioned*
+ *            match (e.g. only "Springfield, IL") would miss step 1 (its
+ *            COALESCE(region_id,0) ≠ 0), skip step 2 (no region requested), and
+ *            the caller would INSERT a second, region-less duplicate — the BUG-33
+ *            class arriving through the reverse door.
  */
 async function findOrUpgradeCity(
   db: ReturnType<typeof getDb>,
@@ -165,7 +175,21 @@ async function findOrUpgradeCity(
         .returning();
       return upgraded[0];
     }
+    // Has-region path ends here: step 1 + step 2 are authoritative for a
+    // region-bearing request. Do NOT fall through to the reverse branch below.
+    return null;
   }
+
+  // Step 2b — reverse single-match (only when NO region was requested). Match on
+  // (name, country_code) regardless of region; exactly one → return it (the
+  // no-regression case §4.2.1 mandates), two or more → null (ambiguous → caller
+  // creates pending, D14 disambiguates).
+  const sameName = await db
+    .select()
+    .from(cities)
+    .where(and(eq(cities.countryCode, countryCode), sql`${cities.name} = ${name} COLLATE NOCASE`))
+    .limit(2);
+  if (sameName.length === 1) return sameName[0];
 
   return null;
 }

--- a/src/backend/routes/geocode.ts
+++ b/src/backend/routes/geocode.ts
@@ -1,0 +1,77 @@
+/**
+ * Travel Tracker — Geocode Proxy Router (ADL-46 D7 §5.1 / BUG-55)
+ *
+ * A first-party backend proxy for Nominatim lookups. Replaces the direct
+ * browser fetch in useCities.ts, which could never be policy-compliant: the
+ * Nominatim usage policy requires an identifying User-Agent, and `User-Agent`
+ * is a forbidden header name in browser fetch() (silently dropped). The
+ * server-side client sends a compliant User-Agent and — crucially — routes
+ * through the single serialized egress chokepoint (nominatim-client), so the
+ * 1 req/s per-application limit is actually enforceable across all callers
+ * (§5.1.1). Removing the cross-origin call also makes the fix immune to the
+ * QUAL-18 CSP environment-parity gap (there is no connect-src to allowlist).
+ *
+ * Serves two callers with one route:
+ *   - GE-15 country auto-populate: the top candidate's country_code / region_iso.
+ *   - ADL-46 D14 (§4.3.2): the full candidate list, so the frontend can populate
+ *     the region selector rather than the backend guessing data[0].
+ *
+ * requireAuth (applied globally via app.use('/api/', requireAuth) in server.ts)
+ * is the only gate — it is a first-party egress surface and must never be
+ * callable anonymously. No userId scoping: this reads no user data (tier-1
+ * reference lookup).
+ */
+
+import { Router } from 'express';
+import { asyncHandler } from '../middleware/error-handler.js';
+import { validateQuery } from '../middleware/validate.js';
+import { nominatimSearch } from '../services/nominatim-client.js';
+import { GeocodeQuerySchema } from '../validation/geocode.schemas.js';
+
+export const geocodeRouter = Router();
+
+// ----------------------------------------------------------------
+// GET /api/geocode?q=...&country_code=...&region_iso=...
+// ----------------------------------------------------------------
+// nosemgrep: travel-tracker.express-route-no-auth -- reason: requireAuth applied globally via app.use('/api/', requireAuth) in server.ts
+geocodeRouter.get(
+  '/',
+  validateQuery(GeocodeQuerySchema),
+  asyncHandler(async (req, res) => {
+    const { q, country_code, region_iso } = req.query as {
+      q: string;
+      country_code?: string;
+      region_iso?: string;
+    };
+
+    const params: Record<string, string> = { q, limit: '10' };
+    if (country_code) params.countrycodes = country_code.toLowerCase();
+
+    const result = await nominatimSearch(params);
+    let candidates = result.status === 'ok' ? result.candidates : [];
+
+    // D12 step 2: if a region ISO was supplied and any candidate matches it,
+    // narrow to those — but never fabricate a result when none match.
+    if (region_iso) {
+      const matches = candidates.filter(
+        (c) => c.regionIso?.toUpperCase() === region_iso.toUpperCase(),
+      );
+      if (matches.length) candidates = matches;
+    }
+
+    res.json({
+      // Full candidate list (D14) — labelled by region for the selector.
+      candidates: candidates.map((c) => ({
+        name: c.name,
+        display_name: c.displayName,
+        country_code: c.countryCode,
+        region_iso: c.regionIso,
+        latitude: c.latitude,
+        longitude: c.longitude,
+      })),
+      // GE-15 auto-populate convenience — the top candidate's country/region.
+      country_code: candidates[0]?.countryCode ?? null,
+      region_iso: candidates[0]?.regionIso ?? null,
+    });
+  }),
+);

--- a/src/backend/routes/places.ts
+++ b/src/backend/routes/places.ts
@@ -18,6 +18,7 @@ import { cities, getDb, items, tripPlaceActivitiesMap, tripPlaces } from '../db/
 import { ConflictError, NotFoundError, ValidationError } from '../errors.js';
 import { asyncHandler } from '../middleware/error-handler.js';
 import { validateBody } from '../middleware/validate.js';
+import { activityRepository } from '../repositories/activities.js';
 import { placeRepository } from '../repositories/places.js';
 import { assertNotLocked, executeCarryForward } from '../services/items.service.js';
 import { CarryForwardBodySchema } from '../validation/items.schemas.js';
@@ -137,13 +138,27 @@ placesRouter.patch(
     const placeId = parseInt(String(req.params.placeId), 10);
     if (Number.isNaN(tripId) || Number.isNaN(placeId)) throw new NotFoundError('Place');
 
-    const { arrived_on, departed_on } = req.body;
+    const { arrived_on, departed_on, city_id } = req.body;
+    const db = getDb();
 
     // Ownership + lock verified before any read/mutation (audit invariant 17)
     await placeRepository.assertWritable(userId, tripId);
 
     const existing = await placeRepository.findById(userId, placeId);
     if (!existing || existing.tripId !== tripId) throw new NotFoundError('Place');
+
+    // ADL-46 D11 (§4.4.2): re-pointing to a corrected city. Validate the target
+    // city exists (global reference data — no owner/user scoping on cities), so a
+    // bad city_id is a 404 rather than an FK error. Ownership is already enforced
+    // on the place above, so this opens no new access surface.
+    if (city_id !== undefined && city_id !== existing.cityId) {
+      const cityRows = await db
+        .select({ id: cities.id })
+        .from(cities)
+        .where(eq(cities.id, city_id))
+        .limit(1);
+      if (!cityRows.length) throw new NotFoundError('City');
+    }
 
     // BUG-28: validate effective date order against the merged result — stored
     // values fill in for omitted fields (same pattern as trips PATCH / BUG-A).
@@ -163,6 +178,7 @@ placesRouter.patch(
       placeId,
       arrived_on,
       departed_on,
+      city_id,
     );
 
     res.json({
@@ -254,6 +270,19 @@ placesRouter.post(
     // Verify place belongs to trip owned by user (ownership BEFORE lock check)
     const place = await placeRepository.findById(userId, placeId);
     if (!place || place.tripId !== tripId) throw new NotFoundError('Place');
+
+    // ADL-46 §3.3 / F1(b): activities are per-user now, and the
+    // trip_place_activities_map FK targets activities.id (no user dimension),
+    // so SQLite cannot stop a caller tagging a place with ANOTHER user's
+    // activity. Validate ownership in application code — the same 400 contract
+    // replaceAssociations uses for trip-level associations. This is the half of
+    // F1 that outlives the current table contents (a permanent write-path gap).
+    const invalidActivityIds = await activityRepository.validateOwnership(userId, [activity_id]);
+    if (invalidActivityIds.length) {
+      throw new ValidationError(
+        `Activity ID(s) not found or not owned by user: ${invalidActivityIds.join(', ')}`,
+      );
+    }
 
     // BUG-27: locked trips are read-only — activity tagging is a write
     await assertNotLocked(tripId);

--- a/src/backend/server-test-app.ts
+++ b/src/backend/server-test-app.ts
@@ -25,9 +25,12 @@ import helmet from 'helmet';
 
 import { requireAuth } from './middleware/auth.js';
 import { errorHandler } from './middleware/error-handler.js';
+import { activitiesRouter } from './routes/activities.js';
 import { adminRouter } from './routes/admin.js';
+import { categoriesRouter } from './routes/categories.js';
 import { citiesRouter } from './routes/cities.js';
 import { companionsRouter } from './routes/companions.js';
+import { geocodeRouter } from './routes/geocode.js';
 import { mapRouter } from './routes/map.js';
 import { meRouter } from './routes/me.js';
 import { tripsRouter } from './routes/trips.js';
@@ -117,6 +120,9 @@ app.use('/api/cities', citiesRouter);
 app.use('/api/map', mapRouter);
 app.use('/api/admin', adminRouter);
 app.use('/api/companions', companionsRouter); // ADL-28 (AD-08): requireAuth only, userId-scoped
+app.use('/api/categories', categoriesRouter); // ADL-46 (AD-09, D3): requireAuth only, userId-scoped
+app.use('/api/activities', activitiesRouter); // ADL-46 (AD-09, D3): requireAuth only, userId-scoped
+app.use('/api/geocode', geocodeRouter); // ADL-46 (D7): geocoding proxy — requireAuth, egress chokepoint
 app.use('/api/me', meRouter); // BUG-26: identity endpoint for frontend owner gating
 
 // Health check

--- a/src/backend/server.ts
+++ b/src/backend/server.ts
@@ -38,9 +38,12 @@ import { getDb } from './db/index.js';
 import { requireAuth } from './middleware/auth.js';
 import { errorHandler } from './middleware/error-handler.js';
 import { userRepository } from './repositories/users.js';
+import { activitiesRouter } from './routes/activities.js';
 import { adminRouter } from './routes/admin.js';
+import { categoriesRouter } from './routes/categories.js';
 import { citiesRouter } from './routes/cities.js';
 import { companionsRouter } from './routes/companions.js';
+import { geocodeRouter } from './routes/geocode.js';
 import { mapRouter } from './routes/map.js';
 import { meRouter } from './routes/me.js';
 import { tripsRouter } from './routes/trips.js';
@@ -210,6 +213,9 @@ app.use('/api/cities', citiesRouter);
 app.use('/api/map', mapRouter);
 app.use('/api/admin', adminRouter);
 app.use('/api/companions', companionsRouter); // ADL-28 (AD-08): requireAuth only, userId-scoped
+app.use('/api/categories', categoriesRouter); // ADL-46 (AD-09, D3): requireAuth only, userId-scoped
+app.use('/api/activities', activitiesRouter); // ADL-46 (AD-09, D3): requireAuth only, userId-scoped
+app.use('/api/geocode', geocodeRouter); // ADL-46 (D7): geocoding proxy — requireAuth, egress chokepoint
 app.use('/api/me', meRouter); // BUG-26: identity endpoint for frontend owner gating
 
 // Health check (useful for development)

--- a/src/backend/services/__tests__/geocoding.service.test.ts
+++ b/src/backend/services/__tests__/geocoding.service.test.ts
@@ -1,0 +1,203 @@
+/**
+ * ADL-46 D10 (§4.4.1) + D12/D14 (§4.3.1/§4.3.2) — geocoding classification and
+ * name-resolution unit tests.
+ *
+ * The Nominatim egress chokepoint (nominatim-client) is mocked so the failure
+ * class each branch returns is controllable without any network. GEOCODING_ENABLED
+ * is toggled per-test with vi.stubEnv because the service reads it live.
+ */
+
+import { eq } from 'drizzle-orm';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as schema from '../../db/schema.js';
+import { createTestDb, type TestDb } from '../../repositories/__tests__/test-db.js';
+import type { NominatimSearchResult } from '../nominatim-client.js';
+
+let testDb: TestDb | null = null;
+
+vi.mock('../../db/index.js', async (importOriginal) => {
+  const real = await importOriginal<typeof import('../../db/index.js')>();
+  return {
+    ...real,
+    getDb: () => {
+      if (!testDb) throw new Error('[TEST] testDb not initialised');
+      return testDb;
+    },
+  };
+});
+
+// Controllable chokepoint — each test sets what the next search returns.
+let nextResult: NominatimSearchResult = { status: 'ok', candidates: [] };
+vi.mock('../nominatim-client.js', () => ({
+  nominatimSearch: vi.fn(async () => nextResult),
+}));
+
+const { resolveCity, resolveCityName, processQueue } = await import('../geocoding.service.js');
+
+async function seedCountryAndCity(
+  db: TestDb,
+  opts: { status?: 'pending' | 'resolved' | 'unresolvable'; attempts?: number } = {},
+): Promise<number> {
+  await db
+    .insert(schema.countries)
+    .values({ countryCode: 'US', name: 'United States', regionTierEnabled: 0 })
+    .onConflictDoNothing();
+  const [city] = await db
+    .insert(schema.cities)
+    .values({
+      name: 'Testville',
+      countryCode: 'US',
+      geocodeStatus: opts.status ?? 'pending',
+      geocodeAttempts: opts.attempts ?? 0,
+    })
+    .returning();
+  return city.id;
+}
+
+beforeEach(async () => {
+  testDb = await createTestDb();
+  vi.stubEnv('GEOCODING_ENABLED', 'true');
+  nextResult = { status: 'ok', candidates: [] };
+});
+
+afterEach(() => {
+  testDb = null;
+  vi.unstubAllEnvs();
+});
+
+describe('ADL-46 D10 — resolveCity failure classification', () => {
+  it("no-match (geocoder answered, empty) marks the row 'unresolvable' and processQueue never re-selects it", async () => {
+    const cityId = await seedCountryAndCity(testDb!);
+    nextResult = { status: 'ok', candidates: [] };
+
+    const ok = await resolveCity(cityId);
+    expect(ok).toBe(false);
+
+    const [row] = await testDb!.select().from(schema.cities).where(eq(schema.cities.id, cityId));
+    expect(row.geocodeStatus).toBe('unresolvable');
+    expect(row.geocodeAttempts).toBe(0); // terminal — not counted as a recoverable attempt
+
+    // processQueue selects only pending rows → this terminal row is skipped.
+    nextResult = { status: 'ok', candidates: [candidate()] };
+    await processQueue();
+    const [after] = await testDb!.select().from(schema.cities).where(eq(schema.cities.id, cityId));
+    expect(after.geocodeStatus).toBe('unresolvable'); // untouched
+  });
+
+  it("recoverable failure leaves the row 'pending' and increments geocode_attempts", async () => {
+    const cityId = await seedCountryAndCity(testDb!);
+    nextResult = { status: 'error' };
+
+    const ok = await resolveCity(cityId);
+    expect(ok).toBe(false);
+
+    const [row] = await testDb!.select().from(schema.cities).where(eq(schema.cities.id, cityId));
+    expect(row.geocodeStatus).toBe('pending');
+    expect(row.geocodeAttempts).toBe(1);
+  });
+
+  it('GEOCODING_ENABLED=false (global) does NOT increment geocode_attempts', async () => {
+    const cityId = await seedCountryAndCity(testDb!, { attempts: 2 });
+    vi.stubEnv('GEOCODING_ENABLED', 'false');
+
+    const ok = await resolveCity(cityId);
+    expect(ok).toBe(false);
+
+    const [row] = await testDb!.select().from(schema.cities).where(eq(schema.cities.id, cityId));
+    expect(row.geocodeStatus).toBe('pending');
+    expect(row.geocodeAttempts).toBe(2); // unchanged — offline is not a per-city failure
+  });
+
+  it('a successful resolution sets coordinates and status resolved', async () => {
+    const cityId = await seedCountryAndCity(testDb!);
+    nextResult = { status: 'ok', candidates: [candidate({ lat: 39.7, lon: -104.9 })] };
+
+    const ok = await resolveCity(cityId);
+    expect(ok).toBe(true);
+
+    const [row] = await testDb!.select().from(schema.cities).where(eq(schema.cities.id, cityId));
+    expect(row.geocodeStatus).toBe('resolved');
+    expect(row.latitude).toBeCloseTo(39.7);
+    expect(row.longitude).toBeCloseTo(-104.9);
+  });
+
+  it('processQueue does not re-select a row that has exhausted its recoverable-retry cap', async () => {
+    // attempts already at the cap (5) — must not be picked up again.
+    const cityId = await seedCountryAndCity(testDb!, { attempts: 5 });
+    nextResult = { status: 'ok', candidates: [candidate()] };
+
+    await processQueue();
+
+    const [row] = await testDb!.select().from(schema.cities).where(eq(schema.cities.id, cityId));
+    expect(row.geocodeStatus).toBe('pending'); // never resolved — was skipped
+  });
+});
+
+describe('ADL-46 D12/D14 — resolveCityName', () => {
+  it("disabled (GEOCODING_ENABLED=false) returns status 'disabled' with no candidates", async () => {
+    vi.stubEnv('GEOCODING_ENABLED', 'false');
+    const r = await resolveCityName('Denver', 'US');
+    expect(r.status).toBe('disabled');
+  });
+
+  it("exactly one candidate resolves to 'ok' with that candidate", async () => {
+    nextResult = { status: 'ok', candidates: [candidate({ name: 'Denver' })] };
+    const r = await resolveCityName('Denver', 'US');
+    expect(r.status).toBe('ok');
+    expect(r.best?.name).toBe('Denver');
+  });
+
+  it("D14: two or more comparable candidates return 'ambiguous' rather than auto-selecting", async () => {
+    nextResult = {
+      status: 'ok',
+      candidates: [
+        candidate({ name: 'Springfield', regionIso: 'US-IL' }),
+        candidate({ name: 'Springfield', regionIso: 'US-MO' }),
+      ],
+    };
+    const r = await resolveCityName('Springfield', 'US');
+    expect(r.status).toBe('ambiguous');
+    expect(r.candidates).toHaveLength(2);
+    expect(r.best).toBeUndefined();
+  });
+
+  it('D12: a supplied region ISO disambiguates two same-name candidates', async () => {
+    nextResult = {
+      status: 'ok',
+      candidates: [
+        candidate({ name: 'Springfield', regionIso: 'US-IL' }),
+        candidate({ name: 'Springfield', regionIso: 'US-MO' }),
+      ],
+    };
+    const r = await resolveCityName('Springfield', 'US', { regionIso: 'US-MO' });
+    expect(r.status).toBe('ok');
+    expect(r.best?.regionIso).toBe('US-MO');
+  });
+
+  it("no candidates resolves to 'unresolved'", async () => {
+    nextResult = { status: 'ok', candidates: [] };
+    const r = await resolveCityName('Nowhereville', 'US');
+    expect(r.status).toBe('unresolved');
+  });
+});
+
+function candidate(
+  overrides: {
+    name?: string;
+    lat?: number;
+    lon?: number;
+    countryCode?: string | null;
+    regionIso?: string | null;
+  } = {},
+) {
+  return {
+    displayName: overrides.name ?? 'Testville',
+    name: overrides.name ?? 'Testville',
+    latitude: overrides.lat ?? 1,
+    longitude: overrides.lon ?? 1,
+    countryCode: overrides.countryCode ?? 'US',
+    regionIso: overrides.regionIso ?? null,
+    class: 'place',
+    type: 'city',
+  };
+}

--- a/src/backend/services/geocoding.service.ts
+++ b/src/backend/services/geocoding.service.ts
@@ -1,52 +1,117 @@
 /**
  * Travel Tracker — Geocoding Service (Nominatim)
  *
- * Resolves city coordinates via the Nominatim OpenStreetMap geocoding API.
- * ADL-10: strictly complies with Nominatim usage policy — 1 req/sec max,
- * User-Agent required, results stored permanently (no re-querying).
+ * Resolves city coordinates via Nominatim. ADL-10: strict usage-policy
+ * compliance (1 req/s, identifying User-Agent, results stored permanently).
+ *
+ * ADL-46 (§5.1.1 / D7): ALL Nominatim egress now goes through the single
+ * serialized chokepoint in nominatim-client.ts — this service no longer opens
+ * its own fetch or runs an isOnline() HEAD probe (the probe doubled the request
+ * rate; a failed search is caught and classified instead).
+ *
+ * ADL-46 (§4.4.1 / D10): failures are CLASSIFIED, not merely counted.
+ *   - Terminal ("the geocoder answered: no match") → geocode_status = 'unresolvable',
+ *     never retried, drops out of the pending partial index.
+ *   - Recoverable (network/timeout/5xx/429) → stays 'pending', geocode_attempts++,
+ *     retried until a cap.
+ *   - Global (GEOCODING_ENABLED=false) → does NOT increment — one offline weekend
+ *     must not burn every pending city's retry budget.
  *
  * All Nominatim errors are caught and logged — never propagated to API callers.
- * GE-12: offline-safe — network unreachable is handled gracefully.
+ * GE-12: offline-safe — city creation never depends on the geocoder.
  */
 
-import { asc, eq } from 'drizzle-orm';
-import { cities, countries, getDb } from '../db/index.js';
+import { and, asc, eq, lt, sql } from 'drizzle-orm';
+import { cities, getDb, regions } from '../db/index.js';
+import { type NominatimCandidate, nominatimSearch } from './nominatim-client.js';
 
-const NOMINATIM_BASE = 'https://nominatim.openstreetmap.org/search';
-const USER_AGENT = 'TravelTracker/1.0 (personal-use-app)';
-const REQUEST_DELAY_MS = 1100; // 100ms above the 1 req/s limit (ADL-10)
-const CONNECTIVITY_TIMEOUT_MS = 3000;
+/** When GEOCODING_ENABLED=false, all geocoding is skipped (e.g. CI contract tests). */
+const geocodingEnabled = (): boolean => process.env.GEOCODING_ENABLED !== 'false';
 
-/** When GEOCODING_ENABLED=false, all geocoding is skipped (e.g. CI contract tests) */
-const GEOCODING_ENABLED = process.env.GEOCODING_ENABLED !== 'false';
+/**
+ * ADL-46 D10: recoverable failures retry until this cap, then the row stays
+ * 'pending' but is no longer re-selected by processQueue. Terminal ('no match')
+ * rows never reach the cap — they become 'unresolvable' on the first answer.
+ * Tunable; 5 chosen as a small safety net for the recoverable class.
+ */
+const GEOCODE_ATTEMPT_CAP = 5;
 
-/** Pauses execution for the given number of milliseconds */
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
+/** Result of a name→candidates resolution (resolve-then-create and the proxy). */
+export interface CityResolution {
+  /**
+   * - 'ok'         — a single best candidate was determined (see `best`).
+   * - 'ambiguous'  — two or more comparable settlement candidates survived the
+   *                  country/region constraint; the caller must NOT guess (D14).
+   * - 'unresolved' — the geocoder answered with no usable candidate.
+   * - 'disabled'   — GEOCODING_ENABLED=false or a recoverable error; degrade to pending.
+   */
+  status: 'ok' | 'ambiguous' | 'unresolved' | 'disabled';
+  candidates: NominatimCandidate[];
+  best?: NominatimCandidate;
 }
 
 /**
- * Checks network connectivity by performing a HEAD request to Nominatim.
- * Returns false if the request fails or times out.
+ * Resolves a city NAME to geocoder candidates WITHOUT requiring a cities row.
+ * Used by resolve-then-create (POST /api/cities) and the geocode proxy route.
+ *
+ * ADL-46 D12 (§4.3.1): the caller has already validated country_code (and often
+ * region), so the lookup is CONSTRAINED by them and the lookup may never
+ * override them:
+ *   1. countrycodes filter from the validated country_code — removes the
+ *      London-UK-vs-Ontario / Cambridge-UK-vs-MA classes entirely.
+ *   2. where a region ISO is known, prefer the candidate whose subdivision matches.
+ *   3. exactly one settlement candidate → 'ok'; two or more → 'ambiguous' (never
+ *      guess — D14); zero → 'unresolved'.
+ *
+ * @param name       - The user-submitted city name.
+ * @param countryCode- Validated ISO 3166-1 alpha-2 (e.g. 'US').
+ * @param opts.regionIso - ISO 3166-2 subdivision (e.g. 'US-CO') to disambiguate.
  */
-async function isOnline(): Promise<boolean> {
-  try {
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), CONNECTIVITY_TIMEOUT_MS);
-    const resp = await fetch(NOMINATIM_BASE, {
-      method: 'HEAD',
-      headers: { 'User-Agent': USER_AGENT },
-      signal: controller.signal,
-    });
-    clearTimeout(timer);
-    return resp.ok || resp.status < 500;
-  } catch {
-    return false;
+export async function resolveCityName(
+  name: string,
+  countryCode: string,
+  opts: { regionIso?: string | null } = {},
+): Promise<CityResolution> {
+  if (!geocodingEnabled()) return { status: 'disabled', candidates: [] };
+
+  const result = await nominatimSearch({
+    q: name,
+    countrycodes: countryCode.toLowerCase(),
+    limit: '10',
+  });
+
+  if (result.status === 'disabled' || result.status === 'error') {
+    // Global / recoverable — degrade to pending; the queue will retry the row.
+    return { status: 'disabled', candidates: [] };
   }
+
+  const candidates = result.candidates;
+  if (!candidates.length) return { status: 'unresolved', candidates: [] };
+
+  // D12 step 2: if the user gave a region, prefer the candidate whose ISO matches.
+  if (opts.regionIso) {
+    const regionMatches = candidates.filter(
+      (c) => c.regionIso?.toUpperCase() === opts.regionIso!.toUpperCase(),
+    );
+    if (regionMatches.length === 1) {
+      return { status: 'ok', best: regionMatches[0], candidates };
+    }
+    if (regionMatches.length > 1) {
+      return { status: 'ambiguous', candidates: regionMatches };
+    }
+    // No region match — fall through to the general count.
+  }
+
+  if (candidates.length === 1) {
+    return { status: 'ok', best: candidates[0], candidates };
+  }
+  // D14: two or more comparable candidates → ambiguous, do not guess.
+  return { status: 'ambiguous', candidates };
 }
 
 /**
- * Attempts to resolve coordinates for a single city via Nominatim.
+ * Attempts to resolve coordinates for a single EXISTING city row via Nominatim
+ * (the geocode queue / on-create trigger path). Applies D10's classification.
  *
  * @param cityId - The cities.id to resolve.
  * @returns true if coordinates were resolved and saved, false otherwise.
@@ -54,16 +119,16 @@ async function isOnline(): Promise<boolean> {
 export async function resolveCity(cityId: number): Promise<boolean> {
   const db = getDb();
 
-  // Load city and its country name for the search query
   const rows = await db
     .select({
       id: cities.id,
       name: cities.name,
       geocodeStatus: cities.geocodeStatus,
-      countryName: countries.name,
+      countryCode: cities.countryCode,
+      regionIso: regions.iso3166_2,
     })
     .from(cities)
-    .leftJoin(countries, eq(countries.countryCode, cities.countryCode))
+    .leftJoin(regions, eq(regions.id, cities.regionId))
     .where(eq(cities.id, cityId))
     .limit(1);
 
@@ -73,100 +138,116 @@ export async function resolveCity(cityId: number): Promise<boolean> {
     return false;
   }
 
-  // Never re-query a resolved city (ADL-10)
-  if (city.geocodeStatus === 'resolved') {
-    return true;
-  }
+  // Never re-query a resolved city (ADL-10). Unresolvable rows are terminal.
+  if (city.geocodeStatus === 'resolved') return true;
+  if (city.geocodeStatus === 'unresolvable') return false;
 
-  if (!GEOCODING_ENABLED) {
-    return false;
-  }
+  // GEOCODING_ENABLED=false is a GLOBAL condition — do NOT increment attempts.
+  if (!geocodingEnabled()) return false;
 
-  if (!(await isOnline())) {
-    console.info('[GEO] Nominatim unreachable — skipping geocoding');
-    return false;
-  }
-
-  // Record attempt time before making the request
   const attemptedAt = new Date().toISOString();
   await db
     .update(cities)
     .set({ geocodeAttemptedAt: attemptedAt, updatedAt: attemptedAt })
     .where(eq(cities.id, cityId));
 
-  try {
-    const params = new URLSearchParams({
-      q: `${city.name}, ${city.countryName ?? ''}`,
-      format: 'json',
-      limit: '1',
-      addressdetails: '0',
-    });
+  const result = await nominatimSearch({
+    q: city.name,
+    countrycodes: city.countryCode.toLowerCase(),
+    limit: '10',
+  });
 
-    const resp = await fetch(`${NOMINATIM_BASE}?${params}`, {
-      headers: { 'User-Agent': USER_AGENT },
-    });
-
-    if (!resp.ok) {
-      console.warn(`[GEO] Nominatim HTTP ${resp.status} for city ${cityId}`);
-      return false;
-    }
-
-    const data = (await resp.json()) as Array<{ lat: string; lon: string }>;
-
-    if (!data.length) {
-      // No results — leave as pending, will retry on next queue run
-      console.info(`[GEO] No results for city ${cityId} (${city.name})`);
-      return false;
-    }
-
-    const lat = parseFloat(data[0].lat);
-    const lon = parseFloat(data[0].lon);
-    const resolvedAt = new Date().toISOString();
-
-    await db
-      .update(cities)
-      .set({
-        latitude: lat,
-        longitude: lon,
-        geocodeStatus: 'resolved',
-        geocodeAttemptedAt: resolvedAt,
-        updatedAt: resolvedAt,
-      })
-      .where(eq(cities.id, cityId));
-
-    console.info(`[GEO] Resolved city ${cityId} (${city.name}): ${lat}, ${lon}`);
-    return true;
-  } catch (err) {
-    // All errors are caught — geocoding is fire-and-forget (GE-12)
-    console.error(`[GEO] Error resolving city ${cityId}:`, (err as Error).message);
+  if (result.status === 'disabled') {
+    // Global — no increment (offline / disabled between the check above and here).
     return false;
   }
+
+  if (result.status === 'error') {
+    // Recoverable — increment the counter, stay pending, retry later (up to cap).
+    await incrementAttempts(cityId);
+    return false;
+  }
+
+  // result.status === 'ok' — the geocoder answered.
+  const best = pickBest(result.candidates, city.regionIso);
+  if (!best) {
+    // TERMINAL: the geocoder answered with no usable match. Never retried (D10).
+    const now = new Date().toISOString();
+    await db
+      .update(cities)
+      .set({ geocodeStatus: 'unresolvable', geocodeAttemptedAt: now, updatedAt: now })
+      .where(eq(cities.id, cityId));
+    console.info(`[GEO] City ${cityId} (${city.name}) unresolvable — no match`);
+    return false;
+  }
+
+  const resolvedAt = new Date().toISOString();
+  await db
+    .update(cities)
+    .set({
+      latitude: best.latitude,
+      longitude: best.longitude,
+      geocodeStatus: 'resolved',
+      geocodeAttemptedAt: resolvedAt,
+      updatedAt: resolvedAt,
+    })
+    .where(eq(cities.id, cityId));
+
+  console.info(`[GEO] Resolved city ${cityId} (${city.name}): ${best.latitude}, ${best.longitude}`);
+  return true;
+}
+
+/** Picks the region-matching candidate if a region ISO is known, else the first. */
+function pickBest(
+  candidates: NominatimCandidate[],
+  regionIso: string | null,
+): NominatimCandidate | undefined {
+  if (!candidates.length) return undefined;
+  if (regionIso) {
+    const match = candidates.find((c) => c.regionIso?.toUpperCase() === regionIso.toUpperCase());
+    if (match) return match;
+  }
+  return candidates[0];
+}
+
+/** ADL-46 D10: increment the recoverable-failure counter for a pending row. */
+async function incrementAttempts(cityId: number): Promise<void> {
+  const db = getDb();
+  const now = new Date().toISOString();
+  await db
+    .update(cities)
+    .set({
+      geocodeAttempts: sql`${cities.geocodeAttempts} + 1`,
+      geocodeAttemptedAt: now,
+      updatedAt: now,
+    })
+    .where(eq(cities.id, cityId));
 }
 
 /**
- * Processes all cities with geocode_status = 'pending'.
- * Uses the geocoding queue SQL from ER schema §6.3.
- * Called on startup and every 15 minutes.
- * Enforces 1100ms delay between Nominatim requests (ADL-10).
+ * Processes cities with geocode_status = 'pending' AND geocode_attempts < CAP.
+ * Called on startup and every 15 minutes. Rate limiting is owned by the
+ * chokepoint (nominatim-client), so this loop no longer sleeps itself.
+ *
+ * ADL-46 D10: the predicate excludes 'unresolvable' rows (terminal) and rows
+ * that have exhausted their recoverable-retry budget — the partial index
+ * idx_cities_geocode already drops 'unresolvable' rows, keeping the scan tight.
  */
 export async function processQueue(): Promise<void> {
   const db = getDb();
 
-  // ER schema §6.3: oldest attempts first (NULLS first = never attempted first)
-  const pending = await db
-    .select({
-      id: cities.id,
-      name: cities.name,
-      geocodeAttemptedAt: cities.geocodeAttemptedAt,
-    })
-    .from(cities)
-    .where(eq(cities.geocodeStatus, 'pending'))
-    .orderBy(asc(cities.geocodeAttemptedAt));
-
-  if (!GEOCODING_ENABLED) {
+  if (!geocodingEnabled()) {
     console.info('[GEO] Geocoding disabled (GEOCODING_ENABLED=false) — queue skipped');
     return;
   }
+
+  const pending = await db
+    .select({ id: cities.id, name: cities.name })
+    .from(cities)
+    .where(
+      and(eq(cities.geocodeStatus, 'pending'), lt(cities.geocodeAttempts, GEOCODE_ATTEMPT_CAP)),
+    )
+    .orderBy(asc(cities.geocodeAttemptedAt));
 
   if (!pending.length) {
     console.info('[GEO] Geocoding queue empty — nothing to process');
@@ -175,18 +256,10 @@ export async function processQueue(): Promise<void> {
 
   console.info(`[GEO] Processing ${pending.length} pending cities`);
 
-  if (!(await isOnline())) {
-    console.info('[GEO] Nominatim unreachable — queue deferred');
-    return;
-  }
-
-  for (let i = 0; i < pending.length; i++) {
-    const city = pending[i];
+  for (const city of pending) {
+    // Each call serializes through the chokepoint, which owns the 1.1s spacing
+    // and lets interactive proxy lookups interleave rather than starve.
     await resolveCity(city.id);
-    // Enforce rate limit between requests (not after the last one)
-    if (i < pending.length - 1) {
-      await sleep(REQUEST_DELAY_MS);
-    }
   }
 
   console.info('[GEO] Geocoding queue processing complete');

--- a/src/backend/services/nominatim-client.ts
+++ b/src/backend/services/nominatim-client.ts
@@ -1,0 +1,183 @@
+/**
+ * Travel Tracker — Nominatim Egress Chokepoint (ADL-46 §5.1.1 / D7)
+ *
+ * THE single point through which ALL Nominatim egress passes: the 15-minute
+ * geocode queue (processQueue), resolve-then-create on every POST /api/cities,
+ * and the user-interactive geocode proxy route. Before ADL-46 there were three
+ * uncoordinated call sites sharing one User-Agent and one egress IP against a
+ * 1 req/s per-application policy — consolidating egress without a chokepoint
+ * strictly increases rate-limit exposure (a violation now blocks the whole app
+ * rather than an anonymous browser).
+ *
+ * Design:
+ *   - A single serialized promise chain enforces >= REQUEST_DELAY_MS between the
+ *     START of consecutive requests, application-wide. One module owns the delay,
+ *     not three callers each sleeping independently.
+ *   - The isOnline() HEAD probe is deliberately NOT used here (§5.1.1): a probe
+ *     before every search doubled the request rate to establish something the
+ *     search itself reveals. A failed search is caught and reported as "no
+ *     result / recoverable" by the caller instead.
+ *   - GEOCODING_ENABLED=false (CI, ADL-10) short-circuits to an empty result with
+ *     no egress and no queue delay.
+ *
+ * Interactive fairness (§5.1.1): interactive lookups (the proxy) are NOT starved
+ * behind a long batch run because each request only waits for the single-slot
+ * delay since the last request, not for a whole batch — processQueue awaits each
+ * search through this same chokepoint, so an interactive request interleaves
+ * naturally rather than queueing behind the entire pending set. D10's give-up
+ * rule bounds how large the batch can ever get.
+ */
+
+const NOMINATIM_BASE = 'https://nominatim.openstreetmap.org/search';
+const USER_AGENT = 'TravelTracker/1.0 (personal-use-app)';
+/** 100ms above Nominatim's 1 req/s policy (ADL-10). */
+const REQUEST_DELAY_MS = 1100;
+const REQUEST_TIMEOUT_MS = 5000;
+
+/** When GEOCODING_ENABLED=false, all egress is skipped (e.g. CI contract tests). */
+function geocodingEnabled(): boolean {
+  return process.env.GEOCODING_ENABLED !== 'false';
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+// The serialized queue: every request appends to this chain, so at most one
+// Nominatim request is in flight at a time and consecutive requests are spaced
+// by REQUEST_DELAY_MS. Module-level = process-wide (single egress IP).
+let chain: Promise<unknown> = Promise.resolve();
+let lastRequestAt = 0;
+
+/** A single settlement-type candidate parsed from a Nominatim response. */
+export interface NominatimCandidate {
+  displayName: string;
+  /** The place name (the first comma-separated segment of display_name). */
+  name: string;
+  latitude: number;
+  longitude: number;
+  /** ISO 3166-1 alpha-2, upper-cased, if the response carried address details. */
+  countryCode: string | null;
+  /** ISO 3166-2 subdivision code (e.g. 'US-CO'), if present. */
+  regionIso: string | null;
+  /** Nominatim class/type — used to filter to settlements. */
+  class?: string;
+  type?: string;
+}
+
+interface RawNominatimResult {
+  lat: string;
+  lon: string;
+  display_name?: string;
+  name?: string;
+  class?: string;
+  type?: string;
+  address?: {
+    country_code?: string;
+    'ISO3166-2-lvl4'?: string;
+  };
+}
+
+const SETTLEMENT_TYPES = new Set(['city', 'town', 'village', 'hamlet', 'municipality']);
+
+/**
+ * Discriminated result of one search (ADL-46 D10 §4.4.1): the caller must
+ * distinguish "the geocoder answered, and the answer was no match" (terminal)
+ * from "the question was never actually answered" (recoverable) and from the
+ * global GEOCODING_ENABLED=false / offline condition (must not count against a
+ * per-city retry budget).
+ */
+export type NominatimSearchResult =
+  /** Geocoder answered. candidates may be empty — that is a terminal "no match". */
+  | { status: 'ok'; candidates: NominatimCandidate[] }
+  /** GEOCODING_ENABLED=false — a global condition, never a per-city failure. */
+  | { status: 'disabled' }
+  /** Network error, timeout, 5xx, 429, host unreachable — recoverable, retry. */
+  | { status: 'error' };
+
+/**
+ * Runs one Nominatim search through the serialized chokepoint. Never throws.
+ *
+ * @param params - Query entries (q, countrycodes, limit, etc.). The module
+ *                 always forces format=json and addressdetails=1.
+ */
+export async function nominatimSearch(
+  params: Record<string, string>,
+): Promise<NominatimSearchResult> {
+  if (!geocodingEnabled()) return { status: 'disabled' };
+
+  const run = async (): Promise<NominatimSearchResult> => {
+    // Space requests: wait out the remainder of the delay window since the last
+    // request START, application-wide.
+    const elapsed = Date.now() - lastRequestAt;
+    if (elapsed < REQUEST_DELAY_MS) {
+      await sleep(REQUEST_DELAY_MS - elapsed);
+    }
+    lastRequestAt = Date.now();
+
+    const search = new URLSearchParams({
+      ...params,
+      format: 'json',
+      addressdetails: '1',
+    });
+
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+    try {
+      const resp = await fetch(`${NOMINATIM_BASE}?${search}`, {
+        headers: { 'User-Agent': USER_AGENT },
+        signal: controller.signal,
+      });
+      if (!resp.ok) {
+        // Recoverable (4xx/5xx/429) — caller keeps the row pending and retries.
+        console.warn(`[GEO] Nominatim HTTP ${resp.status}`);
+        return { status: 'error' };
+      }
+      const data = (await resp.json()) as RawNominatimResult[];
+      const candidates = data
+        .map(parseCandidate)
+        .filter(
+          (c): c is NominatimCandidate =>
+            c !== null && (c.type == null || SETTLEMENT_TYPES.has(c.type)),
+        );
+      return { status: 'ok', candidates };
+    } finally {
+      clearTimeout(timer);
+    }
+  };
+
+  // Append to the serialized chain; swallow errors so one failure never breaks
+  // the chain for the next caller.
+  const result = chain.then(run, run);
+  chain = result.catch(() => undefined);
+  try {
+    return await result;
+  } catch (err) {
+    console.warn('[GEO] Nominatim request failed:', (err as Error).message);
+    return { status: 'error' };
+  }
+}
+
+function parseCandidate(raw: RawNominatimResult): NominatimCandidate | null {
+  const lat = parseFloat(raw.lat);
+  const lon = parseFloat(raw.lon);
+  if (Number.isNaN(lat) || Number.isNaN(lon)) return null;
+  const displayName = raw.display_name ?? raw.name ?? '';
+  const name = raw.name ?? displayName.split(',')[0]?.trim() ?? '';
+  return {
+    displayName,
+    name,
+    latitude: lat,
+    longitude: lon,
+    countryCode: raw.address?.country_code?.toUpperCase() ?? null,
+    regionIso: raw.address?.['ISO3166-2-lvl4'] ?? null,
+    class: raw.class,
+    type: raw.type,
+  };
+}
+
+/** Test-only: reset the serialized queue's timing state between suites. */
+export function __resetChokepointForTests(): void {
+  chain = Promise.resolve();
+  lastRequestAt = 0;
+}

--- a/src/backend/services/startup.service.ts
+++ b/src/backend/services/startup.service.ts
@@ -14,10 +14,9 @@ import { readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { count, sql } from 'drizzle-orm';
-import { activities, countries, getDb, regions, tripCategories } from '../db/index.js';
-
-// Re-import seed data from the DATABASE seed script to avoid duplication
-import { ACTIVITIES, TRIP_CATEGORIES } from '../db/seed-data.js';
+import { countries, getDb, regions, users } from '../db/index.js';
+import { activityRepository } from '../repositories/activities.js';
+import { tripCategoryRepository } from '../repositories/tripCategories.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -81,34 +80,35 @@ export async function assertForeignKeysEnabled(): Promise<void> {
 // ----------------------------------------------------------------
 
 /**
- * Seeds trip_categories and activities with default values if any are
- * missing. Uses onConflictDoNothing() — idempotent, safe on every startup.
+ * Reconciles per-user trip_categories and activities defaults for every
+ * existing user. Idempotent — each per-user seed uses onConflictDoNothing on
+ * the (user_id, name) unique index.
  *
- * ADL-28 (AD-07/AD-08): companions and map_shading_config used to be seeded
- * here too, but both are now per-user (userId NOT NULL FK) — there is no
- * single global row set to seed at server startup any more. companions has
- * no default list post-migration; map_shading_config is lazily seeded
- * per-user on first access to the shading config endpoint
- * (shadingConfigRepository.seedDefaults, ADL-28 repository section —
- * Backend brief, not yet implemented). trip_categories and activities
- * remain global seeded defaults (AD-09, unaffected by this ADL).
+ * ADL-46 (AD-09, D3): trip_categories and activities are now per-user
+ * (userId NOT NULL FK) — there is no single global row set to seed at startup
+ * any more. New users are lazily seeded on first access (read or write) via
+ * the repositories' ensureSeeded; this startup pass is the reconciliation
+ * half of §3.2.1 — it back-fills defaults for users who predate the change
+ * (e.g. a pre-existing non-owner whose lists were never populated by the S3
+ * migration's owner-only CROSS JOIN backfill). Because ensureSeeded only fires
+ * when a user has zero rows, this pass will NOT resurrect entries a user has
+ * deactivated — it seeds only users who have no rows at all.
+ *
+ * ADL-28 (AD-07/AD-08): companions and map_shading_config are likewise per-user;
+ * companions have no default list post-migration, and map_shading_config is
+ * lazily seeded per-user on first access to the shading config endpoint.
  */
 export async function seedAdminData(): Promise<void> {
   const db = getDb();
 
-  // -- trip_categories --
-  await db
-    .insert(tripCategories)
-    .values([...TRIP_CATEGORIES])
-    .onConflictDoNothing();
-  console.info('[STARTUP] Admin data: trip_categories seeded');
-
-  // -- activities --
-  await db
-    .insert(activities)
-    .values([...ACTIVITIES])
-    .onConflictDoNothing();
-  console.info('[STARTUP] Admin data: activities seeded');
+  const allUsers = await db.select({ id: users.id }).from(users);
+  for (const u of allUsers) {
+    await tripCategoryRepository.ensureSeeded(u.id);
+    await activityRepository.ensureSeeded(u.id);
+  }
+  console.info(
+    `[STARTUP] Admin data: per-user categories/activities reconciled for ${allUsers.length} user(s)`,
+  );
 }
 
 // ----------------------------------------------------------------

--- a/src/backend/validation/geocode.schemas.ts
+++ b/src/backend/validation/geocode.schemas.ts
@@ -1,0 +1,15 @@
+/**
+ * Travel Tracker — Geocode Proxy Validation Schemas (ADL-46 D7 §5.1)
+ */
+
+import { z } from 'zod';
+import { zCountryCode } from './common.js';
+
+export const GeocodeQuerySchema = z.object({
+  q: z.string().trim().min(2, 'Search query must be at least 2 characters'),
+  // Optional — when present, constrains the lookup to this country (D12 step 1).
+  // Absent for the GE-15 country auto-populate discovery case.
+  country_code: zCountryCode.optional(),
+  // Optional ISO 3166-2 subdivision (e.g. 'US-CO') to prefer a region (D12 step 2).
+  region_iso: z.string().trim().min(2).optional(),
+});

--- a/src/backend/validation/places.schemas.ts
+++ b/src/backend/validation/places.schemas.ts
@@ -29,6 +29,11 @@ export const CreatePlaceSchema = z
 
 export const UpdatePlaceDatesSchema = z
   .object({
+    // ADL-46 D11 (§4.4.2): city_id makes a place re-pointable — the correction
+    // path for a mistyped/wrong city. Ownership is validated on the place, so
+    // this adds no new access surface (the target city's existence is checked
+    // in the handler).
+    city_id: z.number().int().positive().optional(),
     arrived_on: z.string().nullable().optional(),
     departed_on: z.string().nullable().optional(),
   })

--- a/tests/contract/places.contract.test.ts
+++ b/tests/contract/places.contract.test.ts
@@ -315,7 +315,7 @@ describe('POST /api/trips/:tripId/places/:placeId/activities', () => {
     placeId = placeRes.body.id;
 
     // Fetch an existing activity from the admin list
-    const activitiesRes = await api.get('/api/admin/activities').expect(200);
+    const activitiesRes = await api.get('/api/activities').expect(200);
     if (activitiesRes.body.length > 0) {
       activityId = activitiesRes.body[0].id;
     }
@@ -383,7 +383,7 @@ describe('DELETE /api/trips/:tripId/places/:placeId/activities/:activityId', () 
       .expect(201);
     placeId = placeRes.body.id;
 
-    const activitiesRes = await api.get('/api/admin/activities').expect(200);
+    const activitiesRes = await api.get('/api/activities').expect(200);
     if (activitiesRes.body.length > 0) {
       activityId = activitiesRes.body[0].id;
       // Tag it first

--- a/vitest.config.backend.ts
+++ b/vitest.config.backend.ts
@@ -7,5 +7,13 @@ export default defineConfig({
     environment: 'node',
     globals: true,
     fileParallelism: true,
+    // Match CI (ci.yml GEOCODING_ENABLED=false) and the ADL-46 acceptance suite's
+    // stated assumption: no live Nominatim egress in unit tests. Every geocode
+    // path (resolveCity, resolveCityName, the proxy) degrades deterministically —
+    // resolve-then-create falls to a 'pending' row from the user's text, and the
+    // find-or-create logic under test runs without a network dependency.
+    env: {
+      GEOCODING_ENABLED: 'false',
+    },
   },
 });


### PR DESCRIPTION
Backend stage (2 of 3) of the ADL-46 per-user access-model release. Targets the
integration branch **release/adl46-access-model** (NOT main). Implements the
backend logic against the already-merged DB stage (migrations 0014/0015) and
turns the QA ATDD acceptance suite + the DB-stage red green.

Authoritative brief: **ADL-46 §9.2**. BRD home: **§GE-16** (also AD-09/BUG-63).
Related: DB stage #332 (merged on this branch).

## What landed (per §9.2 task)
- **S1/S3 categories & activities → per-user (AD-09, D3):** new per-user
  repositories + `/api/categories` and `/api/activities` routers (requireAuth,
  userId-scoped), lazy-seeded on first access. Admin-list factory + mounts
  removed from `admin.ts` (no scaffolding left, §9.1/§9.3). startup/seed/
  reset-staging reconciled to per-user (resolves the 20 TS2769 errors).
- **F1 cross-user write closure:** ownership validation in
  `replaceAssociations` (category/activity) **and** the place-level activities
  route (400 on cross-user id).
- **S1/S4 cities:** `POST /api/cities` opened (curation stays owner-only);
  **D13** three-step find-or-create (exact `COALESCE(region_id,0)` → wildcard
  upgrade → insert), `createdByUserId` set; **GE-16** search containment
  (resolved OR mine OR NULL-creator); **D11** `city_id` on PATCH place.
- **S2 egress:** single serialized **Nominatim chokepoint** (all egress passes
  through it; isOnline HEAD probe dropped); **geocode proxy** at `/api/geocode`
  (requireAuth); **resolve-then-create** with **D12** country/region constraint;
  **D14** candidate return; **D10** failure classification (unresolvable /
  pending+attempts++ / no-increment) + queue cap.

## QA acceptance status
`adl46-access-model.test.ts` — **32/32 green** (Groups A/B/C incl. B2 wildcard
upgrade, B4 ambiguity, C1–C3 containment, place-level 400). No assertions in the
ATDD file were edited. Full backend suite **646 green**; frontend **228 green**.
§8/§8.2 files re-pointed (security.access-matrix, owner-access incl. HC-06→201,
qa-backend-fixes, places.contract); §8.1 unskip already present. New unit tests
for D10/D11/D12/D14 + chokepoint.

## Security checklist
- New route (geocode proxy): `requireAuth` only, never anonymous. ✅
- S1/S2 routes are tier-1 reference data — no userId scoping (deliberate). ✅
- S3 routes userId-scoped throughout. ✅
- `cities.createdByUserId` deliberately nullable, `ON DELETE SET NULL` — confirmed, not "fixed". ✅
- Egress chokepoint built (`nominatim-client.ts`). ✅

## CI note
Contract/E2E require a live backend; the frontend still calls the old
`/api/admin/*` routes until the **Frontend stage (3 of 3)** repoints
`useAdmin`/`useCities`, so E2E is expected red until then. Backend unit +
type-check + lint + status all green locally.

ADL-46 §9.2 · BRD §GE-16

🤖 Generated with [Claude Code](https://claude.com/claude-code)