### PR TITLE
feat(BRD-GE16): ADL-46 frontend stage — repoint admin/geocode calls, consume D14 candidates (#340)

### DIFF
--- a/jobs/COO/inbox/20260731_2130-FRONTEND-adl46-stage4-complete.txt
+++ b/jobs/COO/inbox/20260731_2130-FRONTEND-adl46-stage4-complete.txt
@@ -98,3 +98,64 @@ WHAT IS NOW UNBLOCKED
   end-to-end: DB, QA, Backend, and now Frontend stages all landed on
   release/adl46-access-model. Ready for COO review/merge of PR #341, then
   whatever release-branch → main promotion step ADL-46 calls for.
+
+═══════════════════════════════════════════════════════════════════════════
+UPDATE 2026-07-31 (same day) — COO review defect fixed, PR #341 commit a5b9c3b
+
+COO reviewed PR #341 against the diff and found a real defect in the D14
+region-narrowing logic: candidateRegionIsos was only ever set when the
+geocode lookup itself returned 2+ distinct region_iso values, but the
+render-time intersection with the locally-seeded `regions` table (a known-
+incomplete hand-curated seed — BUG-30 backfilled missing UK regions after
+the fact, OQ-06 is the still-open question about a systematic replacement)
+could still collapse to zero or one matching row. regionOptions was the
+selector's sole data source, so a zero-match collapse left the user looking
+at an empty selector ("No <region> selected" and nothing else, not even
+regions that ARE seeded and legitimately pickable) with no discoverable way
+out short of toggling the country away and back. The ambiguity hint was
+also gated on regionOptions.length > 1, so it disappeared exactly when the
+user most needed the explanation.
+
+FIX (src/frontend/components/TripDetail/AddPlaceFlow.tsx): compute the
+candidate-narrowed set separately, and only use it when it has 2+ entries
+(i.e. actually presents a choice) — otherwise fall back to the full
+countryRegions list. The ambiguity hint now reflects "the lookup detected
+an ambiguous name" (candidateRegionIsos !== null) independent of whether
+the narrowing survived, so the user still learns the name was ambiguous
+even when shown the unfiltered list. Confirmed no auto-select was
+introduced for the single-match case — that would reintroduce the exact
+silent guess D14 exists to prevent, now guessing from a table already known
+to be incomplete.
+
+TEST GAP — answering the COO's direct question: the gap was the scenario,
+not a weak test, because there was no test at all. AddPlaceFlow had zero
+test coverage before this fix; the D14 narrowing logic shipped in the first
+commit with only hook-level tests (useCities.geocode.test.tsx), which
+mock apiGet and never render the component, so they had no way to see the
+selector collapse. Added
+src/frontend/components/TripDetail/__tests__/AddPlaceFlow.test.tsx (new)
+with two cases: candidate region ISOs matching zero seeded regions (the
+reported defect — asserts the full country list, e.g. California/Texas,
+is still offered and the hint stays visible) and matching 2+ seeded
+regions (regression guard that narrowing still works when it should).
+Verified the first case actually catches the defect by hand: reverted the
+fix locally (git apply -R against the fix commit's diff, not git stash, per
+the standing rule), re-ran the test file and watched it fail exactly as
+expected (1 failed / 1 passed), then re-applied the fix and confirmed both
+pass.
+
+RE-VERIFIED: npm run check (biome) clean; type:check:all clean; test:backend
+650/650 (untouched); test:frontend 235/235 (233 + 2 new AddPlaceFlow
+tests); full E2E suite 52/52 (Playwright's own summary line, re-run after
+this change since AddPlaceFlow.tsx was touched again); /pre-push all green;
+CI on PR #341 all 9 checks green at commit a5b9c3b (scripts/ci-wait.sh pr
+341 → PASS).
+
+SIDE QUESTION ANSWERED (not fixed, not in scope): Companion.is_active
+carries the identical number-vs-boolean mismatch, and yes — the backend
+does serialize it as a real boolean too. src/backend/routes/companions.ts's
+serializeCompanion returns `is_active: row.isActive === 1` (same pattern as
+categories.ts/activities.ts), while types/api.ts's Companion interface
+still declares `is_active: number`. Left untouched per instruction — a
+same-shaped follow-on to what I already fixed for Category/Activity in
+this PR.

--- a/jobs/COO/inbox/20260731_2130-FRONTEND-adl46-stage4-complete.txt
+++ b/jobs/COO/inbox/20260731_2130-FRONTEND-adl46-stage4-complete.txt
@@ -1,0 +1,100 @@
+FRONTEND COMPLETION REPORT
+
+Tracker: BRD-GE16 · GitHub #340 · PR #341 · BRD §GE-16 · ADL-46 §9.2 (D7, D14)
+Branch: feat/adl46-frontend-stage → release/adl46-access-model (NOT main)
+Stage 4 of 4 (final) of the ADL-46 per-user access-model release.
+
+WHAT WAS BUILT
+
+1. useAdmin.ts — repointed all 10 categories/activities call sites from the
+   removed /api/admin/categories|activities to /api/categories|activities
+   (the new requireAuth, userId-scoped routers PR #338 added). Companions and
+   Countries untouched, as instructed.
+
+2. useCities.ts — lookupCityCountry now calls GET /api/geocode via apiGet
+   instead of fetching nominatim.openstreetmap.org directly from the browser.
+   Deleted NOMINATIM_BASE / NOMINATIM_USER_AGENT. Kept the existing
+   fire-and-forget silent-failure contract ({countryCode: null, regionIso:
+   null}, now also candidates: []) so AddPlaceFlow's manual-entry fallback is
+   unaffected.
+
+3. AddPlaceFlow.tsx (D14 ambiguity) — used the EXISTING region <select>, no
+   new component/modal. When the geocode proxy returns multiple candidates
+   with differing region_iso for the resolved country (Springfield IL vs
+   Springfield MO), the selector's options are narrowed to just those
+   candidate regions instead of silently auto-picking candidates[0], with a
+   small inline hint text ("multiple matches found, please choose"). The
+   single-best-guess auto-select path is unchanged for the unambiguous case.
+
+4. types/api.ts — added GeocodeCandidate/GeocodeResult types for the new
+   endpoint response.
+
+CONTRADICTED THE BRIEF / THINGS FOUND ALONG THE WAY
+
+- Task 1 told me to verify response shapes rather than assume, and fix the
+  frontend type if it differs. It did: Category.is_active and
+  Activity.is_active were typed `number` (SQLite 0|1) but both
+  categories.ts's and activities.ts's serializers actually coerce to a real
+  boolean (`row.isActive === 1`) before the response ever goes out — and this
+  was already true of the pre-ADL-46 admin routers too (checked git history
+  at 28a24d7~1), so it's not something PR #338 introduced, just something
+  nobody had fixed. Companion has the identical mismatch (already shipped,
+  untouched here — out of scope, not touching companions per the brief).
+  Fixed Category/Activity's types to `boolean`. Confirmed no runtime
+  behavior change: every current usage is a truthy check
+  (`cat.is_active ? … : …`, `!cat.is_active`) that works identically for
+  0/1 or false/true, and no test mock uses a numeric is_active for these two
+  types (grepped — only the untouched Companion test file does).
+- Everything else in the brief (route mounts, response shapes for
+  categories/activities/geocode, the "don't build new UI" instruction, the
+  Nominatim firewall note) matched what I found on the integration branch.
+  No other contradictions.
+
+FULL-FILE REWRITES: none. All four modified files were edited in place
+(Edit tool); one new test file was created (Write, appropriate — it didn't
+exist before).
+
+TESTING / CI
+
+- src/e2e/admin.spec.ts: the 4 previously-failing tests (create category,
+  rename category via inline edit, deactivate/re-activate category, create
+  activity) now pass.
+- Full E2E suite: 52/52 passing (Playwright's own summary line: "52 passed
+  (51.3s)" — not a grep; 48 baseline + these 4).
+- npm run test:frontend: 233/233 passing (228 baseline + 5 new, all in
+  useCities.geocode.test.tsx: top-candidate success, D14 ambiguity/multiple
+  distinct region_iso, and the silent-failure-returns-nulls case).
+- npm run test:backend: 650/650 (untouched — no backend files modified).
+- npm run type:check:all: clean.
+- npm run check (biome): clean.
+- npm run status:check: STATUS.md already in sync, no regen needed.
+- /pre-push checklist: all green.
+- CI on PR #341: all 9 checks green (scripts/ci-wait.sh pr 341 → PASS) —
+  Backend Tests, Contract Tests, Dependency Vulnerability Scan, E2E Tests,
+  Type Check, Biome, Secret Scanning, Frontend Tests, Static Analysis.
+
+ENVIRONMENT NOTE (expected, not a bug)
+Live Nominatim egress is unreachable from this devcontainer (firewall
+allowlist is GitHub/npm/Anthropic only). The E2E run logs
+"[GEO] Nominatim request failed: fetch failed" repeatedly from the backend's
+pre-existing background geocoding queue on city creation — that's a
+different code path (server-side queue, not the lookupCityCountry/
+/api/geocode path this brief touches) and pre-dates this PR. No E2E spec
+exercises the "Add new city" UI that would call lookupCityCountry directly,
+so the D14/geocode-proxy path itself wasn't exercised by real network calls
+in CI either — only by the mocked apiGet unit tests. Per the brief, this
+gets verified against real Nominatim on staging during UAT.
+
+WORKTREE SETUP NOTE
+The worktree had no .env.local (gitignored, not carried over) — db:migrate/
+the backend failed to start with "Invalid or missing DB_TYPE" until I copied
+/workspace/.env.local into the worktree. Not a code change, just local setup;
+flagging in case this trips up a future worktree-isolated E2E run.
+
+OPEN ISSUES OR BLOCKERS: none. This closes the release's remaining red.
+
+WHAT IS NOW UNBLOCKED
+- ADL-46 (per-user categories/activities + geocode proxy) is fully wired
+  end-to-end: DB, QA, Backend, and now Frontend stages all landed on
+  release/adl46-access-model. Ready for COO review/merge of PR #341, then
+  whatever release-branch → main promotion step ADL-46 calls for.

--- a/jobs/frontend/context/current.txt
+++ b/jobs/frontend/context/current.txt
@@ -542,3 +542,16 @@ NEXT STEPS (when resumed)
   the last of the 4 ADL-46 release stages, so merging it completes the
   release-branch work (whatever release/adl46-access-model → main promotion
   step follows is a COO/Architect call, not decided in this brief).
+
+UPDATE 2026-07-31 (same day): COO review of PR #341 caught a real defect —
+D14's region-selector narrowing could collapse to zero options when the
+geocode candidates' region_iso values matched no seeded row in the
+(known-incomplete, BUG-30/OQ-06) local regions table, locking the user out
+of the selector entirely. Fixed to fall back to the full country region
+list whenever the narrowed intersection has fewer than 2 entries, keeping
+the "ambiguous name" hint visible independent of whether narrowing
+survived. Added AddPlaceFlow.tsx's first-ever component test file
+(src/frontend/components/TripDetail/__tests__/AddPlaceFlow.test.tsx) —
+confirmed by hand (git apply -R, not stash) that the zero-overlap case
+fails without the fix. PR #341 commit a5b9c3b, CI 9/9 green. Full detail
+appended to jobs/COO/inbox/20260731_2130-FRONTEND-adl46-stage4-complete.txt.

--- a/jobs/frontend/context/current.txt
+++ b/jobs/frontend/context/current.txt
@@ -478,3 +478,67 @@ NEXT STEPS (when resumed)
   needed to close BRD-IT0809 per the mandatory UAT gate — suggest checking
   the two-probe-confirmed IT-09 net-new page in particular, since it's the
   one part of this brief that didn't exist in any form before today.
+
+═══════════════════════════════════════════════════════════════════════════
+
+FRONTEND CONTEXT — as of 2026-07-31 (BRD-GE16, ADL-46 Stage 4/4, GitHub #340)
+
+STATUS: feat/adl46-frontend-stage branch → PR #341 opened against
+  release/adl46-access-model (NOT main — this is the final stage of the
+  ADL-46 per-user access-model release; DB/QA/Backend stages already landed
+  on that integration branch via PR #338 etc.). CI green, 9/9 checks.
+
+  Repointed useAdmin.ts's 10 categories/activities call sites from the
+  removed /api/admin/categories|activities to the new requireAuth,
+  userId-scoped /api/categories|activities (companions/countries untouched).
+  Repointed useCities.ts's lookupCityCountry from a direct browser fetch to
+  nominatim.openstreetmap.org (CSP-blocked in prod per BUG-55, and
+  User-Agent is a forbidden fetch header so it never worked properly anyway)
+  to GET /api/geocode via apiGet — same silent-failure contract preserved.
+  Added D14 candidate disambiguation to AddPlaceFlow.tsx's EXISTING region
+  <select> (no new component/modal, per explicit brief instruction): when
+  the geocode proxy returns multiple candidates with differing region_iso
+  for the resolved country (Springfield IL vs MO), the selector narrows to
+  just those regions instead of silently auto-picking candidates[0].
+
+  Found and fixed a pre-existing type/reality mismatch while verifying
+  shapes per the brief's instruction (don't just trust the summary):
+  Category/Activity.is_active was typed `number` but both routes actually
+  serialize a real `boolean`. Pre-dates ADL-46 (same true of the old admin
+  router and of the untouched Companion type) — fixed the two frontend
+  types since I was already touching this file; Companion left alone
+  (out of scope). No runtime behavior change — all consumers do truthy
+  checks that work for 0/1 or false/true either way.
+
+  4 previously-failing src/e2e/admin.spec.ts tests now green; full E2E
+  suite 52/52 (Playwright's own summary line). test:frontend 233/233 (+5
+  new in useCities.geocode.test.tsx covering the repointed geocode path
+  incl. the silent-failure case). test:backend 650/650 unaffected (no
+  backend files touched). type:check:all and biome clean.
+
+  Worktree had no .env.local (gitignored, not inherited) — db:migrate/start
+  failed with "Invalid or missing DB_TYPE" until copied from
+  /workspace/.env.local. Local setup only, not a code issue; noting in case
+  it recurs for the next worktree-isolated agent needing to run E2E.
+
+KEY FILE LOCATIONS (changed this thread)
+  src/frontend/hooks/useAdmin.ts (10 call-site repoints)
+  src/frontend/hooks/useCities.ts (lookupCityCountry repointed to
+    GET /api/geocode, NOMINATIM_BASE/NOMINATIM_USER_AGENT deleted)
+  src/frontend/components/TripDetail/AddPlaceFlow.tsx (D14 candidate
+    narrowing on the existing region selector)
+  src/frontend/types/api.ts (GeocodeCandidate/GeocodeResult added;
+    Category/Activity.is_active number → boolean)
+  src/frontend/hooks/__tests__/useCities.geocode.test.tsx (new)
+
+OPEN FLAGS FOR COO
+  None blocking. Full detail, including the is_active type-fix rationale
+  and the environment note on Nominatim being unreachable from this
+  devcontainer (expected, verified on staging during UAT), in
+  jobs/COO/inbox/20260731_2130-FRONTEND-adl46-stage4-complete.txt.
+
+NEXT STEPS (when resumed)
+  COO: review PR #341, merge via /coo-merge-and-close when ready — this is
+  the last of the 4 ADL-46 release stages, so merging it completes the
+  release-branch work (whatever release/adl46-access-model → main promotion
+  step follows is a COO/Architect call, not decided in this brief).

--- a/src/frontend/components/TripDetail/AddPlaceFlow.tsx
+++ b/src/frontend/components/TripDetail/AddPlaceFlow.tsx
@@ -63,6 +63,13 @@ export function AddPlaceFlow({
   const [newCityCountryCode, setNewCityCountryCode] = useState('');
   const [newCityRegionId, setNewCityRegionId] = useState<number | null>(null);
   const [autoRegionIso, setAutoRegionIso] = useState<string | null>(null);
+  // ADL-46 D14: when the geocode proxy returns multiple candidates with
+  // differing region_iso for the resolved country (e.g. Springfield IL vs
+  // Springfield MO), this narrows the existing region <select>'s options to
+  // just those candidates instead of auto-picking candidates[0] — the user
+  // chooses from the (already-present) selector rather than being silently
+  // guessed for. null means "no ambiguity — show the full country region list".
+  const [candidateRegionIsos, setCandidateRegionIsos] = useState<string[] | null>(null);
   const [countryLookupPending, setCountryLookupPending] = useState(false);
   const [addedPlaceId, setAddedPlaceId] = useState<number | null>(null);
   const [addedCityId, setAddedCityId] = useState<number | null>(null);
@@ -96,6 +103,16 @@ export function AddPlaceFlow({
   const { data: countryRegions = [] } = useCountryRegions(
     showRegionDropdown ? newCityCountryCode : undefined,
   );
+
+  // ADL-46 D14: when the geocode lookup found an ambiguous city name (multiple
+  // regions within the resolved country), narrow the existing region selector
+  // to just those candidate regions rather than listing every region in the
+  // country — same <select>, filtered options.
+  const regionOptions = candidateRegionIsos
+    ? countryRegions.filter((r) => candidateRegionIsos.includes(r.iso_3166_2))
+    : countryRegions;
+  const regionChoiceIsAmbiguous = candidateRegionIsos !== null && regionOptions.length > 1;
+
   const addPlace = useAddPlace();
   const createCity = useCreateCity();
   const { data: carryForwardCandidates = [], isFetched: candidatesFetched } =
@@ -196,12 +213,34 @@ export function AddPlaceFlow({
     setNewCityCountryCode('');
     setNewCityRegionId(null);
     setAutoRegionIso(null);
+    setCandidateRegionIsos(null);
     if (cityName.trim().length >= 2) {
       setCountryLookupPending(true);
       lookupCityCountry(cityName.trim())
-        .then(({ countryCode, regionIso }) => {
+        .then(({ countryCode, regionIso, candidates }) => {
           if (countryCode) setNewCityCountryCode(countryCode);
-          if (regionIso) setAutoRegionIso(regionIso);
+
+          // D14: collect the distinct region_iso values among candidates that
+          // share the resolved country. More than one means the city name is
+          // ambiguous within that country (Springfield IL vs Springfield MO) —
+          // narrow the region selector to just those instead of auto-picking
+          // the top candidate's region.
+          const sameCountryRegionIsos = countryCode
+            ? [
+                ...new Set(
+                  candidates
+                    .filter((c) => c.country_code === countryCode && c.region_iso)
+                    .map((c) => c.region_iso as string),
+                ),
+              ]
+            : [];
+
+          if (sameCountryRegionIsos.length > 1) {
+            setCandidateRegionIsos(sameCountryRegionIsos);
+            // Ambiguous — leave newCityRegionId unset so the user must choose.
+          } else if (regionIso) {
+            setAutoRegionIso(regionIso);
+          }
           setCountryLookupPending(false);
         })
         .catch(() => setCountryLookupPending(false));
@@ -376,6 +415,9 @@ export function AddPlaceFlow({
                   setNewCityCountryCode(e.target.value);
                   setNewCityRegionId(null);
                   setAutoRegionIso(null);
+                  // A manual country change invalidates any D14 candidate
+                  // narrowing computed for the previously auto-detected country.
+                  setCandidateRegionIsos(null);
                 }}
                 required
               >
@@ -393,6 +435,12 @@ export function AddPlaceFlow({
               <div className="mb-4">
                 <label className={labelClass}>
                   {regionLabel} <span className="font-normal text-gray-500">(optional)</span>
+                  {regionChoiceIsAmbiguous && (
+                    <span className="font-normal text-amber-600 text-xs">
+                      {' '}
+                      — multiple matches found, please choose
+                    </span>
+                  )}
                 </label>
                 <select
                   className={inputClass}
@@ -402,7 +450,7 @@ export function AddPlaceFlow({
                   }
                 >
                   <option value="">No {regionLabel.toLowerCase()} selected</option>
-                  {countryRegions.map((r) => (
+                  {regionOptions.map((r) => (
                     <option key={r.id} value={r.id}>
                       {r.name}
                     </option>

--- a/src/frontend/components/TripDetail/AddPlaceFlow.tsx
+++ b/src/frontend/components/TripDetail/AddPlaceFlow.tsx
@@ -108,10 +108,32 @@ export function AddPlaceFlow({
   // regions within the resolved country), narrow the existing region selector
   // to just those candidate regions rather than listing every region in the
   // country — same <select>, filtered options.
-  const regionOptions = candidateRegionIsos
+  //
+  // The narrowed set is only used when it actually presents a choice (2+
+  // matches). Nominatim's region_iso values are open-ended while the local
+  // `regions` table is a hand-curated seed known to be incomplete (BUG-30
+  // added missing UK regions after the fact; OQ-06 is the still-open
+  // question about replacing per-country hand-seeding with a systematic
+  // ISO 3166-2 list) — nothing guarantees a geocode region_iso corresponds
+  // to a seeded row, so the narrowed set matching zero or one row is
+  // expected, not exceptional. Falling back to the full list in that case
+  // (rather than leaving the user with an empty/single-option selector)
+  // avoids locking out regions that ARE seeded and legitimately choosable.
+  // Never auto-select the lone survivor either — that would reintroduce the
+  // silent guess D14 exists to prevent, now guessing from a table already
+  // known to be incomplete.
+  const narrowedRegionOptions = candidateRegionIsos
     ? countryRegions.filter((r) => candidateRegionIsos.includes(r.iso_3166_2))
     : countryRegions;
-  const regionChoiceIsAmbiguous = candidateRegionIsos !== null && regionOptions.length > 1;
+  const regionOptions =
+    candidateRegionIsos && narrowedRegionOptions.length >= 2
+      ? narrowedRegionOptions
+      : countryRegions;
+  // Reflects "the lookup detected an ambiguous city name", independent of
+  // whether the narrowing survived the intersection with seeded regions —
+  // the user should still learn the name was ambiguous even when they end
+  // up looking at the unfiltered full list.
+  const regionChoiceIsAmbiguous = candidateRegionIsos !== null;
 
   const addPlace = useAddPlace();
   const createCity = useCreateCity();

--- a/src/frontend/components/TripDetail/__tests__/AddPlaceFlow.test.tsx
+++ b/src/frontend/components/TripDetail/__tests__/AddPlaceFlow.test.tsx
@@ -1,0 +1,210 @@
+/**
+ * Scenario tests for AddPlaceFlow's ADL-46 D14 region-selector narrowing.
+ *
+ * D14: when the geocode proxy returns multiple candidates with differing
+ * region_iso for the resolved country, AddPlaceFlow narrows the existing
+ * region <select> to just those candidates instead of silently taking
+ * candidates[0]. The local `regions` table is a hand-curated seed known to
+ * be incomplete (BUG-30 backfilled missing UK regions; OQ-06 is the
+ * still-open question about a systematic replacement) — nothing guarantees
+ * a geocode region_iso corresponds to a seeded row, so this file's main
+ * scenario is the narrowed set matching zero seeded regions, which must
+ * fall back to the full country list rather than leaving the selector
+ * empty.
+ *
+ * Mocks:
+ *   - useCountries/useCountryRegions from hooks/useAdmin — controls the
+ *     seeded region list and region_tier_enabled gating
+ *   - lookupCityCountry/useCitySearch/useCreateCity/useCarryForwardCandidates
+ *     from hooks/useCities — controls the geocode result
+ *   - useAddPlace from hooks/usePlaces — unused in these scenarios but
+ *     called unconditionally by the component
+ *
+ * Source: src/frontend/components/TripDetail/AddPlaceFlow.tsx
+ */
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Country, GeocodeCandidate, Region } from '../../../types/api';
+import { AddPlaceFlow } from '../AddPlaceFlow';
+
+const mockLookupCityCountry = vi.fn();
+
+vi.mock('../../../hooks/useCities', () => ({
+  lookupCityCountry: (cityName: string) => mockLookupCityCountry(cityName),
+  useCitySearch: () => ({ data: [], isLoading: false }),
+  useCreateCity: () => ({ mutateAsync: vi.fn(), isPending: false, error: null }),
+  useCarryForwardCandidates: () => ({ data: [], isFetched: false }),
+}));
+
+vi.mock('../../../hooks/usePlaces', () => ({
+  useAddPlace: () => ({ mutateAsync: vi.fn(), isPending: false, error: null }),
+}));
+
+const usCountry: Country = {
+  country_code: 'US',
+  name: 'United States',
+  region_tier_enabled: true,
+  region_tier_label: 'State',
+};
+
+// Seeded regions that do NOT include either candidate's region_iso — models
+// the known-incomplete local table (BUG-30/OQ-06), not a contrived edge case.
+const seededRegionsNoOverlap: Region[] = [
+  {
+    id: 1,
+    country_code: 'US',
+    name: 'California',
+    iso_3166_2: 'US-CA',
+    created_at: '',
+    updated_at: '',
+  },
+  {
+    id: 2,
+    country_code: 'US',
+    name: 'Texas',
+    iso_3166_2: 'US-TX',
+    created_at: '',
+    updated_at: '',
+  },
+];
+
+const seededRegionsOneOverlap: Region[] = [
+  ...seededRegionsNoOverlap,
+  {
+    id: 3,
+    country_code: 'US',
+    name: 'Illinois',
+    iso_3166_2: 'US-IL',
+    created_at: '',
+    updated_at: '',
+  },
+];
+
+let countryRegionsFixture: Region[] = seededRegionsNoOverlap;
+
+vi.mock('../../../hooks/useAdmin', () => ({
+  useCountries: () => ({ data: [usCountry] }),
+  useCountryRegions: () => ({ data: countryRegionsFixture }),
+}));
+
+function springfieldCandidates(): GeocodeCandidate[] {
+  return [
+    {
+      name: 'Springfield',
+      display_name: 'Springfield, Illinois, USA',
+      country_code: 'US',
+      region_iso: 'US-IL',
+      latitude: 39.78,
+      longitude: -89.65,
+    },
+    {
+      name: 'Springfield',
+      display_name: 'Springfield, Missouri, USA',
+      country_code: 'US',
+      region_iso: 'US-MO',
+      latitude: 37.2,
+      longitude: -93.29,
+    },
+  ];
+}
+
+/** Types a query and opens the "Add new city" form, triggering the geocode lookup. */
+async function openNewCityForm(user: ReturnType<typeof userEvent.setup>, cityName: string) {
+  const input = screen.getByPlaceholderText('Search city name…');
+  await user.type(input, cityName);
+  const addNew = await screen.findByText(`+ Add new: "${cityName}"`, {}, { timeout: 2000 });
+  await user.click(addNew);
+}
+
+describe('AddPlaceFlow — ADL-46 D14 region selector narrowing', () => {
+  beforeEach(() => {
+    mockLookupCityCountry.mockReset();
+    countryRegionsFixture = seededRegionsNoOverlap;
+  });
+
+  it('falls back to the full country region list when the narrowed candidates match no seeded region', async () => {
+    countryRegionsFixture = seededRegionsNoOverlap; // neither US-IL nor US-MO is seeded
+    mockLookupCityCountry.mockResolvedValue({
+      countryCode: 'US',
+      regionIso: 'US-IL',
+      candidates: springfieldCandidates(),
+    });
+    const user = userEvent.setup();
+
+    render(
+      <AddPlaceFlow
+        tripId={1}
+        onClose={vi.fn()}
+        tripStartDate="2026-01-01"
+        tripEndDate="2026-01-10"
+        isFirstPlace={false}
+      />,
+    );
+
+    await openNewCityForm(user, 'Springfield');
+
+    // Full seeded list is still offered — the user is not locked out of
+    // regions that ARE seeded just because the narrowing found no overlap.
+    await waitFor(() => {
+      expect(screen.getByRole('option', { name: 'California' })).toBeInTheDocument();
+    });
+    expect(screen.getByRole('option', { name: 'Texas' })).toBeInTheDocument();
+
+    // The lookup DID detect ambiguity — the hint stays visible even though
+    // the selector fell back to the unfiltered list.
+    expect(screen.getByText(/multiple matches found, please choose/i)).toBeInTheDocument();
+
+    // Nothing was silently auto-selected from the incomplete table — the
+    // region <select> (identified via its "No <label> selected" placeholder
+    // option, since the label isn't htmlFor-associated) still shows no
+    // selection.
+    const regionSelect = screen
+      .getByRole('option', { name: /no state selected/i })
+      .closest('select') as HTMLSelectElement;
+    expect(regionSelect).toHaveValue('');
+  });
+
+  it('narrows to just the matching candidate regions when 2+ seeded regions overlap', async () => {
+    countryRegionsFixture = [
+      ...seededRegionsOneOverlap,
+      {
+        id: 4,
+        country_code: 'US',
+        name: 'Missouri',
+        iso_3166_2: 'US-MO',
+        created_at: '',
+        updated_at: '',
+      },
+    ]; // California, Texas, Illinois, Missouri all seeded — IL and MO both overlap
+    mockLookupCityCountry.mockResolvedValue({
+      countryCode: 'US',
+      regionIso: 'US-IL',
+      candidates: springfieldCandidates(),
+    });
+    const user = userEvent.setup();
+
+    render(
+      <AddPlaceFlow
+        tripId={1}
+        onClose={vi.fn()}
+        tripStartDate="2026-01-01"
+        tripEndDate="2026-01-10"
+        isFirstPlace={false}
+      />,
+    );
+
+    await openNewCityForm(user, 'Springfield');
+
+    await waitFor(() => {
+      expect(screen.getByText(/multiple matches found, please choose/i)).toBeInTheDocument();
+    });
+
+    expect(screen.getByRole('option', { name: 'Illinois' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'Missouri' })).toBeInTheDocument();
+    // Narrowed away — not offered even though seeded, because the geocode
+    // lookup gave no signal pointing at either of them.
+    expect(screen.queryByRole('option', { name: 'California' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('option', { name: 'Texas' })).not.toBeInTheDocument();
+  });
+});

--- a/src/frontend/hooks/__tests__/useCities.geocode.test.tsx
+++ b/src/frontend/hooks/__tests__/useCities.geocode.test.tsx
@@ -1,0 +1,115 @@
+/**
+ * Tests for lookupCityCountry (ADL-46 D7/D14) — the repointed geocode path.
+ *
+ * Source: src/frontend/hooks/useCities.ts
+ *
+ * ADL-46 moved this from a direct browser fetch to nominatim.openstreetmap.org
+ * (CSP-blocked in production, BUG-55, and unable to carry the required
+ * User-Agent header) to GET /api/geocode via apiGet. lookupCityCountry keeps
+ * its pre-existing fire-and-forget error contract — any failure resolves to
+ * nulls/empty rather than throwing — so AddPlaceFlow's manual-entry fallback
+ * keeps working.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { GeocodeResult } from '../../types/api';
+import { apiGet } from '../../utils/apiClient';
+import { lookupCityCountry } from '../useCities';
+
+vi.mock('../../utils/apiClient', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../utils/apiClient')>();
+  return {
+    ...actual,
+    apiGet: vi.fn(),
+  };
+});
+
+describe('lookupCityCountry', () => {
+  beforeEach(() => {
+    vi.mocked(apiGet).mockReset();
+  });
+
+  it('calls GET /api/geocode with the city name as the q param', async () => {
+    const result: GeocodeResult = { candidates: [], country_code: null, region_iso: null };
+    vi.mocked(apiGet).mockResolvedValue(result);
+
+    await lookupCityCountry('Springfield');
+
+    expect(apiGet).toHaveBeenCalledWith('/api/geocode?q=Springfield');
+  });
+
+  it('returns the top candidate country/region and the full candidate list on success', async () => {
+    const result: GeocodeResult = {
+      candidates: [
+        {
+          name: 'Springfield',
+          display_name: 'Springfield, Illinois, USA',
+          country_code: 'us',
+          region_iso: 'US-IL',
+          latitude: 39.78,
+          longitude: -89.65,
+        },
+      ],
+      country_code: 'us',
+      region_iso: 'US-IL',
+    };
+    vi.mocked(apiGet).mockResolvedValue(result);
+
+    const { countryCode, regionIso, candidates } = await lookupCityCountry('Springfield');
+
+    expect(countryCode).toBe('US');
+    expect(regionIso).toBe('US-IL');
+    expect(candidates).toEqual(result.candidates);
+  });
+
+  it('surfaces all candidates for the ambiguity (D14) case — multiple regions in one country', async () => {
+    const result: GeocodeResult = {
+      candidates: [
+        {
+          name: 'Springfield',
+          display_name: 'Springfield, Illinois, USA',
+          country_code: 'us',
+          region_iso: 'US-IL',
+          latitude: 39.78,
+          longitude: -89.65,
+        },
+        {
+          name: 'Springfield',
+          display_name: 'Springfield, Missouri, USA',
+          country_code: 'us',
+          region_iso: 'US-MO',
+          latitude: 37.2,
+          longitude: -93.29,
+        },
+      ],
+      country_code: 'us',
+      region_iso: 'US-IL',
+    };
+    vi.mocked(apiGet).mockResolvedValue(result);
+
+    const { candidates } = await lookupCityCountry('Springfield');
+
+    expect(candidates).toHaveLength(2);
+    expect(new Set(candidates.map((c) => c.region_iso))).toEqual(new Set(['US-IL', 'US-MO']));
+  });
+
+  it('returns nulls and an empty candidate list without throwing when the proxy call fails (silent-failure contract)', async () => {
+    vi.mocked(apiGet).mockRejectedValue(new Error('network error'));
+
+    await expect(lookupCityCountry('Nowhere')).resolves.toEqual({
+      countryCode: null,
+      regionIso: null,
+      candidates: [],
+    });
+  });
+
+  it('returns nulls when the proxy resolves with no candidates', async () => {
+    const result: GeocodeResult = { candidates: [], country_code: null, region_iso: null };
+    vi.mocked(apiGet).mockResolvedValue(result);
+
+    const { countryCode, regionIso, candidates } = await lookupCityCountry('Zzznotacity');
+
+    expect(countryCode).toBeNull();
+    expect(regionIso).toBeNull();
+    expect(candidates).toEqual([]);
+  });
+});

--- a/src/frontend/hooks/useAdmin.ts
+++ b/src/frontend/hooks/useAdmin.ts
@@ -4,6 +4,11 @@
  * Covers categories, activities, companions, and countries.
  * All three list types (categories, activities, companions) share the same
  * CRUD pattern, so helper factories are used to reduce duplication.
+ *
+ * ADL-46 (AD-09, D3): categories and activities moved off /api/admin/* to
+ * /api/categories and /api/activities (requireAuth, userId-scoped) — same
+ * response shape, per-user data — exactly as ADL-28 moved companions to
+ * /api/companions. See src/backend/routes/categories.ts / activities.ts.
  */
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import type { Activity, Category, Companion, Country } from '../types/api';
@@ -20,7 +25,7 @@ import { apiDelete, apiGet, apiPatch, apiPost } from '../utils/apiClient';
 export function useCategories() {
   return useQuery({
     queryKey: ['admin', 'categories'],
-    queryFn: () => apiGet<Category[]>('/api/admin/categories'),
+    queryFn: () => apiGet<Category[]>('/api/categories'),
   });
 }
 
@@ -31,7 +36,7 @@ export function useCategories() {
 export function useActiveCategories() {
   return useQuery({
     queryKey: ['admin', 'categories', 'active'],
-    queryFn: () => apiGet<Category[]>('/api/admin/categories/active'),
+    queryFn: () => apiGet<Category[]>('/api/categories/active'),
   });
 }
 
@@ -39,7 +44,7 @@ export function useActiveCategories() {
 export function useCreateCategory() {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: (name: string) => apiPost<Category>('/api/admin/categories', { name }),
+    mutationFn: (name: string) => apiPost<Category>('/api/categories', { name }),
     onSuccess: () => {
       void qc.invalidateQueries({ queryKey: ['admin', 'categories'] });
     },
@@ -51,7 +56,7 @@ export function useUpdateCategory() {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: ({ id, data }: { id: number; data: { name?: string; is_active?: boolean } }) =>
-      apiPatch<Category>(`/api/admin/categories/${id}`, data),
+      apiPatch<Category>(`/api/categories/${id}`, data),
     onSuccess: () => {
       void qc.invalidateQueries({ queryKey: ['admin', 'categories'] });
     },
@@ -62,7 +67,7 @@ export function useUpdateCategory() {
 export function useDeleteCategory() {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: (id: number) => apiDelete(`/api/admin/categories/${id}`),
+    mutationFn: (id: number) => apiDelete(`/api/categories/${id}`),
     onSuccess: () => {
       void qc.invalidateQueries({ queryKey: ['admin', 'categories'] });
     },
@@ -77,7 +82,7 @@ export function useDeleteCategory() {
 export function useActivities() {
   return useQuery({
     queryKey: ['admin', 'activities'],
-    queryFn: () => apiGet<Activity[]>('/api/admin/activities'),
+    queryFn: () => apiGet<Activity[]>('/api/activities'),
   });
 }
 
@@ -85,7 +90,7 @@ export function useActivities() {
 export function useActiveActivities() {
   return useQuery({
     queryKey: ['admin', 'activities', 'active'],
-    queryFn: () => apiGet<Activity[]>('/api/admin/activities/active'),
+    queryFn: () => apiGet<Activity[]>('/api/activities/active'),
   });
 }
 
@@ -93,7 +98,7 @@ export function useActiveActivities() {
 export function useCreateActivity() {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: (name: string) => apiPost<Activity>('/api/admin/activities', { name }),
+    mutationFn: (name: string) => apiPost<Activity>('/api/activities', { name }),
     onSuccess: () => {
       void qc.invalidateQueries({ queryKey: ['admin', 'activities'] });
     },
@@ -105,7 +110,7 @@ export function useUpdateActivity() {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: ({ id, data }: { id: number; data: { name?: string; is_active?: boolean } }) =>
-      apiPatch<Activity>(`/api/admin/activities/${id}`, data),
+      apiPatch<Activity>(`/api/activities/${id}`, data),
     onSuccess: () => {
       void qc.invalidateQueries({ queryKey: ['admin', 'activities'] });
     },
@@ -116,7 +121,7 @@ export function useUpdateActivity() {
 export function useDeleteActivity() {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: (id: number) => apiDelete(`/api/admin/activities/${id}`),
+    mutationFn: (id: number) => apiDelete(`/api/activities/${id}`),
     onSuccess: () => {
       void qc.invalidateQueries({ queryKey: ['admin', 'activities'] });
     },

--- a/src/frontend/hooks/useCities.ts
+++ b/src/frontend/hooks/useCities.ts
@@ -4,58 +4,55 @@
  * City search, creation, and the carry-forward candidates endpoint.
  */
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import type { CarryForwardCandidate, City, CityItem } from '../types/api';
+import type {
+  CarryForwardCandidate,
+  City,
+  CityItem,
+  GeocodeCandidate,
+  GeocodeResult,
+} from '../types/api';
 import { apiGet, apiPost } from '../utils/apiClient';
 import type { RatingSortOrder } from './useItems';
 
 // ============================================================
-// NOMINATIM GEOCODING (GE-15 — country auto-populate)
+// GEOCODING (ADL-46 D7/D14, GE-15 — country/region auto-populate)
 // ============================================================
 
-const NOMINATIM_BASE = 'https://nominatim.openstreetmap.org/search';
-const NOMINATIM_USER_AGENT = 'TravelTracker/1.0 (personal-use-app)';
-
-/** Shape of a Nominatim search result with address details. */
-interface NominatimResult {
-  address?: {
-    country_code?: string;
-    'ISO3166-2-lvl4'?: string;
-  };
-}
-
 /**
- * Looks up a city name via Nominatim and returns the ISO 3166-1 alpha-2
- * country code (upper-cased) and ISO 3166-2 subdivision code if found.
+ * Looks up a city name via the backend geocode proxy (GET /api/geocode) and
+ * returns the top candidate's ISO 3166-1 alpha-2 country code and ISO 3166-2
+ * subdivision code, plus the full candidate list for D14 ambiguity handling.
+ *
+ * ADL-46 (D7): this used to call nominatim.openstreetmap.org directly from
+ * the browser. Two independent reasons that could never work in production:
+ * CSP blocks the cross-origin fetch (BUG-55), and `User-Agent` is a forbidden
+ * header name that fetch() silently drops, so the call never carried the
+ * identifying UA Nominatim's usage policy requires. The proxy owns egress now.
  *
  * Used by AddPlaceFlow to auto-populate the country and region fields (GE-15, UX-04).
- * Fire-and-forget style — errors are silently swallowed so the user
- * can still select the country/region manually if lookup fails.
+ * Fire-and-forget style — errors are silently swallowed (same contract as
+ * before the D7 repoint) so the user can still select the country/region
+ * manually if lookup fails.
  *
  * @param cityName - The city name to look up.
- * @returns Object with upper-cased country code (e.g. "FR") and region ISO (e.g. "US-CA"), both nullable.
+ * @returns Upper-cased country code (e.g. "FR"), region ISO (e.g. "US-CA"),
+ *   both nullable, and the full candidate list (empty on any failure).
  */
-export async function lookupCityCountry(
-  cityName: string,
-): Promise<{ countryCode: string | null; regionIso: string | null }> {
+export async function lookupCityCountry(cityName: string): Promise<{
+  countryCode: string | null;
+  regionIso: string | null;
+  candidates: GeocodeCandidate[];
+}> {
   try {
-    const params = new URLSearchParams({
-      q: cityName,
-      format: 'json',
-      limit: '1',
-      addressdetails: '1',
-    });
-    const resp = await fetch(`${NOMINATIM_BASE}?${params}`, {
-      headers: { 'User-Agent': NOMINATIM_USER_AGENT },
-    });
-    if (!resp.ok) return { countryCode: null, regionIso: null };
-    const data = (await resp.json()) as NominatimResult[];
-    const item = data[0];
+    const params = new URLSearchParams({ q: cityName });
+    const result = await apiGet<GeocodeResult>(`/api/geocode?${params}`);
     return {
-      countryCode: item?.address?.country_code?.toUpperCase() ?? null,
-      regionIso: item?.address?.['ISO3166-2-lvl4'] ?? null,
+      countryCode: result.country_code?.toUpperCase() ?? null,
+      regionIso: result.region_iso ?? null,
+      candidates: result.candidates,
     };
   } catch {
-    return { countryCode: null, regionIso: null };
+    return { countryCode: null, regionIso: null, candidates: [] };
   }
 }
 

--- a/src/frontend/types/api.ts
+++ b/src/frontend/types/api.ts
@@ -37,7 +37,12 @@ export type ShadingStateKey =
 export interface Category {
   id: number;
   name: string;
-  is_active: number; // SQLite boolean: 0 | 1
+  // ADL-46: serializeCategory (src/backend/routes/categories.ts) coerces the
+  // SQLite 0|1 column to a real boolean before it ever reaches the wire —
+  // this type had said `number` since before the route moved and never
+  // matched the actual JSON. Fixed as part of the ADL-46 frontend stage
+  // (issue #340) per its instruction to verify shapes rather than assume.
+  is_active: boolean;
   created_at: string;
   updated_at: string;
 }
@@ -45,7 +50,7 @@ export interface Category {
 export interface Activity {
   id: number;
   name: string;
-  is_active: number;
+  is_active: boolean; // see Category.is_active — same pre-existing fix
   created_at: string;
   updated_at: string;
 }
@@ -72,6 +77,26 @@ export interface Region {
   iso_3166_2: string;
   created_at: string;
   updated_at: string;
+}
+
+/**
+ * A single candidate from GET /api/geocode's `candidates` array (ADL-46 D7/D14).
+ * See src/backend/routes/geocode.ts for the serialization.
+ */
+export interface GeocodeCandidate {
+  name: string;
+  display_name: string;
+  country_code: string | null;
+  region_iso: string | null;
+  latitude: number;
+  longitude: number;
+}
+
+/** Response shape of GET /api/geocode (ADL-46 D7/D14, GE-15). */
+export interface GeocodeResult {
+  candidates: GeocodeCandidate[];
+  country_code: string | null;
+  region_iso: string | null;
 }
 
 // Minimal association shapes used inside trip responses


### PR DESCRIPTION
Closes #340

Stage 4/4 (final) of the ADL-46 per-user access-model release. Branched off and targeting `release/adl46-access-model`, not `main`.

## Changes

**Task 1 — repoint `useAdmin.ts` (10 call sites)**
- All categories/activities queries and mutations moved from `/api/admin/categories|activities` to `/api/categories|activities`, matching the routers PR #338 added. Companions and countries untouched.
- Verified response shapes against `src/backend/routes/categories.ts` / `activities.ts` on the integration branch rather than assuming per the brief. Found a pre-existing mismatch: `Category`/`Activity.is_active` was typed `number` but both routes (and the pre-existing `Companion` type, same pattern) actually serialize it as a real `boolean`. Fixed the two frontend types. All current usages are truthy checks (`cat.is_active ? … : …`), so this was a type-accuracy fix, not a behavior change — confirmed no test mocks used numeric `is_active` for these two types.

**Task 2 — repoint `lookupCityCountry` to the geocode proxy**
- Replaced the direct `fetch('https://nominatim.openstreetmap.org/search')` call with `apiGet('/api/geocode?q=...')`. Deleted `NOMINATIM_BASE` / `NOMINATIM_USER_AGENT`.
- Kept the existing fire-and-forget silent-failure contract (`{ countryCode: null, regionIso: null }`, now also `candidates: []`) so `AddPlaceFlow`'s manual-entry fallback is unaffected.

**Task 3 — D14 candidate disambiguation via the existing region selector**
- No new component or modal. When the proxy returns multiple candidates with differing `region_iso` for the resolved country (e.g. Springfield IL vs Springfield MO), `AddPlaceFlow`'s existing region `<select>` is narrowed to just those candidate regions instead of silently auto-picking `candidates[0]`, with a small inline hint ("multiple matches found, please choose"). The single-best-guess auto-select path is unchanged for the unambiguous case.

## Testing
- `src/e2e/admin.spec.ts`: the 4 previously-failing tests (create category, rename category, deactivate/re-activate category, create activity) now pass.
- Full E2E suite: **52/52 passing** (Playwright's own summary line, not a grep).
- `npm run test:frontend`: **233/233 passing** (5 new tests added in `useCities.geocode.test.tsx` covering top-candidate success, D14 ambiguity, and the silent-failure-returns-nulls case).
- `npm run test:backend`: 650/650 passing (untouched, backend not modified in this brief).
- `npm run type:check:all`: clean.
- `npm run check` (biome): clean.
- `/pre-push` checklist: all green.

## Known environment limit (expected, not a bug)
Live Nominatim egress can't be reached from this devcontainer (firewall allowlist is GitHub/npm/Anthropic only) — the E2E run shows `[GEO] Nominatim request failed: fetch failed` from the backend's background geocoding queue on city creation, which is pre-existing and unrelated to this change (background queue, not the `lookupCityCountry` path touched here — no E2E test exercises the "Add new city" UI that would call `lookupCityCountry`/`/api/geocode` directly). This gets verified on staging per the brief.