### PR TITLE
docs(ADL-46): Architect ruling on F1/F2 — ambiguity discriminator + wildcard-upgrade predicate

### DIFF
--- a/jobs/COO/inbox/20260801_1200-ARCHITECT-adl46-f1-f2-ruling.txt
+++ b/jobs/COO/inbox/20260801_1200-ARCHITECT-adl46-f1-f2-ruling.txt
@@ -1,0 +1,64 @@
+TO: COO
+FROM: Architect
+ADL: ADL-46 (amended, not superseded) · Branch: chore/adl46-f1-f2-ruling → PR vs release/adl46-access-model
+BRD: §5.2 GE-16, §5.11 SE-03 (v3.13) — no amendment needed, no new requirement ID
+Deliverable: jobs/architect/tech/20260801-ADL46-F1-F2-ruling.md
+
+WHAT WAS DECIDED
+The F1/F2 blocking questions are ruled. F1's fix is one shared classifier replacing pickBest,
+with ambiguity defined as more than one distinct region_iso rather than more than one candidate;
+F2's wildcard upgrade gains a status+creator predicate. Backend-implementable as written — no
+schema change, no migration, no BRD bump.
+
+PER-DECISION VERDICT
+R1  F2 predicate — ADOPTED with four amendments. Whitelist IN ('pending','unresolvable'), not
+    <> 'resolved'. Step 2 only; steps 1 and 2b stay creator- and status-blind or the insert
+    collides on uniq_cities_name_country_region_ci. Reset geocode_attempts and re-fire
+    resolveCity on a pending upgrade. Declining falls through to insert.
+R1b The COO's RATIONALE — REJECTED. "Deliberately the same predicate GE-16 uses for visibility"
+    is false: `resolved` is a GRANT in the visibility disjunction and a BAR in the upgrade
+    predicate. The mnemonic inverts in SQL. Replacement principle in ruling §3.1. The predicate
+    itself survives on the stronger reason and the duplicate class it admits is bounded at one
+    row, analysed concretely in §3.2.
+R2  Ambiguity discriminator — ADOPTED. Distinct non-null region_iso set over country-eligible
+    candidates; eligibility takes a SET of permitted country codes (empty = unconstrained), so
+    the trip-declared-countries follow-on is a two-line change and nothing is unpicked.
+    Identical to the rule the frontend already computes — parity is a contract, with a test.
+R3  Region requested, no candidate matches — ADOPTED: stays pending. Not unresolvable.
+R4  Retry disposition — ADOPTED: consume geocode_attempts, never mark unresolvable. The budget
+    belongs to the question, so region_id changing resets it (and deliberately does not for
+    unresolvable). This answers the review's "ambiguous rows retry forever" without a new status.
+R5  Map consequence — STATED for UAT, not solved. Two corrections to the framing you gave me,
+    both material, below.
+    Review F7 (doubled egress on the 'unresolved' path) — NOT authorised here; needs its own call.
+
+TWO THINGS YOU SHOULD ACT ON
+1. THE HAPPY PATH IS ALREADY BROKEN ON THE BRANCH and it is in neither the review nor your
+   chain. resolveCityName returns 'ambiguous' whenever two or more candidates match the
+   REQUESTED region (geocoding.service.ts:99-101). UX-04 auto-populates the region and Nominatim
+   returns one city at several granularities, so ordinary submissions may be producing pending
+   rows today. The ruling fixes it incidentally. FREQUENCY IS UNVERIFIED — firewall blocks live
+   Nominatim; mechanism established by reading, rate is not. Put one region-tier city submission
+   into the staging shakedown and check the resulting geocode_status.
+2. R5 CORRECTIONS. (a) "Pending cities still shade correctly" holds at COUNTRY level only — a
+   multi-region-ambiguous row has no region by definition, so it contributes to no REGION
+   shading either. Three simultaneous gaps for one place, not one; set the UAT expectation on
+   all three. (b) The pending volume does NOT move only upward: the case in item 1 moves the
+   other way and is the more common one, so the net could plausibly be a reduction. I did not
+   assert a direction — see ruling §6.
+
+CI: no source files changed — docs only (ruling + ADL-46 §4.2.1/§4.3.2 amendments + ADL log
+amendment + context/park/this report). PR CI confirmed green before filing.
+
+BLOCKERS: none.
+
+ALSO FLAGGED (not mine to fix in this dispatch): ADL-47 has zero occurrences in the main ADL
+log despite being in force on this release and cited in CLAUDE.md. /record-decision item 2
+requires the log entry regardless of a standalone file; ADL-28 is the precedent for this drift.
+
+NOW UNBLOCKED
+Backend: a single implementation brief covering F1 + F2 with named functions, signatures, the
+ordered algorithm, the exact SQL predicate, and five test obligations (ruling §4 — the fix must
+NOT land behind the geocoder mocks that hid F1, per review F4).
+QA: the F1 assertion ATDD B4 was too weak to make is specified in ruling §4 item 2.
+UX: ruling §5.4 is the premise for the parallel UX brief, deliberately unanswered.

--- a/jobs/architect/context/current.txt
+++ b/jobs/architect/context/current.txt
@@ -786,3 +786,77 @@ PO SUMMARY UPDATED — it carried the two-users framing that item 0 rejects. Add
   answering the three review points in his own terms, rewrote the trade-offs section, added
   the duplicate-names and ask-which-one rows to the what-changes table, and replaced the
   "acceptable for two people" paragraph with the triggered follow-on.
+
+================================================================================
+2026-08-01 — ADL-46 F1/F2 RULING (pre-merge, integration branch release/adl46-access-model)
+================================================================================
+Narrow blocking ruling, NOT a feature design. Deliverable:
+jobs/architect/tech/20260801-ADL46-F1-F2-ruling.md. Amends ADL-46 §4.2.1 (D13) and
+§4.3.2 (D14) plus the main ADL log entry. No schema change, no migration, no BRD bump,
+no new requirement ID. Scope boundary held: did NOT rule on trip-country-constrained
+lookups, the shortlist selector, the verification rule, or Roma/Rome canonicalisation —
+a UX brief runs first, by design, and the name sits inside D13's identity key.
+
+R2 (F1) — the discriminator is the DISTINCT REGION SET, not the candidate count.
+  Ambiguous iff the eligible candidates carry >1 distinct non-null region_iso.
+  Eligibility takes a SET of permitted country codes (empty = unconstrained) so the
+  trip-declared-countries follow-on needs no unpicking; countrycodes= already accepts a
+  comma list, so that follow-on is a two-line change at query + post-filter.
+  Byte-for-byte the rule AddPlaceFlow.tsx:250-263 already computes. Parity is a CONTRACT.
+  STRUCTURAL INSTRUCTION THAT MATTERS MOST: delete pickBest, one classifier
+  (classifyCandidates) called by BOTH resolveCityName and resolveCity. F1 exists because
+  one question had two decision procedures; a fix that leaves two will diverge again.
+
+R3 — row HAS a region, no candidate matches it → stays pending. Not unresolvable (GE-16
+  reserves that for a geocoder "no match" and makes it terminal). The region field
+  survived today; the coordinates contradicted it.
+
+R4 — ambiguity consumes the existing geocode_attempts budget. THE BUDGET IS ATTACHED TO
+  THE QUESTION: setting region_id resets it (a region constraint can collapse an
+  ambiguity); deliberately does NOT reset for unresolvable (a region cannot turn zero
+  candidates into some). That asymmetry is the whole answer to the review's
+  "ambiguous rows retry forever" objection without inventing a new status.
+
+R1 (F2) — ACCEPTED the COO's predicate, REJECTED the COO's reason for it.
+  "Deliberately the same predicate GE-16 uses for visibility" is FALSE: visibility is a
+  disjunction where `resolved` GRANTS; the upgrade predicate flips it to a BAR. An
+  implementer told "adopt a row you can see" writes the wrong SQL. Better principle, on
+  record: READ-THROUGH IS GLOBAL BECAUSE THE UNIQUE INDEX IS GLOBAL; WRITE-THROUGH IS
+  SCOPED BECAUSE NOTHING FORCES IT TO BE. Step 1 is a forced accommodation; step 2 is not.
+  Four amendments: whitelist IN ('pending','unresolvable') not <> 'resolved' (fails closed
+  against §4.4.3's contemplated 4th status); step 2 ONLY (steps 1/2b stay creator- and
+  status-blind or the insert collides on uniq_cities_name_country_region_ci); reset
+  attempts + re-fire resolveCity on a pending upgrade; declining falls through to insert.
+  Duplicate class it admits: analysed concretely, BOUNDED AT ONE ROW (the index permits at
+  most one region-less row per name+country, so step 2's limit(1) is exact and the filter
+  can exclude at most one row; fallback insert lands on a key step 1 proved vacant). Not
+  the BUG-33 class. There is NO version of adopting a resolved row a non-owner can perform
+  correctly — correcting it means rewriting shared coordinates, which is owner curation.
+
+FOUND WHILE RULING, in neither the review nor the COO's chain: THE HAPPY PATH IS ALREADY
+  BROKEN ON THE BRANCH. resolveCityName returns 'ambiguous' whenever >=2 candidates match
+  the requested region (geocoding.service.ts:99-101), and UX-04 auto-populates the region —
+  so a common city returning city+municipality hits produces a pending row TODAY. The new
+  discriminator fixes it incidentally. Invisible in CI for the same reason F1 was (review
+  F4: every route suite mocks the geocoder). FREQUENCY IS UNVERIFIED — firewall blocks live
+  Nominatim; mechanism established by reading, rate is not. Staging shakedown must exercise it.
+
+R5 — UAT consequence. Verified two ways each: shading reads country_code/region_id and
+  never geocode_status or coordinates; pins require resolved AND coords; coords and
+  'resolved' are always written together and nothing demotes a resolved row (three probes:
+  latitude write sites, geocodeStatus write sites, PatchCitySchema .strict()).
+  THE NUANCE THE COO'S FRAMING MISSED: a multi-region-ambiguous row has NO region by
+  definition, so it contributes to no REGION shading either — country shaded, region
+  unshaded, no pin. Three gaps for one place.
+  AND THE VOLUME IS NOT MONOTONIC: the happy-path case above moves the other way and is
+  the more common one. Net could plausibly be FEWER pending. Did not assert which way.
+  PO framing recorded verbatim and deliberately not solved: the user never sees
+  coordinates; a wrong pin is reported as a bug as fast as a missing one. "Stay pending"
+  is the right trade only because a wrong resolved row is shared/global/never re-queried/
+  owner-only-to-repair while a pending row stays in its creator's reach via D11 — and that
+  argument EXPIRES without an affordance, which does not exist. Premise for the UX brief.
+
+DOC-LIFECYCLE GAP NOTICED, not mine to fix here: ADL-47 (expand/contract, cited in
+  CLAUDE.md and in force on this release) has NO entry in the main ADL log — zero hits for
+  "ADL-47" in 20260307-architecture-decisions-log.md. /record-decision item 2 says the log
+  always gets the entry; standalone-only numbering has drifted before (ADL-28). Flagged to COO.

--- a/jobs/architect/park-docs/20260801-ARCHITECT-park.txt
+++ b/jobs/architect/park-docs/20260801-ARCHITECT-park.txt
@@ -1,0 +1,72 @@
+ARCHITECT PARK DOCUMENT — 2026-08-01
+Thread: ADL-46 F1/F2 blocking ruling (pre-merge, integration branch)
+Branch: chore/adl46-f1-f2-ruling  →  PR against release/adl46-access-model (NOT main)
+
+WHAT THIS THREAD WAS
+A narrow, blocking design ruling on three questions raised by the OP-27 fresh-eyes review
+of the assembled ADL-46 release (jobs/architect/tech/20260731-ADL46-release-fresh-eyes-
+review.md, PR #342): the F2 wildcard-upgrade predicate, the F1 ambiguity discriminator, and
+the map consequence for UAT. Explicitly NOT a feature design brief — scope discipline was
+named as the most important property of the dispatch and was held.
+
+DELIVERABLE
+jobs/architect/tech/20260801-ADL46-F1-F2-ruling.md — five rulings (R1–R5), a test-obligation
+section, and a what-I-could-not-verify section. Actionable by a Backend agent without further
+design decisions: function names, signatures, the exact algorithm in order, and the exact SQL
+predicate are all in it.
+
+ALSO CHANGED (amend, never rewrite)
+- ADL-46-non-owner-access-model.md §4.2.1 and §4.3.2 — dated AMENDED blocks, prior text intact.
+- 20260307-architecture-decisions-log.md — dated AMENDMENT appended to the ADL-46 entry.
+- jobs/architect/context/current.txt — appended dated entry.
+No supersession stamps needed: every change is a refinement of ADL-46, not a replacement.
+No BRD change, no new requirement ID, no schema change, no migration.
+
+THE FIVE RULINGS IN ONE LINE EACH
+R1  F2 predicate: accept, with four amendments; reject the COO's stated rationale (§3.1).
+R2  Ambiguity = more than one distinct non-null region_iso among country-eligible candidates.
+R3  Region requested, no candidate matches it → stays pending, never resolved elsewhere.
+R4  Ambiguity consumes geocode_attempts; the budget belongs to the question, so region_id
+    changing resets it — and deliberately does not for unresolvable.
+R5  Map: pending shades country, not region, and shows no pin. Volume change is not monotonic.
+
+THE THREE THINGS A SUCCESSOR MOST NEEDS TO KNOW
+1. ONE CLASSIFIER, TWO CALLERS. pickBest must be deleted, not patched. F1's root cause is
+   that one question (which candidate, if any?) had two independent decision procedures.
+   Any fix that leaves two in place regresses the moment either is touched.
+2. THE HAPPY PATH IS ALREADY BROKEN ON THE BRANCH, and nobody had found it. resolveCityName
+   returns 'ambiguous' whenever two or more candidates match the REQUESTED region
+   (geocoding.service.ts:99-101). UX-04 auto-populates the region, and Nominatim returns one
+   city at several granularities, so ordinary submissions produce pending rows. The ruling
+   fixes it incidentally, but the frequency is UNVERIFIED (firewall blocks live Nominatim)
+   and must be exercised on staging. If the shakedown finds it common, this was the single
+   largest user-visible defect in the release and it was not in the review.
+3. THE COO'S PREDICATE WAS RIGHT AND ITS JUSTIFICATION WAS WRONG. "Same predicate GE-16 uses
+   for visibility" is false — `resolved` is a GRANT in the visibility disjunction and a BAR
+   in the upgrade predicate. Ratifying the reasoning would have propagated a rule that reads
+   correctly in prose and inverts in SQL. The replacement principle is on record: read-through
+   is global because the unique index is global; write-through is scoped because nothing
+   forces it to be.
+
+VERIFICATION POSTURE (negative-findings rule)
+Every negative claim in the deliverable carries two probes that could fail differently, or is
+marked UNVERIFIED with the probe and its blind spot named:
+- Shading ignores geocode_status/coordinates: read the four query builders AND a symbol grep
+  across services/ and repositories/ (zero hits in shading.service.ts).
+- Coordinates and 'resolved' always written together, nothing demotes: three probes — latitude
+  write sites, geocodeStatus write sites, PatchCitySchema .strict().
+- Unique index is unconditional (no creator/status WHERE): schema.ts:146 AND the applied DDL
+  at 0015_fluffy_payback.sql:63.
+- Live Nominatim behaviour: UNVERIFIED, firewall (GitHub/npm/Anthropic only), no probe run.
+  Named explicitly in ruling §6 with what follows from it and what does not.
+
+OPEN / HANDED BACK, NOT SOLVED
+- The UX brief owns: what the map shows for unlocated places, whether the three geocode states
+  get an affordance, and Roma/Rome canonicalisation. The ruling deliberately constrains none of
+  them — classifyCandidates takes candidates and returns a verdict; a name-agreement clause is
+  an added condition, not a rewrite.
+- Review F7 (doubled egress on the 'unresolved' create path) was NOT authorised here. The
+  ruling only removes the provably-redundant call on the 'ambiguous' path.
+- DOC-LIFECYCLE GAP flagged to COO: ADL-47 has zero occurrences in the main ADL log despite
+  being in force on this release and cited in CLAUDE.md. /record-decision item 2 requires the
+  log entry; standalone-only numbering has drifted before (ADL-28 is the precedent).

--- a/jobs/architect/tech/20260307-architecture-decisions-log.md
+++ b/jobs/architect/tech/20260307-architecture-decisions-log.md
@@ -3815,3 +3815,78 @@ flagged as a separate item (single-probe finding, marked as such in the standalo
 
 **Open question closed:** D-12 item 1 in `jobs/COO/open-dialogues.md` ("the three-role model has
 drifted from reality") is answered by D1/D5. Items 2–4 remain open.
+
+**AMENDMENT (2026-08-01) — D13 and D14 refined pre-merge after the second OP-27 review.
+Ruling: `jobs/architect/tech/20260801-ADL46-F1-F2-ruling.md`. Status: decided, backend
+implementation pending; no schema change, no migration, no BRD amendment, no new requirement ID.**
+The OP-27 fresh-eyes review of the *assembled release*
+(`jobs/architect/tech/20260731-ADL46-release-fresh-eyes-review.md`, PR #342) returned SHIP WITH
+FOLLOW-ONS with one HIGH finding. Three rulings, all amending rather than superseding:
+
+- **D14 — the ambiguity discriminator was wrong, and the queue was never specified.** "More than one
+  remaining candidate" is replaced by **"more than one distinct non-null `region_iso` among the
+  eligible candidates"**: Nominatim returns one real city at several administrative granularities,
+  so the count marks nearly everything ambiguous, and the region set is the discriminator because
+  the region selector is the control D14 asks through. Country eligibility takes a **set** of
+  permitted codes (empty = unconstrained) so the trip-declared-countries follow-on needs no
+  unpicking. The rule is deliberately identical to the one the frontend already computes — parity is
+  a contract. Separately, §4.3.2 never said what `processQueue`/the on-create trigger do with an
+  ambiguous name, and the implementation resolved that silence with the pre-existing `candidates[0]`
+  auto-pick (`pickBest`), undoing D14 roughly one second after a user declined to choose and
+  breaking two GE-16 success criteria. **`pickBest` is deleted; one classifier serves both callers**
+  — two decision procedures for one question is the root cause and would diverge again. An ambiguous
+  verdict leaves the row `pending` with no coordinates and consumes the existing `geocode_attempts`
+  budget (bounded, never retried forever); it is **never** `unresolvable`, which GE-16 reserves for a
+  geocoder "no match" and defines as terminal. **The retry budget is attached to the question:**
+  setting `region_id` resets it, because a region constraint can collapse an ambiguity — and
+  deliberately does *not* reset for an `unresolvable` row, where a region cannot turn zero candidates
+  into some. Also ruled: a row that *has* a region and no candidate matching it stays `pending`
+  rather than taking a candidate from a different region — the field survived but the coordinates
+  contradicted the user's explicit selection.
+- **D13 — step 2's wildcard upgrade gains a predicate** (review F2, a genuine spec conflict, not an
+  implementation bug: the code follows §4.2.1 verbatim). As specified, any authenticated user could
+  mutate a **`resolved`, globally visible** row — or another creator's private one — on a
+  `requireAuth` path, which SE-03/GE-16 make owner-only and which §4.4.2's own reasoning rejects.
+  Step 2 is restricted to `geocode_status IN ('pending','unresolvable')` **and**
+  `created_by_user_id = caller OR IS NULL`. The principle, stated because it is what makes the
+  asymmetry with step 1 defensible: **read-through is global because the unique index is global;
+  write-through is scoped because nothing forces it to be.** Steps 1 and 2b stay creator- and
+  status-blind — a filtered step 1 would miss and then collide on
+  `uniq_cities_name_country_region_ci`. The duplicate class the restriction admits is **bounded at
+  one row** (the index permits at most one region-less row per name+country, the fallback insert
+  lands on a key step 1 proved vacant, and a repeat request hits step 1) and its residue is
+  §4.4.3's already-triggered owner-repair follow-on. It is **not** the BUG-33 class, which was
+  unbounded duplication on an identical key. There is no version of adopting a `resolved` row that a
+  non-owner can perform *correctly*, because correcting it means rewriting shared coordinates.
+- **Direction this is step one of** (PO, post-release): *`resolved` should ultimately mean the
+  user's explicit selection and the geocoder independently agree; a selection the geocoder cannot
+  confirm stays `pending`.* The ruling implements that for **country and region** — the two
+  dimensions a user can select today. **Name canonicalisation ("Roma"/"Rome") is deliberately not
+  ruled on**: the name sits inside D13's identity key, and whether that model survives depends on a
+  UX brief being written first, by design, so the data model serves the experience rather than the
+  reverse.
+
+**One finding surfaced while ruling that neither the review nor the COO's chain had:** the *happy
+path* is already broken on the branch. `resolveCityName` returns `'ambiguous'` whenever two or more
+candidates match the requested region (`geocoding.service.ts:99-101`), and UX-04 auto-populates the
+region — so a common city returning `city` + `municipality` hits produces a `pending` row today. The
+new discriminator fixes it. It is invisible in CI for the same reason F1 was (review F4: every route
+suite mocks the geocoder away), which is why the ruling carries explicit service-level test
+obligations. **Frequency is UNVERIFIED** — the devcontainer firewall (GitHub/npm/Anthropic only)
+blocks live Nominatim; the mechanism is established by code reading, the real-world rate is not, and
+it must be exercised during the staging shakedown.
+
+**UAT consequence, recorded so it is not logged as a false product bug (OP-32).** Shading reads
+`country_code`/`region_id` and never `geocode_status` or coordinates (`shading.service.ts`); pins
+require both `resolved` and coordinates (`CityMarkers.tsx:52-58`). So a pending city shades its
+country, shows no pin — and, because `multi-region` ambiguity by definition means no region was
+chosen, contributes to **no region shading either**: three simultaneous gaps for one place, not one.
+The net change in pending volume is **not** monotonic — the happy-path case above moves the other
+way and is the more common one. **Framing the PO set, recorded and deliberately not solved here:**
+*the user never sees coordinates — a pin in the wrong place is reported as a bug exactly as fast as a
+missing pin.* "Stay pending" trades one user-visible defect class for another; it is the right trade
+only because a wrong `resolved` row is shared, global, never re-queried and owner-only to repair,
+while a `pending` row stays in its creator's own reach via D11. That argument expires the moment the
+affordance is missing — and it is: the three states are surfaced nowhere in the UI, and GE-16's
+correction-by-re-point works but is undiscoverable. **This is the premise for the UX brief, not a
+defect to log.**

--- a/jobs/architect/tech/20260801-ADL46-F1-F2-ruling.md
+++ b/jobs/architect/tech/20260801-ADL46-F1-F2-ruling.md
@@ -1,0 +1,466 @@
+# ADL-46 F1/F2 — Architect ruling (pre-merge, integration branch)
+
+**Date:** 2026-08-01
+**Author:** Architect (fresh dispatch; no authorship of any ADL-46 stage or of the OP-27 review)
+**Branch under ruling:** `release/adl46-access-model` @ `79ea9a4`
+**Inputs:** `jobs/architect/tech/20260731-ADL46-release-fresh-eyes-review.md` (F1 HIGH, F2 MEDIUM);
+ADL-46 §4.2.1 (D13), §4.3.2 (D14), §4.4/§4.4.1 (D5/D10); BRD v3.13 GE-16, SE-03.
+**Status:** Decided. Backend-implementable as written. **No schema change, no migration, no BRD
+amendment, no new requirement ID.** Amends ADL-46 §4.2.1 and §4.3.2; supersedes neither.
+**Scope:** F1 and F2 only. The country-constrained lookup, the shortlist selector, the
+selection-plus-geocoder verification rule, name canonicalisation (Roma/Rome), and what the map
+shows for unlocated places are **out of scope by dispatch** and are not ruled on here.
+
+---
+
+## 1. Summary table
+
+| # | Decision | Ruling | Confidence |
+|---|---|---|---|
+| **R1** | F2 — predicate for D13 step 2 (wildcard upgrade) | **Accept the COO's predicate, with four amendments.** Status half becomes an explicit **whitelist** (`IN ('pending','unresolvable')`), not `<> 'resolved'`. Applies to **step 2 only** — steps 1 and 2b stay creator- and status-blind. Upgrading a `pending` row resets `geocode_attempts` and re-fires resolution. The COO's stated *rationale* is wrong even though the predicate is right (§3.1) | **High** |
+| **R2** | F1 — the ambiguity discriminator | **Distinct region set, not candidate count.** Ambiguous iff the eligible candidates carry **more than one distinct non-null `region_iso`**. Eligibility is a **set** of permitted country codes (empty = unconstrained). One shared function, called by both the create path and the queue | **High** |
+| **R3** | F1(b) — row has a region, no candidate matches it | **Stays `pending`.** Never resolve to a candidate outside the user's selected region. `unresolvable` is wrong here (the geocoder did not answer "no match") | **High** |
+| **R4** | Retry disposition for a row left pending by ambiguity | **Consume the existing `geocode_attempts` budget; never mark `unresolvable`.** The budget is attached to the *question*; changing `region_id` resets it | **High** |
+| **R5** | Map consequence for UAT | **Stated factually in §5.** Net effect on pending count is **not** monotonic — one currently-shipped case moves the other way. UX consequence recorded, not solved | **High** (states) / **Unverified** (volumes — §6) |
+
+**Two findings surfaced while ruling, not in the review or the COO's chain:**
+
+- **A shipped regression the ruling incidentally fixes.** `resolveCityName` returns `'ambiguous'`
+  whenever **two or more candidates match the requested region** (`geocoding.service.ts:99-101`).
+  Two Nominatim hits for one city at different granularities (`city` + `municipality`, both
+  surviving `SETTLEMENT_TYPES` at `nominatim-client.ts:81`) share one `region_iso`, so the
+  *happy path* — UX-04 auto-populates the region, user submits — currently produces a `pending`
+  row. This is exactly the failure mode the dispatch's requirement (a) forbids, already in the
+  release. It is invisible in CI because every route suite mocks the geocoder (review F4).
+  Under R2 it resolves correctly. See §6 for what I could and could not verify about it.
+- **The COO's justification for the F2 predicate is not sound, though its conclusion is.** §3.1.
+
+---
+
+## 2. R2/R3/R4 — the F1 ruling
+
+### 2.1 The single most important structural instruction
+
+F1 exists because two code paths decide the same question with different logic: the interactive
+path (`resolveCityName`) and the background path (`pickBest`). **Delete `pickBest`
+(`geocoding.service.ts:200-211`) and replace both decision sites with one exported function.**
+A fix that leaves two decision procedures in place will diverge again.
+
+### 2.2 The function
+
+In `src/backend/services/geocoding.service.ts`:
+
+```ts
+/**
+ * Countries a candidate is permitted to come from — upper-cased ISO 3166-1
+ * alpha-2. An EMPTY set means UNCONSTRAINED. Today every caller passes a set
+ * of one; the trip-declared-countries follow-on passes many.
+ */
+export type PermittedCountries = ReadonlySet<string>;
+
+export type CandidateVerdict =
+  | { status: 'ok'; best: NominatimCandidate; eligible: NominatimCandidate[] }
+  | {
+      status: 'ambiguous';
+      /** Why we are not choosing. Not persisted; drives logging and the follow-on. */
+      reason: 'multi-region' | 'region-unconfirmed';
+      regionIsos: string[];
+      eligible: NominatimCandidate[];
+    }
+  | { status: 'unresolved'; eligible: [] };
+
+export function classifyCandidates(
+  candidates: NominatimCandidate[],
+  permitted: PermittedCountries,
+  requestedRegionIso: string | null,
+): CandidateVerdict;
+```
+
+**Algorithm — implement exactly this, in this order.**
+
+1. **Country eligibility.** If `permitted.size === 0`, `eligible = candidates`. Otherwise
+   `eligible` = candidates where `c.countryCode != null && permitted.has(c.countryCode.toUpperCase())`.
+   A candidate with a null `countryCode` is **dropped** when the set is non-empty — a candidate we
+   cannot attribute to a country cannot confirm the user's country selection. (This matches the
+   frontend, which filters on `c.country_code === countryCode`, `AddPlaceFlow.tsx:254`.)
+2. **Zero eligible → `{ status: 'unresolved' }`.** Terminal; unchanged from today.
+3. **A region was requested** (`requestedRegionIso != null`):
+   `matches = eligible.filter(c => c.regionIso?.toUpperCase() === requestedRegionIso.toUpperCase())`
+   - `matches.length >= 1` → `{ status: 'ok', best: matches[0] }`.
+     **The count is deliberately irrelevant here** — every match is in the region the user chose,
+     so they cannot disagree about the thing the user selected; take Nominatim's own ranking.
+     *This clause is the fix for the shipped regression named in §1.*
+   - `matches.length === 0` → `{ status: 'ambiguous', reason: 'region-unconfirmed', regionIsos: <distinct set over eligible> }`.
+     **This is R3.** The geocoder cannot confirm the region the user explicitly selected; we do not
+     get to overrule them (GE-16: *"the country and region a user explicitly selected are never
+     overwritten by the lookup"*) and we do not get to attach coordinates that contradict them.
+4. **No region was requested:**
+   `regionIsos` = distinct, upper-cased, non-null `regionIso` over `eligible`.
+   - `regionIsos.length > 1` → `{ status: 'ambiguous', reason: 'multi-region', regionIsos }`.
+   - otherwise → `{ status: 'ok', best: eligible[0] }`.
+
+**Why the discriminator is the region set and not the candidate count.** Nominatim returns one real
+city at several administrative granularities. Counting hits marks nearly every city ambiguous —
+strictly worse than the bug. The region set is the right discriminator because it is *the thing the
+user can act on*: D14's entire mechanism is the region selector already on screen, so "ambiguous"
+must mean "there is more than one answer the region selector can distinguish between."
+
+**Frontend parity — this is a hard contract, not a coincidence.** Step 4 is byte-for-byte the rule
+`AddPlaceFlow.tsx:250-263` already computes (distinct non-null `region_iso` among candidates whose
+`country_code` matches, ambiguous when `> 1`). Step 3 has no frontend counterpart because the
+frontend has no selected region at lookup time — it is running step 4 to *produce* one. The two
+sides therefore agree on every state the frontend can reach. **Any future change to step 4 changes
+both sides or neither.** Note the sets are *derived* differently and legitimately so: the backend's
+is the user's validated `country_code`; the frontend's is the top candidate's country, because the
+user has not chosen one yet and the frontend's lookup is unconstrained.
+
+**Known, accepted limit — state it, do not fix it here.** When `eligible.length >= 2` and **no**
+candidate carries a `region_iso`, step 4 yields a set of size 0 or 1 and resolves to `eligible[0]`.
+That is a guess. It is accepted for this release because (i) it is the frontend's behaviour, and
+parity is the harder requirement, and (ii) the case is dominated by non-region-tier countries, where
+`region_id` must be NULL (`cities.ts:106-108`) and the region selector does not render — so there is
+no control to ask through, and leaving the row pending forever would trade a rare wrong pin for a
+guaranteed missing one with no affordance to fix it. This is the residual the fresh-eyes review named
+("for non-region-tier countries ambiguity degrades straight to the F1 path") and it belongs to the UX
+brief, not here.
+
+### 2.3 Call site 1 — `resolveCityName` (the create path)
+
+Keep the signature; add the escape hatch and delegate the decision:
+
+```ts
+export async function resolveCityName(
+  name: string,
+  countryCode: string,
+  opts: { regionIso?: string | null; permittedCountryCodes?: PermittedCountries } = {},
+): Promise<CityResolution>
+```
+
+- `permitted = opts.permittedCountryCodes ?? new Set([countryCode.toUpperCase()])`.
+- Delete the inline region/count logic (`geocoding.service.ts:91-109`) and return
+  `classifyCandidates(result.candidates, permitted, opts.regionIso ?? null)`, mapped onto
+  `CityResolution`. **Add `reason?: 'multi-region' | 'region-unconfirmed'` to `CityResolution`**
+  and carry it through — it is not persisted, it exists so the follow-on and the logs can tell the
+  two ambiguity classes apart without a breaking change later.
+- `countryCode` stays singular: it is the user's ground truth and D12 rule 3 forbids the lookup
+  overriding it. The **set** lives on the *check*, which is what the dispatch requires. The follow-on
+  that constrains by the trip's declared countries changes two lines — `countrycodes=` already
+  accepts a comma-joined list (`nominatim-client.ts:118-122` passes params through verbatim), and
+  `permittedCountryCodes` is already the post-filter. Nothing here is unpicked to get there.
+
+### 2.4 Call site 2 — `resolveCity` (the queue and the on-create trigger). **This is F1.**
+
+Replace `pickBest(result.candidates, city.regionIso)` (`geocoding.service.ts:172`) with
+`classifyCandidates(result.candidates, new Set([city.countryCode.toUpperCase()]), city.regionIso)`.
+
+| Verdict | Action | Change |
+|---|---|---|
+| `unresolved` | `geocode_status = 'unresolvable'`, terminal | unchanged |
+| `ok` | write `latitude`/`longitude` + `geocode_status = 'resolved'` | unchanged |
+| `ambiguous` (either reason) | **Write no coordinates. Leave `geocode_status = 'pending'`. Call `incrementAttempts(cityId)`. Log at info with `reason` and `regionIsos`. Return `false`.** | **new — this is the fix** |
+
+### 2.5 R4 — why `geocode_attempts`, and why never `unresolvable`
+
+The review correctly flags that "just refuse it" makes ambiguous rows retry forever (D10 has no
+terminal state for ambiguity). The answer needs no new state:
+
+- **`unresolvable` is not available.** GE-16 defines it as *"the geocoder answered and reported **no
+  match**"*, and it is **never retried**. An ambiguous answer is not a no-match, and marking it
+  terminal would foreclose the correct future outcome — the user picks a region, the row gains one,
+  and the now-constrained lookup succeeds.
+- **`geocode_attempts` is a budget, not a diagnosis.** The queue predicate is already
+  `pending AND attempts < CAP` (`geocoding.service.ts:244-250`). Incrementing on ambiguity means the
+  row drops out of the queue after `GEOCODE_ATTEMPT_CAP` (5) and stops costing egress, while staying
+  `pending` — which is precisely what GE-16 says a declined choice produces: *"declining to choose
+  still creates a usable pending record."*
+- **The budget is attached to the question. Changing `region_id` changes the question and resets it**
+  (implemented in R1, §3.3). This is the rule that makes retry-until-cap correct rather than merely
+  bounded: re-asking an unchanged question is what the cap stops; re-asking a *changed* one is what
+  the reset enables.
+- **Deliberate asymmetry, stated so it is not "fixed" later:** the reset does **not** apply to a row
+  adopted while `unresolvable`. There, the geocoder returned *zero* candidates; adding a region
+  constraint cannot turn zero into some, so re-asking would burn budget to re-learn the same answer.
+
+### 2.6 `POST /api/cities` step 4c — do not fire the resolver into a known answer
+
+At `cities.ts:329` the route fires `resolveCity(city.id)` on every 4c row. When
+`resolution.status === 'ambiguous'`, the route **already holds** the verdict `resolveCity` would
+recompute — under R2 the second call provably reaches the identical result, costs a second Nominatim
+request against a 1 req/s application budget, and burns an attempt.
+
+**Rule: skip the fire-and-forget when `resolution.status === 'ambiguous'`.** Keep it for
+`'disabled'` (the answer is genuinely unknown) and for `'unresolved'` (the route would otherwise
+have to duplicate D10's terminal classification in the route layer — collapsing that second request
+is review F7's optimisation and is **not** authorised by this ruling; it needs its own sign-off).
+
+The 15-minute queue will still pick the pending ambiguous row up and spend its 5 attempts over
+roughly 75 minutes before dropping it. That is the bounded cost and it is intended; it is stated
+here so nobody diagnoses it as a leak.
+
+### 2.7 This is step one of the PO's direction, not a detour from it
+
+The direction — *`resolved` means the user's explicit selection and the geocoder independently
+agree; a selection the geocoder cannot confirm stays `pending`* — is **fully implemented by this
+ruling on both dimensions the user can currently select**:
+
+- **Country:** the query is `countrycodes`-constrained *and* the verdict is country-post-filtered
+  (step 1), so a candidate outside the user's selection can never win. The post-filter is redundant
+  today and load-bearing the moment the query accepts a set — which is why it goes in now.
+- **Region:** step 3 resolves **only** on an affirmative match to the user's selection; no match
+  means `pending`. That is the target rule verbatim.
+
+The dimension left open is the **name** — a user's "Roma" against a geocoder's "Rome" is agreement
+that this ruling does not test, because the identity key `(name, country_code, COALESCE(region_id,0))`
+puts the name string inside identity and whether that model survives is the UX brief's to answer.
+**Explicitly not ruled on here.** Nothing above constrains that answer: `classifyCandidates` takes
+candidates and returns a verdict, and a name-agreement clause is an added condition on step 3/4, not
+a rewrite.
+
+---
+
+## 3. R1 — the F2 wildcard-upgrade predicate
+
+### 3.1 The COO's predicate is right. The COO's reason for it is not.
+
+> *"deliberately the same predicate GE-16 already uses for visibility, so the rule reads as one idea:
+> you may adopt a row you can see and that the system does not already treat as authoritative."*
+
+**It is not the same predicate, and an implementer told it is will write the wrong SQL.** GE-16
+visibility is a **disjunction** in which `resolved` *grants* visibility:
+`resolved OR creator = caller OR creator IS NULL` (`cities.ts:61-65`). The upgrade predicate is
+`NOT resolved AND (creator = caller OR creator IS NULL)` — the `resolved` term flips from a grant to
+a **bar**. A resolved row is visible to you and must **not** be upgradeable. "You may adopt a row you
+can see" is therefore false as stated; only the second half of the sentence carries the rule. Drop
+the first half.
+
+The predicate survives on a different and stronger justification, which I want on the record because
+it is what makes the asymmetry with step 1 principled rather than arbitrary:
+
+> **Read-through is global because the unique index is global. Write-through is scoped because
+> nothing forces it to be global.**
+
+Step 1 must return another user's pending row — the index
+`uniq_cities_name_country_region_ci` is unconditional (verified two ways: `schema.ts:146` and the
+applied DDL at `0015_fluffy_payback.sql:63` — neither carries a `WHERE`), so a creator-filtered step 1
+would miss and the follow-on insert would violate it. That is a forced accommodation, correctly taken
+(§8 row 6 / OP-27 P2). Step 2 is under no such pressure: declining to upgrade simply inserts a row on
+a **distinct** identity key, which D13 made legal on purpose. Mutating a record you cannot see, when
+the alternative is a legal insert, has no justification at all.
+
+### 3.2 Does it reintroduce a duplicate class? Yes — one, bounded, and it is the right trade
+
+I am answering this concretely as instructed rather than asserting safety.
+
+**The class.** Region-tier country; catalogue holds a **region-less `resolved`** row for
+(name, country); a user posts the same name **with** a region. Step 1 misses (key `0` ≠ `R`), step 2
+now declines, and we insert `(name, country, R)`. Two rows for what may be one real city.
+
+**Why it is nonetheless correct.** The alternative is what ships today: adopt the resolved row, set
+`region_id = R`, **leave its coordinates untouched**. That produces the review's Springfield case — a
+shared, globally-visible row whose coordinates say Illinois and whose region says Missouri, which
+user A's place now renders as Missouri. Making it *not* wrong would require overwriting the shared
+row's coordinates, and that is catalogue curation — owner-only under SE-03 and GE-16. **There is no
+version of adopting a resolved row that a non-owner is permitted to perform correctly.** Trading a
+silent cross-user corruption for a visible extra row is the right direction, and D13 legalised extra
+rows for exactly this reason.
+
+**Why the class is bounded, precisely.** The unique index makes at most **one** region-less row exist
+per (name, country) — `COALESCE(region_id, 0) = 0` is a single key. So step 2's `.limit(1)` is exact,
+not arbitrary, and the new predicate can exclude **at most one row**. The fallback insert lands on a
+key step 1 has already proven vacant, so it **cannot collide**, and a repeat of the same request hits
+step 1 and returns the row. Maximum rows for a name+country is therefore `1 + (distinct regions
+actually used)` — unchanged from D13's intended shape. **This is not the BUG-33 class**, which was
+unbounded duplication on an identical key.
+
+**Where the residue goes.** The sub-case where the region-less resolved row's coordinates really are
+in region R produces a genuine redundant pair. That is §4.4.3's already-owned lifecycle — a real city
+with correct coordinates, indistinguishable from a seeded row nobody has visited — collected by the
+owner catalogue-repair follow-on, which already carries a trigger (before a third account exists).
+It adds volume to that follow-on; it does not add a new problem to it.
+
+**The creator half admits a second, smaller case:** user A holds a private `pending` region-less
+"Foo"; user B posts "Foo" + region → B inserts `(Foo, country, R)`. Two rows, one of them invisible
+to B. Same bound, same disposition, and the alternative (B silently re-regioning A's private row and
+receiving back a 200 for a city B cannot find in search) is plainly worse.
+
+### 3.3 The ruling, implementable
+
+In `src/backend/routes/cities.ts`, `findOrUpgradeCity` (`:139`). Signature gains the caller:
+
+```ts
+findOrUpgradeCity(db, name, countryCode, regionId, callerUserId: string)
+```
+
+**Step 2's `SELECT` (`:159-170`) gains two conditions and nothing else:**
+
+```
+AND cities.geocode_status IN ('pending', 'unresolvable')
+AND (cities.created_by_user_id = :callerUserId OR cities.created_by_user_id IS NULL)
+```
+
+Four binding amendments to the COO's version:
+
+1. **Whitelist, not blacklist.** Write `IN ('pending','unresolvable')`, never `<> 'resolved'`.
+   §4.4.3 contemplates a fourth status; a blacklist would silently make it upgradeable, a whitelist
+   fails closed. Same reasoning D10 used for the CHECK constraint.
+2. **Step 2 only.** **Step 1 (`:150-158`) and step 2b (`:186-192`) must remain creator-blind and
+   status-blind** — see §3.1. A brief that says "scope the lookup to the caller" without this
+   qualification will produce unique-index violations at insert.
+3. **On a successful upgrade, reset the retry budget and re-ask.** The `UPDATE` at `:172-176` becomes
+   `.set({ regionId, geocodeAttempts: 0, updatedAt: now })`, and when the adopted row's status is
+   `'pending'` the route fires `resolveCity(upgraded.id)` fire-and-forget with the same defensive
+   `.catch(() => {})` as `cities.ts:329`. Rationale in §2.5: the region is the question, and a
+   region-constrained lookup can collapse an ambiguity the unconstrained one could not. Without this
+   the user's disambiguation — pick a region, resubmit — sets the region and then waits up to 15
+   minutes for the queue. Do **not** fire for an adopted `'unresolvable'` row (§2.5, asymmetry).
+   Resetting `geocodeAttempts` unconditionally is fine and simpler: only `pending` rows are queued,
+   so it is inert elsewhere.
+4. **Declining is not an error.** Step 2 declining must fall through to the normal insert path, which
+   is what the current control flow already does — no new error branch.
+
+### 3.4 Not ruled on
+
+Whether the *owner* should be able to perform the resolved-row upgrade (with a coordinate re-resolve)
+is the deferred creator/owner `PATCH /api/cities/:id` work in §4.4.3. This ruling neither builds nor
+forecloses it.
+
+---
+
+## 4. Test obligations (so the fix is not green-for-the-wrong-reason)
+
+Review F4 established that every route suite mocks the geocoder away, which is why both F1 and the
+§1 regression reached the integration branch. **A fix landing behind the same mocks proves nothing.**
+Minimum, at the service level with a candidate-returning fake:
+
+1. `classifyCandidates` — table-driven, one row per branch: empty permitted set; candidate with null
+   `countryCode` excluded; two same-region candidates with a region requested → **`ok`** (the §1
+   regression, and it must fail before the fix); zero region matches with a region requested →
+   `ambiguous`/`region-unconfirmed`; two distinct regions, none requested → `ambiguous`/`multi-region`;
+   two candidates both with null `regionIso` → `ok` (the accepted limit, pinned so a later change to
+   it is deliberate).
+2. `resolveCity` with a **multi-region** fake → row still `pending`, `latitude`/`longitude` still
+   NULL, `geocode_attempts` incremented, status **not** `unresolvable`. This is the F1 assertion the
+   ATDD suite's B4 was too weak to make.
+3. `resolveCity` at `attempts = CAP` → not re-selected by `processQueue`.
+4. `findOrUpgradeCity` — step 2 declines on a `resolved` row (new row inserted, original untouched
+   including its coordinates); declines on another creator's `pending` row; **succeeds** on a
+   NULL-creator `pending` row; succeeds on the caller's own, with `geocode_attempts` reset.
+5. One route-level test of step 2b's two-or-more path proving no unique-index violation, since §3.3
+   amendment 2 is the guard against exactly that.
+
+Parity is a contract, not a comment (§2.2): add a frontend unit test over
+`AddPlaceFlow`'s distinct-region computation using the same fixtures as (1)'s step-4 rows.
+
+---
+
+## 5. R5 — the map consequence, for the UAT expectation
+
+### 5.1 Verified mechanics
+
+Shading and pins are driven by different columns, and only pins depend on the geocoder.
+
+- **Shading ignores `geocode_status` and ignores coordinates.** `getAllCountryShading`,
+  `getCountryShading`, `getRegionShading` and `getCityShading` join
+  `countries`/`regions` → `cities` → `trip_places` → `trips` on `country_code`, `region_id` and
+  `city_id`, filtered only by `trips.userId` (`shading.service.ts:255-380`). Verified two ways that
+  could fail differently: reading the four query builders, **and** a symbol grep for
+  `geocode|geocodeStatus|latitude` across `src/backend/services/` and `src/backend/repositories/`,
+  which returns **zero** hits in `shading.service.ts`.
+- **Pins require both `geocode_status === 'resolved'` and non-null coordinates**
+  (`CityMarkers.tsx:52-58`) — a positive, self-verifying finding.
+- **Coordinates and `resolved` are written together, always, and nothing ever demotes a resolved
+  row.** Three independent probes: a grep for every `latitude` occurrence in `src/backend` (only two
+  write sites — `cities.ts:293` and `geocoding.service.ts:188`, each paired with
+  `geocodeStatus: 'resolved'` two lines later); a grep for every `geocodeStatus:` write (schema
+  default `'pending'`, `cities.ts:295/:317`, `geocoding.service.ts:178/:190` — no
+  `resolved → pending` transition anywhere); and `PatchCitySchema`, which is `.strict()` and accepts
+  `region_id` only, so the one owner write surface cannot touch either column.
+
+### 5.2 The reachable states — all three, and the one the COO's framing missed
+
+For a city referenced by a trip place:
+
+| `geocode_status` | Coordinates | Country shading | **Region shading** | City pin |
+|---|---|---|---|---|
+| `resolved` | always present | **yes** | yes *if* `region_id` set | **yes** |
+| `pending` | always NULL | **yes** | **only if `region_id` set** | **no** |
+| `unresolvable` | always NULL | **yes** | only if `region_id` set | **no** |
+
+**"Pending cities still shade correctly" is true at country level and not at region level.** Region
+shading joins `cities.region_id = regions.id` (`shading.service.ts:337-341`), so a **region-less**
+row contributes to no region — and a region-less row is the *typical* output of the F1 fix, because
+`multi-region` ambiguity is by definition the case where no region was chosen. So in a region-tier
+country the fixed behaviour produces three simultaneous gaps for one place: **country shaded, region
+unshaded, no pin.** Set the UAT expectation on all three, not just the pin.
+
+The `region-unconfirmed` case (R3) behaves differently and better: the user *did* select a region, so
+`region_id` is set and region shading works. Only the pin is missing.
+
+### 5.3 Volume — the direction is not uniform
+
+Four cases change; **they do not all move the same way**, and the COO's framing ("fixing F1
+deliberately increases pending") is directionally right about three of them and wrong about the
+fourth:
+
+| Case | Today | After the fix |
+|---|---|---|
+| 1. Region-tier country, **no region** supplied, ≥2 distinct candidate regions | `resolved` to `candidates[0]` — wrong pin possible | **`pending`** — more pending |
+| 2. Region supplied, **no** candidate matches it | `resolved` to `candidates[0]` — pin in the wrong region | **`pending`** — more pending |
+| 3. Non-region-tier country, ≥2 candidates, no region ISOs | `resolved` to `candidates[0]` | **unchanged** — still resolves |
+| 4. Region supplied, **≥2 candidates in that region** (granularity duplicates) | **`pending`** (the §1 shipped regression) | **`resolved`** — *fewer* pending |
+
+Case 4 is on the happy path (UX-04 auto-populates the region, so most submissions carry one), and
+cases 1–2 require a genuinely ambiguous name. **The net could plausibly be a reduction in pending
+cities.** I will not assert which way it goes — see §6.
+
+### 5.4 The framing to carry forward — recorded, not solved
+
+Per PO direction, recorded verbatim as the premise for the UX work, and **explicitly not answered
+here**:
+
+> **The user never sees coordinates. A pin in the wrong place will be reported as a bug exactly as
+> fast as a missing pin.**
+
+"Stay pending" trades one user-visible defect class for another; it does not eliminate one. The
+architectural reason it is still the right trade *for this release* is narrow and worth naming so it
+is not mistaken for a claim that the problem is solved: a wrong `resolved` row is **shared, global,
+never re-queried, and repairable only by the owner through a surface that does not exist yet**,
+whereas a `pending` row is **creator-scoped, still in the queue, and repairable by its own creator
+today via D11's place re-point**. The bug that stays inside the user's own reach is the better bug.
+That argument runs out the moment the affordance is missing — which it is:
+
+- The three states are not surfaced anywhere in the UI. `geocode_status` is carried all the way to
+  the client (`places.ts:108`, `types/api.ts`) and consumed by exactly one thing: whether to draw a
+  pin.
+- GE-16's correction mechanism (re-point the place to a different city) exists and works, but nothing
+  tells a user that a place is unlocated, why, or that re-pointing is the fix.
+
+**This is the UX brief's premise, not a defect to be logged.** It is also why R2 declines to make the
+discriminator any stricter than the frontend's: every additional pending row is a place with no pin
+and no explanation, and until there is an affordance, more pending is a real cost and not a safe
+default.
+
+---
+
+## 6. What I could not verify, and the blind spot in each probe
+
+1. **Live Nominatim response shapes — UNVERIFIED, and it is load-bearing for §5.3.** The devcontainer
+   firewall allows GitHub, npm and Anthropic only; I ran no live query. Consequently: that Nominatim
+   routinely returns multiple same-region settlement hits (the §1 regression's real-world frequency),
+   how often `ISO3166-2-lvl4` is present, and the true balance of §5.3's four cases are all
+   **unmeasured**. What *is* established by code reading and is not in doubt: the `regionMatches.length > 1`
+   branch (`geocoding.service.ts:99-101`) returns `'ambiguous'`, so **if** two same-region candidates
+   are returned the happy path produces a pending row. **Blind spot:** frequency, not mechanism.
+   This must be exercised on staging during the deployment shakedown (OP-32) — one submission of a
+   well-known city in a region-tier country with the region auto-populated, checking the resulting
+   row's `geocode_status`.
+2. **The §5.3 net direction.** Follows entirely from (1). Stated as "could plausibly reduce"; do not
+   promote it to a claim.
+3. **The `type == null` pass-through in the settlement filter** (`nominatim-client.ts:141`) — a
+   candidate with no `type` survives filtering. Unexercised against real payloads, same firewall
+   reason. It widens `eligible` and therefore can only make step 4's region set larger, never
+   smaller — so it biases toward `ambiguous`, the safe direction. Inherited from the fresh-eyes
+   review's own could-not-verify list; not re-probed.
+4. **UI behaviour.** I read `AddPlaceFlow.tsx`, `CityMarkers.tsx` and the shading service but drove no
+   browser. The parity claim in §2.2 is established by reading both computations and comparing them,
+   not by observing them agree at runtime — hence the test obligation in §4.

--- a/jobs/architect/tech/ADL-46-non-owner-access-model.md
+++ b/jobs/architect/tech/ADL-46-non-owner-access-model.md
@@ -520,6 +520,19 @@ arriving through the front door.
    different city — specialising it is correct and prevents the duplicate.
 3. **Insert** only if both miss.
 
+> **AMENDED (2026-08-01) — step 2 gains a predicate.** See
+> `jobs/architect/tech/20260801-ADL46-F1-F2-ruling.md` §3 (ruling R1), raised as **F2** by the OP-27
+> fresh-eyes review of the assembled release. As written above, step 2 lets any authenticated user
+> mutate a **`resolved`, globally-visible** row — or another creator's private one — on a
+> `requireAuth` path, which contradicts §4.4.2's own reasoning and SE-03/GE-16's owner-only
+> curation rule. Step 2 is now restricted to rows where
+> `geocode_status IN ('pending','unresolvable')` **and**
+> `created_by_user_id = <caller> OR created_by_user_id IS NULL`; on a successful upgrade
+> `geocode_attempts` resets to 0 and a `'pending'` row is re-resolved. **Steps 1 and 2b are
+> unchanged and must stay creator- and status-blind** — the unique index is global, so a filtered
+> step 1 would miss and then collide on insert. The duplicate class the restriction admits is
+> bounded at one row and analysed in the ruling §3.2; the text above otherwise stands.
+
 **And the reverse case, which has no safe automatic answer.** If the request carries *no* region
 while two or more rows share that name and country (e.g. Springfield IL and MO both exist), we cannot
 tell which the user means. Returning the first is exactly the silent-wrong-entry failure this whole
@@ -704,6 +717,37 @@ filter to settlement-type results (Nominatim `class=place`, `type` in city/town/
 cutoff is a number nobody can justify and everybody re-tunes. If the Backend brief finds the filter
 leaves common cities ambiguous in practice (e.g. a capital plus its suburbs) it *may* add a dominance
 rule, but **must state it explicitly** rather than leaving it implicit.
+
+> **AMENDED (2026-08-01) — "more than one remaining candidate" is replaced as the discriminator, and
+> D14 is extended to the background path.** See `jobs/architect/tech/20260801-ADL46-F1-F2-ruling.md`
+> §2 (rulings R2/R3/R4), raised as **F1 (HIGH)** by the OP-27 fresh-eyes review of the assembled
+> release. Three things this section left unstated or got wrong:
+>
+> 1. **The count is the wrong discriminator.** Nominatim returns one real city at several
+>    administrative granularities (`city` + `municipality`, both surviving `SETTLEMENT_TYPES`), so
+>    counting hits marks nearly every city ambiguous. **Ambiguous now means the eligible candidates
+>    carry more than one distinct non-null `region_iso`** — the region set, because the region
+>    selector is the control D14 asks through. Country eligibility is expressed as a **set** of
+>    permitted country codes (empty = unconstrained) so the trip-declared-countries follow-on does
+>    not have to unpick it. This is deliberately identical to the rule the frontend already computes
+>    (`AddPlaceFlow.tsx:250-263`); parity between the two sides is a contract, not a coincidence.
+> 2. **This section never said what the *queue* does**, and the implementation resolved the silence
+>    in favour of the pre-existing `candidates[0]` auto-pick (`pickBest`), which undid D14 within
+>    about a second of a user declining to choose. `resolveCity` now runs the **same** classifier —
+>    one function, two callers, `pickBest` deleted — and an ambiguous verdict leaves the row
+>    `pending` with no coordinates, consuming the existing `geocode_attempts` budget so it is
+>    bounded rather than retried forever. It is **never** marked `unresolvable`: GE-16 reserves that
+>    for a geocoder "no match", and it is terminal.
+> 3. **A row that HAS a region and no candidate matching it** must also stay `pending` — resolving
+>    it to a candidate in a different region contradicts GE-16's *"the country and region a user
+>    explicitly selected are never overwritten by the lookup"* with coordinates, even though the
+>    field itself survives.
+>
+> Step one of the direction the PO set after this release: *`resolved` should ultimately mean the
+> user's explicit selection and the geocoder independently agree; a selection the geocoder cannot
+> confirm stays `pending`.* The ruling implements that for country and region; **name
+> canonicalisation ("Roma"/"Rome") is deliberately not ruled on** and awaits the UX brief, because
+> the name sits inside D13's identity key.
 
 **Degradation is unchanged and non-blocking (GE-12).** Offline, service error, or zero candidates all
 still create a `pending` row from the user's text. **Ambiguity never blocks city creation** — if the


### PR DESCRIPTION
Architect ruling on the two blocking findings from the OP-27 fresh-eyes review of the assembled ADL-46 release (PR #342 — F1 HIGH, F2 MEDIUM). Targets the integration branch, not `main`.

**Deliverable:** `jobs/architect/tech/20260801-ADL46-F1-F2-ruling.md`
**BRD:** §5.2 GE-16, §5.11 SE-03 (v3.13) — no amendment required, no new requirement ID
**Amends** ADL-46 §4.2.1 (D13) and §4.3.2 (D14) plus the main ADL log entry. Supersedes nothing — every change is a refinement, so the prior text stands with dated `AMENDED` blocks.

Docs only. No source, schema, migration or BRD change.

## Rulings

| # | Ruling |
|---|---|
| **R1** (F2) | Wildcard upgrade restricted to `geocode_status IN ('pending','unresolvable')` **and** `created_by_user_id = caller OR IS NULL`. **Step 2 only** — steps 1 and 2b stay creator- and status-blind, because `uniq_cities_name_country_region_ci` is global and a filtered step 1 would miss and then collide on insert. On upgrade, reset `geocode_attempts` and re-resolve a `pending` row. |
| **R2** (F1) | Ambiguity is **more than one distinct non-null `region_iso`** among country-eligible candidates — not `candidates.length > 1`, which would mark nearly every city ambiguous. Eligibility takes a **set** of permitted country codes (empty = unconstrained), so the trip-declared-countries follow-on is a two-line change. Byte-for-byte the rule `AddPlaceFlow.tsx:250-263` already computes; parity is a contract with a test. **`pickBest` is deleted — one classifier serves both `resolveCityName` and `resolveCity`**, since one question having two decision procedures is F1's root cause. |
| **R3** | A row that has a region and no candidate matching it stays `pending`. Not `unresolvable` — GE-16 reserves that for a geocoder "no match" and makes it terminal. |
| **R4** | Ambiguity consumes the existing `geocode_attempts` budget. The budget belongs to the **question**: setting `region_id` resets it, and `unresolvable` deliberately does not (a region cannot turn zero candidates into some). This answers the review's "ambiguous rows retry forever" objection without inventing a status. |
| **R5** | Map consequence stated for UAT, deliberately not solved. |

## Where this disagrees with what it was handed

- **The COO's F2 predicate is adopted; its stated rationale is rejected.** "Deliberately the same predicate GE-16 uses for visibility" does not hold — `resolved` is a *grant* in the visibility disjunction and a *bar* in the upgrade predicate. The mnemonic reads correctly in prose and inverts in SQL. Replacement principle on record in §3.1: read-through is global because the unique index is global; write-through is scoped because nothing forces it to be. The duplicate class the restriction admits is analysed concretely and is bounded at one row (§3.2).
- **Two corrections to the R5 framing.** "Pending cities still shade correctly" holds at country level only — a multi-region-ambiguous row has no region by definition, so it contributes to no *region* shading either: three simultaneous gaps for one place. And the pending volume does not move only upward (see below), so the net could plausibly be a reduction; no direction is asserted.

## Surfaced while ruling — in neither the review nor the COO's chain

`resolveCityName` returns `'ambiguous'` whenever **two or more candidates match the requested region** (`geocoding.service.ts:99-101`). UX-04 auto-populates the region, and Nominatim returns one city at several administrative granularities, so the *happy path* may already be producing `pending` rows on this branch. R2 fixes it incidentally. It is invisible in CI for the same reason F1 was (review F4: every route suite mocks the geocoder away), which is why the ruling carries explicit service-level test obligations (§4).

**Frequency is UNVERIFIED.** The devcontainer firewall allows GitHub, npm and Anthropic only, so no live Nominatim probe was run. The mechanism is established by reading the branch; the real-world rate is not, and it must be exercised during the staging shakedown (OP-32). Ruling §6 lists this and three other could-not-verify items with each probe's blind spot named.

## Verification posture

Every negative claim carries two probes that could fail differently, or is marked UNVERIFIED:
- Shading reads `country_code`/`region_id` only — the four query builders read, **and** a symbol grep across `services/` and `repositories/` returning zero geocode/coordinate hits in `shading.service.ts`.
- Coordinates and `'resolved'` are always written together and nothing demotes a resolved row — three probes (every `latitude` write site, every `geocodeStatus:` write site, `PatchCitySchema` being `.strict()` with `region_id` only).
- The unique index carries no creator/status predicate — `schema.ts:146` **and** the applied DDL at `0015_fluffy_payback.sql:63`.

## Notes for the COO

- No GitHub issue existed for this ruling, so there is no `Closes #N`. It answers F1 and F2 in PR #342.
- The review doc's F1/F2 recommendations become answered once this merges; that doc lives on the still-open #342, so it could not be stamped here.
- **Flagged, out of scope:** ADL-47 has zero occurrences in the main ADL log despite being in force on this release and cited in CLAUDE.md. `/record-decision` item 2 requires the log entry regardless of a standalone file; ADL-28 is the precedent for this drift.
- Review F7 (doubled egress on the `'unresolved'` create path) was **not** authorised here — the ruling removes only the provably redundant call on the `'ambiguous'` path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
