### PR TITLE
fix(BRD-GE16): ADL-46 F1/F2 — ambiguity classifier + wildcard-upgrade predicate (#345)

### DIFF
--- a/jobs/COO/inbox/20260801_1300-BACKEND-adl46-f1-f2-ruling-complete.txt
+++ b/jobs/COO/inbox/20260801_1300-BACKEND-adl46-f1-f2-ruling-complete.txt
@@ -1,0 +1,200 @@
+BACKEND completion report — ADL-46 F1/F2 ruling implementation (issue #345)
+Date: 2026-08-01
+Branch: fix/adl46-f1-f2-ruling (off release/adl46-access-model)
+PR: https://github.com/ryanv11/travel-tracker/pull/346 (Closes #345)
+CI: PASS — all 9 checks green on PR #346 @ 3d8a39d9037cfbfef5929e63bdd68d53ab2525b9
+    (Secret Scanning, Static Analysis/Semgrep, Dependency Vulnerability Scan, Biome,
+    Type Check, Backend Tests, Frontend Tests, Contract Tests, E2E Tests)
+
+=== WORKING DIRECTORY CONFIRMATION ===
+First action was `pwd` + `git rev-parse --show-toplevel`, both resolved to
+/workspace/.claude/worktrees/agent-a412c50ba10fde17f — the assigned worktree, not
+/workspace. `npm install` run inside the worktree before any test/type-check command
+(fresh worktree, no inherited node_modules). .env.local copied from /workspace/.env.local
+to run the backend locally for contract/E2E.
+
+=== SPEC FOLLOWED ===
+jobs/architect/tech/20260801-ADL46-F1-F2-ruling.md (read in full before writing code).
+Implemented R1-R4 exactly as specified; R5 is a UAT-expectation record only, no code.
+
+=== WHAT CHANGED ===
+
+1. src/backend/services/geocoding.service.ts (targeted edits, not a rewrite)
+   - Deleted `pickBest` entirely (ruling §2.1 — the single most important
+     structural instruction).
+   - Added exported `PermittedCountries` type, `CandidateVerdict` type, and
+     `classifyCandidates(candidates, permitted, requestedRegionIso)` — the ONE
+     shared classifier, implementing the ruling §2.2 algorithm exactly (country
+     eligibility filter → zero-eligible terminal → region-requested branch →
+     no-region-requested branch, distinct non-null region_iso count as the
+     ambiguity discriminator, not candidate count).
+   - `resolveCityName` (call site 1, create path): deleted the inline
+     region/count logic, now delegates entirely to classifyCandidates. Signature
+     gained `opts.permittedCountryCodes` (defaults to `{countryCode}` — the
+     follow-on trip-constrained lookup changes nothing else per the ruling).
+     Added `reason?: 'multi-region' | 'region-unconfirmed'` to `CityResolution`.
+   - `resolveCity` (call site 2, queue/on-create trigger — this is F1): replaced
+     `pickBest(...)` with `classifyCandidates(...)`. New ambiguous branch (R2/R4):
+     writes no coordinates, leaves geocode_status='pending', calls
+     incrementAttempts, logs reason+regionIsos, returns false. Never sets
+     'unresolvable' for an ambiguous verdict.
+
+2. src/backend/routes/cities.ts (targeted edits, not a rewrite)
+   - `findOrUpgradeCity` signature gained `callerUserId: string`.
+   - Step 2 (wildcard upgrade) SELECT gained exactly two conditions per ruling
+     §3.3: `geocode_status IN ('pending','unresolvable')` (whitelist, not
+     `<> 'resolved'`) AND `(created_by_user_id = callerUserId OR
+     created_by_user_id IS NULL)`. Steps 1 and 2b left untouched — deliberately
+     creator/status-blind, per §3.1/§3.3 amendment 2.
+   - On a successful upgrade: `geocodeAttempts: 0` added to the UPDATE; if the
+     adopted row's status is 'pending', fires `resolveCity(upgraded.id)` with
+     the same defensive `.catch(() => {})` pattern used elsewhere in this file.
+     Not fired for an adopted 'unresolvable' row (ruling §2.5 asymmetry).
+   - Both call sites of `findOrUpgradeCity` updated to pass `userId`.
+   - §2.6: step 4c's `resolveCity(city.id)` fire-and-forget now skipped when
+     `resolution.status === 'ambiguous'` (kept for 'unresolved'/'disabled').
+
+No migrations touched. No new columns. No changes to auth middleware or route
+gating.
+
+=== §4.1 REGRESSION — DEMONSTRATED FAILING PRE-FIX ===
+
+Method (git apply -R, never git stash, per the mandatory rule — refs/stash is
+shared across this repo's worktrees):
+
+1. After writing the full fix + all tests, created a scratch diff of ONLY the
+   two production files:
+   `git diff -- src/backend/services/geocoding.service.ts src/backend/routes/cities.ts > scratch/f1f2-prodfix.diff`
+2. `git apply -R scratch/f1f2-prodfix.diff` — reverted both production files to
+   their pre-fix state, left all test files (including the new tests) in place.
+3. Ran the regression test in isolation:
+   `npx vitest run src/backend/services/__tests__/geocoding.service.test.ts -t "REGRESSION"`
+   Result: 2 failed / 18 skipped.
+     - The resolveCityName-based regression test (exercises the REAL pre-existing
+       call path, not the new classifyCandidates export) failed with:
+       `AssertionError: expected 'ambiguous' to be 'ok'` — this is the actual
+       shipped bug, reproduced live against pre-fix code.
+     - The classifyCandidates-based regression test failed with
+       `TypeError: classifyCandidates is not a function` — expected, since that
+       export doesn't exist pre-fix; not evidence of the regression itself, the
+       resolveCityName test above is.
+4. `git apply scratch/f1f2-prodfix.diff` — re-applied the fix.
+5. Re-ran the full backend suite: 34 files / 665 tests passed, confirming the
+   fix restores green.
+
+=== ALL FIVE §4 TEST OBLIGATIONS + FRONTEND PARITY ===
+
+Written against a candidate-returning fake at the Nominatim chokepoint, not the
+mocked-away geocoder every existing route suite uses (review finding F4 — this is
+exactly why F1 and the regression reached the branch behind green tests).
+
+1. `classifyCandidates` table-driven (geocoding.service.test.ts, new describe
+   block) — 6 cases: empty permitted set (unconstrained), null-countryCode
+   candidate excluded, the §4.1 regression case (two same-region candidates,
+   region requested → ok), zero region matches with a region requested →
+   ambiguous/region-unconfirmed, two distinct regions none requested →
+   ambiguous/multi-region, two null-regionIso candidates → ok (accepted, pinned
+   limit).
+2. `resolveCity` with a multi-region fake → pending, coordinates NULL, attempts
+   incremented, never unresolvable (geocoding.service.test.ts).
+3. `resolveCity` at attempts=CAP with a multi-region fake available → not
+   re-selected by processQueue (geocoding.service.test.ts).
+4. `findOrUpgradeCity` step 2, route-level, real geocoding.service (new file
+   src/backend/routes/__tests__/cities.f1f2-ruling.test.ts): declines on a
+   resolved row (new row inserted, original's region/status/coordinates
+   untouched), declines on another creator's pending row (original untouched),
+   succeeds on a NULL-creator pending row (adopted), succeeds on the caller's
+   own pending row with geocode_attempts reset to 0.
+5. Route-level step 2b two-or-more-match path (same new file): two existing
+   regioned rows (IL+MO), no region requested → step 2b declines, geocoder has
+   no candidates, route falls to step 4c and inserts a third region-less pending
+   row without a unique-index violation (201, not 500) — proves the §3.3
+   amendment 2 guard actually works end to end, not just in isolation.
+6. Frontend parity (AddPlaceFlow.test.tsx, two new tests): the same two-
+   same-region fixture that is the backend regression case does NOT trigger
+   AddPlaceFlow's ambiguous-region-selector UI (region auto-selects to
+   Colorado); the existing two-distinct-region fixture still does. Confirms the
+   frontend's distinct-region computation and classifyCandidates step 4 agree
+   on both directions.
+
+=== ROOT-CAUSING THE QA ACCEPTANCE SUITE ===
+
+adl46-access-model.test.ts: ran unmodified before AND after this change —
+32/32 passed both times, no delta. Investigated why per the brief's warning about
+F8: that file's `vi.mock('../../services/geocoding.service.js', ...)` only
+exports `resolveCity`, not `resolveCityName`. Since cities.ts imports
+`resolveCityName` from that module, every call to it in that suite resolves to
+`undefined`, calling `undefined(...)` throws a TypeError, and the route's
+`try { resolution = await resolveCityName(...) } catch { resolution = {status:
+'disabled', ...} }` swallows it — every POST in that suite degrades to the
+pending-insert path regardless of what a real resolver would do. This is a
+pre-existing mock/module-surface drift (review finding F8), not something this
+change caused or fixed: my new `permittedCountryCodes` parameter is optional, so
+the call shape cities.ts uses is unchanged, and the mock's incompleteness
+produces the identical TypeError-swallow before and after. Root cause:
+adl46-access-model.test.ts's mock is a QA-owned frozen acceptance file; not
+touched, per the brief's explicit instruction not to patch it to green. Flagging
+this to COO as a known, unresolved coverage gap — that suite currently cannot
+exercise a real ambiguous/ok verdict through the route layer at all.
+
+=== SECURITY CHECKLIST ===
+
+1. Auth middleware — unchanged by this brief. POST /api/cities remains
+   requireAuth-only (GE-16, D4 — city creation is open to any authenticated
+   user by design); PATCH /api/cities/:id remains requireOwner (verified at
+   src/backend/routes/cities.ts:427, unchanged). No new routes added.
+2. userId scoping on repository queries touching user data — the new step 2
+   predicate correctly scopes by created_by_user_id (caller OR NULL, matching
+   the existing GE-16 containment pattern used elsewhere in this file). Steps 1
+   and 2b are deliberately NOT scoped, per the ruling's own §3.1 reasoning (the
+   unique index is unconditional; scoping them would miss another user's row
+   and collide on insert) — documented inline in the code, not an oversight.
+3. New user-data columns with FK — none added. No schema/migration changes.
+
+=== DISAGREEMENTS / UNDERSPECIFIED AREAS ===
+
+None found underspecified — the ruling document lived up to its own claim that
+no design decisions were left to the implementer. One judgment call I made and
+want on record: for test obligation 4's "succeeds on the caller's own pending
+row" case, the ruling's re-fire-on-upgrade behavior (§3.3 amendment 3) meant I
+had to give the fake a region-confirming candidate so the fire-and-forget
+resolveCity call didn't log a spurious second ambiguous case during the test —
+this doesn't affect the assertions (which check the HTTP response and the
+attempts-reset, both settled before the fire-and-forget resolves) but is worth
+noting in case a future reader wonders why that particular test's fake isn't
+empty like the others.
+
+=== FULL-FILE REWRITES ===
+
+None. All four production/test file changes were targeted Edits, not Write
+replacements — declared per OP-28 even though none applied here.
+
+=== FINAL TEST/CI NUMBERS ===
+
+- npm run test:backend: 34 files / 665 tests passed (baseline was 33/650 —
+  net +1 file, +15 tests: 10 new in geocoding.service.test.ts, 5 new in the new
+  cities.f1f2-ruling.test.ts)
+- npm run test:frontend: 31 files / 237 tests passed (baseline was 31/235 —
+  +2 tests in AddPlaceFlow.test.tsx)
+- npm run test:contract: 5 files / 115 tests passed (against a locally started
+  backend using CI's exact env recipe: DB_TYPE=sqlite, GEOCODING_ENABLED=false,
+  BYPASS_AUTH=true, OWNER_CLERK_ID=test_clerk_id)
+- npm run test:e2e: 52/52 passed
+- npm run type:check:all: clean
+- npm run check (Biome): clean (one formatting fix applied to the new test file
+  before this was clean)
+- npm run status:check: STATUS.md in sync, no update needed
+- CI on PR #346: 9/9 checks green
+
+=== FILES ===
+- src/backend/services/geocoding.service.ts (edited)
+- src/backend/routes/cities.ts (edited)
+- src/backend/services/__tests__/geocoding.service.test.ts (edited — added
+  classifyCandidates + resolveCity ambiguity/R4 describe blocks, regression test)
+- src/backend/routes/__tests__/cities.f1f2-ruling.test.ts (new)
+- src/frontend/components/TripDetail/__tests__/AddPlaceFlow.test.tsx (edited —
+  added F1/F2 parity describe block)
+
+No tracker entry exists yet for #345/F1/F2 (grepped tracker.json for "F1/F2",
+"ADL46-F1", "20260801-ADL46" — no hits); per CLAUDE.md tracker.json is
+COO-maintained, left for COO to create/link alongside merging this PR.

--- a/jobs/backend/context/current.txt
+++ b/jobs/backend/context/current.txt
@@ -1,3 +1,50 @@
+BACKEND CONTEXT — 2026-08-01 (ADL-46 F1/F2 ruling thread, latest)
+PROJECT: Travel Tracker
+CURRENT STATUS: implemented the Architect's F1/F2 ruling
+  (jobs/architect/tech/20260801-ADL46-F1-F2-ruling.md, R1-R4) on the ADL-46
+  integration branch. Branch fix/adl46-f1-f2-ruling off release/adl46-access-model,
+  issue #345, PR #346, CI green (9/9).
+  1. Deleted pickBest (geocoding.service.ts). Added exported classifyCandidates
+     — the ONE shared classifier both resolveCityName (create path) and
+     resolveCity (queue/on-create) now delegate to. Ambiguous = more than one
+     distinct non-null region_iso among eligible candidates, not candidate
+     count.
+  2. Fixed a shipped regression incidentally: two same-region Nominatim hits
+     for one city at different granularities (city + municipality) were being
+     marked 'ambiguous' pre-fix (geocoding.service.ts:99-101). Demonstrated
+     failing pre-fix via `git apply -R` of a scratch diff of just the two
+     production files (never git stash — refs/stash is shared across
+     worktrees in this repo), ran the new regression test in isolation
+     (failed with "expected 'ambiguous' to be 'ok'" against the real
+     pre-existing resolveCityName call path), then re-applied the fix.
+  3. R4: an ambiguous verdict consumes geocode_attempts and never sets
+     'unresolvable'; changing region_id resets the budget.
+  4. R1/F2: findOrUpgradeCity (cities.ts) step 2's wildcard-upgrade SELECT now
+     requires geocode_status IN ('pending','unresolvable') (whitelist) AND
+     (created_by_user_id = caller OR NULL) — a resolved row stays visible
+     under GE-16 but is never upgradeable by a non-owner. Steps 1 and 2b
+     deliberately stay creator/status-blind (unconditional unique index).
+     Successful upgrade resets geocode_attempts and re-fires resolveCity
+     (never for an adopted 'unresolvable' row).
+  5. POST /api/cities step 4c skips the resolveCity fire-and-forget when
+     resolution.status === 'ambiguous' (route already holds that verdict).
+  6. All 5 ruling §4 test obligations + frontend parity test written against
+     a candidate-returning fake, not the mocked-away geocoder every existing
+     route suite uses (review finding F4): geocoding.service.test.ts
+     (classifyCandidates table-driven + resolveCity ambiguity/CAP), new
+     src/backend/routes/__tests__/cities.f1f2-ruling.test.ts (route-level
+     findOrUpgradeCity + step 2b two-or-more no-unique-violation proof), and
+     two new tests in AddPlaceFlow.test.tsx (frontend/backend parity on the
+     same fixtures).
+  7. adl46-access-model.test.ts (QA-owned, not touched): 32/32 unaffected
+     before and after. Root-caused per the brief's F8 warning: its mock only
+     exports resolveCity, not resolveCityName, so every resolveCityName call
+     in that suite throws a TypeError swallowed by the route's own try/catch
+     — pre-existing coverage gap, not caused or fixed by this change.
+  8. No migrations, no new columns, no route-gating changes. Full backend
+     (665), frontend (237), contract (115), and E2E (52) suites green; full
+     detail in jobs/COO/inbox/20260801_1300-BACKEND-adl46-f1-f2-ruling-complete.txt.
+
 BACKEND CONTEXT — 2026-07-28 (B4 thread, latest)
 PROJECT: Travel Tracker
 CURRENT STATUS: B4 brief (BUG-52, BUG-56, QUAL-02 findings 1-2, QUAL-17),

--- a/src/backend/routes/__tests__/cities.f1f2-ruling.test.ts
+++ b/src/backend/routes/__tests__/cities.f1f2-ruling.test.ts
@@ -1,0 +1,311 @@
+/**
+ * ADL-46 F1/F2 ruling (2026-08-01) — route-level test obligations §4, items 4 and 5.
+ *
+ * Review finding F4 established that every existing route suite (cities.test.ts,
+ * cities-find-or-create.test.ts, adl46-access-model.test.ts) mocks
+ * geocoding.service.js away wholesale — which is exactly why F1 and the shipped
+ * multi-region regression reached this branch behind green tests. A fix landing
+ * behind the same mocks proves nothing (ruling §4).
+ *
+ * This file deliberately does NOT mock geocoding.service.js. It mocks only the
+ * Nominatim egress chokepoint (nominatim-client.js) with a controllable
+ * candidate-returning fake, so findOrUpgradeCity's step 2 predicate,
+ * classifyCandidates, and resolveCity all execute for real through the route.
+ *
+ * Covers:
+ *   §4 item 4 — findOrUpgradeCity step 2: declines on a resolved row (original
+ *     untouched including coordinates), declines on another creator's pending
+ *     row, succeeds on a NULL-creator pending row, succeeds on the caller's own
+ *     with geocode_attempts reset.
+ *   §4 item 5 — step 2b's two-or-more path does not violate the unique index
+ *     (ruling §3.3 amendment 2: step 1 and step 2b stay creator/status-blind on
+ *     purpose, precisely to avoid this).
+ */
+
+import { eq } from 'drizzle-orm';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as schema from '../../db/schema.js';
+import { createTestDb, type TestDb } from '../../repositories/__tests__/test-db.js';
+import type { NominatimSearchResult } from '../../services/nominatim-client.js';
+
+const USER_A_ID = 'user-f1f2-a-0000-0000-0000-000000000000';
+const USER_B_ID = 'user-f1f2-b-0000-0000-0000-000000000000';
+
+let testDb: TestDb | null = null;
+let mockUserId = USER_A_ID;
+let nextResult: NominatimSearchResult = { status: 'ok', candidates: [] };
+
+vi.mock('../../db/index.js', async (importOriginal) => {
+  const real = await importOriginal<typeof import('../../db/index.js')>();
+  return {
+    ...real,
+    getDb: () => {
+      if (!testDb) throw new Error('[TEST] testDb not initialised');
+      return testDb;
+    },
+  };
+});
+
+vi.mock('../../middleware/auth.js', () => ({
+  requireAuth: (
+    req: import('express').Request,
+    _res: import('express').Response,
+    next: import('express').NextFunction,
+  ) => {
+    (req as import('express').Request & { user?: unknown }).user = {
+      id: mockUserId,
+      clerkId: 'clerk_f1f2',
+      email: 'f1f2@example.com',
+      isOwner: 0,
+    };
+    next();
+  },
+}));
+
+// The ONLY geocoding-adjacent mock in this file — a controllable candidate
+// fake at the Nominatim egress chokepoint. geocoding.service.js (resolveCity,
+// resolveCityName, classifyCandidates) runs for real.
+vi.mock('../../services/nominatim-client.js', () => ({
+  nominatimSearch: vi.fn(async () => nextResult),
+}));
+
+vi.mock('../../services/shading.service.js', () => ({
+  getAllCountryShading: async () => [],
+  getCountryShading: async () => null,
+  getRegionShading: async () => [],
+  invalidateConfigCache: () => undefined,
+}));
+
+const { default: app } = await import('../../server-test-app.js');
+const supertest = (await import('supertest')).default;
+
+function candidate(
+  overrides: {
+    name?: string;
+    lat?: number;
+    lon?: number;
+    countryCode?: string | null;
+    regionIso?: string | null;
+  } = {},
+) {
+  return {
+    displayName: overrides.name ?? 'Testville',
+    name: overrides.name ?? 'Testville',
+    latitude: overrides.lat ?? 1,
+    longitude: overrides.lon ?? 1,
+    countryCode: overrides.countryCode ?? 'US',
+    regionIso: overrides.regionIso ?? null,
+    class: 'place',
+    type: 'city',
+  };
+}
+
+async function seedUser(db: TestDb, id: string) {
+  const now = new Date();
+  await db
+    .insert(schema.users)
+    .values({
+      id,
+      clerkId: `clerk_${id}`,
+      email: `${id}@example.com`,
+      isOwner: 0,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .onConflictDoNothing();
+}
+
+async function seedRegionTierCountry(db: TestDb) {
+  await db
+    .insert(schema.countries)
+    .values({ countryCode: 'US', name: 'United States', regionTierEnabled: 1 })
+    .onConflictDoNothing();
+}
+
+async function seedRegion(db: TestDb, name: string, iso: string): Promise<number> {
+  const [r] = await db
+    .insert(schema.regions)
+    .values({ countryCode: 'US', name, iso3166_2: iso })
+    .returning({ id: schema.regions.id });
+  return r.id;
+}
+
+async function seedCity(
+  db: TestDb,
+  overrides: Partial<typeof schema.cities.$inferInsert> & { name: string },
+) {
+  const [row] = await db
+    .insert(schema.cities)
+    .values({ countryCode: 'US', ...overrides })
+    .returning();
+  return row;
+}
+
+beforeEach(async () => {
+  testDb = await createTestDb();
+  vi.stubEnv('GEOCODING_ENABLED', 'true');
+  mockUserId = USER_A_ID;
+  nextResult = { status: 'ok', candidates: [] };
+  await seedUser(testDb, USER_A_ID);
+  await seedUser(testDb, USER_B_ID);
+  await seedRegionTierCountry(testDb);
+});
+
+afterEach(() => {
+  testDb = null;
+  vi.unstubAllEnvs();
+});
+
+describe('ADL-46 F1/F2 ruling — findOrUpgradeCity step 2 predicate (§4 item 4)', () => {
+  it('declines to upgrade a RESOLVED region-less row: new row inserted, original untouched including its coordinates', async () => {
+    const coId = await seedRegion(testDb!, 'Colorado', 'US-CO');
+    const resolved = await seedCity(testDb!, {
+      name: 'Denver',
+      regionId: null,
+      geocodeStatus: 'resolved',
+      latitude: 39.7,
+      longitude: -104.9,
+      createdByUserId: USER_A_ID,
+    });
+
+    // Caller is the row's own creator, and even so a resolved row must not be
+    // upgraded (§3.1: resolved is a bar for step 2, not a grant).
+    mockUserId = USER_A_ID;
+    nextResult = { status: 'ok', candidates: [] }; // resolve-then-create degrades to pending
+    const res = await supertest(app)
+      .post('/api/cities')
+      .send({ name: 'Denver', country_code: 'US', region_id: coId });
+
+    expect(res.status).toBe(201);
+    expect(res.body.id).not.toBe(resolved.id);
+
+    const [originalAfter] = await testDb!
+      .select()
+      .from(schema.cities)
+      .where(eq(schema.cities.id, resolved.id));
+    expect(originalAfter.regionId).toBeNull();
+    expect(originalAfter.geocodeStatus).toBe('resolved');
+    expect(originalAfter.latitude).toBeCloseTo(39.7);
+    expect(originalAfter.longitude).toBeCloseTo(-104.9);
+  });
+
+  it("declines to upgrade another creator's PENDING row: new row inserted, the other user's row untouched", async () => {
+    const coId = await seedRegion(testDb!, 'Colorado', 'US-CO');
+    const otherPending = await seedCity(testDb!, {
+      name: 'Denver',
+      regionId: null,
+      geocodeStatus: 'pending',
+      createdByUserId: USER_A_ID,
+    });
+
+    mockUserId = USER_B_ID;
+    nextResult = { status: 'ok', candidates: [] };
+    const res = await supertest(app)
+      .post('/api/cities')
+      .send({ name: 'Denver', country_code: 'US', region_id: coId });
+
+    expect(res.status).toBe(201);
+    expect(res.body.id).not.toBe(otherPending.id);
+
+    const [originalAfter] = await testDb!
+      .select()
+      .from(schema.cities)
+      .where(eq(schema.cities.id, otherPending.id));
+    expect(originalAfter.regionId).toBeNull(); // untouched
+    expect(originalAfter.geocodeAttempts).toBe(0);
+  });
+
+  it('succeeds on a NULL-creator PENDING row: adopted (same id, region now set)', async () => {
+    const coId = await seedRegion(testDb!, 'Colorado', 'US-CO');
+    const orphanPending = await seedCity(testDb!, {
+      name: 'Denver',
+      regionId: null,
+      geocodeStatus: 'pending',
+      // createdByUserId intentionally omitted → NULL
+    });
+
+    mockUserId = USER_B_ID; // any caller — the row belongs to nobody
+    nextResult = { status: 'ok', candidates: [] };
+    const res = await supertest(app)
+      .post('/api/cities')
+      .send({ name: 'Denver', country_code: 'US', region_id: coId });
+
+    expect(res.status).toBe(200);
+    expect(res.body.id).toBe(orphanPending.id);
+    expect(res.body.region_id).toBe(coId);
+  });
+
+  it("succeeds on the caller's own PENDING row, resetting geocode_attempts", async () => {
+    const coId = await seedRegion(testDb!, 'Colorado', 'US-CO');
+    const ownPending = await seedCity(testDb!, {
+      name: 'Denver',
+      regionId: null,
+      geocodeStatus: 'pending',
+      geocodeAttempts: 3,
+      createdByUserId: USER_A_ID,
+    });
+
+    mockUserId = USER_A_ID;
+    // Region-constrained re-ask fires on adoption (ruling §3.3 amendment 3) —
+    // give it a candidate that confirms the newly-set region so it resolves
+    // rather than looping back to pending (irrelevant to this assertion, but
+    // keeps the fire-and-forget call from logging a spurious ambiguous case).
+    nextResult = { status: 'ok', candidates: [candidate({ name: 'Denver', regionIso: 'US-CO' })] };
+    const res = await supertest(app)
+      .post('/api/cities')
+      .send({ name: 'Denver', country_code: 'US', region_id: coId });
+
+    expect(res.status).toBe(200);
+    expect(res.body.id).toBe(ownPending.id);
+    expect(res.body.region_id).toBe(coId);
+
+    const [row] = await testDb!
+      .select()
+      .from(schema.cities)
+      .where(eq(schema.cities.id, ownPending.id));
+    expect(row.geocodeAttempts).toBe(0);
+  });
+});
+
+describe('ADL-46 F1/F2 ruling — step 2b two-or-more path, no unique-index violation (§4 item 5)', () => {
+  it('two existing regioned rows (IL+MO), no region requested → ambiguous fallback insert lands on a distinct key, no crash', async () => {
+    const ilId = await seedRegion(testDb!, 'Illinois', 'US-IL');
+    const moId = await seedRegion(testDb!, 'Missouri', 'US-MO');
+    await seedCity(testDb!, {
+      name: 'Springfield',
+      regionId: ilId,
+      geocodeStatus: 'pending',
+      createdByUserId: USER_A_ID,
+    });
+    await seedCity(testDb!, {
+      name: 'Springfield',
+      regionId: moId,
+      geocodeStatus: 'pending',
+      createdByUserId: USER_A_ID,
+    });
+
+    // Step 1 misses (no region-less row exists). Step 2 is skipped (no
+    // region_id in the request). Step 2b (creator/status-blind by ruling
+    // §3.3 amendment 2) finds 2 rows sharing the name+country → declines
+    // (returns null) rather than picking one. The geocoder also can't help
+    // (no candidates), so the route falls to step 4c and inserts a THIRD,
+    // region-less pending row. That insert must succeed — it lands on the
+    // COALESCE(region_id,0)=0 key, which step 1 already proved was vacant —
+    // not violate uniq_cities_name_country_region_ci.
+    mockUserId = USER_A_ID;
+    nextResult = { status: 'ok', candidates: [] };
+    const res = await supertest(app)
+      .post('/api/cities')
+      .send({ name: 'Springfield', country_code: 'US' });
+
+    expect(res.status).toBe(201); // no 500 from a unique-index violation
+    expect(res.body.region_id).toBeNull();
+
+    const allSpringfields = await testDb!
+      .select({ id: schema.cities.id, regionId: schema.cities.regionId })
+      .from(schema.cities)
+      .where(eq(schema.cities.name, 'Springfield'));
+    expect(allSpringfields).toHaveLength(3);
+    expect(allSpringfields.filter((r) => r.regionId === null)).toHaveLength(1);
+  });
+});

--- a/src/backend/routes/cities.ts
+++ b/src/backend/routes/cities.ts
@@ -110,12 +110,31 @@ function serializeCity(row: {
  * §8 row 6) rather than colliding with the index on insert.
  *
  *   Step 1 — exact match on (name COLLATE NOCASE, country_code, COALESCE(region_id,0)),
- *            mirroring uniq_cities_name_country_region_ci exactly.
+ *            mirroring uniq_cities_name_country_region_ci exactly. Creator- and
+ *            status-blind: the unique index is unconditional, so a filtered
+ *            step 1 would miss another user's row and the follow-on insert
+ *            would collide on it (ADL-46 F1/F2 ruling §3.1/§3.3 amendment 2).
  *   Step 2 — WILDCARD UPGRADE: if the request carries a region and step 1 missed,
  *            adopt a region-less row of the same name+country by SETTING its
  *            region_id. A region-less row is an under-specified record, not a
  *            different city — specialising it prevents the duplicate that naively
  *            adding `AND COALESCE(region_id,0)=…` would create (the BUG-33 class).
+ *            ADL-46 F1/F2 ruling §3.3 (R1): scoped to rows the caller may
+ *            legitimately mutate — `geocode_status IN ('pending','unresolvable')`
+ *            (whitelist, not `<> 'resolved'`: fails closed on a future status)
+ *            AND `(created_by_user_id = caller OR created_by_user_id IS NULL)`.
+ *            A `resolved` row is visible to the caller (GE-16) but must NOT be
+ *            upgradeable — read-through is global because the index is global;
+ *            write-through is scoped because nothing forces it to be. Declining
+ *            falls through to the ordinary insert on a distinct identity key
+ *            (legal under D13, at most one extra row per name+country). On a
+ *            successful upgrade the retry budget resets and, if the adopted row
+ *            is still 'pending', resolution is re-fired — the region is the
+ *            question, and a region-constrained lookup can collapse an
+ *            ambiguity the unconstrained one could not (ruling §2.5/§3.3
+ *            amendment 3). Not fired for an adopted 'unresolvable' row: the
+ *            geocoder returned zero candidates, and a region constraint cannot
+ *            turn zero into some (ruling §2.5 asymmetry).
  *
  *   Step 2b (reverse, NO region requested) — collapse to (name, country_code)
  *            regardless of region. This is the "today's behaviour" case the old
@@ -136,10 +155,12 @@ async function findOrUpgradeCity(
   name: string,
   countryCode: string,
   regionId: number | null,
+  callerUserId: string,
 ) {
   const regionKey = regionId ?? 0;
 
-  // Step 1 — exact match on the composite identity key.
+  // Step 1 — exact match on the composite identity key. Creator- and
+  // status-blind on purpose (see doc comment above).
   const exact = await db
     .select()
     .from(cities)
@@ -154,6 +175,7 @@ async function findOrUpgradeCity(
   if (exact.length) return exact[0];
 
   // Step 2 — wildcard upgrade (only when the request carries a region).
+  // ADL-46 F1/F2 ruling §3.3 (R1): whitelist status + creator-or-null scoping.
   if (regionId != null) {
     const regionless = await db
       .select()
@@ -163,6 +185,8 @@ async function findOrUpgradeCity(
           eq(cities.countryCode, countryCode),
           sql`${cities.name} = ${name} COLLATE NOCASE`,
           isNull(cities.regionId),
+          inArray(cities.geocodeStatus, ['pending', 'unresolvable']),
+          or(eq(cities.createdByUserId, callerUserId), isNull(cities.createdByUserId)),
         ),
       )
       .limit(1);
@@ -170,10 +194,20 @@ async function findOrUpgradeCity(
       const now = new Date().toISOString();
       const upgraded = await db
         .update(cities)
-        .set({ regionId, updatedAt: now })
+        .set({ regionId, geocodeAttempts: 0, updatedAt: now })
         .where(eq(cities.id, regionless[0].id))
         .returning();
-      return upgraded[0];
+      const upgradedRow = upgraded[0];
+      // Re-ask: the region is the question, and a region-constrained lookup
+      // can collapse an ambiguity the unconstrained one could not. Never fired
+      // for an adopted 'unresolvable' row (ruling §2.5 asymmetry — zero
+      // candidates cannot become some just because a region was added).
+      if (upgradedRow.geocodeStatus === 'pending') {
+        resolveCity(upgradedRow.id).catch(() => {
+          /* handled internally — defensive catch */
+        });
+      }
+      return upgradedRow;
     }
     // Has-region path ends here: step 1 + step 2 are authoritative for a
     // region-bearing request. Do NOT fall through to the reverse branch below.
@@ -250,7 +284,7 @@ citiesRouter.post(
     }
 
     // Pass 1 (§4.3 step 2) — find-or-create against the user's submitted name.
-    const found1 = await findOrUpgradeCity(db, name, country_code, region_id ?? null);
+    const found1 = await findOrUpgradeCity(db, name, country_code, region_id ?? null, userId);
     if (found1) {
       res.status(200).json(serializeCity(found1));
       return;
@@ -273,7 +307,13 @@ citiesRouter.post(
 
       // Pass 2 (§4.3 step 4a) — find-or-create against the CANONICAL name. This
       // is the step that does the real convergence work and is easy to omit.
-      const found2 = await findOrUpgradeCity(db, canonicalName, country_code, region_id ?? null);
+      const found2 = await findOrUpgradeCity(
+        db,
+        canonicalName,
+        country_code,
+        region_id ?? null,
+        userId,
+      );
       if (found2) {
         res.status(200).json(serializeCity(found2));
         return;
@@ -326,9 +366,20 @@ citiesRouter.post(
     // Fire-and-forget the queue re-resolution so a legitimate city created while
     // the geocoder was unreachable is promoted to 'resolved' (and globally
     // visible) on its own (GE-12 / §4.4). Never throws.
-    resolveCity(city.id).catch(() => {
-      /* handled internally — defensive catch */
-    });
+    //
+    // ADL-46 F1/F2 ruling §2.6: SKIP this when resolution.status === 'ambiguous'
+    // — the route already holds the verdict resolveCity would recompute, and
+    // under R2 a second call provably reaches the identical result while
+    // costing a second Nominatim request against a 1 req/s budget and burning
+    // an attempt for nothing. Still fired for 'unresolved' and 'disabled': the
+    // answer there is genuinely unknown to this route. The 15-minute queue
+    // still picks the pending ambiguous row up and spends its bounded retry
+    // budget — that cost is intended, not a leak.
+    if (resolution.status !== 'ambiguous') {
+      resolveCity(city.id).catch(() => {
+        /* handled internally — defensive catch */
+      });
+    }
 
     const fresh = await db.select().from(cities).where(eq(cities.id, city.id)).limit(1);
     res.status(201).json(serializeCity(fresh[0] ?? city));

--- a/src/backend/services/__tests__/geocoding.service.test.ts
+++ b/src/backend/services/__tests__/geocoding.service.test.ts
@@ -32,7 +32,9 @@ vi.mock('../nominatim-client.js', () => ({
   nominatimSearch: vi.fn(async () => nextResult),
 }));
 
-const { resolveCity, resolveCityName, processQueue } = await import('../geocoding.service.js');
+const { resolveCity, resolveCityName, processQueue, classifyCandidates } = await import(
+  '../geocoding.service.js'
+);
 
 async function seedCountryAndCity(
   db: TestDb,
@@ -47,6 +49,33 @@ async function seedCountryAndCity(
     .values({
       name: 'Testville',
       countryCode: 'US',
+      geocodeStatus: opts.status ?? 'pending',
+      geocodeAttempts: opts.attempts ?? 0,
+    })
+    .returning();
+  return city.id;
+}
+
+/** Like seedCountryAndCity, but the city carries a region (US-CO by default),
+ * needed to exercise resolveCity's region-aware classification. */
+async function seedCountryAndCityWithRegion(
+  db: TestDb,
+  opts: { status?: 'pending' | 'resolved' | 'unresolvable'; attempts?: number } = {},
+): Promise<number> {
+  await db
+    .insert(schema.countries)
+    .values({ countryCode: 'US', name: 'United States', regionTierEnabled: 1 })
+    .onConflictDoNothing();
+  const [region] = await db
+    .insert(schema.regions)
+    .values({ countryCode: 'US', name: 'Colorado', iso3166_2: 'US-CO' })
+    .returning();
+  const [city] = await db
+    .insert(schema.cities)
+    .values({
+      name: 'Denver',
+      countryCode: 'US',
+      regionId: region.id,
       geocodeStatus: opts.status ?? 'pending',
       geocodeAttempts: opts.attempts ?? 0,
     })
@@ -161,6 +190,34 @@ describe('ADL-46 D12/D14 — resolveCityName', () => {
     expect(r.best).toBeUndefined();
   });
 
+  // ADL-46 F1/F2 ruling §1/§2.2 — THE SHIPPED REGRESSION, and its fix, exercised
+  // through the real pre-existing call site (resolveCityName), not the new
+  // classifyCandidates export, so this test is meaningful both BEFORE and
+  // AFTER the fix. Pre-fix: geocoding.service.ts:99-101's `regionMatches.length
+  // > 1` branch marked this 'ambiguous' even though every match agrees with
+  // the region the user selected — Nominatim routinely returns one real city
+  // at several administrative granularities (city + municipality) sharing one
+  // region_iso. Post-fix (R2 step 3): count is irrelevant once a region was
+  // requested and at least one candidate matches it — 'ok'.
+  //
+  // Demonstrated failing pre-fix by reverting ONLY the production diff
+  // (geocoding.service.ts + cities.ts) via `git apply -R` on a scratch patch
+  // (never `git stash` — refs/stash is shared across this repo's worktrees)
+  // and re-running this test in isolation; see the Backend completion report
+  // for the exact commands and output.
+  it('REGRESSION (§4.1): two candidates sharing the REQUESTED region resolve to ok, not ambiguous', async () => {
+    nextResult = {
+      status: 'ok',
+      candidates: [
+        candidate({ name: 'Denver', regionIso: 'US-CO' }), // e.g. Nominatim's "city" hit
+        candidate({ name: 'Denver', regionIso: 'US-CO' }), // e.g. Nominatim's "municipality" hit
+      ],
+    };
+    const r = await resolveCityName('Denver', 'US', { regionIso: 'US-CO' });
+    expect(r.status).toBe('ok');
+    expect(r.best?.regionIso).toBe('US-CO');
+  });
+
   it('D12: a supplied region ISO disambiguates two same-name candidates', async () => {
     nextResult = {
       status: 'ok',
@@ -178,6 +235,171 @@ describe('ADL-46 D12/D14 — resolveCityName', () => {
     nextResult = { status: 'ok', candidates: [] };
     const r = await resolveCityName('Nowhereville', 'US');
     expect(r.status).toBe('unresolved');
+  });
+});
+
+// ================================================================
+// ADL-46 F1/F2 ruling (2026-08-01) §2.1/§2.2/§4.1 — classifyCandidates.
+// THE single shared classifier: both resolveCityName (above) and resolveCity
+// (below) delegate to this function exclusively. Table-driven, one case per
+// branch of the algorithm as specified by the ruling.
+// ================================================================
+describe('ADL-46 F1/F2 ruling — classifyCandidates (single shared classifier)', () => {
+  it('empty permitted set → unconstrained: every candidate is eligible regardless of country', () => {
+    const verdict = classifyCandidates(
+      [candidate({ name: 'Anywhere', countryCode: 'FR', regionIso: null })],
+      new Set(),
+      null,
+    );
+    expect(verdict.status).toBe('ok');
+  });
+
+  it('a candidate with a null countryCode is EXCLUDED when the permitted set is non-empty', () => {
+    // Built directly rather than via candidate() — that helper's `?? 'US'`
+    // default would silently turn an explicit `null` back into 'US'.
+    const nullCountryCandidate = {
+      displayName: 'Mystery',
+      name: 'Mystery',
+      latitude: 1,
+      longitude: 1,
+      countryCode: null,
+      regionIso: null,
+      class: 'place',
+      type: 'city',
+    };
+    const verdict = classifyCandidates([nullCountryCandidate], new Set(['US']), null);
+    // Zero eligible (the sole candidate was dropped) → terminal unresolved,
+    // not a guess at a candidate we cannot attribute to the user's country.
+    expect(verdict.status).toBe('unresolved');
+  });
+
+  it('REGRESSION (§4.1): two candidates sharing the REQUESTED region → ok, count is irrelevant', () => {
+    const verdict = classifyCandidates(
+      [
+        candidate({ name: 'Denver', countryCode: 'US', regionIso: 'US-CO' }),
+        candidate({ name: 'Denver', countryCode: 'US', regionIso: 'US-CO' }),
+      ],
+      new Set(['US']),
+      'US-CO',
+    );
+    expect(verdict.status).toBe('ok');
+    if (verdict.status === 'ok') {
+      expect(verdict.best.regionIso).toBe('US-CO');
+    }
+  });
+
+  it("zero region matches with a region requested → ambiguous/'region-unconfirmed' (R3)", () => {
+    const verdict = classifyCandidates(
+      [
+        candidate({ name: 'Springfield', countryCode: 'US', regionIso: 'US-IL' }),
+        candidate({ name: 'Springfield', countryCode: 'US', regionIso: 'US-NY' }),
+      ],
+      new Set(['US']),
+      'US-MO', // the user's selection matches neither candidate
+    );
+    expect(verdict.status).toBe('ambiguous');
+    if (verdict.status === 'ambiguous') {
+      expect(verdict.reason).toBe('region-unconfirmed');
+      expect(new Set(verdict.regionIsos)).toEqual(new Set(['US-IL', 'US-NY']));
+    }
+  });
+
+  it("two distinct regions, none requested → ambiguous/'multi-region'", () => {
+    const verdict = classifyCandidates(
+      [
+        candidate({ name: 'Springfield', countryCode: 'US', regionIso: 'US-IL' }),
+        candidate({ name: 'Springfield', countryCode: 'US', regionIso: 'US-MO' }),
+      ],
+      new Set(['US']),
+      null,
+    );
+    expect(verdict.status).toBe('ambiguous');
+    if (verdict.status === 'ambiguous') {
+      expect(verdict.reason).toBe('multi-region');
+      expect(new Set(verdict.regionIsos)).toEqual(new Set(['US-IL', 'US-MO']));
+    }
+  });
+
+  it('two candidates both with null regionIso → ok (accepted, pinned limit — §2.2)', () => {
+    // Non-region-tier-country shape: no candidate carries a region_iso at all,
+    // so the distinct-region-set is empty (not >1) and step 4 resolves to the
+    // first eligible candidate. This is a known, accepted guess (ruling §2.2)
+    // — pinned here so a future change to it is deliberate, not accidental.
+    const verdict = classifyCandidates(
+      [
+        candidate({ name: 'Springfield', countryCode: 'AU', regionIso: null }),
+        candidate({ name: 'Springfield', countryCode: 'AU', regionIso: null }),
+      ],
+      new Set(['AU']),
+      null,
+    );
+    expect(verdict.status).toBe('ok');
+  });
+});
+
+// ================================================================
+// ADL-46 F1/F2 ruling §2.4/§2.5 (R2/R3/R4) — resolveCity's ambiguity handling.
+// F4: every route suite mocks the geocoder away, which is why this branch of
+// resolveCity had no service-level coverage before now. These tests run
+// against the real classifyCandidates through resolveCity, with only the
+// Nominatim chokepoint faked.
+// ================================================================
+describe('ADL-46 F1/F2 ruling — resolveCity ambiguity (R2/R3/R4)', () => {
+  it('a multi-region fake leaves the row pending, coordinates NULL, attempts incremented, status NOT unresolvable', async () => {
+    const cityId = await seedCountryAndCityWithRegion(testDb!); // regionIso = US-CO
+    // Two candidates that do NOT match the city's selected region (US-CO) and
+    // disagree with each other → ambiguous/region-unconfirmed.
+    nextResult = {
+      status: 'ok',
+      candidates: [
+        candidate({ name: 'Denver', regionIso: 'US-TX' }),
+        candidate({ name: 'Denver', regionIso: 'US-NY' }),
+      ],
+    };
+
+    const ok = await resolveCity(cityId);
+    expect(ok).toBe(false);
+
+    const [row] = await testDb!.select().from(schema.cities).where(eq(schema.cities.id, cityId));
+    expect(row.geocodeStatus).toBe('pending'); // NOT unresolvable — the geocoder did not say "no match"
+    expect(row.latitude).toBeNull();
+    expect(row.longitude).toBeNull();
+    expect(row.geocodeAttempts).toBe(1); // R4: the ambiguity budget was consumed
+  });
+
+  it('a row at attempts = CAP is not re-selected by processQueue, even with a multi-region fake available', async () => {
+    const cityId = await seedCountryAndCityWithRegion(testDb!, { attempts: 5 });
+    nextResult = {
+      status: 'ok',
+      candidates: [
+        candidate({ name: 'Denver', regionIso: 'US-TX' }),
+        candidate({ name: 'Denver', regionIso: 'US-NY' }),
+      ],
+    };
+
+    await processQueue();
+
+    const [row] = await testDb!.select().from(schema.cities).where(eq(schema.cities.id, cityId));
+    expect(row.geocodeStatus).toBe('pending'); // never touched — was skipped by the CAP predicate
+    expect(row.geocodeAttempts).toBe(5); // unchanged — processQueue never called resolveCity for it
+  });
+
+  // Bonus coverage beyond the mandatory five (R3, not separately enumerated in
+  // ruling §4 but directly exercises the rule stated in §2.2 step 3 / §2.4).
+  it('bonus — R3: a region was requested but no candidate matches it → stays pending, never resolves outside the selected region', async () => {
+    const cityId = await seedCountryAndCityWithRegion(testDb!); // regionIso = US-CO
+    nextResult = {
+      status: 'ok',
+      candidates: [candidate({ name: 'Denver', regionIso: 'US-WA' })], // disagrees with US-CO
+    };
+
+    const ok = await resolveCity(cityId);
+    expect(ok).toBe(false);
+
+    const [row] = await testDb!.select().from(schema.cities).where(eq(schema.cities.id, cityId));
+    expect(row.geocodeStatus).toBe('pending');
+    expect(row.latitude).toBeNull();
+    expect(row.geocodeAttempts).toBe(1);
   });
 });
 

--- a/src/backend/services/geocoding.service.ts
+++ b/src/backend/services/geocoding.service.ts
@@ -40,14 +40,120 @@ const GEOCODE_ATTEMPT_CAP = 5;
 export interface CityResolution {
   /**
    * - 'ok'         — a single best candidate was determined (see `best`).
-   * - 'ambiguous'  — two or more comparable settlement candidates survived the
-   *                  country/region constraint; the caller must NOT guess (D14).
+   * - 'ambiguous'  — the eligible candidates disagree about `region_iso`, or a
+   *                  region the user selected could not be confirmed; the
+   *                  caller must NOT guess (D14). See `reason`.
    * - 'unresolved' — the geocoder answered with no usable candidate.
    * - 'disabled'   — GEOCODING_ENABLED=false or a recoverable error; degrade to pending.
    */
   status: 'ok' | 'ambiguous' | 'unresolved' | 'disabled';
   candidates: NominatimCandidate[];
   best?: NominatimCandidate;
+  /**
+   * Why an 'ambiguous' verdict was reached. Not persisted anywhere — exists so
+   * logging (and a future frontend contract) can tell the two ambiguity
+   * classes apart without a breaking change later. ADL-46 F1/F2 ruling §2.2/§2.3.
+   */
+  reason?: 'multi-region' | 'region-unconfirmed';
+}
+
+/**
+ * Countries a candidate is permitted to come from — upper-cased ISO 3166-1
+ * alpha-2. An EMPTY set means UNCONSTRAINED. Today every caller passes a set
+ * of one; a future trip-declared-countries lookup would pass many.
+ * ADL-46 F1/F2 ruling §2.2.
+ */
+export type PermittedCountries = ReadonlySet<string>;
+
+/** Verdict returned by {@link classifyCandidates}. ADL-46 F1/F2 ruling §2.2. */
+export type CandidateVerdict =
+  | { status: 'ok'; best: NominatimCandidate; eligible: NominatimCandidate[] }
+  | {
+      status: 'ambiguous';
+      /** Why we are not choosing. Not persisted; drives logging and the follow-on. */
+      reason: 'multi-region' | 'region-unconfirmed';
+      regionIsos: string[];
+      eligible: NominatimCandidate[];
+    }
+  | { status: 'unresolved'; eligible: [] };
+
+/** Distinct, upper-cased, non-null `regionIso` values across the given candidates. */
+function distinctRegionIsos(candidates: NominatimCandidate[]): string[] {
+  return [
+    ...new Set(
+      candidates
+        .filter((c): c is NominatimCandidate & { regionIso: string } => c.regionIso != null)
+        .map((c) => c.regionIso.toUpperCase()),
+    ),
+  ];
+}
+
+/**
+ * ADL-46 F1/F2 ruling (2026-08-01), §2.1-§2.2 — THE single shared classifier.
+ * Both decision sites (`resolveCityName`'s create path and `resolveCity`'s
+ * queue/on-create-trigger path) call this and only this; there is exactly one
+ * answer to "is this ambiguous?" in the codebase.
+ *
+ * "Ambiguous" means more than one DISTINCT non-null `region_iso` among the
+ * eligible candidates — NOT candidate count. Nominatim routinely returns one
+ * real city at several administrative granularities (`city` + `municipality`,
+ * both surviving the settlement-type filter) sharing one `region_iso`;
+ * counting hits would mark nearly every city ambiguous, which is strictly
+ * worse than the bug this fixes (geocoding.service.ts:99-101, pre-fix).
+ *
+ * Algorithm — implemented in this order, per the ruling:
+ *   1. Country eligibility: `permitted.size === 0` → unconstrained (all
+ *      candidates eligible). Otherwise a candidate survives only if its
+ *      `countryCode` is non-null AND in `permitted` — a candidate we cannot
+ *      attribute to a country cannot confirm the user's country selection.
+ *   2. Zero eligible → terminal 'unresolved'.
+ *   3. A region was requested: any eligible candidate matching it → 'ok'
+ *      (count is irrelevant — every match agrees with what the user chose);
+ *      zero matches → 'ambiguous'/'region-unconfirmed' (R3: never resolve to
+ *      a candidate outside the region the user explicitly selected).
+ *   4. No region requested: >1 distinct eligible `region_iso` → 'ambiguous'/
+ *      'multi-region'; otherwise → 'ok' (this covers both "one shared region"
+ *      and the accepted "no candidate carries a region" guess limit).
+ *
+ * @param candidates          - Raw settlement candidates from Nominatim.
+ * @param permitted           - Country codes the result must come from (empty = any).
+ * @param requestedRegionIso  - The region the user explicitly selected, if any.
+ */
+export function classifyCandidates(
+  candidates: NominatimCandidate[],
+  permitted: PermittedCountries,
+  requestedRegionIso: string | null,
+): CandidateVerdict {
+  const eligible =
+    permitted.size === 0
+      ? candidates
+      : candidates.filter(
+          (c) => c.countryCode != null && permitted.has(c.countryCode.toUpperCase()),
+        );
+
+  if (eligible.length === 0) {
+    return { status: 'unresolved', eligible: [] };
+  }
+
+  if (requestedRegionIso != null) {
+    const upperRequested = requestedRegionIso.toUpperCase();
+    const matches = eligible.filter((c) => c.regionIso?.toUpperCase() === upperRequested);
+    if (matches.length >= 1) {
+      return { status: 'ok', best: matches[0], eligible };
+    }
+    return {
+      status: 'ambiguous',
+      reason: 'region-unconfirmed',
+      regionIsos: distinctRegionIsos(eligible),
+      eligible,
+    };
+  }
+
+  const regionIsos = distinctRegionIsos(eligible);
+  if (regionIsos.length > 1) {
+    return { status: 'ambiguous', reason: 'multi-region', regionIsos, eligible };
+  }
+  return { status: 'ok', best: eligible[0], eligible };
 }
 
 /**
@@ -56,21 +162,23 @@ export interface CityResolution {
  *
  * ADL-46 D12 (§4.3.1): the caller has already validated country_code (and often
  * region), so the lookup is CONSTRAINED by them and the lookup may never
- * override them:
- *   1. countrycodes filter from the validated country_code — removes the
- *      London-UK-vs-Ontario / Cambridge-UK-vs-MA classes entirely.
- *   2. where a region ISO is known, prefer the candidate whose subdivision matches.
- *   3. exactly one settlement candidate → 'ok'; two or more → 'ambiguous' (never
- *      guess — D14); zero → 'unresolved'.
+ * override them. ADL-46 F1/F2 ruling §2.3: the decision itself is delegated
+ * entirely to {@link classifyCandidates}.
  *
  * @param name       - The user-submitted city name.
- * @param countryCode- Validated ISO 3166-1 alpha-2 (e.g. 'US').
+ * @param countryCode- Validated ISO 3166-1 alpha-2 (e.g. 'US'). Stays singular —
+ *                     it is the user's ground truth (D12 rule 3); the SET used
+ *                     for the eligibility check defaults to `{countryCode}`
+ *                     unless the caller passes `permittedCountryCodes`.
  * @param opts.regionIso - ISO 3166-2 subdivision (e.g. 'US-CO') to disambiguate.
+ * @param opts.permittedCountryCodes - Eligibility set for classifyCandidates;
+ *   defaults to a set of one (`countryCode`). A future trip-declared-countries
+ *   lookup passes a larger set here without changing anything else.
  */
 export async function resolveCityName(
   name: string,
   countryCode: string,
-  opts: { regionIso?: string | null } = {},
+  opts: { regionIso?: string | null; permittedCountryCodes?: PermittedCountries } = {},
 ): Promise<CityResolution> {
   if (!geocodingEnabled()) return { status: 'disabled', candidates: [] };
 
@@ -85,28 +193,16 @@ export async function resolveCityName(
     return { status: 'disabled', candidates: [] };
   }
 
-  const candidates = result.candidates;
-  if (!candidates.length) return { status: 'unresolved', candidates: [] };
+  const permitted = opts.permittedCountryCodes ?? new Set([countryCode.toUpperCase()]);
+  const verdict = classifyCandidates(result.candidates, permitted, opts.regionIso ?? null);
 
-  // D12 step 2: if the user gave a region, prefer the candidate whose ISO matches.
-  if (opts.regionIso) {
-    const regionMatches = candidates.filter(
-      (c) => c.regionIso?.toUpperCase() === opts.regionIso!.toUpperCase(),
-    );
-    if (regionMatches.length === 1) {
-      return { status: 'ok', best: regionMatches[0], candidates };
-    }
-    if (regionMatches.length > 1) {
-      return { status: 'ambiguous', candidates: regionMatches };
-    }
-    // No region match — fall through to the general count.
+  if (verdict.status === 'unresolved') {
+    return { status: 'unresolved', candidates: [] };
   }
-
-  if (candidates.length === 1) {
-    return { status: 'ok', best: candidates[0], candidates };
+  if (verdict.status === 'ambiguous') {
+    return { status: 'ambiguous', candidates: verdict.eligible, reason: verdict.reason };
   }
-  // D14: two or more comparable candidates → ambiguous, do not guess.
-  return { status: 'ambiguous', candidates };
+  return { status: 'ok', best: verdict.best, candidates: verdict.eligible };
 }
 
 /**
@@ -168,9 +264,16 @@ export async function resolveCity(cityId: number): Promise<boolean> {
     return false;
   }
 
-  // result.status === 'ok' — the geocoder answered.
-  const best = pickBest(result.candidates, city.regionIso);
-  if (!best) {
+  // result.status === 'ok' — the geocoder answered. ADL-46 F1/F2 ruling §2.4:
+  // this is F1 — the single shared classifier replaces the old `pickBest`,
+  // which decided "is this ambiguous?" differently than resolveCityName did.
+  const verdict = classifyCandidates(
+    result.candidates,
+    new Set([city.countryCode.toUpperCase()]),
+    city.regionIso,
+  );
+
+  if (verdict.status === 'unresolved') {
     // TERMINAL: the geocoder answered with no usable match. Never retried (D10).
     const now = new Date().toISOString();
     await db
@@ -181,6 +284,21 @@ export async function resolveCity(cityId: number): Promise<boolean> {
     return false;
   }
 
+  if (verdict.status === 'ambiguous') {
+    // ADL-46 F1/F2 ruling §2.4/§2.5 (R2/R3/R4): the geocoder DID answer, but
+    // could not confirm a single region — this is not a "no match" (D10's
+    // 'unresolvable' does not apply) and it must not guess (D14). Consume the
+    // existing geocode_attempts budget (a bounded question, re-askable if the
+    // row's region_id later changes — R1 §3.3) and leave the row 'pending'.
+    await incrementAttempts(cityId);
+    console.info(
+      `[GEO] City ${cityId} (${city.name}) ambiguous (${verdict.reason}): regions=${verdict.regionIsos.join(',')}`,
+    );
+    return false;
+  }
+
+  // verdict.status === 'ok'
+  const best = verdict.best;
   const resolvedAt = new Date().toISOString();
   await db
     .update(cities)
@@ -195,19 +313,6 @@ export async function resolveCity(cityId: number): Promise<boolean> {
 
   console.info(`[GEO] Resolved city ${cityId} (${city.name}): ${best.latitude}, ${best.longitude}`);
   return true;
-}
-
-/** Picks the region-matching candidate if a region ISO is known, else the first. */
-function pickBest(
-  candidates: NominatimCandidate[],
-  regionIso: string | null,
-): NominatimCandidate | undefined {
-  if (!candidates.length) return undefined;
-  if (regionIso) {
-    const match = candidates.find((c) => c.regionIso?.toUpperCase() === regionIso.toUpperCase());
-    if (match) return match;
-  }
-  return candidates[0];
 }
 
 /** ADL-46 D10: increment the recoverable-failure counter for a pending row. */

--- a/src/frontend/components/TripDetail/__tests__/AddPlaceFlow.test.tsx
+++ b/src/frontend/components/TripDetail/__tests__/AddPlaceFlow.test.tsx
@@ -208,3 +208,111 @@ describe('AddPlaceFlow — ADL-46 D14 region selector narrowing', () => {
     expect(screen.queryByRole('option', { name: 'Texas' })).not.toBeInTheDocument();
   });
 });
+
+/**
+ * ADL-46 F1/F2 ruling (2026-08-01) §2.2/§4 — frontend/backend parity contract.
+ *
+ * The ruling states this is byte-for-byte the same rule the backend's
+ * classifyCandidates step 4 computes (distinct non-null region_iso among
+ * same-country candidates, ambiguous when > 1) — "any future change to step 4
+ * changes both sides or neither." These tests reuse the same fixture shapes as
+ * the backend's classifyCandidates table-driven tests
+ * (geocoding.service.test.ts) so a divergence between the two shows up here.
+ *
+ * The requested-region case (backend classifyCandidates step 3) has no
+ * frontend counterpart by design — the frontend has no selected region yet at
+ * lookup time, per the ruling — so only step 4 (no region requested) is
+ * exercised here.
+ */
+describe('AddPlaceFlow — ADL-46 F1/F2 parity: distinct-region computation matches classifyCandidates step 4', () => {
+  beforeEach(() => {
+    mockLookupCityCountry.mockReset();
+  });
+
+  it('REGRESSION FIXTURE PARITY: two candidates sharing ONE region are NOT flagged ambiguous (matches backend classifyCandidates ok verdict)', async () => {
+    // Same shape as geocoding.service.test.ts's §4.1 regression fixture: two
+    // Nominatim hits for one city at different granularities, one region.
+    countryRegionsFixture = [
+      ...seededRegionsNoOverlap,
+      {
+        id: 5,
+        country_code: 'US',
+        name: 'Colorado',
+        iso_3166_2: 'US-CO',
+        created_at: '',
+        updated_at: '',
+      },
+    ];
+    mockLookupCityCountry.mockResolvedValue({
+      countryCode: 'US',
+      regionIso: 'US-CO',
+      candidates: [
+        {
+          name: 'Denver',
+          display_name: 'Denver, Colorado, USA',
+          country_code: 'US',
+          region_iso: 'US-CO',
+          latitude: 39.74,
+          longitude: -104.98,
+        },
+        {
+          name: 'Denver',
+          display_name: 'Denver County, Colorado, USA',
+          country_code: 'US',
+          region_iso: 'US-CO',
+          latitude: 39.74,
+          longitude: -104.98,
+        },
+      ],
+    });
+    const user = userEvent.setup();
+
+    render(
+      <AddPlaceFlow
+        tripId={1}
+        onClose={vi.fn()}
+        tripStartDate="2026-01-01"
+        tripEndDate="2026-01-10"
+        isFirstPlace={false}
+      />,
+    );
+
+    await openNewCityForm(user, 'Denver');
+
+    // Auto-selection ran (proves the ambiguous branch was NOT taken) — the
+    // region <select> shows Colorado selected, not the "no selection" state.
+    await waitFor(() => {
+      const regionSelect = screen
+        .getByRole('option', { name: 'Colorado' })
+        .closest('select') as HTMLSelectElement;
+      expect(regionSelect.value).not.toBe('');
+    });
+    expect(screen.queryByText(/multiple matches found, please choose/i)).not.toBeInTheDocument();
+  });
+
+  it('two distinct regions with no seeded overlap still surface the ambiguous hint (matches backend multi-region verdict)', async () => {
+    countryRegionsFixture = seededRegionsNoOverlap;
+    mockLookupCityCountry.mockResolvedValue({
+      countryCode: 'US',
+      regionIso: 'US-IL',
+      candidates: springfieldCandidates(),
+    });
+    const user = userEvent.setup();
+
+    render(
+      <AddPlaceFlow
+        tripId={1}
+        onClose={vi.fn()}
+        tripStartDate="2026-01-01"
+        tripEndDate="2026-01-10"
+        isFirstPlace={false}
+      />,
+    );
+
+    await openNewCityForm(user, 'Springfield');
+
+    await waitFor(() => {
+      expect(screen.getByText(/multiple matches found, please choose/i)).toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
Closes #345

Implements the Architect's F1/F2 ruling (`jobs/architect/tech/20260801-ADL46-F1-F2-ruling.md`, R1-R4) on the ADL-46 integration branch. BRD GE-16 / ADL-46 §4.2.1 (D13), §4.3.2 (D14).

## Defect class (OP-32)
Regression — F1 and the shipped multi-region regression are both defects in code that shipped to this integration branch this week. Both fixes carry a test that fails before the fix (see below).

## What changed

**R2/R3 (F1) — one shared classifier.** `pickBest` is deleted. Both `resolveCityName` (create path) and `resolveCity` (queue / on-create trigger) now delegate exclusively to a new exported `classifyCandidates`. "Ambiguous" means more than one distinct non-null `region_iso` among eligible candidates — not candidate count. This incidentally fixes a shipped regression: two same-region Nominatim hits for one city at different granularities (e.g. `city` + `municipality`) were previously marked `'ambiguous'` (`geocoding.service.ts:99-101`, pre-fix), leaving a `pending` row with no map pin on the happy path.

**R4 — retry disposition.** A row left `pending` by ambiguity consumes the existing `geocode_attempts` budget and is never marked `unresolvable` (the geocoder did not answer "no match"). Changing `region_id` resets the budget.

**R1 (F2) — wildcard-upgrade predicate.** `findOrUpgradeCity` step 2 (`cities.ts`) now requires `geocode_status IN ('pending','unresolvable')` (whitelist, fails closed) `AND (created_by_user_id = caller OR created_by_user_id IS NULL)`. A `resolved` row is visible under GE-16 but must never be upgraded by a non-owner. Steps 1 and 2b stay creator/status-blind on purpose — the unique index is unconditional, so scoping them would miss another user's row and collide on insert. A successful upgrade resets `geocode_attempts` and re-fires resolution (a region-constrained lookup can collapse an ambiguity the unconstrained one could not); never fired for an adopted `unresolvable` row (zero candidates can't become some).

**§2.6 — don't fire the resolver into a known answer.** `POST /api/cities` step 4c now skips the `resolveCity` fire-and-forget when `resolution.status === 'ambiguous'` — the route already holds the verdict a second call would provably recompute, at the cost of a Nominatim request and an attempt.

## Test obligations (ruling §4) — all five, plus frontend parity

Every existing route suite mocks the geocoder away (review finding F4), which is exactly how F1 and the regression reached this branch behind green tests. All new tests run against a **candidate-returning fake**, not a mocked-away geocoder:

1. `classifyCandidates` table-driven (`geocoding.service.test.ts`) — one case per branch, including the shipped regression and the accepted null-`regionIso` guess limit (pinned, not fixed).
2. `resolveCity` with a multi-region fake → `pending`, coordinates NULL, `geocode_attempts` incremented, never `unresolvable`.
3. `processQueue` does not re-select a row at the attempts cap.
4. Route-level `findOrUpgradeCity` (`cities.f1f2-ruling.test.ts`, new file) — declines on a resolved row and another creator's pending row (originals untouched, including coordinates), succeeds on a NULL-creator row and the caller's own (attempts reset).
5. Route-level step 2b two-or-more-match path — proves no unique-index violation.
6. Frontend parity (`AddPlaceFlow.test.tsx`) — `AddPlaceFlow`'s distinct-region computation agrees with `classifyCandidates` on the same fixtures.

## Regression demonstrated failing pre-fix

Per the defect-taxonomy rule, demonstrated rather than asserted: created a scratch diff of the two production files only (`git diff -- geocoding.service.ts cities.ts`), reverted it with `git apply -R` (never `git stash` — `refs/stash` is shared across this repo's worktrees), ran the new regression test in isolation (`vitest run ... -t REGRESSION`) and confirmed it failed with `expected 'ambiguous' to be 'ok'` against the real pre-existing `resolveCityName` call path, then re-applied the fix and confirmed green.

## Security checklist
1. Auth middleware — unchanged. `POST /api/cities` stays `requireAuth`-only (GE-16, no route-level change here); `PATCH /api/cities/:id` stays `requireOwner`.
2. Repository queries touching user data — the new step 2 predicate scopes by `created_by_user_id` correctly (caller OR NULL); steps 1/2b are deliberately unscoped per the ruling (unconditional unique index) and this is documented in the code.
3. No new user-data columns/migrations — none added.

## Scope notes
- No `accept-language=en` added (deferred to feature work per ruling).
- No trip-country-constrained lookups or UX-spec work — only the set-based `PermittedCountries` eligibility parameter the ruling requires.
- No migrations touched.
- QA's `adl46-access-model.test.ts` (32/32) is unaffected — its geocoding mock only exports `resolveCity`, so `resolveCityName` calls there already degraded to `'disabled'` via the route's own try/catch before this change (review finding F8, a pre-existing coverage gap, not touched here).

## Test plan
- [x] `npm run test:backend` — 34 files / 665 tests passed
- [x] `npm run test:frontend` — 31 files / 237 tests passed
- [x] `npm run test:contract` — 5 files / 115 tests passed (against a locally started backend, CI's exact env recipe)
- [x] `npm run test:e2e` — 52/52 passed
- [x] `npm run type:check:all` — clean
- [x] `npm run check` (Biome) — clean
- [x] `npm run status:check` — STATUS.md in sync