### PR TITLE
fix(BRD-GE16): log four PO shakedown findings — BUG-71/72/73, ENV-02

### DIFF
--- a/.planning/drift-ledger.jsonl
+++ b/.planning/drift-ledger.jsonl
@@ -2527,3 +2527,8 @@
 {"ts":"2026-08-01T16:39:44Z","action":"write","file":"/home/node/.claude/projects/-workspace/memory/feedback_negative_probe_scope.md"}
 {"ts":"2026-08-01T16:39:53Z","action":"edit","file":"/home/node/.claude/projects/-workspace/memory/MEMORY.md"}
 {"ts":"2026-08-01T16:41:37Z","action":"write","file":"/workspace/jobs/COO/park-docs/20260801_1700-COO-park.txt"}
+{"ts":"2026-08-01T16:50:22Z","action":"session_end","reason":"clear"}
+{"ts":"2026-08-01T16:51:27Z","action":"reviewed"}
+{"ts":"2026-08-01T17:09:21Z","action":"edit","file":"/workspace/_project/tracker.json"}
+{"ts":"2026-08-01T17:10:01Z","action":"edit","file":"/workspace/jobs/PO/uat-log.md"}
+{"ts":"2026-08-01T17:10:26Z","action":"edit","file":"/workspace/jobs/COO/open-dialogues.md"}

--- a/_project/STATUS.md
+++ b/_project/STATUS.md
@@ -17,7 +17,7 @@ _Tracker last updated: 2026-07-28 (B9 merged — QUAL-03 + QUAL-11 done, PR #292
 | PHASE-5 | Integrations — Notification Engine | ⬜ Pending |
 | PHASE-6 | v3 Planning-First Delivery | ⬜ Pending |
 
-## Open work (68)
+## Open work (72)
 
 ### P0 — Blockers (1)
 
@@ -25,7 +25,7 @@ _Tracker last updated: 2026-07-28 (B9 merged — QUAL-03 + QUAL-11 done, PR #292
 |---|---|---|---|
 | FEAT-IT | Item Logging | frontend | ◐ Partial |
 
-### P1 — Critical (5)
+### P1 — Critical (6)
 
 | ID | Title | Owner | Status |
 |---|---|---|---|
@@ -34,8 +34,9 @@ _Tracker last updated: 2026-07-28 (B9 merged — QUAL-03 + QUAL-11 done, PR #292
 | BUG-51 | Companion name edits in admin panel don't consistently propagate to trips | frontend | done_pending_uat |
 | BUG-63 | Non-owner cannot add a place to a trip — categories/activities /active reads and POST /api/cities are all owner-gated (REPRODUCED + ROOT-CAUSED) | architect | ⬜ Pending |
 | QUAL-18 | E2E serves the frontend from vite preview, not Express — so no CSP header is ever under test | qa | ⬜ Pending |
+| BUG-71 | Ambiguous city name silently auto-resolves and pre-fills a state — no disambiguation offered (GE-16 violation) | backend | ⬜ Pending |
 
-### P2 — Important (34)
+### P2 — Important (37)
 
 | ID | Title | Owner | Status |
 |---|---|---|---|
@@ -73,6 +74,9 @@ _Tracker last updated: 2026-07-28 (B9 merged — QUAL-03 + QUAL-11 done, PR #292
 | QUAL-21 | Resolve-then-create success path has zero route-level test coverage (review F4) | qa | ⬜ Pending |
 | QUAL-22 | QA ATDD suite's geocoding mock drifted — one group is green for the wrong reason (review F8) | qa | ⬜ Pending |
 | UX-12 | GE-16 correction-by-re-point has no UI — a user cannot fix a wrong city (UX spec MVP) | frontend | ⬜ Pending |
+| BUG-72 | City search dropdown shows name + country only — user selects a specific city blind | backend | ⬜ Pending |
+| BUG-73 | Geocode lookup failure is silent — user cannot distinguish 'picked Virginia' from 'lookup failed' | frontend | ⬜ Pending |
+| ENV-02 | Staging 502s — Railway proxy 'connection dial timeout' to a single-replica service; app-side causes ruled out | coo | ⬜ Pending |
 
 ### P3 — Minor (28)
 
@@ -113,9 +117,9 @@ _Tracker last updated: 2026-07-28 (B9 merged — QUAL-03 + QUAL-11 done, PR #292
 |---|---|---|---|---|
 | feature | `██████████▓░░░░░░░░░` 29/56 | 29 | 27 | 3 |
 | requirement | `███████████████████░` 32/33 | 32 | 1 | 6 |
-| bug | `██████████████░░░░░░` 44/64 | 44 | 20 | 4 |
+| bug | `█████████████░░░░░░░` 44/67 | 44 | 23 | 4 |
 | task | `████████████████████` 9/9 | 9 | 0 | 0 |
-| chore | `█████████▓░░░░░░░░░░` 13/30 | 13 | 17 | 1 |
+| chore | `████████▓░░░░░░░░░░░` 13/31 | 13 | 18 | 1 |
 
 <details>
 <summary>Deferred (10)</summary>
@@ -149,4 +153,4 @@ _Tracker last updated: 2026-07-28 (B9 merged — QUAL-03 + QUAL-11 done, PR #292
 
 ---
 
-_135 done · 10 deferred · 4 closed · 68 open — 217 tracked items_
+_135 done · 10 deferred · 4 closed · 72 open — 221 tracked items_

--- a/_project/tracker.json
+++ b/_project/tracker.json
@@ -2512,6 +2512,58 @@
       "brdRefs": [],
       "phase": 6,
       "notes": "Found by the Frontend agent during the ADL-46 frontend stage while verifying response shapes rather than assuming them, and deliberately left untouched as out of scope. serializeCompanion in src/backend/routes/companions.ts returns is_active: row.isActive === 1 — a real boolean — while the Companion interface in src/frontend/types/api.ts declares is_active: number. The identical mismatch on Category and Activity was fixed in PR #341; this is the third instance of the same class and the only one remaining. Cosmetic, not a runtime defect: every consumer uses a truthy check, so 0/1 and false/true behave identically today. It is a type lie that will mislead the next person to write a strict comparison. Fold into whatever next touches that file rather than raising a standalone brief."
+    },
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // GE-16 first-live-use UAT findings (PO, 2026-08-01) — see uat-log.md
+    // ─────────────────────────────────────────────────────────────────────────
+
+    {
+      "id": "BUG-71",
+      "type": "bug",
+      "title": "Ambiguous city name silently auto-resolves and pre-fills a state — no disambiguation offered (GE-16 violation)",
+      "status": "pending",
+      "owner": "backend",
+      "priority": "P1",
+      "brdRefs": ["GE-16", "GE-15"],
+      "phase": 6,
+      "notes": "Found by the PO on the FIRST real use of the shipped ADL-46 release, on staging, typing 'springfield' into Add Place. The State field arrived pre-populated with 'Virginia' and no ambiguity hint of any kind was rendered — the user has no indication another Springfield exists. Confirmed by two independent probes: (1) PO screenshot of the settled new-city form showing Country=United States of America, State=Virginia with no hint; (2) code read of AddPlaceFlow.tsx:250-263, where the else-branch setAutoRegionIso(regionIso) is taken whenever sameCountryRegionIsos.length <= 1. Directly violates GE-16's success criterion that an ambiguous lookup must not be auto-resolved. CLASS: gap in shipped behaviour — NOT a regression and NOT a deployment defect. Staging was verified running post-release code (Railway deploy of 645757c live at the time of the first occurrence, deploy of a398d10 live at the second). MECHANISM (confirmed): the frontend discovery lookup calls GET /api/geocode?q=<name> with no country constraint (geocode.ts:46), so the proxy queries Nominatim globally at limit:'10'. Those 10 slots spread across every Springfield worldwide, are then thinned by the SETTLEMENT_TYPES filter (nominatim-client.ts:141) and again by the frontend's requirement for a non-null region_iso — collapsing the distinct-region set to 1 and defeating the ambiguity discriminator. IMPORTANT: this exact limit was PREDICTED AND ACCEPTED by the Architect's F1/F2 ruling §2.2 ('That is a guess. It is accepted for this release.'). The PO hit it on first use on the most famous ambiguous US city name, which is strong evidence the limit was accepted too cheaply. Fix direction spans BUG-71 and open-dialogues D-19: constrain the discovery lookup by country/trip-declared-countries so the discriminator gets real evidence, and add the shortlist selector D-19 designed. Do NOT close BRD-GE16 on a clean UAT elsewhere while this is open."
+    },
+
+    {
+      "id": "BUG-72",
+      "type": "bug",
+      "title": "City search dropdown shows name + country only — user selects a specific city blind",
+      "status": "pending",
+      "owner": "backend",
+      "priority": "P2",
+      "brdRefs": ["GE-16"],
+      "phase": 6,
+      "notes": "Raised by the PO alongside BUG-71. The Add Place autocomplete renders a single line per catalogue row: '{city.name} {city.country_code}' (AddPlaceFlow.tsx:357) — e.g. 'Springfield US'. Selecting it binds the trip to one specific cities row with specific coordinates, with nothing on screen identifying WHICH Springfield. Confirmed by two probes: PO screenshot of the dropdown, and the render code itself. The disambiguating field is already in the payload and simply not rendered — GET /api/cities returns region_id per row (cities.ts:72). PO asked whether the dropdown should be REMOVED now that auto-lookup exists; COO recommended against, and the recommendation was: (a) it is the mechanism that makes the shared catalogue converge — without it every user goes through create and spelling variance mints duplicate rows, the BUG-33 class through a different door (staging already holds a row literally named 'edin'); (b) the defect is the label, not the control; (c) rendering the region makes catalogue pollution visible to users, the cheapest detection mechanism available and a prerequisite for UX-12; (d) decisively, removing it would leave ONLY the path that just failed in BUG-71. IMPLEMENTATION NOTE: this is not a pure frontend tweak — the search response carries region_id (an integer), not a name, and the component only loads regions for one selected country. Cleanest fix is a join in the search endpoint returning region_name/region_iso. A row with no region in a region-tier country should render explicitly (e.g. 'Springfield · US — no state set') so the D13 wildcard row is visibly distinct rather than looking like a third Springfield."
+    },
+
+    {
+      "id": "BUG-73",
+      "type": "bug",
+      "title": "Geocode lookup failure is silent — user cannot distinguish 'picked Virginia' from 'lookup failed'",
+      "status": "pending",
+      "owner": "frontend",
+      "priority": "P2",
+      "brdRefs": ["GE-15", "GE-16"],
+      "phase": 6,
+      "notes": "Surfaced when a live staging 502 on GET /api/geocode (see ENV-02) produced no user-visible signal whatsoever. lookupCityCountry keeps a deliberate fire-and-forget silent-failure contract — introduced intentionally in PR #341 so AddPlaceFlow's manual-entry fallback stays unaffected — with the consequence that a failed lookup leaves the country and state fields simply blank. The user therefore cannot distinguish three materially different states: (1) the lookup confidently auto-picked a region, (2) the lookup ran and found nothing, (3) the lookup never completed. The silent-fallback contract is defensible; the absence of any signal in case (3) is not. This is the defect that converts every infrastructure hiccup into a false product bug, which is exactly the failure mode OP-32's deployment shakedown exists to prevent. Fix is a visible non-blocking state on the form (e.g. 'Couldn't look this up — enter country/state manually'), NOT removal of the manual fallback. Pairs with BUG-71: once ambiguity is surfaced properly, these three states each need their own distinct presentation."
+    },
+
+    {
+      "id": "ENV-02",
+      "type": "chore",
+      "title": "Staging 502s — Railway proxy 'connection dial timeout' to a single-replica service; app-side causes ruled out",
+      "status": "pending",
+      "owner": "coo",
+      "priority": "P2",
+      "brdRefs": [],
+      "phase": 6,
+      "notes": "PO hit two 502s on staging while re-testing GE-16 on 2026-08-01: GET /api/cities at 17:04:33Z and GET /api/geocode at 17:05:14Z. Both self-resolved on refresh. EVIDENCE (Railway http log): each failed with totalDuration 15000ms and upstreamErrors of three consecutive 'connection dial timeout' entries at 5000ms against the same deploymentInstanceID — i.e. the edge proxy could not open a TCP connection to the container, not an application error. APP-SIDE CAUSES RULED OUT with evidence rather than assumed: no 'Starting Container' in deploy logs since 16:46:46Z (no restart/crash); the 15-minute geocode queue tick logged normally at 16:46:47Z and 17:01:57Z, spanning the incident, so the process was alive throughout; service metrics over the window show CPU max 0.19 of one core and memory max 0.26GB against a 1.0GB limit, so neither OOM nor CPU saturation. No application error was logged at either timestamp. ROOT CAUSE NOT ESTABLISHED — what remains is Railway-side networking, which cannot be diagnosed from inside the devcontainer. Contributing factor worth weighing: the service runs multiRegionConfig {sfo: {numReplicas: 1}} — a single replica with no failover, so any instance-level hiccup is a total outage. PRODUCT CONSEQUENCE, and the reason this is tracked rather than dismissed: transients of this class manufacture false product bugs during UAT (OP-32), and BUG-73 means they are currently invisible to the user. Sequence: fix BUG-73 first (cheap, in our control, removes the false-bug pathway), then decide on replica count. Relates to QUAL-20 (post-deploy smoke check)."
     }
 
   ]

--- a/jobs/COO/open-dialogues.md
+++ b/jobs/COO/open-dialogues.md
@@ -26,8 +26,32 @@ tracker.json but also weren't safe to let vanish.
 ## Open
 
 ### D-19: Constrain city lookup by the trip's declared countries + shortlist-not-filter selection
-**Raised:** 2026-08-01 (PO) · **Status:** DESIGNED, deferred behind an MVP. Needs a BRD home
-before any brief. UX spec written and merged; Architect design not started.
+**Raised:** 2026-08-01 (PO) · **Status:** ~~DESIGNED, deferred behind an MVP~~ → **DEFERRAL
+NO LONGER JUSTIFIED (amended 2026-08-01, same day).** Needs a BRD home before any brief.
+UX spec written and merged; Architect design not started.
+
+> **AMENDMENT (2026-08-01) — the deferral rested on a premise that was disproved within hours.**
+> This was parked as "probably edge-case territory until measured," on two stated grounds: that the
+> COO's sense of the problem was inflated by a since-fixed defect, and that **nobody could measure
+> the real rate** because `geocode_status` had only just reached main. Both were fair at the time.
+>
+> What happened next: the COO queried `geocode_status` at the next session pickup and found three
+> rows, all `resolved` — no volume, so still unmeasured — and additionally read one correctly-shaped
+> `Springfield → Virginia` row as evidence the live path *worked*. The PO then ran a real browser
+> against staging and found that same row had been produced by the defect: "springfield" silently
+> auto-populates State = Virginia with **no indication another Springfield exists** (now **BUG-71**,
+> P1, with screenshot + code-read confirmation).
+>
+> **The measurement arrived by other means.** One user, the first city typed, wrong result, no
+> recourse. The unconstrained global `limit:'10'` lookup this entry exists to fix is a direct
+> contributing cause: it starves the ambiguity discriminator of the evidence it needs to fire.
+> Two lessons worth keeping separately from the decision: **a correct-looking row is not a correct
+> flow** (the COO's read was wrong, and a DB query was the wrong instrument), and **"unmeasured"
+> is not a synonym for "rare"** — it was treated as one here.
+>
+> **This does not auto-promote D-19 to a brief** — it still needs a BRD home and the PO's call on
+> scope. It does mean the *edge-case* framing should not be reused as the reason to defer it, and
+> that QUAL-21 (F4 route-level coverage), named a prerequisite if D-19 proceeds, is now live.
 
 **The problem.** Adding a place on a US trip and typing "Rome" resolves to Rome, Italy. The
 frontend calls `GET /api/geocode?q=…` with **no constraint at all**, even though the backend

--- a/jobs/PO/uat-log.md
+++ b/jobs/PO/uat-log.md
@@ -51,6 +51,61 @@ Screenshots: save to `jobs/PO/screenshots/[date]-[short-description].png`
 
 ## Open Sessions
 
+### UAT Session — 2026-08-01 (BRD-GE16 / ADL-46 release — PO deployment shakedown, FAIL)
+
+**Scope:** PO's own shakedown of the ADL-46 release on staging, run unprompted at session pickup.
+Add Place → city entry → geocode auto-lookup. This is the OP-32 shakedown, and it did exactly what
+the rule promises: three defects found before a formal UAT round started.
+**Build:** staging @ a398d10 (Railway deploy verified live at the time; the first occurrence was
+under 645757c — both post-release, so **not** a deployment defect)
+**Verdict:** FAIL — GE-16's disambiguation criterion is not met in live use.
+
+#### Findings
+
+- [ ] **BUG-71 (P1) — ambiguous city silently auto-resolves, no disambiguation offered.**
+      Typing "springfield" pre-populated **State = Virginia** with no hint that any other Springfield
+      exists. Violates GE-16 verbatim. Confirmed by two independent probes: PO screenshot of the
+      settled form, and a code read of `AddPlaceFlow.tsx:250-263`.
+      **The Architect's F1/F2 ruling §2.2 predicted and explicitly accepted this exact limit**
+      ("That is a guess. It is accepted for this release."). It was hit on the *first real use*,
+      on the most famous ambiguous US city name — good evidence the limit was accepted too cheaply.
+      Mechanism: the discovery lookup is globally unconstrained at `limit:'10'`, so the candidate
+      set is thinned to a single distinct region and the ambiguity discriminator never fires.
+      Fix spans BUG-71 and **D-19**, which we had deferred as "probably edge case, unmeasured."
+
+- [ ] **BUG-72 (P2) — catalogue dropdown gives no way to tell which Springfield you're picking.**
+      Renders `{name} {country_code}` only, though `region_id` is already in the payload.
+      PO asked whether to remove the dropdown; **COO recommended against** — it is what makes the
+      shared catalogue converge, and removing it would leave only the path that just failed.
+      Fix the label (needs a region join in the search response), don't delete the control.
+
+- [ ] **BUG-73 (P2) — a failed geocode lookup is completely silent.**
+      Surfaced by the ENV-02 502s below. The user cannot distinguish "picked Virginia",
+      "found nothing", and "the lookup never ran". This is the defect that turns every
+      infrastructure hiccup into a false product bug.
+
+- [ ] **ENV-02 (P2) — two staging 502s during the session**, `/api/cities` and `/api/geocode`,
+      both self-resolving. Railway edge proxy "connection dial timeout" × 3; **app-side causes
+      ruled out with evidence** (no restart, queue ticking throughout, CPU max 19%, memory 0.26/1.0 GB).
+      Root cause not established — Railway-side networking, single replica in `sfo`.
+
+#### Notes / Observations
+
+1. **This session is the argument for OP-32's shakedown-before-UAT rule.** The COO had queried
+   `geocode_status` earlier the same morning, seen one correctly-shaped `Springfield/Virginia` row,
+   and concluded the live path "worked". A correct row is not a correct flow — the row was produced
+   by exactly the defect above. Ten minutes of a real browser found what a database query could not.
+2. **D-19 is no longer unmeasured.** It was deferred pending data on how often users hit a wrong
+   city. One user, first city typed, wrong result, no recourse. That is data.
+3. **BRD-GE16 must not close on a clean UAT elsewhere.** It was already `done_pending_uat` carrying
+   a partial-delivery note for UX-12 (no correction UI). This adds three more.
+4. Console also showed `Clerk has been loaded with development keys` on staging. Staging and
+   production share one Clerk pool — worth resolving before the production promotion. Noted against
+   the existing Clerk-pool thread rather than given its own ID.
+5. Clerk telemetry CSP noise reappeared — that is the known **BUG-68**, no functional impact.
+
+---
+
 ### UAT Session — 2026-07-28 (Wave 1 sub-wave B — AWAITING PO, not yet tested)
 
 **Scope:** Three more items shipped by Wave 1 sub-wave B, on top of the seven from sub-wave A


### PR DESCRIPTION
Tracker and documentation only — no source changes.

The PO ran an unprompted deployment shakedown of the ADL-46 release on staging at session pickup. It returned **FAIL**, with three product defects and one infrastructure item.

## Findings

| ID | P | What |
|---|---|---|
| **BUG-71** | P1 | Ambiguous city silently auto-resolves and pre-fills a state — no disambiguation offered. **Violates GE-16 verbatim.** |
| **BUG-72** | P2 | Catalogue dropdown shows name + country only; user selects a specific city blind |
| **BUG-73** | P2 | A failed geocode lookup is entirely silent |
| **ENV-02** | P2 | Two staging 502s — Railway proxy dial timeout; app-side causes ruled out |

## Classification (OP-32)

BUG-71 is a **gap**, not a regression and not a deployment defect. Railway deploy history confirms staging was running post-release code at both occurrences (`645757c` at the first, `a398d10` at the second), so the shipped fix was live and still behaved this way.

Mechanism, confirmed by two independent probes (PO screenshot of the settled form + code read of `AddPlaceFlow.tsx:250-263`): the discovery lookup calls `GET /api/geocode?q=` with no country constraint, so the proxy queries Nominatim globally at `limit:'10'`. Those slots spread worldwide, then get thinned by `SETTLEMENT_TYPES` and by the frontend's non-null `region_iso` requirement — collapsing the distinct-region set to 1, so the ambiguity discriminator never fires and `setAutoRegionIso` runs instead.

**The Architect's F1/F2 ruling §2.2 predicted and explicitly accepted this exact limit** ("That is a guess. It is accepted for this release."). It was hit on the first real use, on the most famous ambiguous US city name.

## ENV-02 — what was ruled out, and what wasn't

App-side causes were eliminated with evidence rather than assumed: no `Starting Container` in deploy logs since 16:46:46Z, the 15-minute geocode queue tick logged normally at 16:46:47Z and 17:01:57Z spanning the incident, CPU max 0.19 of one core, memory max 0.26 GB against a 1.0 GB limit. **Root cause is not established** — what remains is Railway-side networking to a single replica in `sfo` — and the entry says so plainly rather than guessing.

## A COO error recorded in D-19

D-19 was deferred as "probably edge case until measured." Earlier the same morning I queried `geocode_status`, saw one correctly-shaped `Springfield → Virginia` row, and read it as evidence the live path worked. It was produced by the defect. **A correct-looking row is not a correct flow**, and "unmeasured" was treated as a synonym for "rare." Both are recorded in the D-19 amendment.

## Other

- `uat-log.md`: new session block, appended not rewritten (OP-28)
- `STATUS.md` regenerated (same-PR doc-lifecycle rule)
- BUG-72 records a COO recommendation **against** the PO's suggestion to remove the dropdown, with reasoning
- Console also showed Clerk **development keys** on staging; staging and prod share one Clerk pool — noted against the existing Clerk-pool thread, worth resolving before production promotion

**BRD-GE16 stays `done_pending_uat` and must not close on a clean UAT elsewhere.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)