### PR TITLE
fix(BUG-73): geocode lookup failure is silent — add retry and a visible failure state

### DIFF
--- a/jobs/COO/inbox/20260801_1040-FRONTEND-bug73-geocode-retry-complete.txt
+++ b/jobs/COO/inbox/20260801_1040-FRONTEND-bug73-geocode-retry-complete.txt
@@ -1,0 +1,60 @@
+BUG-73 · GitHub #352 / PR #354 · BRD §GE-15, §GE-16 · Branch fix/bug73-geocode-failure-visible
+
+WHAT WAS BUILT
+GET /api/geocode bypassed React Query entirely (lookupCityCountry is a plain
+async function), so the QueryClient's retry:3 default never applied to it —
+a transient failure rendered identically to "found nothing" and "never ran"
+(no signal at all). Added an explicit retry (3 attempts, 250ms backoff)
+inside lookupCityCountry itself, and a `failed: boolean` discriminator on
+its resolved value so retries-exhausted is now distinguishable from a
+genuine no-match. AddPlaceFlow shows a non-blocking failure banner with a
+manual Retry action once retries are exhausted; manual entry stays fully
+usable throughout.
+
+ACCEPTANCE CRITERIA
+1. Transient failure retried before any error shown — PASS
+2. Test proves retry actually happens (2 failures then success → populated
+   result) — PASS
+3. Non-blocking visible failure message once retries exhausted — PASS
+4. Manual-entry fallback works in every failure case — PASS
+5. Three outcomes distinguishable; found-nothing never renders as failure — PASS
+6. Failure state clears on a subsequent successful lookup (Retry action) — PASS
+7. test:frontend green, type:check:all clean, biome clean — PASS
+
+CI: gh pr checks 354 — 18/18 green (scripts/ci-wait.sh pr 354 confirmed PASS)
+
+MECHANISM CHOSEN: retry inside the existing plain function (not useMutation
+or useQuery+enabled). Reasoning in the PR description and park doc — smallest
+blast radius, keeps lookupCityCountry's call site/never-throws contract
+unchanged, and avoids restructuring AddPlaceFlow.tsx or its D14 test mock
+while BUG-71 is in flight on the same file/component.
+
+BOUNDARIES RESPECTED
+- AddPlaceFlow.tsx:250-263 (D14 ambiguity computation) + setAutoRegionIso:
+  verified byte-for-byte unchanged via `git diff origin/main` — the block
+  does not appear in the diff at all, only lines above/below it were added.
+- City search dropdown label (BUG-72): untouched.
+- No backend files touched.
+
+DECLARED SOURCE CHANGES
+- src/frontend/hooks/useCities.ts: lookupCityCountry's return type gained a
+  `failed` field and its implementation now retries internally — a scoped
+  behavior change to an existing exported function (not a full-file
+  rewrite), required directly by the brief's success criterion 5
+  (distinguishability). Existing tests updated to match; the pre-existing
+  "silent-failure contract" test now documents the retries-exhausted case
+  instead of a single-attempt failure.
+- No full-file rewrites of any source file.
+
+OPEN ISSUES / BLOCKERS
+None. One non-blocking note for later: the 250ms×3 backoff is untuned
+against real Nominatim/proxy latency (this devcontainer can't reach either
+to observe it) — constants are isolated at the top of useCities.ts if a
+tune is ever needed.
+
+WHAT'S NOW UNBLOCKED
+BUG-73 closed pending merge. A transient geocode failure now self-heals
+silently in the common case and is visible + recoverable in the remainder.
+No other in-flight thread depends on this; BUG-71/BUG-72 unaffected.
+
+Full detail: jobs/frontend/park-docs/20260801-FRONTEND-bug73-geocode-retry-park.txt

--- a/jobs/frontend/context/current.txt
+++ b/jobs/frontend/context/current.txt
@@ -555,3 +555,27 @@ survived. Added AddPlaceFlow.tsx's first-ever component test file
 confirmed by hand (git apply -R, not stash) that the zero-overlap case
 fails without the fix. PR #341 commit a5b9c3b, CI 9/9 green. Full detail
 appended to jobs/COO/inbox/20260731_2130-FRONTEND-adl46-stage4-complete.txt.
+
+UPDATE 2026-08-01 — BUG-73 (#352/PR #354): geocode lookup failure made
+visible. lookupCityCountry (src/frontend/hooks/useCities.ts) bypasses React
+Query, so main.tsx's QueryClient retry:3 default never applied to it — a
+transient GET /api/geocode failure (the ENV-02 502s from the ADL-46
+shakedown) rendered identically to "found nothing" and "never ran", no
+signal reached the user. Added fetchGeocodeResultWithRetry (3 retries, 250ms
+fixed backoff, matches the query default's attempt count) inside
+lookupCityCountry itself — chose this over useMutation/useQuery+enabled
+specifically to avoid restructuring AddPlaceFlow's call site or its D14 test
+mock while BUG-71 is in flight on the same file. lookupCityCountry's
+resolved value now carries `failed: boolean`, so "retries exhausted" is
+distinguishable from a genuine "no match" (previously both collapsed to the
+same null/empty shape) — AddPlaceFlow.tsx shows a non-blocking failure
+message with a manual Retry action once retries are exhausted; manual entry
+stays fully usable throughout. Did not touch AddPlaceFlow.tsx:250-263 (D14
+ambiguity logic, BUG-71) — content is byte-for-byte unchanged, only
+surrounding lines added. New test file
+src/frontend/components/TripDetail/__tests__/AddPlaceFlow.geocodeFailure.test.tsx
+(kept separate from the existing D14-scoped AddPlaceFlow.test.tsx to avoid
+touching that file at all). useCities.geocode.test.tsx extended with a
+retry-proof test (apiGet fails twice, succeeds on the 3rd call) and the
+`failed` discriminator across all existing cases. CI 18/18 green on PR #354.
+No backend files touched; BUG-72's city-search dropdown label untouched.

--- a/jobs/frontend/park-docs/20260801-FRONTEND-bug73-geocode-retry-park.txt
+++ b/jobs/frontend/park-docs/20260801-FRONTEND-bug73-geocode-retry-park.txt
@@ -1,0 +1,142 @@
+FRONTEND PARK DOCUMENT — 2026-08-01
+Thread: BUG-73 geocode lookup failure is silent — retry + visible failure state (fix/bug73-geocode-failure-visible, GitHub #352, PR #354)
+
+SUMMARY
+GET /api/geocode (proxied via lookupCityCountry, src/frontend/hooks/useCities.ts)
+bypasses React Query — it's a plain async function, not a useQuery hook — so the
+QueryClient's `retry: 3` default (src/frontend/main.tsx:33) never applied to it.
+Found during the ADL-46 deployment shakedown (PO, jobs/PO/uat-log.md,
+2026-08-01): `/api/geocode` 502'd twice on staging (ENV-02, an infra transient)
+in the same outage window `/api/cities` (a real useQuery) self-healed via its
+inherited retry. The user saw nothing — no country, no state, no message — and
+the three possible outcomes (auto-populated / ran-but-found-nothing / never
+completed) were indistinguishable.
+
+WHAT CHANGED
+1. src/frontend/hooks/useCities.ts — added fetchGeocodeResultWithRetry, a
+   retry wrapper around the GET /api/geocode call: up to 3 retries (matching
+   the query default's attempt count) with a fixed 250ms backoff, before
+   rethrowing. lookupCityCountry now calls this instead of a single apiGet.
+   Its resolved value gained a `failed: boolean` field — `true` only when
+   retries were exhausted without success. lookupCityCountry itself still
+   never throws (the pre-existing fire-and-forget contract for the caller is
+   unchanged), but the shape it resolves to is no longer identical for "found
+   nothing" (`failed: false`, empty candidates) and "gave up after retrying"
+   (`failed: true`, empty candidates) — those previously collapsed to the
+   exact same object.
+2. src/frontend/components/TripDetail/AddPlaceFlow.tsx — added
+   `geocodeLookupFailed` state. Reset to false at the top of
+   handleOpenNewCityForm (same place the other lookup-related state resets
+   already live). The `.then` callback checks `failed` first and, if true,
+   sets the failure state and returns immediately — the D14 ambiguity
+   computation below it never runs on a failed lookup (nothing to
+   disambiguate: no country, no candidates). The `.catch` (defensive
+   fallback for an unexpected throw, since lookupCityCountry itself
+   shouldn't throw) also sets the failure state. Added a non-blocking amber
+   banner under the Country field, shown only when geocodeLookupFailed is
+   true: "Automatic lookup failed — you can select country and region
+   manually." plus a "Retry" button that re-invokes
+   handleOpenNewCityForm(newCityName) — reusing the exact same open/reset/
+   lookup path rather than a new code path, so a retry gets a full clean
+   re-attempt (country/region/candidates state resets, then the lookup runs
+   again with its own internal 3-retry policy).
+3. src/frontend/hooks/__tests__/useCities.geocode.test.tsx — extended.
+   Every existing assertion on the resolved shape now checks `failed`
+   too. The old "silent-failure contract" test (single rejection,
+   `.resolves.toEqual({countryCode:null,...})`) is now the retries-
+   exhausted case: uses fake timers, asserts `apiGet` was called 4 times
+   (1 initial + 3 retries) and the result carries `failed: true`. New test:
+   "retries a transient failure and succeeds" — apiGet mocked to reject
+   twice then resolve, asserts exactly 3 calls and a populated,
+   `failed: false` result. This is the test proving retry actually
+   happens, not just that failure is eventually reported — a fix that
+   "looks like retry" but silently doesn't retry would fail this test's
+   call-count assertion specifically.
+4. New src/frontend/components/TripDetail/__tests__/AddPlaceFlow.geocodeFailure.test.tsx
+   (4 tests) — kept as its own file rather than added to the existing
+   AddPlaceFlow.test.tsx (which is BUG-71's D14 test file, in flight
+   separately) to avoid touching that file at all. Covers: failure message
+   shown + "detecting…" cleared on failure; failure message NOT shown on a
+   successful "found nothing" result; manual country selection stays fully
+   usable (and the submit button stays enabled) after a failure; clicking
+   Retry re-runs the lookup and clears the message on a subsequent success.
+5. jobs/frontend/context/current.txt — appended (not rewritten) with a
+   2026-08-01 entry summarizing this thread.
+
+MECHANISM CHOICE (per the issue's explicit ask to state and justify it)
+The issue named three options: useMutation, useQuery with enabled:false +
+refetch(), or retry inside the existing plain function. Chose the third.
+
+Why not useMutation: it would fit the codebase's existing mutation
+conventions (AddPlaceFlow already uses two — addPlace, createCity) and gets
+retry "for free" via React Query's machinery, IF retry is set explicitly
+(the issue's called-out trap: defaultOptions.queries.retry doesn't apply to
+mutations). But lookupCityCountry's non-throwing, always-resolves contract
+is asserted directly by an existing test ("silent-failure contract") and
+depended on by AddPlaceFlow's call site — routing it through useMutation
+would mean either changing that contract more invasively (a mutation's
+mutationFn needs to throw for retry to engage) or wrapping it awkwardly. It
+would also mean AddPlaceFlow.test.tsx's module-level mock of
+`hooks/useCities` (`lookupCityCountry`, `useCitySearch`, `useCreateCity`,
+`useCarryForwardCandidates`) would need a new `useGeocodeLookup`-shaped
+entry added for the D14 tests to keep passing — touching the exact test
+file BUG-71 has in flight, for a change unrelated to what BUG-71 is
+deciding. Retry-inside-the-function avoids all of that: lookupCityCountry's
+signature, call site, and never-throws contract are unchanged from
+AddPlaceFlow's perspective (only the resolved value gained one field), so
+zero risk of colliding with BUG-71's concurrent work on the same component
+and its test file. The tradeoff acknowledged in the issue — this duplicates
+retry policy that already exists in main.tsx's QueryClient — is accepted:
+the duplication is small (one loop, one constant), commented with why it
+exists, and the alternative's collision risk against in-flight BUG-71 work
+was judged the bigger cost right now.
+
+WHAT WAS EXPLICITLY NOT CHANGED
+- AddPlaceFlow.tsx:250-263 (the D14 distinct-region-ISO computation) and
+  the setAutoRegionIso call immediately after it — content is byte-for-byte
+  identical to before this PR. Diffed the final file against origin/main to
+  confirm: those lines appear unchanged, only new lines were added above
+  and below the block.
+- The existing AddPlaceFlow.test.tsx (D14 suite) — not touched at all; its
+  mock of lookupCityCountry doesn't include a `failed` field in its fixture
+  resolves, and that's fine — `failed` is `undefined` there, which is
+  falsy, so the `if (failed) {...return;}` branch is never taken and the
+  D14 logic executes exactly as it did before this PR. Ran that file
+  unmodified against the new component code to confirm — still 6/6 green.
+- AddPlaceFlow.tsx:357 (city search dropdown label) — untouched, BUG-72's
+  scope.
+- No backend files touched — ENV-02's infra cause is tracked separately.
+
+VERIFICATION RUN (all local, this worktree)
+  npm run check                clean (biome)
+  npm run type:check:all       clean
+  npm run test:backend         665 passed
+  npm run test:frontend        242 passed (32 files, includes both new/
+                                extended geocode test files)
+  npm run status:check         STATUS.md in sync
+  CI (PR #354)                 18/18 checks green (scripts/ci-wait.sh)
+  Manual browser check: NOT performed — same sandbox limitation as every
+  prior Frontend thread (no real Clerk key, firewall doesn't reach Clerk's
+  hosted sign-in from this devcontainer). The retry-proof test
+  (fake-timer-driven, asserting exact apiGet call counts) and the four
+  AddPlaceFlow UI-state tests are the verification for both the retry
+  mechanism and its visibility — no live network transient was available
+  to reproduce by hand in this environment.
+
+OPEN FLAGS FOR COO
+None blocking. One thing worth a look when convenient: the retry backoff
+(250ms fixed, 3 retries) adds up to ~750ms of extra wait in the worst case
+before the failure banner appears — reasonable for a foreground modal
+lookup but untested against real-world Nominatim/proxy latency distributions
+since this environment can't reach either. If ENV-02 recurs and the delay
+feels wrong in practice, the constants are isolated at the top of
+useCities.ts (GEOCODE_RETRY_ATTEMPTS, GEOCODE_RETRY_DELAY_MS) for an easy
+tune.
+
+WHAT'S NOW UNBLOCKED
+- BUG-73 is closed pending COO merge. A transient geocode proxy failure now
+  self-heals silently in the common case (retry) and, in the remaining
+  case, is visible and recoverable (manual entry always available, plus an
+  in-form Retry action) rather than a silent dead end.
+- No other thread depends on this directly; BUG-71 (D14 ambiguity ruling)
+  and BUG-72 (dropdown label) remain unaffected and un-collided-with.

--- a/src/frontend/components/TripDetail/AddPlaceFlow.tsx
+++ b/src/frontend/components/TripDetail/AddPlaceFlow.tsx
@@ -71,6 +71,12 @@ export function AddPlaceFlow({
   // guessed for. null means "no ambiguity — show the full country region list".
   const [candidateRegionIsos, setCandidateRegionIsos] = useState<string[] | null>(null);
   const [countryLookupPending, setCountryLookupPending] = useState(false);
+  // BUG-73: true only when the geocode lookup exhausted its retries without a
+  // successful response — distinct from a successful lookup that legitimately
+  // found nothing (which leaves this false and the country field simply
+  // unpopulated, same as before). Never blocks the form; manual entry stays
+  // available in every case (GE-15/GE-16 contract).
+  const [geocodeLookupFailed, setGeocodeLookupFailed] = useState(false);
   const [addedPlaceId, setAddedPlaceId] = useState<number | null>(null);
   const [addedCityId, setAddedCityId] = useState<number | null>(null);
   const [showCarryForward, setShowCarryForward] = useState(false);
@@ -236,10 +242,19 @@ export function AddPlaceFlow({
     setNewCityRegionId(null);
     setAutoRegionIso(null);
     setCandidateRegionIsos(null);
+    setGeocodeLookupFailed(false);
     if (cityName.trim().length >= 2) {
       setCountryLookupPending(true);
       lookupCityCountry(cityName.trim())
-        .then(({ countryCode, regionIso, candidates }) => {
+        .then(({ countryCode, regionIso, candidates, failed }) => {
+          // BUG-73: a failed lookup (retries exhausted) never reaches the D14
+          // disambiguation logic below — there's no country/candidates to
+          // reason about, and this is the surfaced-to-the-user failure state.
+          if (failed) {
+            setGeocodeLookupFailed(true);
+            setCountryLookupPending(false);
+            return;
+          }
           if (countryCode) setNewCityCountryCode(countryCode);
 
           // D14: collect the distinct region_iso values among candidates that
@@ -265,7 +280,14 @@ export function AddPlaceFlow({
           }
           setCountryLookupPending(false);
         })
-        .catch(() => setCountryLookupPending(false));
+        // BUG-73: lookupCityCountry resolves rather than throws on a failed
+        // lookup (see its doc comment) — this catch is a defensive fallback
+        // for an unexpected rejection, kept consistent with the same failure
+        // state so an unforeseen throw doesn't regress to the old silent gap.
+        .catch(() => {
+          setGeocodeLookupFailed(true);
+          setCountryLookupPending(false);
+        });
     }
   };
 
@@ -450,6 +472,22 @@ export function AddPlaceFlow({
                   </option>
                 ))}
               </select>
+              {/* BUG-73: non-blocking, visible failure state — retries are
+                  already exhausted by the time this renders (lookupCityCountry
+                  handles retry internally). The form stays fully usable;
+                  country/region can still be picked manually below. */}
+              {geocodeLookupFailed && (
+                <div className="mt-2 px-2.5 py-2 bg-amber-50 border border-amber-200 rounded-md text-amber-800 text-xs flex items-center justify-between gap-2">
+                  <span>Automatic lookup failed — you can select country and region manually.</span>
+                  <button
+                    type="button"
+                    onClick={() => handleOpenNewCityForm(newCityName)}
+                    className="shrink-0 text-teal-700 font-semibold underline hover:text-teal-800 cursor-pointer"
+                  >
+                    Retry
+                  </button>
+                </div>
+              )}
             </div>
 
             {/* Region dropdown — shown only when country has region_tier_enabled */}

--- a/src/frontend/components/TripDetail/__tests__/AddPlaceFlow.geocodeFailure.test.tsx
+++ b/src/frontend/components/TripDetail/__tests__/AddPlaceFlow.geocodeFailure.test.tsx
@@ -1,0 +1,176 @@
+/**
+ * Tests for AddPlaceFlow's BUG-73 geocode-failure visibility.
+ *
+ * Before BUG-73, a failed `GET /api/geocode` lookup (proxied via
+ * lookupCityCountry, hooks/useCities.ts) rendered identically to a
+ * successful lookup that found nothing — the user saw no signal at all.
+ * lookupCityCountry now retries transient failures internally (see
+ * useCities.geocode.test.tsx for that proof) and, once retries are
+ * exhausted, resolves with `failed: true` instead of being indistinguishable
+ * from a genuine "no match". These tests cover AddPlaceFlow's handling of
+ * that signal: a visible, non-blocking failure message; the manual-entry
+ * fallback staying fully usable; a retry action that re-runs the lookup and
+ * clears the failure state on success; and confirming "found nothing" still
+ * renders with no failure message at all.
+ *
+ * This file intentionally does not touch AddPlaceFlow.tsx:250-263's D14
+ * ambiguity computation (BUG-71, in flight separately) — every scenario here
+ * uses single-candidate or empty-candidate fixtures so that branch is never
+ * exercised, and the existing AddPlaceFlow.test.tsx D14 suite is left as-is.
+ *
+ * Mocks: same shape as AddPlaceFlow.test.tsx (D14 suite) — see that file's
+ * header comment for the full mock rationale.
+ *
+ * Source: src/frontend/components/TripDetail/AddPlaceFlow.tsx
+ */
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Country } from '../../../types/api';
+import { AddPlaceFlow } from '../AddPlaceFlow';
+
+const mockLookupCityCountry = vi.fn();
+
+vi.mock('../../../hooks/useCities', () => ({
+  lookupCityCountry: (cityName: string) => mockLookupCityCountry(cityName),
+  useCitySearch: () => ({ data: [], isLoading: false }),
+  useCreateCity: () => ({ mutateAsync: vi.fn(), isPending: false, error: null }),
+  useCarryForwardCandidates: () => ({ data: [], isFetched: false }),
+}));
+
+vi.mock('../../../hooks/usePlaces', () => ({
+  useAddPlace: () => ({ mutateAsync: vi.fn(), isPending: false, error: null }),
+}));
+
+const usCountry: Country = {
+  country_code: 'US',
+  name: 'United States',
+  region_tier_enabled: true,
+  region_tier_label: 'State',
+};
+
+vi.mock('../../../hooks/useAdmin', () => ({
+  useCountries: () => ({ data: [usCountry] }),
+  useCountryRegions: () => ({ data: [] }),
+}));
+
+/** Types a query and opens the "Add new city" form, triggering the geocode lookup. */
+async function openNewCityForm(user: ReturnType<typeof userEvent.setup>, cityName: string) {
+  const input = screen.getByPlaceholderText('Search city name…');
+  await user.type(input, cityName);
+  const addNew = await screen.findByText(`+ Add new: "${cityName}"`, {}, { timeout: 2000 });
+  await user.click(addNew);
+}
+
+function renderFlow() {
+  return render(
+    <AddPlaceFlow
+      tripId={1}
+      onClose={vi.fn()}
+      tripStartDate="2026-01-01"
+      tripEndDate="2026-01-10"
+      isFirstPlace={false}
+    />,
+  );
+}
+
+describe('AddPlaceFlow — BUG-73 geocode failure visibility', () => {
+  beforeEach(() => {
+    mockLookupCityCountry.mockReset();
+  });
+
+  it('shows a visible, non-blocking failure message when the lookup fails', async () => {
+    mockLookupCityCountry.mockResolvedValue({
+      countryCode: null,
+      regionIso: null,
+      candidates: [],
+      failed: true,
+    });
+    const user = userEvent.setup();
+    renderFlow();
+
+    await openNewCityForm(user, 'Nowhereville');
+
+    await waitFor(() => {
+      expect(screen.getByText(/automatic lookup failed/i)).toBeInTheDocument();
+    });
+    // "detecting…" must have cleared — the failure state is distinguishable
+    // from "still pending", not layered on top of it.
+    expect(screen.queryByText(/detecting…/i)).not.toBeInTheDocument();
+  });
+
+  it('does NOT show a failure message when the lookup succeeds but finds nothing (found-nothing != failure)', async () => {
+    mockLookupCityCountry.mockResolvedValue({
+      countryCode: null,
+      regionIso: null,
+      candidates: [],
+      failed: false,
+    });
+    const user = userEvent.setup();
+    renderFlow();
+
+    await openNewCityForm(user, 'Zzznotacity');
+
+    // Give any pending state a chance to settle before asserting absence.
+    await waitFor(() => {
+      expect(screen.queryByText(/detecting…/i)).not.toBeInTheDocument();
+    });
+    expect(screen.queryByText(/automatic lookup failed/i)).not.toBeInTheDocument();
+  });
+
+  it('keeps the manual-entry fallback fully usable after a failed lookup', async () => {
+    mockLookupCityCountry.mockResolvedValue({
+      countryCode: null,
+      regionIso: null,
+      candidates: [],
+      failed: true,
+    });
+    const user = userEvent.setup();
+    renderFlow();
+
+    await openNewCityForm(user, 'Nowhereville');
+    await waitFor(() => {
+      expect(screen.getByText(/automatic lookup failed/i)).toBeInTheDocument();
+    });
+
+    // The form is not disabled/blocked — country can still be picked by hand.
+    const countrySelect = screen
+      .getByRole('option', { name: 'Select country…' })
+      .closest('select') as HTMLSelectElement;
+    expect(countrySelect).toBeEnabled();
+    await user.selectOptions(countrySelect, 'US');
+    expect(countrySelect).toHaveValue('US');
+
+    // Submit button is not stuck disabled by the failure state either.
+    expect(screen.getByRole('button', { name: /add city & place/i })).toBeEnabled();
+  });
+
+  it('retrying after a failure re-runs the lookup and clears the failure message on success', async () => {
+    mockLookupCityCountry
+      .mockResolvedValueOnce({ countryCode: null, regionIso: null, candidates: [], failed: true })
+      .mockResolvedValueOnce({
+        countryCode: 'US',
+        regionIso: null,
+        candidates: [],
+        failed: false,
+      });
+    const user = userEvent.setup();
+    renderFlow();
+
+    await openNewCityForm(user, 'Springfield');
+    await waitFor(() => {
+      expect(screen.getByText(/automatic lookup failed/i)).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole('button', { name: /retry/i }));
+
+    await waitFor(() => {
+      expect(screen.queryByText(/automatic lookup failed/i)).not.toBeInTheDocument();
+    });
+    expect(mockLookupCityCountry).toHaveBeenCalledTimes(2);
+    const countrySelect = screen
+      .getByRole('option', { name: 'Select country…' })
+      .closest('select') as HTMLSelectElement;
+    expect(countrySelect).toHaveValue('US');
+  });
+});

--- a/src/frontend/hooks/__tests__/useCities.geocode.test.tsx
+++ b/src/frontend/hooks/__tests__/useCities.geocode.test.tsx
@@ -1,14 +1,18 @@
 /**
- * Tests for lookupCityCountry (ADL-46 D7/D14) — the repointed geocode path.
+ * Tests for lookupCityCountry (ADL-46 D7/D14, BUG-73) — the repointed geocode path.
  *
  * Source: src/frontend/hooks/useCities.ts
  *
  * ADL-46 moved this from a direct browser fetch to nominatim.openstreetmap.org
  * (CSP-blocked in production, BUG-55, and unable to carry the required
- * User-Agent header) to GET /api/geocode via apiGet. lookupCityCountry keeps
- * its pre-existing fire-and-forget error contract — any failure resolves to
- * nulls/empty rather than throwing — so AddPlaceFlow's manual-entry fallback
- * keeps working.
+ * User-Agent header) to GET /api/geocode via apiGet.
+ *
+ * BUG-73 changed the failure contract: lookupCityCountry still never throws
+ * (AddPlaceFlow's manual-entry fallback keeps working with no try/catch
+ * required) and now retries a transient failure internally before giving up
+ * — see fetchGeocodeResultWithRetry. Critically, a lookup that exhausts its
+ * retries is no longer indistinguishable from one that succeeded and found
+ * nothing: the resolved value now carries `failed: true` vs `failed: false`.
  */
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { GeocodeResult } from '../../types/api';
@@ -54,11 +58,12 @@ describe('lookupCityCountry', () => {
     };
     vi.mocked(apiGet).mockResolvedValue(result);
 
-    const { countryCode, regionIso, candidates } = await lookupCityCountry('Springfield');
+    const { countryCode, regionIso, candidates, failed } = await lookupCityCountry('Springfield');
 
     expect(countryCode).toBe('US');
     expect(regionIso).toBe('US-IL');
     expect(candidates).toEqual(result.candidates);
+    expect(failed).toBe(false);
   });
 
   it('surfaces all candidates for the ambiguity (D14) case — multiple regions in one country', async () => {
@@ -92,24 +97,73 @@ describe('lookupCityCountry', () => {
     expect(new Set(candidates.map((c) => c.region_iso))).toEqual(new Set(['US-IL', 'US-MO']));
   });
 
-  it('returns nulls and an empty candidate list without throwing when the proxy call fails (silent-failure contract)', async () => {
-    vi.mocked(apiGet).mockRejectedValue(new Error('network error'));
+  it('returns nulls and failed:true without throwing once retries are exhausted (BUG-73 silent-failure-to-the-caller contract)', async () => {
+    vi.useFakeTimers();
+    try {
+      vi.mocked(apiGet).mockRejectedValue(new Error('network error'));
 
-    await expect(lookupCityCountry('Nowhere')).resolves.toEqual({
-      countryCode: null,
-      regionIso: null,
-      candidates: [],
-    });
+      const promise = lookupCityCountry('Nowhere');
+      await vi.runAllTimersAsync();
+
+      await expect(promise).resolves.toEqual({
+        countryCode: null,
+        regionIso: null,
+        candidates: [],
+        failed: true,
+      });
+      // 1 initial attempt + 3 retries — proves retry actually ran, not just
+      // that the eventual failure is reported.
+      expect(apiGet).toHaveBeenCalledTimes(4);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
-  it('returns nulls when the proxy resolves with no candidates', async () => {
+  it('BUG-73: retries a transient failure and succeeds — a mocked endpoint failing twice then succeeding populates country/region with failed:false', async () => {
+    vi.useFakeTimers();
+    try {
+      const result: GeocodeResult = {
+        candidates: [
+          {
+            name: 'Springfield',
+            display_name: 'Springfield, Illinois, USA',
+            country_code: 'us',
+            region_iso: 'US-IL',
+            latitude: 39.78,
+            longitude: -89.65,
+          },
+        ],
+        country_code: 'us',
+        region_iso: 'US-IL',
+      };
+      vi.mocked(apiGet)
+        .mockRejectedValueOnce(new Error('502'))
+        .mockRejectedValueOnce(new Error('502'))
+        .mockResolvedValueOnce(result);
+
+      const promise = lookupCityCountry('Springfield');
+      await vi.runAllTimersAsync();
+      const { countryCode, regionIso, candidates, failed } = await promise;
+
+      expect(apiGet).toHaveBeenCalledTimes(3);
+      expect(failed).toBe(false);
+      expect(countryCode).toBe('US');
+      expect(regionIso).toBe('US-IL');
+      expect(candidates).toEqual(result.candidates);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('returns nulls and failed:false when the proxy resolves with no candidates (found-nothing is not a failure)', async () => {
     const result: GeocodeResult = { candidates: [], country_code: null, region_iso: null };
     vi.mocked(apiGet).mockResolvedValue(result);
 
-    const { countryCode, regionIso, candidates } = await lookupCityCountry('Zzznotacity');
+    const { countryCode, regionIso, candidates, failed } = await lookupCityCountry('Zzznotacity');
 
     expect(countryCode).toBeNull();
     expect(regionIso).toBeNull();
     expect(candidates).toEqual([]);
+    expect(failed).toBe(false);
   });
 });

--- a/src/frontend/hooks/useCities.ts
+++ b/src/frontend/hooks/useCities.ts
@@ -19,6 +19,42 @@ import type { RatingSortOrder } from './useItems';
 // ============================================================
 
 /**
+ * BUG-73: `retry: 3` on the QueryClient (main.tsx) governs `useQuery` hooks
+ * only — this call is a plain async function, not a query, so it inherits
+ * none of that policy. Retry has to be implemented explicitly here. Same
+ * attempt count as the query default (3 retries → 4 total attempts); a short
+ * fixed backoff is used rather than the query default's exponential curve
+ * (up to ~7s across 3 retries) because this blocks a foreground modal's
+ * auto-populate state, not a background refetch.
+ */
+const GEOCODE_RETRY_ATTEMPTS = 3;
+const GEOCODE_RETRY_DELAY_MS = 250;
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Calls GET /api/geocode, retrying transient failures up to
+ * GEOCODE_RETRY_ATTEMPTS times before rethrowing the last error.
+ */
+async function fetchGeocodeResultWithRetry(cityName: string): Promise<GeocodeResult> {
+  const params = new URLSearchParams({ q: cityName });
+  let lastError: unknown;
+  for (let attempt = 0; attempt <= GEOCODE_RETRY_ATTEMPTS; attempt++) {
+    try {
+      return await apiGet<GeocodeResult>(`/api/geocode?${params}`);
+    } catch (err) {
+      lastError = err;
+      if (attempt < GEOCODE_RETRY_ATTEMPTS) {
+        await delay(GEOCODE_RETRY_DELAY_MS);
+      }
+    }
+  }
+  throw lastError;
+}
+
+/**
  * Looks up a city name via the backend geocode proxy (GET /api/geocode) and
  * returns the top candidate's ISO 3166-1 alpha-2 country code and ISO 3166-2
  * subdivision code, plus the full candidate list for D14 ambiguity handling.
@@ -30,29 +66,37 @@ import type { RatingSortOrder } from './useItems';
  * identifying UA Nominatim's usage policy requires. The proxy owns egress now.
  *
  * Used by AddPlaceFlow to auto-populate the country and region fields (GE-15, UX-04).
- * Fire-and-forget style — errors are silently swallowed (same contract as
- * before the D7 repoint) so the user can still select the country/region
- * manually if lookup fails.
+ * BUG-73: a transient failure is retried (see fetchGeocodeResultWithRetry)
+ * before being reported. This function itself still never throws — the
+ * caller keeps its manual-entry fallback with no try/catch required — but
+ * unlike the pre-BUG-73 contract, a lookup that fails after retries are
+ * exhausted is now distinguishable from one that succeeded and legitimately
+ * found nothing: `failed: true` vs `failed: false` with null fields. Callers
+ * that only care about "did it resolve" can keep ignoring `failed`; the
+ * caller that needs to be honest with the user in AddPlaceFlow.tsx now checks it.
  *
  * @param cityName - The city name to look up.
  * @returns Upper-cased country code (e.g. "FR"), region ISO (e.g. "US-CA"),
- *   both nullable, and the full candidate list (empty on any failure).
+ *   both nullable, the full candidate list (empty on any failure), and
+ *   `failed` — true only when retries were exhausted without a successful
+ *   response (never true for a successful "no match" response).
  */
 export async function lookupCityCountry(cityName: string): Promise<{
   countryCode: string | null;
   regionIso: string | null;
   candidates: GeocodeCandidate[];
+  failed: boolean;
 }> {
   try {
-    const params = new URLSearchParams({ q: cityName });
-    const result = await apiGet<GeocodeResult>(`/api/geocode?${params}`);
+    const result = await fetchGeocodeResultWithRetry(cityName);
     return {
       countryCode: result.country_code?.toUpperCase() ?? null,
       regionIso: result.region_iso ?? null,
       candidates: result.candidates,
+      failed: false,
     };
   } catch {
-    return { countryCode: null, regionIso: null, candidates: [] };
+    return { countryCode: null, regionIso: null, candidates: [], failed: true };
   }
 }
 


### PR DESCRIPTION
Closes #352
BRD §GE-15, §GE-16

## Problem
`GET /api/geocode` (proxied via `lookupCityCountry`, `src/frontend/hooks/useCities.ts`) bypasses React Query entirely — it's a plain async function, not a `useQuery` — so the QueryClient's `retry: 3` default (`src/frontend/main.tsx:33`) never applied to it. A transient failure (e.g. the ENV-02 502s seen during the ADL-46 deployment shakedown) rendered identically to "the lookup ran and found nothing" and "the lookup never ran" — no signal reached the user at all.

## Fix
- `fetchGeocodeResultWithRetry` (new, `useCities.ts`) retries a failed `GET /api/geocode` up to 3 times (matching the query default's attempt count — 1 initial + 3 retries) with a short fixed 250ms backoff, before giving up.
- `lookupCityCountry`'s resolved value now carries `failed: boolean`. Previously "retries exhausted" and a successful "no match" both collapsed to the identical `{countryCode: null, regionIso: null, candidates: []}` shape — now they're distinguishable. `lookupCityCountry` itself still never throws, so `AddPlaceFlow` needs no try/catch to keep its manual-entry fallback.
- `AddPlaceFlow.tsx` shows a non-blocking amber message ("Automatic lookup failed — you can select country and region manually.") plus a manual **Retry** action once retries are exhausted. The D14 ambiguity computation (`AddPlaceFlow.tsx:250-263`, BUG-71, in flight separately) is byte-for-byte unchanged and is short-circuited (never entered) on a failed lookup — there's nothing to disambiguate.

### Mechanism chosen: retry inside the existing plain function
The issue named three options (`useMutation`, `useQuery` with `enabled:false`, or retry inside the plain function). I chose the third:
- **Smallest blast radius** — `lookupCityCountry`'s call site and never-throws contract in `AddPlaceFlow.tsx` are unchanged; only the resolved shape gained a `failed` field.
- **Avoids the `useMutation` trap called out in the issue** — mutations don't inherit `defaultOptions.queries.retry`, so that path needs its own explicit retry config; not needed here since I never introduce a mutation.
- **Zero collision risk with BUG-71**, in flight on the same component (and the same D14 test file) — switching to a hook-based call would have required restructuring `handleOpenNewCityForm` and updating `AddPlaceFlow.test.tsx`'s module mock, both of which touch the exact area under a separate Architect ruling.

## Success criteria
1. Transient failure retried before any error is shown — PASS (`fetchGeocodeResultWithRetry`, proven in test below)
2. A test proves the retry actually happens — PASS: `useCities.geocode.test.tsx` — "retries a transient failure and succeeds" mocks apiGet failing twice then succeeding, asserts 3 calls and a populated, `failed: false` result
3. Non-blocking visible failure message once retries exhausted — PASS (`AddPlaceFlow.geocodeFailure.test.tsx`)
4. Manual-entry fallback works in every failure case — PASS, covered by "keeps the manual-entry fallback fully usable after a failed lookup"
5. Three outcomes distinguishable; "found nothing" never renders as failure — PASS, covered by dedicated found-nothing test
6. Failure state clears on a subsequent successful lookup — PASS, covered by the Retry-action test
7. `test:frontend` green, `type:check:all` clean, biome clean — PASS (see below)

## Out of scope (respected)
- No changes to `AddPlaceFlow.tsx:250-263`, `candidateRegionIsos`, `setAutoRegionIso` (BUG-71 logic, content unchanged — only surrounding lines added).
- No changes to the city search dropdown label (BUG-72).
- No backend files touched.

## Testing
- `npm run test:frontend` — 242/242 passed (32 files)
- `npm run test:backend` — 665/665 passed
- `npm run type:check:all` — clean
- `npx biome check` — clean
- `npm run status:check` — up to date