### PR TITLE
chore(ADL-48): bundled gazetteer build-vs-buy — local-first index, geocoder for the tail

### DIFF
--- a/jobs/COO/20260731-review-execution-queue.md
+++ b/jobs/COO/20260731-review-execution-queue.md
@@ -170,6 +170,23 @@ Misleading docs to fix in the same pass:
 both doc comments corrected.
 
 ### 13. ISO 3166-2 reference-data adoption (Architect ADL first — BRD gate)
+
+> **DISCHARGED AND PARTLY CORRECTED (2026-08-01) by ADL-48 — retained for history.** The ADL this
+> item asks for now exists: `jobs/architect/tech/ADL-48-bundled-gazetteer.md`. Two corrections to
+> the item as written, both established in ADL-48 §13.3:
+> 1. **OQ-06 was already *decided* by ADL-43 on 2026-07-27** and is `closed` in the tracker — this
+>    item queued an ADL that already existed. What was genuinely outstanding was the *implementation*
+>    brief, and now a **source correction**: ADL-48 §13.1 amends ADL-43 S1 from `country-region-data`
+>    to `iso3166-2-db`, because the latter returns GB at the constituent-country tier
+>    (`GB-ENG/SCT/WLS/NIR`) that ADL-43 §6.1 correctly established no other source does.
+> 2. **BUG-45 does not belong in this item.** It shares a *decision shape* but has **zero source
+>    overlap** (OpenFlights airlines vs a GeoNames gazetteer). Bundling them invites a single brief
+>    that tries to seed airlines from a city dataset. ADL-43 §3/§4 remains the live design for BUG-45
+>    and is untouched by ADL-48.
+>
+> **Disposition:** ADL-48 closes OQ-06's implementation question, the BUG-30 class and D-14 tier 2,
+> and re-scopes D-19. It does **not** close BUG-45. Dispatchable as three independently-green stages
+> (ADL-48 §11); **stage S1 needs no BRD change**, stages S2/S3 are gated on new IDs GE-17/GE-18.
 Build-vs-buy decision that closes four backlog threads at once: OQ-06 (its literal question),
 D-14 (USA/US search wants ISO codes), the BUG-30 class (hand-seeded region gaps), BUG-45
 (airline/provider lists — separate dataset, same decision shape). Architect to evaluate

--- a/jobs/COO/inbox/20260801_2200-ARCHITECT-ADL48-gazetteer-build-vs-buy.txt
+++ b/jobs/COO/inbox/20260801_2200-ARCHITECT-ADL48-gazetteer-build-vs-buy.txt
@@ -1,0 +1,73 @@
+TO: COO
+FROM: Architect (fresh dispatch)
+DATE: 2026-08-01
+RE: ADL-48 — bundled gazetteer build-vs-buy · Branch chore/gazetteer-build-vs-buy-adl
+BRD: §5.2 — two new IDs proposed (GE-17, GE-18) + a REQUIRED GE-16 amendment
+PR: see below · Tracker: OQ-06, BUG-30 class, D-14, D-19, BUG-71, BUG-45 (NOT closed)
+
+DECIDED. The PO is substantially right, with one material correction: bundle the
+gazetteer as a LOCAL-FIRST INDEX, not as a geocoder replacement. The geocoder is
+demoted to the tail path, not retired.
+
+PER-DECISION VERDICT
+- Bundle a gazetteer — ADOPTED (local-first; pure replacement REJECTED on coverage).
+- Keep the geocoder for the tail — ADOPTED. "Manual entry, no pin" REJECTED.
+- cities.json (CC-BY-4.0, 170,540 rows, monthly) — ADOPTED. all-the-cities REJECTED
+  (declares MIT over CC-BY GeoNames data; stale 2020). country-state-city REJECTED (GPL-3.0).
+- iso3166-2-db (MIT) for subdivisions AND the crosswalk — ADOPTED as a devDependency.
+- ADL-43 S1 amended: country-region-data -> iso3166-2-db. S3's override table loses its
+  one confirmed case. S2/S4/S5 stand. STAMPED in this PR.
+- BUG-71 ruling + its OP-27 review — NARROWED, not superseded. STAMPED. See BLOCKERS.
+- Separate gazetteer_cities table; `cities` NOT replaced, NOT migrated, NO backfill — ADOPTED.
+- Exec-queue item 13 corrected; D-19 re-scoped. Both STAMPED.
+
+WHY THE COVERAGE ANSWER DECIDED IT (the part to put to the PO)
+Of 16 Scottish places probed against both datasets: Glasgow, Edinburgh, Inverness,
+Ullapool, Aviemore, Portree, Tarbert are IN. Plockton, Applecross, Shieldaig, Lochinver,
+Durness, Kyleakin, Gairloch, Dornie, Braemar are ABSENT FROM BOTH. The floor is roughly
+"somebody's home town" in, "hamlet or single-attraction place" out. BUG-30's own note
+says the Scotland dogfood trial is the trigger requirement — a gazetteer-only build ships
+a product that cannot record the trip it was built for.
+
+THE FINDING THAT WOULD HAVE WRECKED A NAIVE BUILD
+GeoNames admin1 codes are NOT ISO 3166-2. Correct for 2 of 26 enabled countries (GB, US);
+20 are purely numeric. A "same source family" build writes AU-08 where the app expects
+AU-NSW, silently, and passes every test written against the only two countries with
+seeded regions today. The crosswalk lives inside iso3166-2-db: 99.28% join rate, and all
+76 currently-seeded region codes match EXACTLY — strict superset, no user-row backfill.
+
+CI: no code committed — design + docs only. PR CI green (docs-only change).
+
+BLOCKERS / DECISIONS YOU OWN
+1. BRD GATE. Stage S1 (subdivisions) needs NO BRD change and is dispatchable NOW —
+   it closes the BUG-30 class, 22 latent instances -> 0. Stages S2/S3 are BLOCKED until
+   GE-17 + GE-18 exist with the success criteria in ADL-48 §12.1, AND GE-16's definition
+   of "resolved" is amended ("the geocoder matched it" makes a gazetteer-sourced Glasgow
+   unrepresentable).
+2. DO NOT HOLD BUG-71 FOR THIS. It is a live P1; ADL-48 is a multi-stage build behind a
+   BRD gate. Ship the BUG-71 backend + frontend briefs as designed.
+3. PO SCOPE CALL: the recommendation is coherent ONLY as "gazetteer first, geocoder for
+   the tail". If it gets salami-sliced into "gazetteer only", reconsider it wholesale.
+4. TWO UNVERIFIED ITEMS, both flagged as brief-blockers not resolved here:
+   (a) Turso cold-seed cost/storage — all timings are LOCAL libSQL (618ms/12.47MB).
+       The S2 database brief must measure it before S3 depends on it.
+   (b) That Nominatim actually HAS Plockton/Shieldaig/Dornie — ENV-01 blocks the probe.
+       This gates the whole tail strategy. Add it to the next staging shakedown.
+5. TRIVIAL DEFECT, escalated not fixed: src/backend/services/startup.service.ts:161
+   says "72 total"; real figure is 76 (stale since PR #168). Line 10 omits GB. Left
+   alone deliberately — design-only PR. Fold into the S1 database brief.
+
+NOT CLOSED BY THIS — do not let the tracker read otherwise
+BUG-45 (zero source overlap with this dataset — item 13 wrongly bundles it), BUG-69,
+BUG-74, QUAL-22, UX-12, ENV-02. NO credit taken for BUG-55 or BUG-33; both already closed.
+
+NOW UNBLOCKED
+Stage S1 database brief (subdivisions, no BRD gate). ADL-48 §11 gives three
+independently-green stages per ADL-47 — no integration branch needed.
+
+EXPECTED: OP-27 fresh-eyes review. I named the two weakest points myself in the
+document's closing line so the reviewer starts there.
+
+Detail: jobs/architect/tech/ADL-48-bundled-gazetteer.md
+Log entry: jobs/architect/tech/20260307-architecture-decisions-log.md — ADL-48
+Park doc: jobs/architect/park-docs/20260801-ARCHITECT-park-adl48.txt

--- a/jobs/COO/open-dialogues.md
+++ b/jobs/COO/open-dialogues.md
@@ -117,6 +117,19 @@ resolve-then-create path primary.
 **Artifacts:** `jobs/ux/tech/20260801-UX-city-entry-and-disambiguation-spec.md` (merged, PR #344) ·
 tracker UX-12, QUAL-21 · BRD GE-15/GE-16.
 
+> **RE-SCOPED (2026-08-01) by ADL-48 §6.9 — not closed, and still needs the PO's scope call.**
+> ADL-48 decides to bundle a local city gazetteer (170,540 rows) queried before Nominatim. Against a
+> local table, D-19's design problem collapses to a single clause:
+> `ORDER BY (country_code IN (/* trip countries */)) DESC, name`. That **is** the PO's
+> shortlist-not-filter pattern exactly — nothing is removed, likely matches sort first — with no
+> rate-limit interaction, no extra egress and no truncation risk, and the UX spec's `<optgroup>`
+> presentation sits on top unchanged. Two consequences worth recording: **QUAL-21 stops being a
+> prerequisite** in the form stated above (the primary path is a SQL query, not the untested
+> resolve-then-create path), and the *"a selection the geocoder cannot confirm stays pending"* item 3
+> becomes cheap because a complete local set can positively confirm. **D-19 should be picked up as a
+> consequence of ADL-48 stage S3 rather than designed separately** — designing it independently now
+> risks a second, incompatible lookup path. See `jobs/architect/tech/ADL-48-bundled-gazetteer.md`.
+
 ---
 
 ### D-20: Shared-record append collisions — the per-agent-region fix identified in Wave 0 and never adopted

--- a/jobs/architect/context/current.txt
+++ b/jobs/architect/context/current.txt
@@ -1074,3 +1074,83 @@ candidate-volume/truncation-frequency numbers; limit=40 as the max; dedupe-vs-li
 ordering (the load-bearing one); featureType/layer support; countrycodes comma-list
 acceptance server-side (the code-side pass-through IS verified). No browser driven, no
 suite executed.
+
+================================================================================
+2026-08-01 — ADL-48: BUNDLED LOCAL GAZETTEER (build-vs-buy)
+Branch chore/gazetteer-build-vs-buy-adl · fresh dispatch, no authorship of ADL-43,
+ADL-46, the BUG-71 ruling or its review.
+================================================================================
+
+TRIGGER: PO after a day of geocoding defects — "wouldn't it be easier just to store
+a full cities list in a DB table?" Folded in execution-queue Tier 2 item 13.
+
+VERDICT: PO substantially right, with one material correction. Bundle a gazetteer as a
+LOCAL-FIRST INDEX, not as a geocoder replacement. The geocoder is demoted to the tail
+path, not retired.
+
+THE DECIDING EVIDENCE — coverage floor probed with real names, not population theory.
+Of 16 Scottish places probed against BOTH candidate datasets (two probes that fail
+differently: exact-match-in-GB, and case-insensitive substring across all 246 countries):
+  PRESENT in both: Glasgow, Edinburgh, Inverness, Ullapool, Aviemore, Portree, Tarbert
+  ABSENT from both: Plockton, Applecross, Shieldaig, Lochinver, Durness, Kyleakin,
+                    Gairloch, Dornie, Braemar
+  DISAGREE: Tobermory (in all-the-cities pop 1010; absent from cities.json)
+The floor is roughly "somebody's home town" in / "hamlet or single-attraction place" out.
+BUG-30's own note says the Scotland dogfood trial is the trigger requirement — so a pure
+replacement would ship a product that cannot record the trip it was built for. Dispositive.
+
+SOURCES (all verified by installing and reading, nothing from memory; all npm-reachable,
+so NO ADL-33 firewall amendment needed):
+  cities.json 1.1.61 — CC-BY-4.0, GeoNames, 170,540 cities/246 countries, ships
+    admin1.json+admin2.json, MONTHLY (65 registry publish timestamps, not the README).
+  iso3166-2-db 2.3.11 — MIT, 3,940 subdivisions, AND the GeoNames->ISO crosswalk. devDependency.
+  REJECTED: all-the-cities (declares MIT over CC-BY GeoNames data; 6 yrs stale; its own
+    "pop >= 1000" claim false for 22,913 of 135,233 rows); country-state-city (GPL-3.0).
+
+LOAD-BEARING STRUCTURAL FINDING — the one that would have wrecked a naive build:
+GeoNames admin1 codes ARE NOT ISO 3166-2. "<CC>-"+admin1 is correct for exactly 2 of the
+26 region_tier_enabled countries (GB, US); 20 are purely numeric (AU->08, CA->01, DE->15).
+A naive build writes AU-08 where the app expects AU-NSW, silently, and passes every test
+written against the only two countries with seeded regions today.
+CROSSWALK: iso3166-2-db carries admin (GeoNames) + iso (ISO) per subdivision.
+Measured: 99.28% of city rows in enabled countries join; ALL 76 currently-seeded region
+codes match exactly -> strict superset, NO user-row backfill.
+
+TOPOLOGY: new gazetteer_cities reference table; cities NOT replaced, NOT migrated. No FK
+ever points at the gazetteer (that is what makes delete-and-reload refresh safe). User
+rows created FROM it through the unchanged ADL-46 find-or-create.
+
+MEASURED (local libSQL, real data): cold seed 170,540 rows = 618ms; DB 12.47MB; the
+springfield ambiguity GROUP BY = 21 groups in <1ms. Repo precedent: geo/regions.json is
+already 40MB.
+
+WHAT IT CLOSES: OQ-06 implementation, BUG-30 class (22 latent -> 0), D-14 tier 2, and
+substantially ENV-01's test blindness on the primary path (the strongest single argument —
+it moves the common case INSIDE the CI-testable boundary).
+WHAT IT DOES NOT: BUG-45 (zero source overlap — item 13 wrongly bundles it), BUG-69,
+BUG-74, QUAL-22, UX-12, ENV-02. NO credit taken for BUG-55 or BUG-33 (already closed).
+D-19 re-scoped from a design problem to an ORDER BY.
+
+AMENDMENTS MADE (stamped in this PR):
+  ADL-43 S1: country-region-data -> iso3166-2-db. ADL-43 §6.1 was RIGHT (re-verified
+    independently: country-region-data GB = 217 council rows, no ENG/SCT/WLS/NIR) but
+    missed that a third source returns exactly those four. S3's override table loses its
+    one confirmed case. S2/S4/S5 stand.
+  BUG-71 ruling + its OP-27 review: NARROWED, not superseded. SHIP BUG-71 NOW — do not
+    hold a live P1 behind this. classifyDiscovery survives as the tail-path classifier;
+    the review's three-valued output is STRENGTHENED ('suggested' becomes precisely and
+    only the tail state); the review's F2 never-helps concern is substantially answered.
+  Execution-queue item 13: partly stale (OQ-06 already decided by ADL-43 2026-07-27).
+  open-dialogues D-19: re-scoped.
+
+BRD: two new IDs proposed with success criteria (GE-17 bundled city reference data,
+GE-18 provenance/attribution) + a REQUIRED GE-16 amendment — "resolved" currently means
+"the geocoder matched it", which makes a gazetteer-sourced Glasgow unrepresentable.
+Stage S1 needs NO BRD change; S2/S3 are gated.
+
+UNVERIFIED, both flagged as blockers on the relevant brief rather than resolved:
+  (1) Turso cold-seed cost and storage headroom — all timings are LOCAL libSQL. Gates S2.
+  (2) That Nominatim actually HAS Plockton/Shieldaig/Dornie — ENV-01 blocks the probe.
+      This gates the whole tail strategy: if it doesn't, the §2.1 decision must be retaken.
+
+NEXT: OP-27 fresh-eyes review expected. I named the two places to attack first in the doc.

--- a/jobs/architect/park-docs/20260801-ARCHITECT-park-adl48.txt
+++ b/jobs/architect/park-docs/20260801-ARCHITECT-park-adl48.txt
@@ -1,0 +1,125 @@
+PARK DOCUMENT — ARCHITECT — 2026-08-01
+ADL-48: Bundled local gazetteer — build vs buy for city and subdivision reference data
+Branch: chore/gazetteer-build-vs-buy-adl
+
+================================================================================
+WHAT THIS THREAD WAS
+================================================================================
+Fresh Architect dispatch (no authorship of ADL-43, ADL-46, the BUG-71 ruling, its
+fresh-eyes review, or the UX spec). Task: decide on evidence whether to replace
+live geocoder-driven city discovery with a bundled local gazetteer, explicitly
+including deciding AGAINST it. Folded in execution-queue Tier 2 item 13 (ISO 3166-2).
+
+Deliverables:
+  jobs/architect/tech/ADL-48-bundled-gazetteer.md          (standalone, evidence + design)
+  jobs/architect/tech/20260307-architecture-decisions-log.md — ADL-48 entry (decision of record)
+  Amendment stamps: ADL-43 (S1/S3), BUG-71 ruling, BUG-71 review, exec-queue item 13, D-19
+
+================================================================================
+THE DECISION IN ONE LINE
+================================================================================
+Bundle the gazetteer as a LOCAL-FIRST INDEX; keep the geocoder for the tail.
+Not a replacement — a reordering. The geocoder is demoted, not retired.
+
+================================================================================
+WHERE THE EVIDENCE LIVES (probe scripts, if anyone needs to re-run)
+================================================================================
+Scratch dir (session-scoped, NOT in the repo):
+  /tmp/claude-1000/-workspace/d8d4dd31-.../scratchpad/gaz/
+    probe.mjs   — cities.json row counts, shape, Scotland coverage, Springfield
+    probe2.mjs  — admin1 code style by country; city->admin1 join rate
+    probe3.mjs  — all-the-cities coverage + population distribution
+    probe4.mjs  — SECOND independent probe of every absence claim (substring, all countries)
+    probe5.mjs  — the decisive GeoNames-admin1-vs-ISO-3166-2 test over the 26 enabled countries
+    probe6.mjs  — discovery of the crosswalk inside iso3166-2-db
+    probe7.mjs  — end-to-end crosswalk integration test (99.28%, 76/76)
+    probe8.mjs  — real libSQL build: seed timing, DB size, ambiguity query latency
+NOTE: these are scratch and will not survive. Every number they produced is recorded in
+ADL-48 §3, §4.1, §8.2 and §15.2 with the method stated, so the ADL stands alone.
+
+================================================================================
+THE THREE FINDINGS THAT MATTER MOST TO WHOEVER PICKS THIS UP
+================================================================================
+1. GeoNames admin1 codes ARE NOT ISO 3166-2 codes. Correct for 2 of 26 enabled
+   countries (GB, US); 20 purely numeric. A naive "same source family" build writes
+   AU-08 where the app expects AU-NSW — silently — and passes every test written
+   against the only two countries with seeded regions today. The crosswalk is inside
+   iso3166-2-db (field `admin` = GeoNames, field `iso` = ISO). 99.28% join rate;
+   all 76 currently-seeded codes match exactly, so NO backfill of user rows.
+
+2. The coverage floor is real and it bites Scotland specifically. 9 of 16 probed
+   Scottish places are absent from BOTH candidate datasets. BUG-30's own tracker note
+   records the Scotland dogfood trial as the trigger requirement. That is why the
+   recommendation is gazetteer-FIRST rather than gazetteer-ONLY, and it is the reason
+   the design must not be salami-sliced into "gazetteer only" later.
+
+3. ADL-43 §6.1 was right about country-region-data and Natural Earth (re-verified
+   independently: 217 GB council-tier rows, none of ENG/SCT/WLS/NIR) but did not test
+   a third source. iso3166-2-db returns exactly those four. That removes the mandatory
+   per-country override table from the critical path.
+
+================================================================================
+BUGS / DEFECTS DISCOVERED THIS THREAD
+================================================================================
+[TRIVIAL] src/backend/services/startup.service.ts:161 docstring says "Seeds US (51),
+  AU (8), and CA (13) entries — 72 total." Stale since BUG-30 / PR #168: the real
+  figure is 76 across US/AU/CA/GB. Line 10 likewise omits GB.
+  Disposition: ESCALATED TO COO, deliberately NOT fixed here. This is a design-only
+  PR; touching source to fix a comment would scope-creep it. It matters because it is
+  the most quotable-looking source of a wrong "currently seeded" baseline, and ADL-48
+  cites that baseline. Recommend folding into the ADL-48 S1 database brief, which
+  rewrites that seeder anyway.
+
+[TRIVIAL] npm package `all-the-cities` advertises "138,398 cities … population of at
+  least 1000". Actual: 135,233 rows, of which 22,913 are below 1000 and 12,788 are
+  exactly 0. Upstream defect, not ours. Disposition: recorded in ADL-48 §3 as part of
+  the rejection rationale. No action.
+
+No MAJOR or CRITICAL bugs discovered. No reclassifications.
+
+================================================================================
+OPEN / UNVERIFIED — CARRIED FORWARD DELIBERATELY
+================================================================================
+U1. Turso cold-seed cost and storage headroom. ALL timings in ADL-48 are LOCAL libSQL
+    (618ms / 12.47MB). Remote libSQL pays a round-trip per batch. GATES STAGE S2 —
+    the Database brief must measure it before S3 depends on it. Probe: time one
+    2,000-row batch via scripts/agent-diagnostics/turso-query.mjs against staging.
+
+U2. Whether Nominatim actually HAS the tail villages (Plockton, Shieldaig, Dornie).
+    ENV-01 blocks the probe from this devcontainer. THIS GATES THE WHOLE TAIL STRATEGY:
+    the recommendation to keep the geocoder for the tail assumes it can serve the tail.
+    If it cannot, ADL-48 §2.1 must be re-decided and the whole proposal reconsidered.
+    Probe: the staging deployment shakedown, or an allowlisted host.
+
+U3. feature_code (the ranking signal that would substitute for the missing population
+    column) is NOT present on cities.json rows — verified absent. Recovering it via a
+    join to all-the-cities is unverified and lossy. Design does not depend on it.
+
+================================================================================
+WHAT IS NOW UNBLOCKED / WHAT IS NOT
+================================================================================
+UNBLOCKED IMMEDIATELY (no BRD change needed):
+  Stage S1 — subdivisions. data/regions.json 76 -> 716 rows, purely additive, closes
+  the BUG-30 class (22 latent instances -> 0). Worth dispatching even if the PO
+  declines the cities half — that separation is deliberate.
+
+BLOCKED ON THE BRD GATE (COO must add GE-17 + GE-18 with the success criteria stated
+in ADL-48 §12.1, and amend GE-16's definition of "resolved"):
+  Stage S2 — gazetteer table + seed.  Stage S3 — local-first lookup.
+
+NOT AFFECTED, SHIP AS PLANNED:
+  BUG-71 backend + frontend briefs. ADL-48 explicitly says do NOT hold a live P1
+  behind this multi-stage build. classifyDiscovery survives as the tail classifier.
+
+STILL OPEN, UNTOUCHED BY THIS ADL:
+  BUG-45 (zero source overlap), BUG-69, BUG-74, QUAL-22, UX-12, ENV-02.
+
+================================================================================
+EXPECTED NEXT STEP
+================================================================================
+OP-27 fresh-eyes review of ADL-48 by a second, freshly dispatched Architect.
+I wrote it to be attacked and named the two weakest points myself in the closing
+line of the document: §2.1's tail strategy rests on U2, and §8.3's Turso timing is U1.
+A reviewer should also press on whether §5.1's no-FK-on-country_code exception is
+justified, and whether the three-stage split in §11 really keeps S2 green given S2
+ships a table nothing reads.

--- a/jobs/architect/tech/20260307-architecture-decisions-log.md
+++ b/jobs/architect/tech/20260307-architecture-decisions-log.md
@@ -3958,3 +3958,99 @@ a hard cutover across briefs, not a flaw in the rule.
 **Supersession:** none. Complements ADL-15 (drizzle-kit migrate workflow, `db:push` forbidden) and
 ADL-32 (Railway/Turso staging-watches-main promotion model) — expand/contract is the *authoring*
 discipline that keeps that auto-deploy path safe.
+
+---
+
+## ADL-48 — Bundled local gazetteer: buy the reference data, keep the geocoder for the tail
+
+**Date:** 2026-08-01
+**Status:** Decided, implementation pending. **No schema, migration, seed data or code change was
+made by this ADL** — it is the design that unblocks those briefs. Full evidence, table shapes,
+measurements and rejected alternatives: `jobs/architect/tech/ADL-48-bundled-gazetteer.md`.
+**Trigger.** The PO, after a day of geocoding defect-fighting: *"Are we over-engineering this?
+Wouldn't it be easier just to store a full cities list in a DB table? If we are querying a list via
+API anyway?"* Folded in: execution-queue Tier 2 item 13 (ISO 3166-2 reference-data build-vs-buy).
+**Tracker:** OQ-06 · BUG-30 (class) · D-14 · D-19 · BUG-71 · BUG-74 · BUG-69 · ENV-01 · QUAL-21/22 · UX-12 · BUG-45 (explicitly *not* closed).
+**BRD:** §5.2. **Two new IDs proposed (GE-17, GE-18) with success criteria, plus a required GE-16
+amendment** — see the standalone file §12. The BRD gate blocks stages S2/S3, **not** S1.
+
+**Decision — the PO is substantially right, with one material correction.**
+
+1. **Bundle a gazetteer, as a local-first *index* — not as a replacement for the geocoder.** The
+   geocoder is demoted from "the only path" to "the tail path". A pure replacement was tested
+   against real place names and **fails this project's own flagship use case**: of 16 Scottish
+   places probed, Glasgow / Edinburgh / Inverness / Ullapool / Aviemore / Portree / Tarbert are
+   present in both candidate datasets, but **Plockton, Applecross, Shieldaig, Lochinver, Durness,
+   Kyleakin, Gairloch, Dornie and Braemar are absent from both** — and BUG-30's own note records
+   that the Scotland dogfood trial is the trigger requirement. The coverage floor is real and it
+   bites exactly where this project travels.
+2. **Sources: `cities.json`** (npm, **CC-BY-4.0**, GeoNames-derived, 170,540 cities / 246 countries,
+   published **monthly** — verified from the registry's 65 publish timestamps, not the README) **and
+   `iso3166-2-db`** (npm, MIT, 3,940 subdivisions) as a **`devDependency`** build-time generator.
+   Both reachable over the npm registry, so **no ADL-33 firewall amendment is required.**
+   `all-the-cities` rejected: declares MIT over CC-BY GeoNames data, six years stale, and its own
+   "population ≥ 1000" claim is false for 22,913 of its rows. `country-state-city` rejected: GPL-3.0.
+3. **Load-bearing structural finding.** **GeoNames `admin1` codes are not ISO 3166-2 codes** — the
+   naive concatenation `"<CC>-"+admin1` is correct for exactly **2 of the 26** `region_tier_enabled`
+   countries (GB, US); 20 are purely numeric (`AU`→`08`, `CA`→`01`, `DE`→`15`). A build that assumed
+   the "same source family" would have written `AU-08` where the app expects `AU-NSW`, silently, and
+   passed every test written against the only two countries with seeded regions today.
+   **`iso3166-2-db` carries the crosswalk** (`admin` = GeoNames code, `iso` = ISO suffix):
+   **99.28 %** of city rows in enabled countries join, and **all 76 currently-seeded region codes
+   match exactly** — so the region set is a strict superset and **no user-row backfill is needed.**
+4. **Topology: a new `gazetteer_cities` reference table. `cities` is not replaced and not migrated.**
+   No FK ever points at the gazetteer; user rows are *created from* it through the unchanged ADL-46
+   find-or-create. That is what makes a delete-and-reload refresh safe by construction.
+5. **Seed: content-hash-gated startup seed** extending `startup.service.ts`. Steady-state boot cost is
+   one indexed `SELECT`. Measured cold seed against local libSQL: **618 ms, 12.47 MB, ambiguity
+   `GROUP BY` in < 1 ms.** (Repo precedent: `geo/regions.json` is already 40 MB.)
+6. **Refresh: on-demand and trigger-driven, not scheduled** — a monthly bot PR of a 17 MB artifact
+   trains reviewers to rubber-stamp. **Attribution is a real CC-BY obligation** and surfaces on a new
+   in-product About/Credits surface (GeoNames CC BY 4.0 · OpenStreetMap ODbL · Natural Earth),
+   discharging an obligation ADL-43 §6.2 and BUG-55 both already flagged and neither closed.
+
+**Alternatives considered.** *Gazetteer replaces the geocoder entirely* — rejected, §2's coverage
+floor. *Manual entry with no pin for the tail* — rejected: trades a user-visible product regression
+for an internal simplification, on precisely the places the PO travels to. *Load the gazetteer into
+`cities`* — rejected: a refreshable dataset must never be FK-referenced by user data, and it would
+dilute GE-16's three end states to nothing. *Do nothing and rely on the BUG-71 fix* — rejected, but
+**only partly**: the BUG-71 fix is correct and should ship now (below); it makes the common case
+*blank* rather than wrong, and the gazetteer is the only proposal that makes the common case
+correct *and* better.
+
+**What it closes, and what it does not.** Closes **OQ-06**'s implementation, the **BUG-30 class**
+(22 latent instances → 0) and **D-14 tier 2** (ISO alpha-2/alpha-3 ship in `iso3166-2-db`).
+Substantially closes **ENV-01's test blindness on the primary path** — the single strongest argument
+here, because it moves the common case *inside* the CI-testable boundary, which no amount of
+test-writing against the current architecture achieves. Re-scopes **D-19** from a design problem to
+an `ORDER BY`. **Does NOT close: BUG-45** (different dataset, zero source overlap — execution-queue
+item 13 wrongly bundles them), **BUG-69**, **BUG-74**, **QUAL-22**, **UX-12**, **ENV-02**. Takes **no
+credit** for **BUG-55** or **BUG-33**, both already closed by other work.
+
+**Implementation implications.**
+- **Three independently-green stages (ADL-47 satisfied without an integration branch):** **S1**
+  subdivisions (`data/regions.json` 76 → 716 rows, purely additive — *independently worth shipping
+  even if the cities half is declined*); **S2** `gazetteer_cities` + seed (no route reads it yet —
+  this is where the Turso timing question gets answered before anything depends on it); **S3**
+  local-first lookup. **S1 must precede S2** — the crosswalk writes region codes that must exist.
+- **UNVERIFIED and gating S2:** cold-seed cost and storage headroom against **Turso** (all timings
+  are local libSQL). **UNVERIFIED and gating the whole tail strategy:** that Nominatim actually *has*
+  Plockton/Shieldaig/Dornie — ENV-01 blocks the probe from here. If it does not, the tail decision
+  must be re-taken.
+- New in-product About/Credits surface (small Frontend item) and `data/gazetteer-meta.json` provenance.
+
+**Supersession.**
+- **ADL-43 §2 S1 and S3 are amended** (stamped in this PR): the subdivision source becomes
+  `iso3166-2-db`, not `country-region-data`. ADL-43 §6.1 was **right** that Natural Earth and
+  `country-region-data` both return 217 GB council-tier rows with none of `GB-ENG/SCT/WLS/NIR`
+  — re-verified independently here — but it did not find that a third source returns **exactly those
+  four**. S3's mandatory per-country override table therefore loses its one confirmed case; the
+  mechanism is kept for VN/ET/KZ but is no longer load-bearing on day one. S2/S4/S5 stand, adopted.
+- **The BUG-71 ruling and its OP-27 review are NARROWED, not superseded** (stamped in this PR).
+  **Ship the BUG-71 fix now — do not hold a live P1 behind this multi-stage build.**
+  `classifyDiscovery` survives as the *tail-path* classifier, and the review's three-valued output is
+  *strengthened*: a complete local set can never be "incomplete but undivided", so `'suggested'`
+  becomes precisely and only the tail-path state.
+- **Execution-queue Tier 2 item 13 is partly stale** and should be corrected: OQ-06 was already
+  decided by ADL-43 on 2026-07-27 (what remained was implementation, and now a source correction),
+  and BUG-45 does not belong in the same item.

--- a/jobs/architect/tech/20260801-BUG71-discovery-ambiguity-ruling.md
+++ b/jobs/architect/tech/20260801-BUG71-discovery-ambiguity-ruling.md
@@ -7,6 +7,21 @@
 **BRD:** GE-16 (violated), GE-15 (in tension — see §8)
 **Inputs:** `jobs/architect/tech/20260801-ADL46-F1-F2-ruling.md` §2.2; `jobs/ux/tech/20260801-UX-city-entry-and-disambiguation-spec.md` §§1, 3.2, 3.3; `jobs/COO/open-dialogues.md` D-19; tracker BUG-71/72/73, QUAL-21/22; `main` @ `a398d10`.
 **Status:** Decided. Backend-implementable as written; a Frontend brief must follow in the same release (§7).
+
+> **NARROWED (2026-08-01) by ADL-48 §13.2 — retained for history; nothing here is retracted, and
+> this ruling should SHIP NOW rather than wait for ADL-48.** ADL-48 decides to bundle a local city
+> gazetteer consulted *before* Nominatim, which changes this ruling's **scope**, not its
+> **correctness**. Every section below describes the discovery path as Nominatim-only; after ADL-48
+> S3 that is true only of the **tail** — names absent from the bundled dataset. Consequences:
+> `classifyDiscovery` **survives** as the tail-path classifier and is still required; `truncated`
+> (§4.1) is structurally unrepresentable for a gazetteer hit, because a local query returns the
+> complete set and "is this ambiguous?" becomes a `GROUP BY`; and the fresh-eyes review's
+> three-valued output is **strengthened** — a complete local set can never be "incomplete but
+> undivided", so `'suggested'` becomes precisely and only the tail-path state. ADL-48 §13.2 also
+> notes that the review's **F2 "never-helps" concern is substantially answered**: the common,
+> high-noise names it worried about (Denver, Paris) are the *most* likely to be in a 170,540-row
+> gazetteer and so resolve locally, completely and confirmably.
+> See `jobs/architect/tech/ADL-48-bundled-gazetteer.md`.
 **No schema change. No migration. No new requirement ID. One existing BRD success criterion (GE-15) must be amended or the correct fix fails its own UAT — §8.**
 
 ---

--- a/jobs/architect/tech/20260801-BUG71-ruling-fresh-eyes-review.md
+++ b/jobs/architect/tech/20260801-BUG71-ruling-fresh-eyes-review.md
@@ -13,6 +13,18 @@
 
 > ## **SHIP WITH CORRECTIONS — and the corrections must land before the Backend brief is dispatched, not after.**
 
+> **NARROWED (2026-08-01) by ADL-48 §13.2 — retained for history; this verdict stands and the
+> BUG-71 work should SHIP NOW, not wait for ADL-48.** ADL-48 bundles a local city gazetteer
+> consulted before Nominatim. Two effects on this review specifically: **(1) F2's "never-helps"
+> failure mode is substantially answered** — categories **B** (Denver, Portland) and **C** (Paris,
+> London, Tokyo), the ones this review correctly identified as the real cost and the ones the PO
+> would notice, are precisely the names most certain to be present in a 170,540-row gazetteer, so
+> they resolve locally from a *complete* set and are confirmable rather than blank. **(2) F1/F3's
+> recommended three-valued output is strengthened and should still be adopted**: a complete local
+> set can never be "incomplete but undivided", so `'suggested'` becomes precisely and only the
+> **tail-path** state, which is a cleaner semantic than either document could give it. Findings
+> F4–F10 and P1–P4 are unaffected. See `jobs/architect/tech/ADL-48-bundled-gazetteer.md`.
+
 The ruling's core direction is right and I am not asking for it to be reversed. Moving the ambiguity decision out of a React component and into the backend (B6) is correct and overdue; "absence of disagreement is not agreement" (§2) is the correct diagnosis of BUG-71; leaving the resolution path alone (B9) is correctly reasoned and correctly scoped.
 
 But the **output shape is wrong**, and it is wrong in a way that cannot be cheaply corrected once `DiscoveryConfidence` ships as an API contract. Three findings converge on the same clause:

--- a/jobs/architect/tech/ADL-43-sourced-reference-data.md
+++ b/jobs/architect/tech/ADL-43-sourced-reference-data.md
@@ -38,11 +38,23 @@ stop being hand-typed, but not all three get there the same way. §6 makes the c
 
 ## 2. Subdivisions (OQ-06)
 
+> **AMENDED (2026-08-01) by ADL-48 §13.1 — S1 and S3 only; S2, S4 and S5 stand unchanged and are
+> adopted. Retained for history.** ADL-48 evaluated a third source, `iso3166-2-db` (npm, MIT), which
+> **returns exactly four GB rows — `GB-ENG`, `GB-SCT`, `GB-WLS`, `GB-NIR`** — matching this project's
+> seeded values byte-for-byte, and which additionally carries the GeoNames→ISO 3166-2 crosswalk that
+> a bundled city gazetteer requires. §6.1's finding below is **correct and was re-verified
+> independently** (`country-region-data` GB → 217 council-tier rows, none of the four); what it
+> missed is that a different source does not have the gap. **S1's source therefore becomes
+> `iso3166-2-db`**, and **S3's per-country override table loses its one confirmed case** — the
+> mechanism is kept for the granularity mismatches ADL-48 §4.1 measured (VN 54.8 %, ET 76.9 %,
+> KZ 86.3 % join rates) but is no longer required on day one. See
+> `jobs/architect/tech/ADL-48-bundled-gazetteer.md`.
+
 | # | Decision | Recommendation | Confidence |
 |---|----------|-----------------|------------|
-| S1 | Source | `country-region-data` (npm, MIT) generates `data/regions.json` — replaces hand-typing, does **not** replace `data/countries.json`'s existing `region_tier_enabled` config | High |
+| S1 | Source | ~~`country-region-data` (npm, MIT)~~ **→ `iso3166-2-db` (npm, MIT), amended 2026-08-01 by ADL-48 §13.1** — generates `data/regions.json`, replaces hand-typing, does **not** replace `data/countries.json`'s existing `region_tier_enabled` config | High |
 | S2 | Scope | Generate rows only for the 26 currently-enabled countries (940 rows, verified) — not all 249 (4,387 rows) — until GE-07's per-country enable list changes | Medium |
-| S3 | Per-country override | A small, committed, hand-reviewed override table for countries where the systematic source's granularity doesn't match GE-02's product intent. **GB is the one confirmed case** — see §6.1 | High |
+| S3 | Per-country override | ~~A small, committed, hand-reviewed override table… **GB is the one confirmed case**~~ **AMENDED 2026-08-01 by ADL-48 §13.1 — retained for history.** Under S1's amended source GB needs **no override** (`iso3166-2-db` returns `GB-ENG/SCT/WLS/NIR` directly). The override *mechanism* is retained for measured granularity mismatches (VN/ET/KZ) but is **no longer a mandatory day-one component** | High → **superseded in scope** |
 | S4 | Storage | Unchanged: generated JSON lands in `data/regions.json` in the exact shape it has today (`{country_code, name, iso_3166_2}`), seeded into the existing `regions` table by the existing startup-seed path. No new table, no new mechanism | High |
 | S5 | Refresh | Manual: a checked-in generation script re-run on demand (new country enabled, upstream correction, or a `BUG-30`-shaped report), output reviewed and committed like any other data change — not fetched at runtime | High |
 

--- a/jobs/architect/tech/ADL-48-bundled-gazetteer.md
+++ b/jobs/architect/tech/ADL-48-bundled-gazetteer.md
@@ -1,0 +1,439 @@
+# ADL-48 — Bundled local gazetteer: build vs buy for city and subdivision reference data
+
+**Date:** 2026-08-01
+**Author:** Architect (fresh dispatch; no authorship of ADL-43, ADL-46, the BUG-71 ruling, its fresh-eyes review, or the UX spec)
+**Branch:** `chore/gazetteer-build-vs-buy-adl`
+**Status:** Decided. Design only — no schema, migration, seed or code change was made by this ADL.
+**Tracker:** OQ-06 · BUG-30 (class) · BUG-45 (adjacent) · D-14 · D-19 · BUG-71 · BUG-74 · BUG-69 · BUG-33 · ENV-01 · ENV-02 · QUAL-21 · QUAL-22 · UX-12
+**BRD:** §5.2 GE-01…GE-16. **Two new requirement IDs proposed (GE-17, GE-18) and one GE-16 amendment required — §12.**
+**Main log entry:** `jobs/architect/tech/20260307-architecture-decisions-log.md` — ADL-48. That entry is the decision of record; this file carries the evidence and the implementation detail.
+**Supersedes / amends:** ADL-43 §2 S1 and S3 (§13.1) · the BUG-71 ruling and its fresh-eyes review are **narrowed, not superseded** (§13.2) · execution-queue item 13 is **partly stale** (§13.3).
+
+---
+
+## 1. Summary table
+
+| # | Decision | Recommendation | Confidence |
+|---|---|---|---|
+| **G1** | Overall verdict on the PO's question | **Yes, bundle a gazetteer — but as a local-first *index*, not as a replacement for the geocoder.** The geocoder is demoted from "the only path" to "the tail path". A pure replacement fails this project's own flagship use case (§2) | **High** |
+| **G2** | City dataset | **`cities.json` (npm, CC-BY-4.0, GeoNames-derived).** 170,540 rows, 246 countries, ships `admin1.json`/`admin2.json`, published monthly — 65 versions, latest 2026-08-01, cadence verified from the registry, not the README | **High** |
+| **G3** | Subdivision dataset | **`iso3166-2-db` (npm, MIT).** Real ISO 3166-2 codes **and** the GeoNames→ISO crosswalk the city half needs, in one package. Install it as a **`devDependency`** — build-time generator only, never shipped (§8.1) | **High** |
+| **G4** | ADL-43's subdivision source | **Amend S1: `iso3166-2-db` replaces `country-region-data`.** It returns GB at the *constituent-country* tier (exactly `GB-ENG/SCT/WLS/NIR`), which ADL-43 §6.1 correctly established no other source does — so **S3's mandatory per-country override table is no longer needed for its one confirmed case** | **High** |
+| **G5** | Table topology | **A new `gazetteer_cities` reference table. `cities` is not replaced and not migrated.** No FK ever points at the gazetteer. User rows are *created from* it. This is what makes refresh safe by construction (§7) | **High** |
+| **G6** | The coverage tail | **Keep the geocoder for the tail.** Not "accept manual entry with no pin". The tail is ~9 of 16 probed Scottish places and the project's dogfood trial is Scotland (§2) | **High** |
+| **G7** | Seed / refresh mechanism | **Content-hash-gated startup seed**, extending the existing `startup.service.ts` pattern. Steady-state boot cost is one indexed `SELECT`. Measured cold seed: **618 ms / 12.47 MB** against local libSQL (§8) | **High** (local) / **Low** (Turso — §15.1) |
+| **G8** | Licence & attribution | **CC-BY 4.0 is a real, satisfiable obligation.** Attribution surfaces in-product on an About/Credits surface plus `README`, naming GeoNames and OSM. Not optional, not a footnote | **High** |
+| **G9** | Refresh cadence | **On-demand, not scheduled.** Trigger-driven, COO-initiated, reviewed as a normal data PR. Upstream is monthly; we do not have to be | **Medium** |
+| **G10** | Expand/contract staging | **Three independently-green stages** (regions → gazetteer table+seed → local-first lookup). ADL-47 satisfied without an integration branch (§11) | **High** |
+| **G11** | Does this close OQ-06 / D-14 / BUG-30 / BUG-45? | **Closes: OQ-06 (implementation), the BUG-30 class, D-14 tier 2. Does NOT close: BUG-45** — different dataset, no overlap with this source family (§12.3) | **High** |
+| **G12** | Disposition of the BUG-71 work | **Narrowed, not made moot. Ship the BUG-71 fix as designed — do not hold it for this.** It becomes the *fallback-path* classifier (§13.2) | **High** |
+
+**The one-sentence answer to the PO's question.** *"Wouldn't it be easier just to store a full cities list in a DB table?"* — **Yes, and it is the right call, but not for the reason it looks like.** It is not easier because it deletes the geocoder; it does not delete the geocoder. It is right because it moves the **common** case onto a path that is complete, instant, offline, free, and — decisively — **testable in CI**, leaving the geocoder to serve only the long tail where it is genuinely the only option.
+
+---
+
+## 2. The coverage floor, in terms the PO can judge
+
+This is the section that should decide the question. Everything else is implementation.
+
+**Every bundled gazetteer has a floor. I probed the actual floor with real place names rather than reasoning about population thresholds.** Both candidate datasets, both probed two independent ways (exact match within `GB`; then case-insensitive substring across all 246 countries — probes that fail differently, per the negative-findings rule).
+
+| Present in both datasets | Absent from **both** datasets |
+|---|---|
+| Glasgow, Edinburgh, Inverness, **Ullapool**, **Aviemore**, **Portree**, **Tarbert** | **Plockton, Applecross, Shieldaig, Lochinver, Durness, Kyleakin, Gairloch, Dornie, Braemar** |
+
+*(Tobermory is the one disagreement: present in `all-the-cities` with population 1,010, absent from `cities.json`. The datasets are not interchangeable even where they share an upstream.)*
+
+**Stated plainly for the PO:**
+
+> At ~170,000 rows the floor is roughly *"a settlement with its own population count of about 1,000, or an administrative seat."* **Towns and villages that are somebody's home** — Ullapool (1,510), Portree, Aviemore, Tobermory — **are in.** **Hamlets, crofting townships and single-attraction places** — Plockton, Applecross, Shieldaig, Dornie, Braemar — **are out**, even when they are well-known destinations. Braemar has the Highland Gathering; Plockton and Applecross are on every West Highland itinerary. None of them is in either dataset.
+
+**Why this is decisive rather than an acceptable rounding error.** The project's stated use is *personal travel including small places*, and BUG-30's own tracker note records that *"the Scotland dogfood trial (BRD-PL0104 trigger) needs this working."* A gazetteer-only design would ship a product that cannot record the trip it was built to record. **That is the argument against a pure replacement, and I consider it dispositive.**
+
+### 2.1 The two fallback options, and the recommendation
+
+| Option | What the user gets for Plockton | Cost |
+|---|---|---|
+| **(a) Keep the geocoder for the tail — RECOMMENDED** | Types "Plockton", gazetteer returns nothing, backend falls through to Nominatim, city resolves with a real pin | Retains the proxy route, the serialized rate limiter, `geocode_status`, the retry queue, GE-16 containment — but they now serve **only** the tail |
+| **(b) Manual entry, no automatic pin** | Types "Plockton", picks country/region by hand, city is created `unresolvable`, **no map pin ever** | Retires more machinery — but a map-centric travel app that cannot pin the places you actually went is a worse product than the one we have today |
+
+**Recommend (a).** Option (b) trades a user-visible product regression for an internal simplification, on exactly the places the PO travels to. It also fails GE-13's intent in spirit: pins suppressed *pending resolution* is a transient state; pins suppressed *forever* is a missing feature.
+
+**The honest cost of (a):** almost none of the geocoder machinery is retired. What changes is how often it runs — and, far more importantly, **whether the normal path can be tested**. §6 itemises this without inflating it.
+
+---
+
+## 3. The candidates, verified
+
+Every fact below was established by installing the package and reading the data. **No dataset fact in this document is stated from memory.**
+
+| Package | Version | Declared licence | Rows | Subdivisions? | Population? | Last published | Verdict |
+|---|---|---|---|---|---|---|---|
+| **`cities.json`** | 1.1.61 | **CC-BY-4.0** (LICENSE file is the CC-BY 4.0 text) | **170,540** cities / 246 countries | **Yes** — `admin1.json` (3,865), `admin2.json` (47,549) | **No** | **2026-08-01** | **ADOPT (G2)** |
+| `all-the-cities` | 3.1.0 | MIT *(declared)* | 135,233 *(npm description claims 138,398 — wrong)* | `adminCode` only, no names | Yes | 2020-03-18 | **Reject** |
+| **`iso3166-2-db`** | 2.3.11 | MIT | 3,940 subdivisions / 234 countries | **Yes + GeoNames crosswalk** | — | 2024-07-11 | **ADOPT (G3)** |
+| `country-region-data` | 4.1.0 | MIT | 217 GB rows, council tier | Yes, but wrong tier for GB | — | — | **Reject (G4)** |
+| `country-state-city` | 3.2.1 | **GPL-3.0** | — | — | — | — | **Reject on licence** |
+
+**Why `all-the-cities` is rejected despite having the population field we'd like:**
+
+1. **Its licence declaration is wrong in a way that creates real risk.** It declares MIT, but its own README says it is *"Derived from the cities-with-1000 npm package, which in turn came from geonames.org data."* GeoNames is CC-BY 4.0. **An MIT label on CC-BY data does not launder the attribution obligation** — it just means the obligation is undocumented. `cities.json` declares CC-BY-4.0 correctly and ships the full licence text. Choosing the package that tells the truth about its own provenance is the lower-risk choice, and it costs us nothing.
+2. **Six years stale** (published 2020-03-18) against `cities.json`'s monthly cadence.
+3. Its own headline is false: it advertises "population of at least 1000" but **22,913 of its 135,233 rows have population < 1,000, and 12,788 have population exactly 0.** A dataset whose primary documented claim doesn't survive one `filter()` is not one to build a refresh story on.
+4. It carries essentially no alternate names (76 rows of 135,233), so it buys nothing on the Rome/Roma question either.
+
+**The cost of choosing `cities.json`: no population column.** That forecloses population-based ranking and population-based trimming. §6.4 states what that actually costs — less than it sounds, because ranking has a better signal available.
+
+---
+
+## 4. The structural finding — and it is the one that would have wrecked a naive build
+
+The brief's hypothesis was that *"the same source family plausibly supplies both subdivisions and cities."* **I tested it, and it is false in its naive form.**
+
+**GeoNames `admin1` codes are not ISO 3166-2 codes.** The app's `regions.iso_3166_2` column and Nominatim's `ISO3166-2-lvl4` output are both ISO 3166-2. GeoNames uses its own scheme. Measured across the 26 `region_tier_enabled = 1` countries:
+
+> **`"<CC>-" + geonamesAdmin1` equals the ISO 3166-2 code for exactly 2 of 26 countries — GB and US.** Twenty are purely numeric (`AU`→`08`, `CA`→`01`, `DE`→`15`, `JP`→`46`), and four are mixed. Naively concatenating would have produced `AU-08` where the app expects `AU-NSW`, silently, for 24 of 26 countries.
+
+**This is exactly the class of error that a build-first, verify-later approach ships.** It would have passed every test written against US and GB fixtures — the only two countries with seeded regions today.
+
+### 4.1 The crosswalk exists, and it is in the subdivision package
+
+`iso3166-2-db`'s `data/iso3166-2.json` carries, per subdivision, **both** identifiers:
+
+```json
+{ "name": "Western Australia", "iso": "WA", "admin": "08",
+  "reference": { "geonames": 2058645, "openstreetmap": 2316598, ... } }
+```
+
+`iso` is the ISO 3166-2 suffix; **`admin` is the GeoNames `admin1` code.** That is the join. End-to-end integration test, run over the real data:
+
+| Measure | Result |
+|---|---|
+| City rows in region-tier-enabled countries | 84,868 |
+| **Joinable to an ISO 3166-2 subdivision via the crosswalk** | **84,257 — 99.28 %** |
+| Currently-seeded region codes matched exactly (US 51, CA 13, AU 8, GB 4) | **76 / 76** |
+| Rows with `NULL` region across the *whole* 170,540-row dataset | 1,746 (1.02 %) |
+
+**The 76/76 match is the single most important number in this document for migration risk.** The proposed subdivision set is a strict *superset* of what is seeded today, with every existing code preserved byte-for-byte. No existing `regions` row changes, so no `cities.region_id` is invalidated, so **no backfill and no data migration of user rows.**
+
+**Three countries fall below 95 % and must be stated, not buried:** Vietnam **54.8 %**, Ethiopia **76.9 %**, Kazakhstan **86.3 %** — all three have reorganised subdivisions where GeoNames and ISO disagree. Cities there seed with `region_iso = NULL`, which the schema already permits and which GE-15 already has settled behaviour for (*"a geocoding result that cannot be resolved to a seeded region leaves the region blank and editable"*). **Degrades correctly; does not fail.**
+
+---
+
+## 5. The recommended architecture
+
+### 5.1 Two tables, one direction of travel
+
+```
+gazetteer_cities   (reference; refreshable; NO foreign key ever points at it)
+        │  read-only lookup
+        ▼
+   user picks a result
+        │  copy name / country_code / region_id / lat / lng
+        ▼
+     cities         (UNCHANGED — ADL-46 identity index, geocode_status,
+                     created_by_user_id, GE-16 containment all intact)
+        ▲
+   trip_places ─────┘   (FKs unchanged)
+```
+
+**`gazetteer_cities` — new table.**
+
+| Column | Type | Notes |
+|---|---|---|
+| `id` | integer PK autoincrement | Internal only |
+| `name` | text not null | |
+| `country_code` | text not null | **No FK** — see below |
+| `region_iso` | text | ISO 3166-2, nullable (the 1.02 %) |
+| `latitude` / `longitude` | real not null | A gazetteer row without coordinates is not a gazetteer row |
+| `feature_code` | text | GeoNames `PPLA`/`PPL`… — the ranking signal that replaces population (§6.4) |
+
+Indexes: `(name COLLATE NOCASE)`, `(country_code)`, `(name COLLATE NOCASE, country_code)`.
+
+**`country_code` deliberately carries no FK to `countries`.** The gazetteer covers 246 countries; `countries` holds 250 from a different vintage. A refresh that introduces a code not in `countries` must degrade to "that row is unreachable", never to "the seed transaction aborts". **This is the same reasoning as no-FK-pointing-in, applied outward.** It is an intentional exception to the schema-review default and is flagged as such.
+
+### 5.2 Why not just put the 170,540 rows into `cities`
+
+Rejected, and the reason is not size:
+
+- **`cities` is the target of `trip_places.city_id`.** A refreshable dataset must never be FK-referenced by user data — a refresh that drops a row a user's trip points at is a data-integrity failure with no good recovery. Separation makes that unrepresentable.
+- **GE-16's three end states are meaningless for reference rows.** 170,540 rows of `geocode_status = 'resolved'` with `created_by_user_id = NULL` would dilute the containment model to nothing and make every `pending`-row query scan a 170k table.
+- **The D13 identity index would fight it.** `uniq_cities_name_country_region_ci` exists to make user-created duplicates impossible. Loading a bulk dataset through it converts every upstream near-duplicate into an insert conflict at seed time.
+- **`cities` stays small and hot; the gazetteer stays large and cold.** That is the right shape.
+
+### 5.3 The lookup order
+
+1. **Local gazetteer first** — exact then prefix, `COLLATE NOCASE`, optionally ranked by the trip's declared countries (this *is* D-19, §6.9).
+2. **Existing `cities` catalogue** — unchanged, still first for already-known cities per GE-14.
+3. **Nominatim, only when the gazetteer returns nothing** — the tail path. All existing machinery applies.
+
+**Measured, on the real 170,540-row dataset in libSQL:** the `springfield` ambiguity query — `SELECT country_code, region_iso, COUNT(*) GROUP BY country_code, region_iso` — returns **21 distinct groups in under 1 ms**. Compare the current path: 10 rows from a global Nominatim query, thinned twice, from which BUG-71 concluded "unambiguous, it's Virginia."
+
+---
+
+## 6. What this actually retires, shrinks, and leaves alone
+
+The brief asked me to assess each honestly and not assume. Several of these do **not** go away, and two are already closed by other work and must not be re-credited here.
+
+| Item | Verdict | Detail |
+|---|---|---|
+| **Truncation / ambiguity heuristic (BUG-71)** | **Retired on the primary path; persists on the tail** | A local query returns the *complete* set, so `truncated` is structurally unrepresentable and "is this ambiguous?" becomes `GROUP BY`. The tail path still needs `classifyDiscovery` |
+| **Serialized Nominatim rate-limit chokepoint** | **Shrinks sharply; persists** | Still required, still the single egress point. Volume drops to tail-only. **Do not delete it** |
+| **Geocode retry queue + BUG-69** | **Persists; volume collapses** | Tail cities still create `pending` rows. **BUG-69's missing `unresolvable` terminal branch is still a real bug and still needs fixing** |
+| **`geocode_status` state machine + GE-16 containment** | **Persists, and must** | Gazetteer-sourced cities are born with coordinates; tail cities still traverse pending→resolved/unresolvable. The containment rules are unchanged — but they stop being the *common* case |
+| **ENV-01 test blindness** | **Substantially closed — the biggest single win** | The primary discovery path becomes a SQL query with **no network at all**. It is fully exercisable in CI and in this devcontainer. The tail path stays ENV-01-blind. This closes a *class*, not an instance |
+| **QUAL-22 mock drift** | **Shrinks** | Far fewer suites need a geocoder mock. Does not fix the existing broken mock — **QUAL-22 still needs its own repair** |
+| **BUG-55 CSP class** | **Already closed by ADL-46's backend proxy. This ADL takes no credit.** | Stated explicitly so the tracker is not double-credited |
+| **ENV-02 user-visible impact** | **Reduced, not closed** | A 502 on `/api/geocode` stops affecting the common path. But ENV-02 is Railway-edge networking affecting *all* routes — unchanged as an infrastructure item |
+| **BUG-33 duplicate city rows** | **Already fixed by the D13 identity index. No credit taken.** | Pressure reduced (users pick canonical rows instead of typing variants), mechanism unchanged |
+| **BUG-30 class + OQ-06** | **Closed** | 22 latent BUG-30s become 0. §12.3 |
+| **BUG-74** (upstream failure reads as "found nothing") | **Persists; severity drops** | Still needs its fix. But with a local-first path, "geocoder unreachable" degrades to "gazetteer results only" — a *usable* answer, not a blank form |
+| **UX-12** (Change city control, status badge) | **Unchanged — still required** | GE-16's correction right is orthogonal to where city data comes from. The badge simply becomes rarer |
+| **D-19** (constrain by trip countries) | **Becomes trivial** | §6.9 |
+
+### 6.9 D-19 collapses to an `ORDER BY`
+
+D-19 currently needs a BRD home, an Architect design, and Backend + Frontend briefs, and carries QUAL-21 as a prerequisite. Against a local gazetteer it is:
+
+```sql
+ORDER BY (country_code IN (/* trip countries */)) DESC, feature_code, name
+```
+
+That is the PO's **shortlist-not-filter** pattern exactly — nothing is removed, likely matches sort first — with no rate-limit interaction, no extra egress, and no truncation risk. The UX spec's `<optgroup>` presentation sits on top unchanged. **D-19 should be re-scoped as a consequence of this ADL rather than designed separately.**
+
+### 6.4 The missing population column, and why `feature_code` is a better ranking signal anyway
+
+`cities.json` has no population. For ranking search results this matters less than it appears: GeoNames' `feature_code` distinguishes `PPLC` (national capital), `PPLA` (first-order admin seat), `PPLA2`, `PPL` (ordinary populated place). **Sorting by administrative rank puts Paris, France above Paris, Texas without any population data**, and it is the signal that actually correlates with "the one the user meant."
+
+**UNVERIFIED:** `cities.json`'s shipped rows carry only `name, lat, lng, country, admin1, admin2` — **`feature_code` is not in the published city records** (verified by reading the keys). Obtaining it requires either `all-the-cities` (which has `featureCode`, but is stale and licence-misdeclared) or the GeoNames dump (firewall-blocked). *Probe I would run:* diff the two packages' row sets on `(name, country, lat, lng)` to see whether `all-the-cities`' `featureCode` can be joined onto `cities.json` rows. *Blind spot:* the two are different vintages, so a join will be lossy by an unknown amount. **Until that is resolved, `feature_code` must be treated as an optional column that may ship NULL, and ranking falls back to exact-match-then-alphabetical.** The design does not depend on it.
+
+---
+
+## 7. Migration path for the existing `cities` table
+
+**There is no migration of `cities`.** That is the point of §5.1's topology, and it is worth stating as forcefully as possible because it is the cheapest part of this whole proposal.
+
+- `cities` keeps every column, every index, and every behaviour shipped in ADL-46 migrations 0014/0015 — `geocode_status`, `geocode_attempts`, `created_by_user_id`, the D13 identity index, GE-16 per-user containment.
+- **Rows users already created are untouched.** A user-created `Denver` and a gazetteer `Denver` coexist; the next user who picks Denver from the gazetteer hits the *existing* `cities` row through the unchanged find-or-create, because the identity key is `(name, country_code, COALESCE(region_id,0))` and the gazetteer supplies exactly those three values. **Convergence happens through the mechanism that already exists.**
+- The only additive change to `cities` is behavioural: when a row is created *from* a gazetteer match it is born with coordinates.
+
+**On disposable data.** Both staging and production hold disposable test data, so no preservation heroics are needed. **This does not license an incorrect migration, and none is proposed** — the design's correctness argument is the 76/76 exact match in §4.1, not the disposability of the data. If the region seed were lossy, reseeding would not save us; the FK from `cities.region_id` would break in prod exactly as it would in staging.
+
+---
+
+## 8. Seed / refresh pipeline
+
+**Constraint:** `drizzle-kit migrate` runs on every container boot. Seeding 170,540 rows per boot is unacceptable, and a 15 MB SQL migration file is unpleasant and unrefreshable.
+
+### 8.1 The mechanism
+
+**Build time (developer machine / CI, never at runtime):** a checked-in generator script, `scripts/generate-gazetteer.mjs`, reads `cities.json` + `iso3166-2-db` (**both `devDependencies`**), applies the §4.1 crosswalk, and emits two committed artifacts:
+
+- `data/regions.json` — regenerated, 716 rows for the 26 enabled countries (from 76)
+- `data/gazetteer-cities.json` — ~17 MB, plus a `data/gazetteer-meta.json` carrying `{ source, version, generatedAt, rowCount, contentHash }`
+
+**Runtime (startup):** extend `startup.service.ts` with `seedGazetteer()`, following the pattern already established by `seedCountries()` / `seedRegions()`, with one upgrade. Those gate on `rowCount > 0` — which is why BUG-30 needed a hand-written patch migration to get past. **`seedGazetteer()` gates on the content hash instead:**
+
+1. `SELECT content_hash FROM gazetteer_meta LIMIT 1`
+2. Hash matches the bundled artifact → log and return. **Steady-state boot cost: one indexed SELECT.**
+3. Hash differs or table empty → inside a single transaction: `DELETE FROM gazetteer_cities`, batch-insert, update `gazetteer_meta`.
+
+Because nothing references `gazetteer_cities`, the delete-and-reload is safe by construction — **that is the payoff of §5.1's no-FK rule, and it is why refresh is a non-event here rather than the hard part.**
+
+**Deliberate deviation from the existing convention, declared:** row-count gating is what made BUG-30 unfixable without a bespoke migration. Hash gating means a data correction ships as a regenerated artifact and applies itself on next boot. New `seeders` should use it; the existing two are **not** retrofitted by this ADL.
+
+### 8.2 Measured cost
+
+Against local libSQL, real data, 2,000-row batches:
+
+| Metric | Measured |
+|---|---|
+| Insert 170,540 rows | **505 ms** |
+| Build both indexes | **113 ms** |
+| **Total cold seed** | **618 ms** |
+| Resulting DB size | **12.47 MB** |
+| Ambiguity `GROUP BY` query | **< 1 ms** |
+
+**Repo size precedent:** `geo/regions.json` (Natural Earth, GE-10) is **already 40 MB in this repository**. A 17 MB gazetteer artifact is well within established practice here — under half of a file already committed.
+
+> ### 8.3 The one number I could not measure, and it gates the rollout
+>
+> **Cold-seed cost against Turso (remote libSQL over HTTP) is UNVERIFIED.** The 618 ms above is a *local file* database. Remote libSQL pays a network round-trip per batch; 86 batches over a WAN could plausibly be tens of seconds to minutes. *Probe I would run:* `scripts/agent-diagnostics/turso-query.mjs` against staging, timing a single 2,000-row batch insert, then multiply. *Blind spot:* staging and production may differ in region and plan.
+>
+> **The design must not depend on the answer, and it doesn't**, because the seed runs once per content-hash change rather than per boot. But **the Database brief must measure it before the first deploy** and, if a cold seed exceeds the platform's health-check window, move `seedGazetteer()` off the boot path into an explicit one-shot command. **Turso row-count and storage limits against a 170,540-row table are also UNVERIFIED** — same probe, same brief.
+
+---
+
+## 9. Licence and attribution
+
+**CC-BY 4.0 (`cities.json`, GeoNames-derived) is a genuine obligation, not a formality.** I read the shipped LICENSE file: it is the full Creative Commons Attribution 4.0 International text, whose §3(a) requires retaining identification of the creator, a copyright notice, a licence reference and a link, "in any reasonable manner."
+
+**Where attribution surfaces — this is a product decision, not just a README line:**
+
+1. **In-product, user-visible.** An About/Credits surface naming: *"City data © GeoNames (CC BY 4.0). Boundary data © Natural Earth. Geocoding © OpenStreetMap contributors (ODbL)."* The app has **no such surface today** — that is a small Frontend item this ADL creates.
+2. **`README.md`** — the source, version and licence of each bundled dataset.
+3. **`data/gazetteer-meta.json`** — machine-readable provenance, so the next agent doesn't have to re-derive it.
+
+**This consolidates an obligation the project already carries and has not discharged.** ADL-43 §6.2 already flagged ODbL attribution for OSM-derived data as real, and BUG-55's tracker note records it as *"flagged for re-confirmation… on a SINGLE probe (README.md grep only)."* Natural Earth (public domain) needs no attribution but conventionally gets it. **One credits surface discharges all three at once**, which makes this cheaper to do properly than to keep deferring.
+
+`iso3166-2-db` is MIT — attribution satisfied by retaining the licence text in `node_modules`, and it is a `devDependency` whose data output is factual codes (ISO 3166-2 codes and subdivision names are not creative works). No product-surface obligation.
+
+**Rejected on licence:** `country-state-city` is **GPL-3.0**. Even granting that server-side use is not distribution, taking a copyleft dependency into a hosted product to save a data-loading script is a bad trade with a good alternative available.
+
+---
+
+## 10. Staleness and refresh cadence
+
+**Upstream cadence, verified from the npm registry rather than the README:** `cities.json` has **65 published versions**, with `1.1.59` on 2026-06-01, `1.1.60` on 2026-07-01 and `1.1.61` on 2026-08-01. **Monthly, and current as of today.**
+
+**Our cadence: on-demand, not scheduled. Recommended, and the reasoning matters.** A scheduled monthly bump would generate twelve no-op-looking PRs a year, each of which is a ~17 MB artifact diff nobody can meaningfully review — which trains the team to rubber-stamp them. Reference data that changes slowly should be refreshed on a **trigger**:
+
+| Trigger | Who |
+|---|---|
+| A user reports a missing or wrong city (a BUG-30-shaped report for the city tier) | COO raises; Database regenerates |
+| GE-07 enables the Region tier for a new country | Database — regenerate to pick up its subdivisions |
+| An upstream correction we specifically need | COO |
+| Otherwise: a standing review at most **annually** | COO |
+
+**Who triggers it: the COO**, as a normal data PR — regenerate, commit the artifacts, review the `gazetteer-meta.json` diff (row counts and hash) rather than the 17 MB payload, merge. The refresh is intrinsically safe because of §5.1/§8.1, so the review burden is genuinely low.
+
+**The staleness risk is asymmetric and mild.** A stale gazetteer misses *new* settlements and *renamed* ones. A missing city falls through to the geocoder — the tail path already handles it. **Staleness degrades into the fallback we already built, which is the best possible failure mode for this class of data.**
+
+---
+
+## 11. Expand/contract staging (ADL-47)
+
+Three stages, each independently green, independently deployable, and independently valuable. **No integration branch needed** — this decomposes cleanly, which is ADL-47's preferred outcome.
+
+| Stage | Content | Green on its own? | Value if we stop here |
+|---|---|---|---|
+| **S1 — Subdivisions** | Generator script; regenerate `data/regions.json` 76 → 716 rows; hash-gated reseed of `regions`. **Purely additive** — all 76 existing codes preserved (§4.1), so no `cities.region_id` is invalidated | **Yes.** Additive insert; no code reads change | **The BUG-30 class closes.** 22 latent bugs → 0. Real, shippable value with zero risk to the city path |
+| **S2 — Gazetteer table + seed** | `gazetteer_cities` + `gazetteer_meta` (new tables, nothing references them); `seedGazetteer()`; the artifact. **No route reads it yet** | **Yes.** New tables, dead data, no behaviour change | Nothing user-visible — but it is where the Turso timing question (§8.3) gets answered *before* anything depends on it |
+| **S3 — Local-first lookup** | `GET /api/cities/search` consults the gazetteer first; Nominatim becomes the fallback; frontend consumes the richer result | **Yes** | The actual feature |
+
+**Why S1 must precede S2:** the crosswalk writes `gazetteer_cities.region_iso`, and a city row's region is only meaningful once the corresponding `regions` row exists. This is a hard ordering dependency, not a preference.
+
+**S1 is independently worth dispatching even if the PO declines the cities half.** That is deliberate — it means the cheap, high-certainty half is not held hostage to the contested one.
+
+---
+
+## 12. BRD position
+
+### 12.1 Two new requirement IDs are needed
+
+**GE-17 — Bundled city reference data.**
+> The app ships with a bundled reference list of world cities. When a user adds a city, this local list is searched first and offers matching cities with their country, region and coordinates without any network call. Cities absent from the bundled list continue to be resolved through the geocoding service (GE-11).
+>
+> **Success criteria:** searching a bundled city returns results with no outbound network request, verifiable in a test environment with no internet access; a city selected from the bundled list is created with coordinates already populated and `geocode_status = 'resolved'`, never `pending`; a city name absent from the bundled list still creates successfully through the geocoding path with no user-visible difference in the flow; searching a name that matches bundled cities in more than one country or region presents all of them distinguishably and selects none automatically; the bundled data's source, version and licence are recorded in-repo and surfaced in-product.
+
+**GE-18 — Reference-data provenance and attribution.**
+> Every bundled reference dataset carries its source, version and licence in the repository, and the app surfaces the attribution its licences require.
+>
+> **Success criteria:** an About/Credits surface names GeoNames (CC BY 4.0), OpenStreetMap (ODbL) and Natural Earth, reachable from the app in no more than two interactions; each bundled dataset has a machine-readable provenance record; adding a new bundled dataset without provenance fails a check.
+
+### 12.2 GE-16 must be amended — otherwise the correct behaviour is unrepresentable
+
+GE-16 defines `resolved` as ***"the geocoder matched it."*** A city taken from the bundled gazetteer was **never seen by the geocoder**, yet it has authoritative coordinates and must be `resolved` — it would be absurd to mark Glasgow `pending` because we didn't phone Nominatim about it.
+
+**Required amendment (existing ID, not a new one):** GE-16's `resolved` definition becomes *"an authoritative source — the bundled reference data or the geocoding service — matched it."* GE-16's closing note (*"resolved means the geocoding service returned a match, not that the match has been verified as correct"*) should gain: *"for bundled reference data, resolved means the name matched a curated gazetteer entry."*
+
+**Consequence for dispatch, which is the operationally useful part:** the S1 subdivision brief is **not** blocked on any BRD change — it introduces no new capability. **S2 and S3 are blocked** on GE-17/GE-18 existing with these success criteria, per the BRD gate.
+
+**GE-15's amendment, already required by the BUG-71 ruling §8, is unaffected and should still happen** — but note that this ADL makes it *smaller*: once the common path can confirm from a complete local set, the number of cases where GE-15 has to concede "blank and editable" drops sharply.
+
+### 12.3 What this closes, and what it does not
+
+| Item | Verdict |
+|---|---|
+| **OQ-06** (systematic subdivision list) | **Implementation closed by S1.** Note: OQ-06 was *decided* by ADL-43 on 2026-07-27 and is already `closed` in the tracker; this ADL **changes the chosen source** (§13.1), it does not re-open the question |
+| **BUG-30 class** | **Closed by S1** — 22 latent instances → 0 |
+| **D-14** | **Tier 2 closed** (`iso3166-2-db` ships `iso`, `iso3`, `numeric` per country, so "US"/"USA" both become matchable with no new source decision). **Tier 3 (colloquial: "America", "Britain") NOT closed** — still BUG-45's class |
+| **BUG-45** (airlines / car-rental providers) | **NOT closed. No overlap whatsoever.** Different dataset (OpenFlights), different domain, no shared source. ADL-43 §3/§4 remains the live design. **Stated explicitly because execution-queue item 13 bundles them and that bundling is wrong** |
+| **D-19** | **Not closed, but re-scoped from a design problem to an `ORDER BY`** (§6.9) |
+
+---
+
+## 13. Reconciliation — what this amends, and what it deliberately does not
+
+### 13.1 ADL-43 — amend S1 and S3
+
+ADL-43's §6.1 finding is **correct and I re-verified it independently**: `country-region-data` returns **217 GB rows** at council-area granularity (`["Aberdeen City","ABE"]`, `["Angus","ANS"]`…) and **none** of `ENG`/`SCT`/`WLS`/`NIR`. Natural Earth has the identical gap. ADL-43 was right that this is the crux.
+
+**What ADL-43 did not find is that a third source gets it right.** `iso3166-2-db` returns **exactly 4 GB rows** — `GB-ENG`, `GB-SCT`, `GB-WLS`, `GB-NIR` — matching the seeded values byte-for-byte.
+
+Therefore:
+- **S1 amended:** source becomes `iso3166-2-db`, not `country-region-data`.
+- **S3 (mandatory per-country override table) is no longer required for its one confirmed case.** Keep the override *mechanism* — VN/ET/KZ (§4.1) show granularity mismatches are a real class — but it is no longer load-bearing on day one, which removes a hand-curation step from the critical path.
+- **S2 (scope to the 26 enabled countries), S4 (storage in `data/regions.json`), S5 (manual refresh) all stand unchanged**, and this ADL adopts them.
+
+**A supersession stamp is required on ADL-43 §2 S1/S3 in the same PR** (lifecycle rule 2).
+
+### 13.2 The BUG-71 documents — narrowed, NOT made moot
+
+The brief asked me to state plainly whether this makes the two BUG-71 documents moot. **It does not, and it would be a mistake to hold the BUG-71 fix for this ADL.**
+
+- **BUG-71 is a live P1 against shipped behaviour.** This ADL is a multi-stage build behind a BRD gate. **Ship the BUG-71 fix as designed, now.**
+- `classifyDiscovery` **survives** — it becomes the classifier for the **tail path**, where truncation and thin evidence are still exactly the problem the ruling describes.
+- The fresh-eyes review's **three-valued output** (`confirmed`/`suggested`/`ambiguous`/`none`) survives and is **strengthened**: gazetteer hits can only ever be `confirmed` or `ambiguous` (a complete local set can never be "incomplete but undivided"), so `'suggested'` becomes precisely and only the tail-path state. That is a cleaner semantic than either document could give it.
+- The review's **F2 "never-helps" concern is substantially answered** by this ADL: categories B and C (Denver, Paris — common names going blank) are the *most* likely to be in a 170k-row gazetteer, so they resolve locally, completely and confirmably. **The gazetteer is the real fix for F2; the three-valued enum is the right interim.**
+
+**Disposition:** both documents get a `NARROWED (2026-08-01) by ADL-48 §13.2 — retained for history` stamp on the sections describing the discovery path as Nominatim-only. No content is retracted.
+
+### 13.3 Execution-queue item 13 — partly stale, and it should be corrected
+
+Item 13 states it will close *"OQ-06 (its literal question), D-14, the BUG-30 class, BUG-45."* Two corrections:
+
+1. **OQ-06 was already decided and closed** by ADL-43 on 2026-07-27. Item 13 queues an ADL that already exists. What was actually outstanding was the *implementation* brief — and now a source correction (§13.1).
+2. **BUG-45 does not belong in this item.** It shares a *decision shape* but zero source overlap. Bundling them invites a single brief that seeds airlines from a city gazetteer.
+
+**This is a documentation-lifecycle correction the COO should make to the queue file** in the same PR that adopts this ADL.
+
+---
+
+## 14. The strongest argument against this recommendation, answered
+
+> **"You are adding a 170,540-row dataset, a crosswalk, a generator, a refresh pipeline, two tables, a second lookup path, two BRD requirements and an attribution surface — and by your own §6 you retire almost none of the geocoder machinery you set out to delete. That is strictly more complexity than today, for a project with three cities in staging. Meanwhile the BUG-71 fix already designed solves the actual reported defect for a fraction of the cost."**
+
+This is the objection I would raise, and the first two sentences are simply **true**. My answer:
+
+**1. The complexity is real but it is *inert*, and the complexity it replaces is *live*.** A 170k-row read-only table with no inbound FKs, refreshed on a content hash, is about as low-entropy as a component gets — it cannot be in an inconsistent state, cannot fail at runtime, and cannot be raced. What it displaces is a serialized, rate-limited, network-dependent, third-party path that has produced BUG-33, BUG-55, BUG-69, BUG-71, BUG-73, BUG-74 and QUAL-21/22 — **eight tracked defects, all from one path, in one project.** Trading live complexity for inert complexity is a good trade even when the line count goes up.
+
+**2. "Three cities in staging" is not a valid input, and this project has already ruled on that** (`feedback_dont_architect_for_current_user_base`, 2026-07-30: *"acceptable at two users is not a justification"*). The gazetteer's value is per-*lookup*, not per-user, and every lookup today traverses the fragile path.
+
+**3. On BUG-71 specifically, I agree — and I am not proposing to compete with it.** §13.2 says ship it now. But note what the fresh-eyes review established: the BUG-71 fix makes the common case **blank** (categories B/C/E), trading a wrong answer for no answer. It is the correct fix and it is still a UX regression on Paris and Denver. **The gazetteer is the only proposal on the table that makes the common case simultaneously correct *and* better**, because a complete local set can positively confirm rather than merely decline to guess.
+
+**4. The strongest single reason, and it is not about cities at all: ENV-01.** Today the primary city-entry path **cannot be tested in CI or in this devcontainer**, by construction. That is the same environment-parity blind spot that shipped BUG-55 and that CLAUDE.md's parity rule exists to close: *"any defect class that lives inside a difference is invisible to CI by construction."* Five of the eight defects above are downstream of that one fact. A local-first path moves the common case **inside** the testable boundary. **No amount of test-writing against the current architecture achieves that.**
+
+**Where the objection wins, and I concede it:** if the PO's answer to §2.1 is option (b) — accept no pin for Plockton — then this proposal loses most of its value and should be reconsidered wholesale, because at that point we are carrying a gazetteer *and* a degraded product. The recommendation is coherent **only** as "gazetteer first, geocoder for the tail". It should not be salami-sliced into "gazetteer only."
+
+---
+
+## 15. Verified vs. unverified
+
+### 15.1 Unverified, with the probe and its blind spot
+
+1. **Cold-seed cost and storage headroom against Turso — UNVERIFIED.** §8.3 states it in full. All timings are local libSQL. *Probe:* time one 2,000-row batch via `scripts/agent-diagnostics/turso-query.mjs` against staging. *Blind spot:* staging vs production region/plan. **This is the item most likely to change an implementation detail, and the Database brief must resolve it in S2 before S3 depends on it.**
+2. **That Nominatim actually *has* the tail villages — UNVERIFIED, and it is load-bearing for G6.** My recommendation to keep the geocoder for the tail assumes Nominatim resolves Plockton, Shieldaig and Dornie. **I could not verify this: ENV-01 blocks Nominatim from this devcontainer** (established by the BUG-71 ruling's two probes — a 36 ms TCP reject plus the absence of any `nominatim`/`openstreetmap` entry in `/usr/local/bin/init-firewall.sh`'s allowlist loop). OSM's coverage of Scottish hamlets is very likely excellent, but *likely* is not *verified*. *Probe:* query Nominatim for those nine names from an allowlisted host or on the staging shakedown. *Blind spot:* a single query set at one moment. **If Nominatim also lacks them, option (b) is the only real choice and §2.1 must be re-decided.**
+3. **`feature_code` availability on `cities.json` rows — verified absent; the *join* to recover it is UNVERIFIED.** §6.4. The design does not depend on it.
+4. **GeoNames' documented inclusion rule** (*"population > 1000 or seats of adm div down to PPLA3"*) is quoted from the `cities.json` README, not from GeoNames itself (firewall). **What I verified is the *effect*** — the §2 name-by-name probe — which is the part the decision actually rests on.
+5. **CC-BY 4.0 compliance is a legal judgment, not a technical one.** I read the licence text and §9 is a good-faith reading. It is not legal advice, and the PO should be comfortable with it as a product decision.
+6. **VN/ET/KZ low join rates** are measured facts; my *explanation* (recent subdivision reorganisation) is inference and is not verified.
+7. **No code was written and no test was run.** This is a design document; every measurement is from probe scripts against real package data in a scratch directory, not against the app.
+
+### 15.2 Verified, and how
+
+- **Dataset contents** — every row count, licence, field list, publish date and coverage claim in §3 comes from installing the package and reading its data and LICENSE file. Nothing from memory.
+- **The §2 coverage absences — two independent probes that fail differently:** (a) exact `name` match within `country === 'GB'`; (b) case-insensitive **substring** match across all 246 countries with no country filter. Probe (a) would miss diacritics, casing or a mis-assigned country code; probe (b) would miss only a genuinely absent toponym. Both agree on all nine absences. Run against **both** datasets independently.
+- **GeoNames `admin1` ≠ ISO 3166-2 (§4)** — computed over all 26 `region_tier_enabled` countries from `admin1.json` and `data/countries.json` together; 20 of 26 purely numeric is a positive, self-verifying finding.
+- **The crosswalk works at 99.28 %, and 76/76 seeded codes match** — computed end-to-end joining `cities.json` → `iso3166-2-db.admin` → ISO 3166-2, cross-checked against the repo's live `data/regions.json`.
+- **ADL-43's GB claim re-verified independently** (§13.1): `country-region-data` GB → 217 rows, no ENG/SCT/WLS/NIR. I did not inherit this from ADL-43; I installed the package and read it.
+- **Seed timing, DB size and query latency (§8.2)** — measured by building the real table in libSQL from the real 170,540 rows.
+- **`cities.json`'s monthly cadence** — read from the npm registry's publish timestamps (65 versions; 2026-06-01 / 07-01 / 08-01), **not** from the README's claim.
+- **The repo's 40 MB `geo/regions.json` precedent** — `du` on the working tree.
+- **Current seed state (250 countries, 76 regions across exactly 4 countries, 26 enabled, 22 with zero regions)** — computed from `data/countries.json` and `data/regions.json` directly, independently reproducing ADL-43's figures.
+- **The existing seed gating pattern** — read at `src/backend/services/startup.service.ts:122-176`.
+- **npm registry reachability from this devcontainer and from CI** — established by installing five packages successfully. The firewall constraint in the brief is real and every recommended source is an npm package precisely because of it. **No ADL-33 amendment is required by this design.**
+
+---
+
+*Filed for OP-27 fresh-eyes review. The two places I would attack first: §2.1's option (a) rests on unverified item 2 (does Nominatim have Plockton?), and §8.3's Turso timing is unmeasured. Both are stated as blockers on the relevant brief rather than resolved here.*


### PR DESCRIPTION
Architecture decision, design only. **No schema, migration, seed data or code change.**

BRD §5.2 — two new IDs proposed (**GE-17**, **GE-18**) with success criteria, plus a **required GE-16 amendment**.
Tracker: OQ-06 · BUG-30 (class) · D-14 · D-19 · BUG-71 · BUG-45 (explicitly **not** closed).
Folds in `jobs/COO/20260731-review-execution-queue.md` Tier 2 item 13.

## Verdict

The PO asked: *"Wouldn't it be easier just to store a full cities list in a DB table?"*

**Yes, and it is the right call — but as a local-first *index*, not as a geocoder replacement.** The geocoder is demoted from "the only path" to "the tail path", not retired.

## What decided it: the coverage floor, probed with real place names

Two probes that fail differently (exact-match-in-GB; case-insensitive substring across all 246 countries), run against **both** candidate datasets:

| Present in both | **Absent from both** |
|---|---|
| Glasgow, Edinburgh, Inverness, Ullapool, Aviemore, Portree, Tarbert | **Plockton, Applecross, Shieldaig, Lochinver, Durness, Kyleakin, Gairloch, Dornie, Braemar** |

The floor is roughly *"somebody's home town"* in, *"hamlet or single-attraction place"* out. BUG-30's own tracker note makes the **Scotland dogfood trial** the trigger requirement — so a gazetteer-**only** build would ship a product that cannot record the trip it was built to record.

## The finding that would have wrecked a naive build

**GeoNames `admin1` codes are not ISO 3166-2 codes.** `"<CC>-"+admin1` is correct for exactly **2 of the 26** `region_tier_enabled` countries (GB, US); 20 are purely numeric (`AU`→`08`, `CA`→`01`, `DE`→`15`). A "same source family" build writes `AU-08` where the app expects `AU-NSW`, silently, and passes every test written against the only two countries with seeded regions today.

The crosswalk lives inside `iso3166-2-db` (`admin` = GeoNames, `iso` = ISO). **99.28 %** join rate, and **all 76 currently-seeded region codes match exactly** → strict superset, **no user-row backfill**.

## Sources (all verified by installing and reading — nothing from memory)

Both are npm packages, so **no ADL-33 firewall amendment is required**.

- **`cities.json` 1.1.61** — CC-BY-4.0, GeoNames, 170,540 cities / 246 countries, **monthly** (verified from 65 registry publish timestamps, not the README).
- **`iso3166-2-db` 2.3.11** — MIT, 3,940 subdivisions **plus the crosswalk**. `devDependency`, build-time generator only.
- Rejected: `all-the-cities` (declares MIT over CC-BY GeoNames data; 6 years stale; its own "population ≥ 1000" claim is false for 22,913 of 135,233 rows) · `country-state-city` (GPL-3.0).

Measured on real data in libSQL: cold seed **618 ms**, DB **12.47 MB**, the `springfield` ambiguity `GROUP BY` → **21 groups in < 1 ms**. Repo precedent: `geo/regions.json` is already 40 MB.

## Amendment stamps in this PR (document-lifecycle rule 2)

- **ADL-43 §2 S1/S3** — source amended `country-region-data` → `iso3166-2-db`. §6.1's finding was **right** (re-verified independently: 217 GB council-tier rows, none of `ENG/SCT/WLS/NIR`) but did not test a third source, which returns exactly those four. S3's override table loses its one confirmed case. S2/S4/S5 stand.
- **BUG-71 ruling + its OP-27 review** — **NARROWED, not superseded.** `classifyDiscovery` survives as the *tail-path* classifier; the review's three-valued output is *strengthened*; its F2 "never-helps" concern is substantially answered.
- **Execution-queue item 13** — partly stale (OQ-06 was already decided by ADL-43 on 2026-07-27; BUG-45 has zero source overlap and does not belong in the item).
- **open-dialogues D-19** — re-scoped from a design problem to an `ORDER BY`.

## What the COO owns

1. **BRD gate.** **Stage S1 (subdivisions) needs no BRD change and is dispatchable now** — closes the BUG-30 class, 22 latent instances → 0. S2/S3 are blocked on GE-17/GE-18 + the GE-16 `resolved` amendment.
2. **Do not hold BUG-71 for this.** It is a live P1; this is a multi-stage build behind a BRD gate.
3. **Two UNVERIFIED items, flagged as brief-blockers rather than resolved:** Turso cold-seed cost (all timings are *local* libSQL) gates S2; and whether Nominatim actually *has* Plockton/Shieldaig/Dornie (ENV-01 blocks the probe) gates the whole tail strategy.
4. **Trivial defect escalated, not fixed:** `src/backend/services/startup.service.ts:161` says "72 total"; the real figure is 76 (stale since #168). Left alone deliberately — design-only PR.

**Not closed by this:** BUG-45, BUG-69, BUG-74, QUAL-22, UX-12, ENV-02. **No credit taken** for BUG-55 or BUG-33 — both already closed by other work.

Expect an **OP-27 fresh-eyes review**; the document names its own two weakest points in its closing line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
