### PR TITLE
chore(QUAL-25): track the ADL-48 gazetteer feasibility spike

### DIFF
--- a/.planning/drift-ledger.jsonl
+++ b/.planning/drift-ledger.jsonl
@@ -2620,3 +2620,6 @@
 {"ts":"2026-08-02T06:21:22Z","action":"write","file":"/home/node/.claude/projects/-workspace/memory/feedback_question_the_frame_not_just_the_answer.md"}
 {"ts":"2026-08-02T06:21:28Z","action":"edit","file":"/home/node/.claude/projects/-workspace/memory/MEMORY.md"}
 {"ts":"2026-08-02T06:22:38Z","action":"write","file":"/workspace/jobs/COO/park-docs/20260802_0030-COO-park.txt"}
+{"ts":"2026-08-02T06:30:34Z","action":"session_end","reason":"clear"}
+{"ts":"2026-08-02T15:52:04Z","action":"reviewed"}
+{"ts":"2026-08-02T16:08:46Z","action":"edit","file":"/workspace/_project/tracker.json"}

--- a/_project/STATUS.md
+++ b/_project/STATUS.md
@@ -17,7 +17,7 @@ _Tracker last updated: 2026-07-28 (B9 merged — QUAL-03 + QUAL-11 done, PR #292
 | PHASE-5 | Integrations — Notification Engine | ⬜ Pending |
 | PHASE-6 | v3 Planning-First Delivery | ⬜ Pending |
 
-## Open work (75)
+## Open work (76)
 
 ### P0 — Blockers (1)
 
@@ -36,7 +36,7 @@ _Tracker last updated: 2026-07-28 (B9 merged — QUAL-03 + QUAL-11 done, PR #292
 | QUAL-18 | E2E serves the frontend from vite preview, not Express — so no CSP header is ever under test | qa | ⬜ Pending |
 | BUG-71 | Ambiguous city name silently auto-resolves and pre-fills a state — no disambiguation offered (GE-16 violation) | backend | ⬜ Pending |
 
-### P2 — Important (40)
+### P2 — Important (41)
 
 | ID | Title | Owner | Status |
 |---|---|---|---|
@@ -79,6 +79,7 @@ _Tracker last updated: 2026-07-28 (B9 merged — QUAL-03 + QUAL-11 done, PR #292
 | BUG-74 | BUG-73's failure signal covers only the browser↔backend hop — an upstream geocoder failure still reports as 'found nothing' | backend | ⬜ Pending |
 | BUG-75 | D13 city identity key cannot represent two distinct same-name towns in the same region — live latent conflation | architect | ⬜ Pending |
 | QUAL-24 | GE-15, GE-16 and UX spec §3.2 contradict each other on city auto-populate — reconcile before the next UAT round | coo | ⬜ Pending |
+| QUAL-25 | Spike — build ADL-48's gazetteer for real and measure it before committing to S1/S2/S3 | architect | 🔄 In progress |
 | ENV-02 | Staging 502s — Railway proxy 'connection dial timeout' to a single-replica service; app-side causes ruled out | coo | ⬜ Pending |
 
 ### P3 — Minor (28)
@@ -122,7 +123,7 @@ _Tracker last updated: 2026-07-28 (B9 merged — QUAL-03 + QUAL-11 done, PR #292
 | requirement | `███████████████████░` 32/33 | 32 | 1 | 6 |
 | bug | `█████████████░░░░░░░` 44/69 | 44 | 25 | 4 |
 | task | `████████████████████` 9/9 | 9 | 0 | 0 |
-| chore | `████████▓░░░░░░░░░░░` 13/32 | 13 | 19 | 1 |
+| chore | `████████▓░░░░░░░░░░░` 13/33 | 13 | 20 | 1 |
 
 <details>
 <summary>Deferred (10)</summary>
@@ -156,4 +157,4 @@ _Tracker last updated: 2026-07-28 (B9 merged — QUAL-03 + QUAL-11 done, PR #292
 
 ---
 
-_135 done · 10 deferred · 4 closed · 75 open — 224 tracked items_
+_135 done · 10 deferred · 4 closed · 76 open — 225 tracked items_

--- a/_project/tracker.json
+++ b/_project/tracker.json
@@ -2591,6 +2591,18 @@
     },
 
     {
+      "id": "QUAL-25",
+      "type": "chore",
+      "title": "Spike — build ADL-48's gazetteer for real and measure it before committing to S1/S2/S3",
+      "status": "in_progress",
+      "owner": "architect",
+      "priority": "P2",
+      "brdRefs": [],
+      "phase": 6,
+      "notes": "PO direction 2026-08-02: pause the ADL-48 dispatch and assess a comprehensive city import on a separate branch first. RATIONALE, and it is the load-bearing fact: ADL-48 is 100% design — its own §15.1 item 7 states 'No code was written and no test was run', and every number in it comes from probe scripts against npm package data in a scratch directory, never against this application. Its OP-27 review then found 7 defects, two blocking. Committing to a three-stage build on that basis is the risk the spike removes. SCOPE (7 questions, branch spike/gazetteer-feasibility, draft PR, nothing merges): Q1 search performance at 170k rows — the PO's primary question; the live search is like(cities.name,'%q%') at cities.ts:48, a leading-wildcard match SQLite cannot serve from an index, free at 3 rows and a full scan per keystroke at 170,540. Q2 narrowing by trip country — trip_countries exists (schema.ts:442, COO-verified), and the PO's own constraint is the crux: region can never be a narrowing key because the user types the city BEFORE the region is known, so country is the last available signal; filter-vs-rank to be settled by measurement, with ranking preferred if fast enough (shortlist-not-filter, ADL-48 §6.9). Q3 Turso cold-seed cost and storage — ADL-48 §8.3's unmeasured number, all its timings are local libSQL; bounded write authorisation to a throwaway scratch table only, dropped after. Q4 does Nominatim actually have Plockton/Shieldaig/Dornie — UNVERIFIED and load-bearing: ADL-48's entire gazetteer-FIRST-not-ONLY shape rests on the geocoder covering the tail, and if it doesn't, §2.1 must be re-decided. Q5 S1 correctness with review findings F2 (regions must be UPSERT on iso_3166_2, never delete-and-reload — cities.region_id FKs into an AUTOINCREMENT id) and F4 (2 of 716 rows generate as garbage 'ID-'/'PH-') folded in. Q6 BUG-75 identity-key call, now decidable against real data. Q7 verdict. || COO NOTE on the rollback half of the PO's proposal, which was ASKED AND ANSWERED, not skipped: the PO asked whether we could selectively roll main back to where it would have been had this been decided upfront. Checked rather than assumed — the answer is that there is no rollback target, because ADL-48 is gazetteer-first, not gazetteer-only. The geocoder is explicitly kept for the tail (Plockton et al. are in no dataset, and Scotland is the dogfood trial), so the geocoding machinery — threaded through 16 non-test files — the geocode_status state machine, BUG-73's retry/banner and the D13 index all stay; the gazetteer sits IN FRONT of that code rather than replacing it. Where the PO's instinct DOES apply is the documents, not the code: QUAL-24's four-way reconciliation should wait, because ADL-48 §12.2 states the GE-15 amendment gets smaller if the gazetteer lands. || A no-go verdict is a successful outcome here; the spike was commissioned precisely because the design has never met real code."
+    },
+
+    {
       "id": "ENV-02",
       "type": "chore",
       "title": "Staging 502s — Railway proxy 'connection dial timeout' to a single-replica service; app-side causes ruled out",


### PR DESCRIPTION
Tracker entry for QUAL-25 — the ADL-48 gazetteer feasibility spike, dispatched on PO direction 2026-08-02.

## Why a spike

ADL-48 recommends a three-stage build (S1 subdivisions → S2 gazetteer table → S3 local-first lookup). Its own §15.1 item 7 states: *"No code was written and no test was run."* Every number in it comes from probe scripts against npm package data in a scratch directory. Its OP-27 fresh-eyes review then found 7 defects, two blocking. The spike builds it for real and measures before we commit.

Branch `spike/gazetteer-feasibility`, draft PR, nothing merges. Seven questions — search performance at 170k rows (the PO's primary question), narrowing by trip country, Turso cold-seed cost, whether Nominatim actually has the tail villages, S1 correctness with review findings F2/F4 folded in, the BUG-75 identity-key call, and a verdict.

## The rollback question, asked and answered

The PO also asked whether we could selectively roll `main` back to where it would have been had this been decided upfront. Checked rather than assumed: **there is no rollback target.** ADL-48 is gazetteer-*first*, not gazetteer-*only* — the geocoder is explicitly kept for the tail, so the geocoding machinery across 16 non-test files, the `geocode_status` state machine, BUG-73's retry/banner and the D13 identity index all stay. The gazetteer sits in front of that code rather than replacing it.

Where the instinct does apply is the documents rather than the code: QUAL-24's four-way reconciliation should wait, since ADL-48 §12.2 states the GE-15 amendment gets smaller if the gazetteer lands.

## Checks

`npm run check`, `type:check:all`, `test:backend` (668), `test:frontend` (242) all pass. `STATUS.md` regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)