### PR TITLE
chore(QUAL-25): ADL-48 gazetteer feasibility spike — evidence and verdict

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,19 @@ test-results/
 # (the watcher script + LaunchAgent plist) is checked in, see .claude/hooks/notify.sh
 .claude/notify/queue/
 
+# ADL-48 gazetteer spike artefacts (spike/gazetteer-feasibility).
+# `data/gazetteer-cities.json` is a ~17 MB generated blob regenerated in one command by
+# `scripts/generate-gazetteer.mjs`. Deliberately NOT committed during the spike — whether
+# that blob ever belongs in git history is one of the open decisions the spike raises, and
+# committing it here would settle it by accident. Its row count, byte size and content hash
+# are recorded in jobs/architect/tech/20260802-ADL48-feasibility-spike.md instead.
+# `data/vendor/` holds upstream inputs copied out of node_modules (see F3 in that report).
+data/gazetteer-cities.json
+data/gazetteer-meta.json
+data/regions.generated.json
+data/vendor/
+spike-gazetteer.db*
+
 # Agent worktrees (isolation: "worktree" dispatches, OP-19). Each is a full checkout of
 # this repo — currently ~492 MB across all of them. ADL-39 assumed these were already
 # ignored; they were not, so any `git add -A` from the main checkout would stage entire

--- a/jobs/COO/inbox/20260802_1000-ARCHITECT-adl48-feasibility-spike-complete.md
+++ b/jobs/COO/inbox/20260802_1000-ARCHITECT-adl48-feasibility-spike-complete.md
@@ -1,0 +1,67 @@
+# ARCHITECT → COO — ADL-48 feasibility spike complete
+
+**Tracker:** OQ-06 · BUG-30 · **BUG-75** · D-19 · ENV-01 · GE-07 · GE-16
+**Branch:** `spike/gazetteer-feasibility` · **DRAFT PR — DO NOT MERGE**
+**BRD:** §5.2 GE-01…GE-18 (recommendations only — no BRD or tracker edits made)
+**Report:** `jobs/architect/tech/20260802-ADL48-feasibility-spike.md`
+
+## Verdict: **GO — WITH FOUR CHANGES**
+
+ADL-48's central decision survived being built. It is cheaper and less risky than the ADL
+argued, because the unmeasured question — search cost at 170k rows — has a clean answer that
+costs the product nothing. Three stated mechanisms must change; one inherited defect is live
+in shipped code today. First ADL-48 work where code was actually run.
+
+## Per-decision verdicts
+
+- **Q1 search perf — ADOPT FTS5 TRIGRAM; REJECT prefix.** Today 8.7 ms reading all 170,540
+  rows/keystroke. Trigram 0.2 ms with a *provably identical* result set (30/30 terms, id-set
+  equality). ADL-48 §5.3's "exact then prefix" is a **silent product regression** — "vegas"
+  stops finding Las Vegas. Trap: trigram returns **0 rows** below 3 chars, so min-3 must be a
+  validated precondition, not a UX convention.
+- **Q1 regime — REFRAMED.** Turso RTT 29.5 ms vs 8.7 ms CPU, so the real latency win is
+  **~22%, not 40×**. Don't let "40×" reach the PO — it's a local-file number. The true
+  argument is **rows read: 4,264× fewer**, and Turso bills on rows read. Min 3 chars, 250 ms
+  debounce, cap 50 + separate COUNT/GROUP BY.
+- **Q2 narrowing — ADOPT RANK, REJECT FILTER.** Under `LIKE` the PO's instinct was right
+  (filter 25× win, rank buys nothing). Under trigram, unnarrowed (0.2 ms) beats *filtered*
+  `LIKE` (0.3 ms) — the performance case dissolves. Filtering would hide **all 49 "bergen"**
+  rows from a GB trip. **Country is NOT the last signal**: the trip's existing places narrow
+  6 GB "Newport"s → **1**; recommend as a later ranking term.
+- **Q3 Turso — NOT A BLOCKER; move seed off boot path day one.** RTT 29.5 ms, `batch(2000)`
+  156 ms as one round trip, 2,000-row `VALUES` **33 ms** (5× better — put it in the brief).
+  Full seed 2.8–13.4 s wire time.
+- **Q4 Nominatim — STILL UNVERIFIED, and the question changed shape.** Unreachable (2 probes;
+  `WebFetch` non-functional, confirmed vs a control host). OSM proxy says all 9 present.
+  **New risk:** `nominatim-client.ts:81`'s settlement-type filter may drop results Nominatim
+  *did* return (Torridon/Gairloch/Applecross/Braemar are features as well as settlements).
+  **The closing probe must check the returned `type`, or it gives a false pass.**
+- **Q5 S1 — SAFE AND DISPATCHABLE.** Generator built and run: 714 rows, **76/76 preserved
+  byte-for-byte** (names too), 0 missing, 0 dup ISO, +638 additive; F4's 2 rows dropped and
+  named. F2 verified by me in `schema.ts`, not inherited. **F3: vendor it** — `iso3166-2-db`
+  costs **11.8 s install** (new number; review had disk only) for one 3.35 MB file.
+- **Q6 BUG-75 — WIDEN THE KEY; DECOUPLE IT.** Live **today** at 8,876 rows / 5.20% (worse
+  than the review, which correctly modelled post-S1 at 5,024 / 2.95% — reproduced exactly).
+  **S1 improves it.** A 0.1° coordinate bucket fixes 98.2%, leaving zero groups >10 km apart.
+
+## CI
+Draft PR opened; `scripts/ci-wait.sh` run to green before filing this. PR # in the branch.
+
+## Open issues / blockers
+- **Turso INSERT throughput UNVERIFIED** — the diagnostic token is read-only. I attempted the
+  authorised scratch-table write deliberately so the refusal was a second independent probe;
+  rejected, **nothing created, nothing to clean up, no user table touched.** Needs a
+  write-capable token from an S2 branch.
+- **Q4 needs one `curl` from any unfirewalled host** (staging shakedown or the PO's laptop).
+- **Open decision I deliberately did not settle:** whether the ~17 MB artifact belongs in git
+  history. Gitignored for now; row count, bytes and SHA-256 are in the report.
+
+## Now unblocked
+- **S0 (BUG-75 key widening)** — new, decoupled, dispatch first; cheapest to fix at 3 rows.
+- **S1** — ready, with the F2 upsert wording and F4 filter both proven.
+- **Database/Backend** — S2/S3 have measured numbers instead of estimates; both still gated on
+  GE-17/GE-18 and the GE-16 amendment (amend as a whole per F6, not one sentence).
+
+**Concession stated in the report §10:** the NW Highlands hold 45 gazetteer rows total, so for
+the Scotland trial the gazetteer is the *minority* path. If that trial is the priority, the
+honest sequencing is S0 → S1 → BUG-71 fix → **pause**, revisiting S2/S3 after.

--- a/jobs/architect/context/current.txt
+++ b/jobs/architect/context/current.txt
@@ -1213,3 +1213,116 @@ STILL UNVERIFIED (unchanged): whether Nominatim actually has Plockton/Shieldaig/
 METHOD NOTE worth keeping: the ADL's two coverage probes were both NAME-based, so one wrong
 assumption (Gaelic/variant toponym) could produce both negatives. Two probes that share an
 assumption are one probe. The coordinate-radius probe is what made the absence claim safe.
+
+================================================================================
+2026-08-02 — ADL-48 FEASIBILITY SPIKE (branch spike/gazetteer-feasibility)
+Deliverable: jobs/architect/tech/20260802-ADL48-feasibility-spike.md
+================================================================================
+PO declined to commit to ADL-48 on design alone. Commissioned a spike: build it for real,
+measure it, return a verdict. First ADL-48 work where code was actually written and run —
+every prior number came from probe scripts against package data in a scratch directory.
+
+VERDICT: GO WITH FOUR CHANGES. The central decision (gazetteer-first, geocoder for the
+tail) survived being built and is cheaper than ADL-48 argued. Three stated mechanisms must
+change and one inherited defect is live in shipped code today.
+
+Q1 SEARCH PERF — the PO's primary question. THE headline finding:
+  Today's LIKE '%q%' = 8.7 ms and reads ALL 170,540 rows per keystroke. Verified by
+  EXPLAIN QUERY PLAN (SCAN using covering index — it does use the index, as a scan, which
+  is why it isn't worse; still O(n)). Prefix LIKE 'q%' gets a real range SEARCH at 0.1 ms
+  but is a SILENT PRODUCT REGRESSION: "vegas" stops finding Las Vegas, "orleans" stops
+  finding New Orleans. FTS5 token-prefix is DIFFERENTLY lossy (misses Alness from "ness":
+  9 rows vs 55). FTS5 TRIGRAM = 0.2 ms with a PROVABLY IDENTICAL result set — 30/30 terms
+  full id-set equality, full case parity. It is a drop-in. Costs +7.2 MB and REPLACES three
+  b-tree indexes. Constraint: undefined below 3 chars, returns 0 silently — the route must
+  enforce min-3 itself or it's a silent-wrong-answer trap.
+  REGIME: network-dominated. Turso RTT 29.5 ms vs 8.7 ms CPU, so trigram cuts total latency
+  only ~22%, NOT 40x. Anyone quoting 40x to the PO is quoting a local-file number the
+  deployed app never sees. The real argument is rows read: 4,264x fewer, and Turso bills on
+  rows read. Fix the shape for cost/server load, not latency; debounce is the latency lever.
+  Min length 3 + 250 ms debounce (1 char matches 65,743 rows). Cap 50 + a SEPARATE
+  COUNT/GROUP BY keeps ambiguity detectable — and unlike BUG-71 the DB knows the true total,
+  so "truncated" is a fact we return, not an inference.
+
+Q2 NARROWING — the tension dissolves rather than resolving:
+  Under LIKE, a hard WHERE filter is a 25x win (7.7 -> 0.3 ms) and ORDER BY rank buys
+  NOTHING (7.5-8.4 ms). So the PO's performance intuition was exactly right for the query
+  shape we have. But trigram unnarrowed (0.2 ms) already beats the FILTERED LIKE (0.3 ms) —
+  so once the shape is fixed there is no performance case for filtering at all and it
+  reverts to a pure product decision. RECOMMEND RANK. Filtering would hide all 3 "calais"
+  and all 49 "bergen" rows from a GB-declared trip — the day-trip-over-the-border case is
+  total, not marginal. Also: no-declared-countries degrades gracefully under rank, whereas a
+  filter has to special-case it.
+  IS COUNTRY THE LAST SIGNAL? NO. The trip's already-added places are an unused and much
+  stronger signal: 6 GB "Newport"s -> 1 within 100 km of an anchor (country only gets 32 -> 8).
+  Region genuinely IS unavailable — PO right on that half, and today doubly so: 22 of 26
+  region-tier countries have ZERO regions seeded. Recommend proximity as a later RANKING
+  term, not day one.
+
+Q3 TURSO — measured; write half blocked and I say so:
+  RTT 29.5 ms, batch(2000) 156 ms as ONE round trip, 2000-row VALUES stmt 33 ms. Full seed
+  wire time 2.8 s (VALUES) to 13.4 s (batch) — the VALUES shape is 5x better, worth putting
+  in the brief. Staging DB today 0.32 MB; production gazetteer footprint ~16.5 MB.
+  WRITES NOT MEASURABLE: the diagnostic token is read-only. I ATTEMPTED the authorised
+  scratch-table write deliberately so the refusal would be a second independent probe rather
+  than inheriting ADL-33 §5's text. Rejected ("SQL write operations are forbidden").
+  Post-check confirmed nothing was created, so nothing to drop. No user table touched.
+  RECOMMEND seedGazetteer() off the boot path FROM DAY ONE, not "if it exceeds the window" —
+  it sits in the awaited startup sequence before listen, and unmeasured write throughput on
+  a path where failure means the container never goes healthy is not worth it.
+
+Q4 NOMINATIM — STILL UNVERIFIED, and a bigger risk found underneath:
+  Unreachable: two probes (full read of init-firewall.sh allowlist; live curl, 23 ms local
+  REJECT). WebFetch was non-functional this session — 6 attempts, 5 hosts, INCLUDING
+  example.com as a control, so it's the tool not the target. Railway staging deploy log
+  array empty (ONE probe — explicitly NOT claiming such logs never existed).
+  OSM-presence proxy says all 9 present (Dornie direct: node 2133123145, typed Hamlet).
+  Stated as a proxy, not a Nominatim query.
+  THE REAL FINDING: nominatim-client.ts:81 filters every result to SETTLEMENT_TYPES
+  {city,town,village,hamlet,municipality}. Torridon/Gairloch/Applecross/Braemar denote
+  FEATURES as well as settlements. The risk is not "Nominatim lacks Plockton", it's
+  "Nominatim returns it and OUR OWN FILTER drops it". Neither ADL-48 nor its review drew
+  this distinction. The closing probe must check the returned `type`, not just that rows
+  came back — testing presence alone would give a FALSE PASS.
+
+Q5 S1 CORRECTNESS — generator built, run, proven:
+  714 rows (F4 dropped exactly 2: ID "West Papua", PH "Negros Island Region", both named in
+  the output, never silent). 76/76 preserved BYTE-FOR-BYTE, 0 missing, 0 name drift (I
+  compared names too, not just codes), 0 duplicate ISO, +638 net additive. F2 verified
+  MYSELF in schema.ts (FK, AUTOINCREMENT, uniq index, existingCount>0 early return) — not
+  inherited. Join 99.24% / NULL 1.37% — reproduces the REVIEWER, not ADL-48 (99.28/1.02).
+  Third independent derivation; ADL-48 §4.1 should be corrected.
+  F3 QUANTIFIED WITH A NUMBER THE REVIEW DIDN'T HAVE — INSTALL TIME: iso3166-2-db is
+  11,837 ms / 283 MB / 42,268 files vs cities.json 546 ms / 19 MB / 9 files, for ONE 3.35 MB
+  file. ~21x the install cost for 0.02% of the payload, paid per worktree AND per CI run.
+  RECOMMEND VENDORING. Spike deliberately did NOT add either package to package.json — a
+  spike shouldn't impose a 283 MB install on every CI run for work that ships nothing.
+
+Q6 BUG-75 — live defect today, and S1 IMPROVES it:
+  I MODELLED IT WRONG FIRST and caught it: grouping by raw region_iso invents a
+  discriminator the app doesn't have (region_id is forced NULL when region_tier_enabled=0),
+  which UNDERCOUNTS. Corrected model is time-dependent, so four scenarios not one:
+    A TODAY (76 regions)      8,876 rows / 5.20% unrepresentable, worst 8,092 km
+    B post-S1 (714 regions)   5,024 / 2.95% — REPRODUCES THE OP-27 REVIEW EXACTLY
+    C +0.1 deg bucket (~11km)    89 / 0.05%, ZERO groups >10 km apart
+    D +0.01 deg bucket (~1.1km)   1 / 0.00%
+  So: the review is right AND models post-S1; TODAY is materially worse and nobody had
+  measured it. COO's inference about the 22 zero-region countries CONFIRMED (list verified
+  from repo data). RECOMMEND the 0.1 deg coordinate bucket — 98.2% fixed, and it's the point
+  where "different town" and "same town" separate cleanly (0.01 deg is too tight and re-opens
+  the BUG-33 duplicate class). Costs ADL-48 §7's "no migration of cities" headline — but that
+  headline is ALREADY FALSE today. Dispatch as S0, DECOUPLED, cheapest to fix at 3 rows.
+
+WHAT I DID NOT CHANGE: ADL-48 G1/G2/G3/G5/G6/G8/G9/G10 all stand. Coverage floor re-verified
+  with three probes that fail differently — and probe 2 is why probe 3 mattered: a name-only
+  method reports Applecross and Braemar as PRESENT (they're elsewhere in the world). The
+  coordinate probe disambiguates. NW Highlands box = 45 rows, reproducing the review's P2.
+
+METHOD NOTES worth keeping:
+  - A speed table hides the decision. The Q1 answer was never "which is fastest" — three
+    shapes are within 0.1 ms of each other. It was "which changes what the user finds", and
+    only a result-SET comparison (not counts) settles it. Counts agreed for `vegas` at 9/9
+    while the row sets differed for `ness` at 55/9.
+  - Measure the regime before optimising the term. Local timings said 40x; the deployed
+    system sees 22%. Both are true and only one is relevant.
+  - When two documents disagree on a figure, derive it a third time rather than picking.

--- a/jobs/architect/park-docs/20260802-ARCHITECT-park-adl48-spike.txt
+++ b/jobs/architect/park-docs/20260802-ARCHITECT-park-adl48-spike.txt
@@ -1,0 +1,114 @@
+ARCHITECT PARK DOCUMENT — 2026-08-02
+ADL-48 bundled-gazetteer FEASIBILITY SPIKE
+Branch: spike/gazetteer-feasibility   ·   SPIKE — nothing ships, draft PR, do not merge
+================================================================================
+
+WHAT THIS THREAD WAS
+The PO declined to commit to ADL-48 on design alone and commissioned a spike: build
+enough of it for real to answer the open questions with measurements, then return a
+go / no-go / go-with-changes verdict. This is the first ADL-48 work in which code was
+written and run — ADL-48's own §15.1 item 7 says "No code was written and no test was
+run", and its OP-27 review was likewise probe-scripts-against-package-data.
+
+DELIVERABLE
+  jobs/architect/tech/20260802-ADL48-feasibility-spike.md   (the report, Q1-Q7)
+  scripts/generate-gazetteer.mjs                            (the generator, F2+F4 fixed)
+  scripts/spike/gazetteer-bench.mjs                         (Q1/Q2 search benchmark)
+  scripts/spike/gazetteer-turso-probe.mjs                   (Q3 Turso latency/seed)
+  scripts/spike/gazetteer-identity-analysis.mjs             (Q1f/Q1g/Q1h/Q2b/Q6)
+  scripts/spike/gazetteer-bug75-scenarios.mjs               (Q6, corrected model)
+
+VERDICT: GO WITH FOUR CHANGES
+  1. Search is FTS5 TRIGRAM — not LIKE, and NOT prefix. ADL-48 §5.3's "exact then
+     prefix" is a silent product regression and must not be briefed as written.
+  2. `regions` is seeded by ADDITIVE UPSERT, never delete-and-reload (F2).
+  3. VENDOR the 3.35 MB crosswalk; drop the iso3166-2-db dependency (F3).
+  4. BUG-75 is DECOUPLED and fixed on its own merits — it is live in shipped code.
+ADL-48's G1/G2/G3/G5/G6/G8/G9/G10 all stand. The spike does not kill the design.
+
+================================================================================
+THE FIVE THINGS A FUTURE READER MOST NEEDS
+================================================================================
+
+1. FTS5 TRIGRAM IS A PROVABLE DROP-IN. 30/30 terms, full result-SET equality (not just
+   counts), full case parity, 0.2 ms vs 8.7 ms, and it REPLACES three b-tree indexes so
+   the net storage change is small. This is the single most useful finding in the spike
+   because it removes a product tradeoff the PO would otherwise have had to make.
+   ITS TRAP: trigram is undefined below 3 characters and returns ZERO ROWS, not an
+   error. The route MUST enforce min-3 as a validated precondition. An implementer who
+   treats "min 3 chars" as a UX convention rather than a correctness requirement ships a
+   silent empty-results bug for 1-2 character queries.
+
+2. THE REGIME MATTERS MORE THAN THE BENCHMARK. Local libSQL says trigram is 40x faster.
+   The deployed app talks to Turso, where the round trip is 29.5 ms and the query is
+   8.7 ms — so the real improvement is ~22%. BOTH numbers are true; only one is
+   relevant to the user. The actual argument for changing the query shape is ROWS READ:
+   170,540 per keystroke vs ~40, a 4,264x difference, and Turso bills on rows read.
+   Do not let anyone quote "40x faster" to the PO.
+
+3. BUG-75 IS WORSE TODAY THAN THE REVIEW REPORTED, AND S1 IMPROVES IT. The OP-27 review's
+   5,024 / 2.95% reproduces EXACTLY — but it models the POST-S1 world. Today, with only
+   76 regions seeded, it is 8,876 rows / 5.20%, worst case 8,092 km. Seeding 638 more
+   subdivisions gives the key a real discriminator in the 22 region-tier countries that
+   currently have none, so S1 takes it DOWN. A 0.1 degree coordinate bucket then removes
+   98.2% and leaves zero colliding groups more than 10 km apart.
+   I MODELLED THIS WRONG ON THE FIRST PASS and caught it: grouping by the gazetteer's raw
+   region_iso invents a discriminator the app does not have, because cities.region_id is
+   forced NULL wherever region_tier_enabled = 0. That UNDERCOUNTS. If anyone re-derives
+   these numbers, model the region-tier invariant or the answer will be too optimistic.
+
+4. Q4 IS STILL OPEN AND THE OPEN QUESTION HAS CHANGED SHAPE. Nominatim remains
+   unreachable from this devcontainer (two probes; WebFetch was also non-functional this
+   session, confirmed against an example.com control). The OSM-presence proxy strongly
+   suggests all nine tail villages exist. BUT the risk that actually matters is
+   nominatim-client.ts:81's SETTLEMENT_TYPES filter — Torridon, Gairloch, Applecross and
+   Braemar denote features as well as settlements, and a result typed `locality`,
+   `peninsula` or `administrative` is discarded by OUR code even though Nominatim
+   returned it. WHOEVER CLOSES THIS must check the returned `type` field, not merely that
+   rows came back. Testing presence alone gives a false pass.
+
+5. COUNTRY IS NOT THE LAST AVAILABLE SIGNAL. The PO is right that region is unavailable
+   (the city is typed before the region is known). But the trip's ALREADY-ADDED PLACES
+   are available and much stronger: 6 GB "Newport"s narrow to 1 within 100 km of an
+   anchor, where country only narrows 32 to 8. Recommended as a later RANKING term, not
+   a filter and not day one.
+
+================================================================================
+STANDING CONSTRAINTS RE-CONFIRMED (do not re-discover these)
+================================================================================
+- The Turso diagnostic token is READ-ONLY. The COO's brief authorised a scratch table;
+  authorisation is not capability. I attempted the write deliberately so the refusal
+  would be an independent second probe. Rejected. Post-check confirmed nothing created,
+  nothing to clean up, no user table touched. TURSO INSERT THROUGHPUT REMAINS UNMEASURED
+  and needs a write-capable token from an S2 branch.
+- iso3166-2-db costs 11.8 s of install time, not just 283 MB of disk. The review had the
+  disk number; the time number is per-worktree AND per-CI-run and is the stronger
+  argument. The spike deliberately did NOT add it to package.json.
+- The generated artifact is GITIGNORED: 170,540 rows, 17,756,562 bytes,
+  sha256:26ea16ec6eed8dee06eb420147b6536f5f5c8af91edfc2fc0423aa1ca0475fd4.
+  Regenerate with scripts/generate-gazetteer.mjs. Whether that blob ever belongs in git
+  history is an OPEN DECISION the spike deliberately did not settle by accident.
+
+================================================================================
+REVISED STAGING (detail in the report §9)
+================================================================================
+  S0  BUG-75 coordinate-bucket key widening   — NEW, DECOUPLED, dispatch first
+  S1  Subdivisions (upsert, 714 rows, vendored crosswalk)  — ready
+  S2  Gazetteer table + trigram + off-boot seed            — needs GE-17/GE-18
+  S3  Local-first lookup (trigram, rank-not-filter)        — needs S0 + S2
+  follow-on: proximity ranking term
+Also decoupled and unchanged: ship the BUG-71 fix now; amend GE-16 as a whole (F6);
+stamp ADL-43 S2's 940-row figure (F5).
+
+THE CONCESSION I MADE EXPLICITLY (report §10)
+The NW Highlands box holds 45 gazetteer rows total, so for the Scotland dogfood trial
+specifically the gazetteer is the MINORITY path. If the PO's priority is that trial
+rather than the product generally, the honest sequencing is S0 -> S1 -> BUG-71 fix ->
+PAUSE, and revisit S2/S3 after. S0 and S1 deliver real value with no dependency on the
+contested half.
+
+NOT DONE / OUT OF SCOPE
+- No schema change, no migration generated, no db:migrate anywhere, no remote write.
+- No BRD or tracker edits (COO records at execution time; I recommend only).
+- ADL-48 and its review were NOT edited — findings are filed in the spike report for
+  COO adjudication, same convention the OP-27 review used.

--- a/jobs/architect/tech/20260802-ADL48-feasibility-spike.md
+++ b/jobs/architect/tech/20260802-ADL48-feasibility-spike.md
@@ -1,0 +1,766 @@
+# ADL-48 feasibility spike — the bundled gazetteer, built and measured
+
+**Date:** 2026-08-02
+**Author:** Architect (fresh dispatch; no authorship of ADL-48, its OP-27 review, ADL-43, ADL-46 or the BUG-71 documents)
+**Branch:** `spike/gazetteer-feasibility` — **SPIKE. Nothing ships. Draft PR, do not merge.**
+**Under test:** `jobs/architect/tech/ADL-48-bundled-gazetteer.md` · `jobs/architect/tech/20260802-ADL48-fresh-eyes-review.md`
+**Tracker:** OQ-06 · BUG-30 · BUG-75 · D-19 · ENV-01 · QUAL-21/22 · GE-07 · GE-16
+**Status:** Complete. Verdict in §1.
+
+Unlike ADL-48 (whose §15.1 item 7 states *"No code was written and no test was run"*), **every number in
+this document was produced by running code against the real 170,540-row dataset loaded into a real libSQL
+database, or against Turso staging over the wire.** Where I could not measure something, it is marked
+UNVERIFIED with the probe and its blind spot, never rounded up into a claim.
+
+---
+
+## 1. Summary table and verdict
+
+> ## VERDICT: **GO — WITH FOUR CHANGES**
+>
+> ADL-48's central decision (gazetteer-first, geocoder for the tail) survived being built. It is
+> **cheaper and less risky than ADL-48 argued**, because the one thing nobody measured — search cost
+> at 170k rows — has a clean answer that costs the product nothing. But **three of ADL-48's stated
+> mechanisms must change**, and one defect it inherits is **live in shipped code today**.
+
+| # | Question | Finding | Recommendation | Confidence |
+|---|---|---|---|---|
+| **Q1** | Search perf at 170k rows | Today's `LIKE '%q%'` = **8.7 ms** and reads **all 170,540 rows per keystroke**. **FTS5 trigram = 0.2 ms with a *provably identical* result set (30/30 terms)** | **Adopt FTS5 trigram. Do NOT switch to prefix matching** — prefix silently loses "New Orleans", "Las Vegas", "East Los Angeles" | **High** |
+| **Q1b** | Latency regime | **Network-dominated.** Turso RTT **29.5 ms** vs 8.7 ms CPU. Query shape cuts total latency only ~22% — but cuts **rows read by 4,264×** | Fix the query shape for **cost and server load**, not for latency. Debounce is the latency lever | **High** |
+| **Q1c** | Min query length | 1 char matches **65,743 rows**; 3 chars matches 6,965. Trigram is unusable below 3 chars (returns 0) | **Minimum 3 characters, 250 ms debounce.** The UX answer and the trigram constraint coincide | **High** |
+| **Q1d** | Result caps | A cap of 50 truncates `san` (6,965 rows) but not `springfield`/`newport`/`york` | Cap rows at 50; keep ambiguity detectable with a **separate `COUNT(*)`/`GROUP BY`**, which is ~0.2 ms under trigram | **High** |
+| **Q2** | Narrow by trip country | Under `LIKE`, filter helps hugely (7.7→0.3 ms), rank not at all. **Under trigram, neither is needed — the performance argument dissolves** | **RANK, don't filter.** The PO's shortlist-not-filter instinct is affordable once the query shape is fixed | **High** |
+| **Q2b** | Is country the last signal? | **No.** The trip's already-added places are a strong unused signal: 6 GB "Newport"s → **1** within 100 km of an anchor. Region genuinely is unavailable — the PO is right about that half | Add a proximity tiebreak later as a **ranking** input. Not day one | **Medium** |
+| **Q3** | Turso cold seed | RTT 29.5 ms; `batch(2000)` = 156 ms as **one** round trip; a 2,000-row `VALUES` statement = **33 ms**. Wire time for a full seed ≈ **3–14 s**. **INSERT throughput NOT measurable — token is read-only, confirmed by an attempted write** | Not a blocker. **Move `seedGazetteer()` off the boot path from day one** anyway | **Medium** (reads High, writes UNVERIFIED) |
+| **Q4** | Does Nominatim have the tail? | **STILL UNVERIFIED.** Unreachable from here (2 probes). OSM-presence proxy says all 9 present. **New risk found: the app's own settlement-type filter is a bigger threat than coverage** | Close it on the staging shakedown, and **test the filter, not just presence** | **Low** (see §5) |
+| **Q5** | S1 correctness | Generator built and run. **714 rows, 76/76 preserved byte-for-byte, 0 missing, 0 name drift, 0 duplicate ISO, +638 additive.** F4's 2 malformed rows dropped and named | **S1 is safe and dispatchable** with the F2 upsert wording | **High** |
+| **Q5b** | F3 `iso3166-2-db` cost | **283 MB, 42,268 files, 11.8 s install** — for one **3.35 MB** file. vs `cities.json` at 19 MB / 9 files / **0.5 s** | **Vendor the 3.35 MB file. Do not take the dependency** | **High** |
+| **Q6** | BUG-75 identity key | **Live defect TODAY: 8,876 rows / 5.20% unrepresentable, worst case 8,092 km.** S1 *improves* it to 5,024 / 2.95%. A 0.1° coordinate bucket fixes **98.2%** (→89 rows) | **Widen the key with a coordinate bucket.** Do it **independently of the gazetteer** — it is broken now | **High** |
+
+### The four changes
+
+1. **Search is FTS5 trigram, not `LIKE`, and not prefix.** (Q1) ADL-48 §5.3 says "exact then prefix" —
+   that is a silent product regression and must not be briefed as written.
+2. **`regions` is seeded by additive upsert, never delete-and-reload.** (Q5 / F2) Implemented and
+   documented in the generator; the S1 brief must say it explicitly.
+3. **Vendor `iso3166-2.json`; drop the `iso3166-2-db` dependency.** (Q5b / F3)
+4. **BUG-75 is decoupled from this ADL and fixed on its own merits.** (Q6) ADL-48 §7's headline
+   *"there is no migration of `cities`"* is **already false today** — the defect is shipped.
+
+### What I am NOT recommending changed
+
+ADL-48's **G1, G2, G3, G5, G6, G8, G9, G10** all stand. The coverage floor (§2), the crosswalk (§4.1),
+the no-FK topology (§5.1) and the "geocoder for the tail" call (G6) all survived independent re-testing —
+see §8.2. **This spike does not kill the design.** It fixes three mechanisms and returns one defect to its
+rightful owner.
+
+---
+
+## 2. Q1 — Search performance at 170,540 rows
+
+### 2.1 First: verify the index inference, don't inherit it
+
+The brief inferred that `like(cities.name, '%${q}%')` (`src/backend/routes/cities.ts:48`, verified by
+reading it) cannot be served from an index, and asked me to check rather than accept. **Measured with
+`EXPLAIN QUERY PLAN` against the real table:**
+
+| Query | Plan |
+|---|---|
+| `LIKE '%york%'` (today) | `SCAN gazetteer_cities USING COVERING INDEX idx_gaz_name_nocase` |
+| `LIKE 'york%'` (prefix) | `SEARCH ... USING COVERING INDEX ... (name>? AND name<?)` |
+| `LIKE 'york%' COLLATE NOCASE` | `SEARCH ... (name>? AND name<?)` |
+| FTS5 `MATCH` | `SCAN gaz_fts VIRTUAL TABLE INDEX 0:M1` |
+
+**The inference is correct in substance, with one nuance worth stating precisely.** A leading wildcard
+cannot **seek** — it gets `SCAN`, not `SEARCH`. But SQLite does still use the index as a *covering* scan,
+reading the narrow index rather than the wide table. That is why today's query is 8.7 ms rather than
+catastrophically worse. **It remains O(n) in table size and reads every row.** The prefix form gets a real
+range seek (`name>? AND name<?`).
+
+### 2.2 The measurements — local libSQL, 170,540 rows, median of 5 runs over 8 terms
+
+| Shape | Median | Min | Max | Semantics |
+|---|---|---|---|---|
+| `LIKE '%q%'` **(today)** | **8.7 ms** | 7.7 | 9.4 | substring, anywhere |
+| `LIKE 'q%'` (prefix) | **0.1 ms** | 0.1 | 0.5 | **prefix only — lossy** |
+| FTS5 token-prefix | **0.2 ms** | 0.1 | 0.4 | word-boundary prefix — **also lossy** |
+| **FTS5 trigram** | **0.2 ms** | 0.1 | 0.3 | **substring — identical to today** |
+
+Build cost, measured: insert 486 ms · b-tree indexes 228 ms · FTS5 784 ms · **trigram 1,183 ms.**
+
+### 2.3 The semantic cost — the part a speed table hides
+
+**This is the section the PO should read.** Same typed text, four shapes, real counts:
+
+| Typed | `LIKE %q%` | `LIKE q%` | FTS5 token | **FTS5 trigram** | What prefix loses |
+|---|---|---|---|---|---|
+| `york` | 40 | 25 | 40 | **40** | `Bridle Path-Sunnybrook-York Mills` |
+| `orleans` | 4 | 3 | 7 | **4** | **New Orleans** |
+| `angeles` | 8 | 1 | 33 | **8** | **East Los Angeles** |
+| `vegas` | 9 | 2 | 9 | **9** | **Las Vegas** |
+| `sur` | 966 | 100 | 923 | **966** | `Ablon-sur-Seine` |
+| `ness` | 55 | 6 | **9** | **55** | `Alness` |
+
+Two things follow, and both are decisions rather than details:
+
+**Prefix matching is a product regression and must not be adopted.** Typing "vegas" stops finding Las
+Vegas; "orleans" stops finding New Orleans. ADL-48 §5.3's *"exact then prefix"* would ship exactly this.
+The brief was right to insist this be surfaced explicitly rather than buried in a benchmark.
+
+**FTS5 token-prefix is not a substitute either, and the `ness` row is why.** It finds `New Orleans` from
+"orleans" (a word boundary) but misses `Alness` from "ness" (mid-word): **9 rows against 55.** It is
+*differently* lossy, not less lossy — for `angeles` it returns 33 where substring returns 8, so it is both
+over- and under-inclusive relative to today.
+
+### 2.4 The finding: trigram is a provable drop-in
+
+I compared **result sets**, not counts, over 30 terms — full id-set equality in both directions:
+
+```
+terms compared        : 30
+IDENTICAL result sets : 30
+differing             : 0
+```
+
+Case parity also holds (`YORK` / `York` / `york` → 40 / 40 / 40 for both). **FTS5 trigram returns exactly
+what `LIKE '%q%'` returns, for 1/40th of the time and 1/4,264th of the rows read.** There is no product
+decision to make here and no user-visible change to communicate — which is the opposite of the prefix
+option.
+
+**Its one real constraint:** trigram is undefined below 3 characters and returns **0 rows**, not an error.
+
+| Query | `LIKE` | trigram |
+|---|---|---|
+| `"y"` (1 ch) | 21,647 | **0** |
+| `"yo"` (2 ch) | 1,132 | **0** |
+
+That is a silent-wrong-answer trap for an implementer. **The route must enforce the 3-character minimum
+itself and never let a 1–2 character query reach the trigram index** — §2.5 shows the minimum is the right
+UX call independently, so this costs nothing, but it must be a validated precondition and not a convention.
+
+### 2.5 Minimum query length and debounce
+
+| Chars | Sample | `LIKE %q%` | Rows matched | FTS5 |
+|---|---|---|---|---|
+| 1 | `s` | 7.2 ms | **65,743** | 2.3 ms |
+| 2 | `sa` | 7.5 ms | 14,571 | 0.7 ms |
+| 3 | `san` | 7.5 ms | 6,965 | 0.3 ms |
+| 4 | `sant` | 7.3 ms | 2,168 | 0.1 ms |
+| 5 | `santa` | 7.6 ms | 1,318 | 0.1 ms |
+
+`LIKE` is flat (~7.5 ms) regardless of length — it always scans. **A 1-character query matches 65,743
+rows: useless to the user and maximally expensive to produce.**
+
+> **Recommendation: minimum 3 characters, 250 ms debounce.** 3 is where the result set becomes plausibly
+> useful *and* is exactly where trigram becomes valid. With a ~30 ms network floor (§4), debounce — not
+> query shape — is what the user actually perceives.
+
+### 2.6 Which regime are we in? — the honest framing
+
+**This determines whether §2 matters at all, and the answer is nuanced.**
+
+| Term | Measured |
+|---|---|
+| Turso staging round-trip (`SELECT 1`) | **29.5 ms** median (min 24.9, max 378.4) |
+| Local `SELECT 1` | ~0.0 ms |
+| Local `LIKE '%q%'` scan | 8.7 ms |
+
+**We are network-dominated for latency.** A search against Turso costs roughly `29.5 + 8.7 ≈ 38 ms`
+today, and `29.5 + 0.2 ≈ 30 ms` with trigram. **That is a 22% improvement, not 40×.** Anyone quoting "40×
+faster" to the PO would be quoting a local-file number that the deployed app never sees.
+
+**So why change the query shape at all?** Because latency is not the only cost:
+
+| Term | `LIKE '%q%'` rows read | trigram rows read | Ratio |
+|---|---|---|---|
+| `york` | 170,540 | 40 | **4,264×** |
+| `newport` | 170,540 | 32 | **5,329×** |
+| `plock` (no match) | 170,540 | 0 | **170,540×** |
+
+**Turso bills on rows read, and every keystroke past the debounce reads the entire table.** That is a
+cost and server-load problem that a single-user latency measurement cannot see, and it scales with users
+and keystrokes rather than with data. This is the real argument, and it is stronger than the latency one:
+*don't architect for the current user base* (2026-07-30) applies directly.
+
+### 2.7 Result caps and ambiguity
+
+Capping re-introduces the truncation problem that caused BUG-71 on the Nominatim path — the brief was
+right to flag it. Measured:
+
+| Term | Total rows | Distinct (country, region) | Truncated at 50? |
+|---|---|---|---|
+| `springfield` | 27 | 22 | no |
+| `newport` | 32 | 25 | no |
+| `york` | 40 | 21 | no |
+| `san` | 6,965 | **885** | **YES** |
+
+**How ambiguity stays detectable under a cap:** the cap truncates the *row list*; a **separate
+`COUNT(*)` and `GROUP BY (country_code, region_iso)`** answers "is this ambiguous, and how?" over the
+*complete* set. Under `LIKE` that second query costs another ~7 ms; under trigram it is ~0.2 ms, so it is
+affordable to always run it.
+
+**This is a structural improvement over the Nominatim path, not a re-run of BUG-71.** BUG-71 happened
+because Nominatim returned 10 rows and the code could not tell truncation from completeness. Here the
+database knows the true total, so `truncated: true` is a *fact we can return*, not an inference. The
+response should carry the true count and group count alongside the capped rows.
+
+---
+
+## 3. Q2 — Narrowing by trip country
+
+### 3.1 Filter vs rank, measured
+
+`trip_countries` exists (`schema.ts`, verified) so the trip's declared countries are available at search
+time. Both shapes measured against the real table:
+
+| Scenario | Unnarrowed | Hard `WHERE` filter | `ORDER BY` rank |
+|---|---|---|---|
+| 1 country (GB) | 7.7 ms | **0.3 ms** | 8.4 ms |
+| 2 countries (GB, FR) | 7.2 ms | **0.9 ms** | 7.5 ms |
+| 4 countries | 7.4 ms | **2.0 ms** | 7.5 ms |
+
+**The PO's performance intuition is exactly right — for the query shape we have today.** A hard filter is
+a 25× win because the country index narrows before the scan. **Ranking buys nothing**, because
+`ORDER BY (country_code IN (...))` still has to scan everything to sort it. ADL-48 §6.9 proposes precisely
+that `ORDER BY` and presents it as free; **it is not free, it is the full 7.5 ms.**
+
+### 3.2 But the tension dissolves — and that is the answer
+
+**Trigram already costs 0.2 ms unnarrowed.** That is faster than the *filtered* `LIKE` query (0.3 ms).
+Once the query shape is fixed, there is **no performance case for filtering at all**, and the choice
+reverts to being purely a product decision.
+
+> **Recommendation: RANK, not filter** — `ORDER BY (country_code IN (...)) DESC, name`, applied on top of
+> the trigram result set. The PO's shortlist-not-filter pattern is preserved, and nothing disappears.
+>
+> **The brief said "if ranking alone is fast enough, recommend ranking." It is — but only because the
+> query shape changes.** Under today's `LIKE`, ranking is genuinely too slow and the PO would have been
+> forced into filtering. This is the clearest case in the spike of a *wrong question* being retired by
+> fixing something else.
+
+### 3.3 What filtering would cost the user — measured
+
+If the numbers *had* forced a hard filter, this is what a trip declaring only GB would lose:
+
+| Typed | Rows worldwide | Rows in GB | Hidden by a filter |
+|---|---|---|---|
+| `calais` | 3 | **0** | **all 3** |
+| `bergen` | 49 | **0** | **all 49** |
+| `newport` | 32 | 8 | 24 |
+
+**The day-trip-over-the-border case is real and total, not marginal.** A user on a France trip who takes
+the ferry from Dover, or a Norway trip that started in GB, gets *zero* results and no explanation. That is
+the failure mode ranking avoids entirely.
+
+### 3.4 Is country genuinely the last available signal? — **No**
+
+The PO asked me to test this rather than accept it. Four candidate signals, assessed against real data:
+
+| # | Signal | Available at search time? | Narrowing power measured |
+|---|---|---|---|
+| 1 | **Trip's declared countries** | **Yes** — `trip_countries` | `newport` 32→8 (75%) · `york` 40→1 (98%) · `springfield` 27→0 (100%) |
+| 2 | **Region / state** | **No** — and the PO's reasoning is correct | n/a |
+| 3 | **The trip's already-added places** | **Yes** — and it is unused | **6 GB "Newport"s → 1** within 100 km of an anchor |
+| 4 | Previous trips' cities | Yes, in principle | Weak and biased toward where they have *been* |
+
+**Signal 2 — the PO is right, and today it is doubly unavailable.** The user types the city before the
+region is known, so region can never be a pre-existing key. Additionally, of the **26** region-tier
+countries only **4** (US, AU, CA, GB) have *any* regions seeded — the other **22** (AR, BD, BR, CN, ET, DE,
+IN, ID, JP, KZ, KR, MY, MX, MM, NG, PK, PH, RU, ZA, TH, UZ, VN) have **zero**, so `region_id` is invariantly
+NULL there and could not narrow anything even if it were known. **S1 is what fixes that**, which is an
+argument for S1 independent of the city half.
+
+**Signal 3 is the real finding, and it is genuinely new.** A trip is a geographic cluster. If the trip
+already contains a place, its coordinates are known, and proximity is a far sharper discriminator than
+country:
+
+```
+6 exact "Newport" rows in GB:
+  Newport  GB-ENG  53.763,-0.700     Newport  GB-WLS  52.017,-4.833
+  Newport  GB-ENG  52.767,-2.377     Newport  GB-ENG  51.984, 0.214
+  Newport  GB-WLS  51.588,-2.998     Newport  GB-ENG  50.701,-1.291
+An anchor at the first row + 100 km radius narrows 6 → 1.
+```
+
+Country narrowing takes 32 worldwide Newports to 8. **Proximity to an existing trip place takes 6 to 1.**
+
+> **Recommendation:** country ranking day one; **proximity as a second ranking term once S3 ships**, not
+> as a filter, and only when the trip already has at least one resolved place. It is a tiebreak, not a
+> gate — and it is the single highest-value follow-on this spike found. **Not day one:** it adds a
+> correlated-subquery term to the hot path and should be measured on its own.
+
+### 3.5 Edge cases the brief asked about
+
+- **Trip with no declared countries.** Ranking degrades gracefully to plain relevance ordering — nothing
+  is hidden and no special case is needed. **A hard filter would have to fall back to "no filter" here,
+  which is a discontinuity in behaviour the user would feel.** Another point for ranking.
+- **City outside the declared countries.** Under ranking it appears, just lower. Under filtering it is
+  invisible (§3.3). This is the whole argument in one line.
+
+---
+
+## 4. Q3 — Turso cold-seed cost and storage headroom
+
+### 4.1 What I could measure
+
+| Measurement (Turso staging, over the wire) | Result |
+|---|---|
+| Single-statement round trip | **29.5 ms** median · min 24.9 · max 378.4 (one cold outlier) |
+| `COUNT(*) FROM cities` | 26.7 ms |
+| `batch(1)` | 32.5 ms |
+| `batch(10)` | 28.0 ms (2.8 ms/stmt) |
+| `batch(100)` | 38.3 ms (0.4 ms/stmt) |
+| `batch(500)` | 49.3 ms (0.1 ms/stmt) |
+| `batch(2000)` | **156.4 ms (0.1 ms/stmt)** |
+| Single statement carrying **2,000 `VALUES` rows** | **33.1 ms** |
+| Staging DB size today | **0.32 MB** (83 pages × 4,096 B); cities=3, regions=76, countries=250 |
+
+**`batch()` costs approximately one round trip regardless of size** — this reproduces the OP-27 review's
+finding independently. Extrapolating 170,540 rows in 86 batches of 2,000:
+
+- via `batch(2000)`: 86 × 156 ms ≈ **13.4 s** of wire time
+- via a 2,000-row `VALUES` statement: 86 × 33 ms ≈ **2.8 s** of wire time
+
+**Neither is "tens of seconds to minutes."** ADL-48 §8.3's worst case is not realised, and the
+`VALUES`-statement shape is 5× better than `batch()` — worth specifying in the brief.
+
+### 4.2 What I could NOT measure, and why — the honest boundary
+
+> **Turso INSERT throughput is UNVERIFIED.** The only Turso credentials in this environment are in
+> `.env.agent-diagnostics`, which ADL-33 §5 makes **read-only by design**. The COO's brief authorised
+> creating a throwaway `spike_gazetteer_probe` table — but **authorisation is not capability.**
+>
+> **I attempted the write deliberately**, so that the refusal would be a second, independent probe rather
+> than my inheriting "it's read-only" from ADL-33's text:
+>
+> ```
+> CREATE TABLE spike_gazetteer_probe → REJECTED:
+>   BLOCKED: Operation was blocked: SQL write operations are forbidden
+>   (current session doesn't have write permission)
+> ```
+>
+> **Two probes, failing differently:** the ADL-33 §5 documentation, and a live rejected write.
+>
+> **Cleanup confirmed:** post-check `SELECT name FROM sqlite_master WHERE name='spike_gazetteer_probe'`
+> returned **0 rows** — nothing was created, so there was nothing to drop. `regions`, `cities`,
+> `countries` and every user table were untouched; the token could not have modified them.
+>
+> **Blind spot:** all figures above are `SELECT`s. Writes traverse the primary and may cost more per
+> batch. **What is bounded is the network round-trip term — the thing ADL-48 §8.3 was actually worried
+> about. What is not bounded is write throughput.** Staging and production may also differ in region and
+> plan; both were measured against **staging only**.
+
+### 4.3 Storage headroom
+
+Measured from the real loaded database (`dbstat`):
+
+| Object | Size |
+|---|---|
+| `gazetteer_cities` table | 7.58 MB |
+| `idx_gaz_name_nocase` | 3.10 MB |
+| `idx_gaz_name_country` | 3.59 MB |
+| `idx_gaz_country` | 1.77 MB |
+| **`gaz_trigram` (data + docsize + idx)** | **7.20 MB** |
+| `gaz_fts` (token, not recommended) | 4.09 MB |
+| **Total db file as built (all options)** | **27.54 MB** |
+
+A production build needs the table + trigram + a country index ≈ **16.5 MB**, and does **not** need
+`idx_gaz_name_nocase`, `idx_gaz_name_country` or `gaz_fts` — **trigram replaces all three for search**.
+Against a staging DB currently at 0.32 MB this is a step change in absolute terms and unremarkable in
+Turso terms.
+
+> **Recommendation: move `seedGazetteer()` off the boot path from day one** — do not wait to see whether
+> it exceeds a health-check window. This agrees with the review's P1. The seed sits in the awaited Express
+> startup sequence *before the server listens*; a 3–14 s wire time plus unmeasured write throughput, on a
+> path where failure means the container never becomes healthy, is not a risk worth taking for a
+> once-per-content-hash operation. **An explicit one-shot command is strictly safer and no harder to
+> build.** This also converts §4.2's UNVERIFIED write throughput from a rollout risk into a non-issue.
+
+---
+
+## 5. Q4 — Does Nominatim actually have the tail villages?
+
+> ### **STILL UNVERIFIED — and I found a second, larger risk underneath it.**
+
+### 5.1 Reachability — confirmed blocked, two independent probes
+
+1. **Config read.** `/usr/local/bin/init-firewall.sh` read in full. The allowlist loop resolves exactly:
+   GitHub CIDRs, `registry.npmjs.org`, `api.anthropic.com`, `sentry.io`, `statsig.com`, three VS Code
+   hosts, `just-raptor-89.clerk.accounts.dev`, the two Turso hosts, `backboard.railway.com`. **No
+   `nominatim` or `openstreetmap` entry.** Policy is `OUTPUT DROP` + explicit REJECT.
+2. **Live network.** `curl https://nominatim.openstreetmap.org/...` → exit 7, *"Failed to connect … after
+   23 ms"*. A 23 ms reject is a local REJECT, not a timeout.
+
+These fail differently (probe 1 misses rules added outside the script; probe 2 misses a transient upstream
+outage). Both agree.
+
+**Other paths attempted and their outcomes** — recorded so the next reader does not re-run them:
+
+| Path | Outcome |
+|---|---|
+| `WebFetch` against Nominatim / OSM / Wikipedia | **Non-functional this session** — 6 attempts across 5 hosts, including `example.com` as a control, all returned no output. The control failure shows it is the tool, not the target |
+| Staging backend's `/api/geocode` proxy | Staging host is **also not on the allowlist** (probe 1) — never available from here |
+| Railway MCP (logs, deployments) | Project `adequate-vision`; staging deployment `WAITING` with an **empty** deploy-log array. No historical `[GEO]` evidence. *Single probe — I do **not** claim such logs never existed* |
+| `WebSearch` | **Worked** — but returns search-engine summaries, not API responses |
+
+### 5.2 What the OSM-presence proxy says
+
+**Explicit inferential gap: this is "OSM has a named settlement object here", not "Nominatim returned
+it."** Nominatim is a direct index of OSM `place=*` objects, so the chain is tight but not airtight.
+
+| Place | In OSM? | Strongest evidence |
+|---|---|---|
+| **Dornie** | yes — **direct** | OSM **node 2133123145**, typed **Hamlet**, Highland |
+| **Applecross** | yes | OSM-derived page typed **Village**, Highland |
+| **Shieldaig** | yes | OSM-derived page typed **Village**, Highland |
+| Plockton | yes | Settlement page, pop 468; school `W31958302`, hotel `N357962410` |
+| Lochinver | yes | Settlement page, pop 651; lifeboat station `W209261934` |
+| Durness | yes | Settlement page, pop 347 |
+| Kyleakin | yes | Settlement page, pop ~300; community centre `W95233486` |
+| Gairloch | yes | Settlement page, pop 620 — but a *"straggling community"* naming several settlements |
+| Braemar | yes | Settlement page; heritage centre `N2466425937` |
+
+Secondary set also present: Tobermory, Kyle of Lochalsh, Mallaig, Arisaig, Glenfinnan, Glenelg, Torridon.
+
+### 5.3 The finding that matters more than the question asked
+
+Reading `src/backend/services/nominatim-client.ts` directly (a positive finding — self-verifying):
+
+```js
+const SETTLEMENT_TYPES = new Set(['city', 'town', 'village', 'hamlet', 'municipality']);
+// ...
+.filter((c) => c !== null && (c.type == null || SETTLEMENT_TYPES.has(c.type)))
+```
+
+`geocoding.service.ts` always queries with `countrycodes: <cc>, limit: '10'`.
+
+**Two consequences, and the second is the risk:**
+
+1. **Good news.** `countrycodes` eliminates the cross-border ambiguity risk — Arisaig (Nova Scotia),
+   Glenelg (Australia), Tobermory (Ontario), Braemar (Ontario) all drop out before ranking.
+2. **The real risk is the type filter, not OSM coverage.** Several of these names denote a *feature* as
+   well as a settlement — **Torridon** (an area), **Applecross** (also a peninsula), **Gairloch** (also a
+   sea loch and a collective name), **Braemar** (also resolves as a Region). A row typed `locality`,
+   `peninsula`, `bay` or `administrative` is **discarded by our own code even though Nominatim returned
+   it.** With `limit=10` the settlement node is usually also in the set — but "usually" is doing real work
+   in that sentence.
+
+   *Partial mitigation, in our favour:* the filter passes rows where `type == null`, so an untyped result
+   survives. That narrows the exposure but does not close it.
+
+> **Therefore ADL-48 §2.1 option (a) is probably safe on coverage grounds and less safe on filter
+> grounds — a distinction neither ADL-48 nor its review drew.**
+>
+> **How to close this properly** (and it is one command from any unfirewalled host — the staging
+> shakedown, or the PO's laptop):
+> ```
+> https://nominatim.openstreetmap.org/search?q=<name>&countrycodes=gb&limit=10&format=json&addressdetails=1
+> ```
+> for all 16 names, checking **not merely that results come back, but that at least one returned row has
+> `type` in {city, town, village, hamlet, municipality}**. Testing presence alone would give a false pass.
+
+**Confidence:** *"unreachable from here"* — **High** (two probes). *"OSM contains all nine"* — **High
+(~90%)**. *"Nominatim returns a candidate our filter accepts"* — **Moderate (~75%)**, and that is the claim
+ADL-48 G6 actually depends on.
+
+---
+
+## 6. Q5 — S1 correctness: the generator, built and run
+
+`scripts/generate-gazetteer.mjs` is committed and was run against the real datasets. Output:
+
+```
+=== SUBDIVISIONS (S1) ===
+  generated rows            : 714
+  dropped (F4, empty ISO)   : 2
+      DROP ID "West Papua"           (admin=39,  fips=39)
+      DROP PH "Negros Island Region" (admin=NIR, fips=NIR)
+  duplicate iso_3166_2      : 0 (none)
+  live regions.json rows    : 76
+  PRESERVED byte-for-byte   : 76 / 76
+  MISSING from generated    : 0
+  name/country mismatches   : 0
+  net NEW rows (additive)   : 638
+
+=== GAZETTEER CITIES (S2) ===
+  rows                      : 170540
+  rows in enabled countries : 84868
+  joined to ISO subdivision : 84226 (99.24%)
+  NULL region (all rows)    : 2336 (1.37%)
+
+=== S1 SEED SAFETY: PASS ===
+```
+
+### 6.1 The proofs the brief asked for
+
+| Requirement | Result |
+|---|---|
+| All **76** currently-seeded codes preserved byte-for-byte | **76 / 76.** Zero missing, and **zero name or country_code drift** — I compared names too, not just codes |
+| Zero duplicate `iso_3166_2` across the generated set | **0** — so `ON CONFLICT (iso_3166_2)` has a well-defined target |
+| Seed is genuinely additive | **+638 net new rows**, no deletions, no mutations of existing codes |
+| Run against a **local** database | Yes — §2 and §7 both run on the generated artifact in local libSQL |
+
+### 6.2 F2 — verified independently, and implemented
+
+I verified the mechanism myself in `src/backend/db/schema.ts` rather than inheriting it:
+
+- `cities.regionId` → `.references(() => regions.id)` — **confirmed**
+- `regions.id` → `integer('id').primaryKey({ autoIncrement: true })` — **confirmed AUTOINCREMENT**
+- `uniqueIndex('uniq_regions_iso_3166_2').on(t.iso3166_2)` — **confirmed, so the upsert target exists**
+- `seedRegions()` gates on `existingCount > 0` and returns early (`startup.service.ts`) — **confirmed**,
+  which is exactly why a regenerated 714-row file would never apply on staging or production without a
+  gating change
+
+**The review's F2 is correct and the risk is real.** ADL-48 §8.1 defines hash-gated seeding *only* as
+`DELETE` + batch-insert, and justifies its safety as *"nothing references `gazetteer_cities`"* — a
+precondition that is **false for `regions`**. An implementer reading §11's S1 row ("hash-gated reseed of
+`regions`") and following §8.1 for the mechanism builds silent `cities.region_id` corruption.
+
+The generator's header documents this at length and the S1 brief must state it:
+
+> `regions` is reseeded by **hash-gated `INSERT … ON CONFLICT (iso_3166_2) DO NOTHING`** (optionally
+> `DO UPDATE SET name = …`). It is **never** deleted and reloaded. §8.1's delete-and-reload applies to
+> `gazetteer_cities` **only**, because that is the only table nothing references.
+
+### 6.3 F4 — confirmed and fixed
+
+Exactly **2** of the 716 raw rows carry an empty ISO code and would have seeded as `"ID-"` / `"PH-"` —
+non-null and distinct, so they pass `NOT NULL` and the unique index and land as permanently unmatchable
+garbage. The generator filters them and **names them in its output rather than dropping silently**. The
+review's warning that this worsens as GE-07 enables more countries is well-founded: the same pattern
+exists across the full 234-country set.
+
+### 6.4 A correction to ADL-48's join figures
+
+| Measure | ADL-48 | OP-27 review | **This spike** |
+|---|---|---|---|
+| Rows in enabled countries | 84,868 | 84,868 | **84,868** |
+| Joined via crosswalk | 84,257 (99.28%) | 84,226 (99.24%) | **84,226 (99.24%)** |
+| NULL region, all rows | 1,746 (1.02%) | 2,336 (1.37%) | **2,336 (1.37%)** |
+
+**Third independent derivation: the review's figures are right and ADL-48's are slightly off.** Not
+decision-bearing, but ADL-48 §4.1 should be corrected so a future implementer doesn't chase the gap.
+
+### 6.5 F3 — the dependency cost, measured
+
+| Package | Unpacked | Files | **Install time** |
+|---|---|---|---|
+| `cities.json@1.1.61` | 19 MB | **9** | **546 ms** |
+| **`iso3166-2-db@2.3.11`** | **283 MB** | **42,268** | **11,837 ms** |
+
+The generator needs exactly one file from it: `data/iso3166-2.json`, **3.35 MB**. The bulk is `regions/`
+(205 MB) and `i18n/` (69 MB), neither of which the crosswalk touches.
+
+**The install-time number is new — the review measured disk, not time.** 11.8 s is paid **per agent
+worktree and on every CI run**, and this repo does both constantly (CLAUDE.md: *"a fresh worktree does not
+inherit `node_modules`"*). At ~21× `cities.json`'s install cost for 0.02% of its useful payload, this is
+the clearest cost/benefit failure in the proposal.
+
+> **Recommendation: vendor `data/vendor/iso3166-2.json` (3.35 MB) with its provenance recorded per GE-18,
+> and do not take the dependency.** It removes 280 MB, 42k files and ~12 s from every install, drops a
+> two-year-stale single-maintainer package from the supply chain, and pins the crosswalk against silent
+> upstream change. The generator already supports this: it resolves inputs from `--iso-db`,
+> `$ISO3166_2_DB`, `data/vendor/`, then `node_modules/` in that order.
+>
+> **The spike deliberately does not add either package to `package.json`** — a spike should not impose a
+> 283 MB install on every CI run for work that ships nothing. Inputs were passed explicitly from a scratch
+> install.
+
+---
+
+## 7. Q6 — BUG-75: the identity-key call
+
+### 7.1 The measurement, and a modelling correction I had to make myself
+
+`uniq_cities_name_country_region_ci ON cities (name COLLATE NOCASE, country_code, COALESCE(region_id, 0))`
+— verified in `schema.ts`.
+
+**My first pass was wrong and I am recording it because the error is instructive.** I grouped by the
+gazetteer's raw `region_iso`, which invents a discriminator the app does not have: `cities.region_id` is
+forced NULL for every country with `region_tier_enabled = 0` (enforced in `cities.ts` POST, documented in
+`schema.ts`). That **undercounts** collisions. The corrected model makes `region_id` non-NULL only where
+the country is region-tier **and** the region is actually seeded — which makes the answer time-dependent,
+so three scenarios must be measured, not one:
+
+| Scenario | Colliding groups | **Unrepresentable rows** | >10 km | >50 km | Worst case |
+|---|---|---|---|---|---|
+| **A — TODAY** (76 regions: US/AU/CA/GB) | 5,900 | **8,876 (5.20%)** | 5,743 | 5,349 | **8,092 km** (Nikol'skoye, RU) |
+| **B — post-S1** (714 regions, 26 countries) | 3,931 | **5,024 (2.95%)** | 3,765 | 3,312 | 1,922 km (Valverde, ES) |
+| **C — post-S1 + 0.1° bucket** (~11 km) | 89 | **89 (0.05%)** | **0** | **0** | 8 km |
+| **D — post-S1 + 0.01° bucket** (~1.1 km) | 1 | **1 (0.00%)** | 0 | 0 | 1 km |
+
+**Scenario B reproduces the OP-27 review exactly** — 5,024 / 2.95% / 3,765 groups >10 km / Valverde at
+1,921 km. Independent confirmation; the review is correct.
+
+**What the review does not report is scenario A, and it is worse.** The COO's inference in the brief —
+that with 22 of 26 region-tier countries holding zero regions the entire country becomes one identity
+bucket — **is confirmed**, and I verified the country list from the repo's own data rather than accepting
+it: AR, BD, BR, CN, ET, DE, IN, ID, JP, KZ, KR, MY, MX, MM, NG, PK, PH, RU, ZA, TH, UZ, VN.
+
+### 7.2 Three consequences that change how this should be briefed
+
+1. **The defect is live in shipped code today, at 5.20%, and is not gazetteer-specific.** It is latent only
+   because `cities` holds 3 rows. **ADL-48 §7's headline — "there is no migration of `cities`" — is
+   already false**, not falsified by the gazetteer. The gazetteer *reveals* the defect; it does not create it.
+2. **S1 makes it better, not worse: 8,876 → 5,024.** Seeding 638 subdivisions gives the key a real
+   discriminator in the 22 countries that currently have none. **This is an additional argument for
+   dispatching S1 first**, and it inverts the natural assumption that more data means more collisions.
+3. **A coordinate bucket is a decisive fix.** 0.1° (~11 km) removes **98.2%** of remaining collisions and
+   leaves **zero** groups more than 10 km apart — i.e. it eliminates every case where the failure is
+   "wrong town", leaving only 89 genuine near-duplicates where conflation is arguably correct behaviour.
+
+Concrete GB cases surviving S1 (scenario B) — these are what a PO would actually hit:
+`Ashington` 478 km · `Rochester` 469 km · `Washington` 450 km · `Newport` (4 rows) 342 km ·
+`Richmond` 340 km · `Wootton` (4 rows) 328 km.
+
+### 7.3 Recommendation
+
+> **Widen the identity key with a coordinate bucket. Reject "accept conflation" and reject "hide
+> colliding rows".**
+>
+> New key: `(name COLLATE NOCASE, country_code, COALESCE(region_id,0), lat_bucket, lng_bucket)` where the
+> buckets are `ROUND(latitude, 1)` / `ROUND(longitude, 1)` stored as generated or explicit columns.
+>
+> **Why not the alternatives:**
+> - *Accept conflation* — 8,876 rows today silently mis-pin, up to 8,092 km. GE-17's own success criterion
+>   ("presents all of them distinguishably") would be honoured in the search list and then thrown away on
+>   selection. That is a worse failure than the bug it replaces, because it is silent.
+> - *Hide colliding rows* — 5,024 real places become unselectable, re-creating the coverage-floor problem
+>   ADL-48 §2 exists to avoid. Solving a coverage argument by deleting coverage.
+>
+> **Why 0.1° and not 0.01°:** 0.01° leaves 1 collision instead of 89, but 1.1 km is tight enough that
+> genuine duplicate entries for the same town (upstream near-duplicates, alternate spellings at slightly
+> different centroids) stop converging — which re-opens the BUG-33 duplicate class the D13 key exists to
+> close. **0.1° is the point where "different town" and "same town" separate cleanly:** zero groups above
+> 10 km remain, so every surviving collision is a genuine same-place duplicate.
+>
+> **Cost, stated plainly:** a new unique index on `cities` — a real migration, staged per ADL-47 (expand:
+> add nullable bucket columns + backfill; migrate: populate on write; contract: swap the unique index).
+> **This blocks S3 and should be dispatched as its own brief, decoupled from ADL-48**, because it is a
+> live defect on shipped code with 3 rows in the table — i.e. the cheapest it will ever be to fix.
+
+---
+
+## 8. Verified vs unverified
+
+### 8.1 Unverified, with the probe and its blind spot
+
+1. **Nominatim's coverage of the tail villages — UNVERIFIED.** §5. Two independent probes establish it is
+   unreachable from this devcontainer; a third path (`WebFetch`) was non-functional this session,
+   confirmed against a control host. Data claims rest on an **OSM-presence proxy**, not a Nominatim query.
+   *Probe to close it:* the 16-name query in §5.3 from any unfirewalled host, **checking the returned
+   `type` field, not merely that rows came back.** *Blind spot:* one query set at one moment.
+2. **Turso INSERT throughput and write limits — UNVERIFIED.** §4.2. The diagnostic token is read-only,
+   confirmed by an attempted write that was rejected. All Turso figures are `SELECT`s. *Probe:* a real
+   batched insert from an S2 branch with a write-capable token. *Blind spot:* staging only — production
+   may differ in region and plan.
+3. **Whether Railway staging deploy logs ever contained `[GEO]` evidence — UNVERIFIED.** One probe (empty
+   log array on a `WAITING` deployment). **I do not claim such logs never existed.**
+4. **Trigram behaviour under Turso's server, at concurrency — UNVERIFIED.** All query timings in §2 are
+   local libSQL, single-user, warm cache. The §2.6 regime analysis composes them with a separately measured
+   network term; it does **not** measure Turso executing a trigram `MATCH` under load. *Probe:* replay the
+   §2 benchmark against a staging table once a write-capable path exists.
+5. **The 0.1° bucket's interaction with real upstream near-duplicates — PARTLY VERIFIED.** I measured that
+   it leaves 89 collisions and zero groups >10 km. I did **not** hand-inspect those 89 to confirm each is a
+   genuine same-place duplicate rather than two adjacent villages.
+6. **`feature_code` recovery** — not attempted; ADL-48 §6.4 already marks it unverified and the design does
+   not depend on it. I confirmed the premise: `cities.json` rows carry only `name, lat, lng, country,
+   admin1, admin2`.
+
+### 8.2 Verified in this spike, and how
+
+- **Query plans, timings, semantic differences, equivalence, storage and rows-scanned (§2)** — by building
+  the real 170,540-row table in local libSQL and running `EXPLAIN QUERY PLAN`, timed benchmarks (median of
+  5–7 runs), full id-set comparison over 30 terms, and `dbstat`.
+- **Filter-vs-rank and the four narrowing signals (§3)** — measured against the same real table.
+- **Turso round-trip, batch behaviour, storage and the read-only boundary (§4)** — live against staging via
+  `@libsql/client`, using the ADL-33 allowlisted path. The write refusal is a deliberate second probe.
+- **Generator correctness: 714 rows, 76/76 byte-for-byte with names, 0 duplicates, 0 missing, +638 additive,
+  2 F4 drops (§6)** — by running `scripts/generate-gazetteer.mjs` against the real packages and diffing
+  against the repo's live `data/regions.json`.
+- **F2's mechanism (§6.2)** — read directly in `schema.ts` and `startup.service.ts`: the FK, the
+  AUTOINCREMENT, the unique index, and the `existingCount > 0` early return. Not inherited from the review.
+- **F3's install cost (§6.5)** — timed `npm install` into a clean scratch directory; `du` and `find` for
+  size and file count.
+- **BUG-75 across four scenarios (§7)** — the identity key computed exactly as `schema.ts` defines it, with
+  the region-tier invariant modelled correctly (after correcting my own first pass), pairwise separations
+  per colliding group. Scenario B independently reproduces the OP-27 review to the decimal.
+- **The 22 zero-region countries (§3.4/§7.1)** — computed from the repo's own `data/countries.json` and
+  `data/regions.json`.
+- **The coverage floor (§8.3)** — re-verified independently by three probes that fail differently.
+- **The settlement-type filter (§5.3)** — read directly in `nominatim-client.ts`; a positive, self-verifying
+  finding.
+
+### 8.3 The coverage floor, re-verified independently
+
+I re-ran ADL-48 §2's load-bearing claim with three probes that fail differently, against the artifact my
+own generator produced:
+
+| Probe | Result |
+|---|---|
+| **1 — exact name match, `country_code='GB'`** | All 9 tail names: **0**. Control set (Glasgow, Edinburgh, Inverness, Ullapool, Aviemore, Portree, Tarbert): **1 each**. Tobermory: **0** |
+| **2 — case-insensitive substring, all 246 countries** | 7 of 9: **0**. `Applecross`: 1, `Braemar`: 2 — **elsewhere in the world**, not Scotland |
+| **3 — name-free, any row within ~15 km of true coordinates** | All 9: **0 rows**. Method self-validates: Ullapool and Portree each return exactly 1 |
+
+**Probe 2 is why probe 3 matters.** A purely name-based method would have reported Applecross and Braemar
+as "present" — they are same-named places in other countries. The coordinate probe is independent of every
+naming assumption and disambiguates. **ADL-48 §2's absences are genuine, and the Tobermory parenthetical is
+correct.**
+
+The review's P2 finding also reproduces exactly: the **NW Highlands box (lat 56.5–58.7, lng −7.5 to −3.5)
+holds 45 rows total.** For the Scotland dogfood trial the gazetteer will be the **minority** path. That does
+not undermine the design — it means S3's user-visible benefit is national/global, not for the trial that
+motivated it, and the PO should hear that plainly.
+
+---
+
+## 9. Revised staging plan
+
+The S1/S2/S3 split **still holds**, with the amendments below. Two items are **decoupled** — they are not
+gazetteer work and should not wait for it.
+
+| Stage | Change from ADL-48 §11 | Blocked on |
+|---|---|---|
+| **S0 — BUG-75 key widening** | **NEW, and decoupled.** Coordinate-bucket unique index on `cities`, staged expand/contract per ADL-47. Live defect, cheapest to fix now at 3 rows | Nothing. **Dispatch first** |
+| **S1 — Subdivisions** | **Additive upsert, never delete-and-reload** (F2). **714 rows, not 716/940** (F4/F5). **Vendor the 3.35 MB crosswalk** (F3) | Nothing. Ready |
+| **S2 — Gazetteer table + seed** | Add **FTS5 trigram** index. **`seedGazetteer()` off the boot path from day one** (§4.3). Use the **2,000-row `VALUES`** shape, 5× better than `batch()`. Pin the `cities.json` version in `gazetteer-meta.json` (P3) | S1; BRD gate GE-17/GE-18 |
+| **S3 — Local-first lookup** | Search is **trigram**, not "exact then prefix". **Rank by trip country, do not filter.** Min 3 chars, 250 ms debounce, cap 50 + separate count | **S0**, S2, GE-16 amendment |
+| **(follow-on)** | Proximity-to-existing-trip-place as a second ranking term (§3.4) | S3 |
+
+**Also decoupled, unchanged from the review's disposition:** the BUG-71 fix should ship now; GE-16 needs
+amending as a whole (F6), not one sentence; ADL-43 S2's 940-row figure needs a stamp (F5).
+
+---
+
+## 10. The strongest argument against my own verdict
+
+> *"You have just added an FTS5 trigram index (+7.2 MB), a coordinate-bucket migration on `cities`, a
+> vendored 3.35 MB data file and an off-boot seed command — on top of everything ADL-48 already proposed —
+> for an app with 3 cities and 2 users. And your own §8.3 says the Scotland trial will mostly miss the
+> gazetteer anyway."*
+
+Three answers, and one concession.
+
+1. **Two of the four changes make the proposal *smaller*, not larger.** Vendoring removes 280 MB and 12 s
+   from every install. Trigram *replaces* three b-tree indexes rather than adding to them. The net
+   implementation surface is close to flat.
+2. **BUG-75 is not new scope — it is existing, shipped, unfixed scope that this exercise measured.** It
+   would be there if ADL-48 were rejected outright. Discovering it at 3 rows is the good outcome; the
+   alternative is discovering it after the table has user data and the migration is expensive.
+3. **The "3 cities" framing is explicitly ruled out on this project** (`feedback_dont_architect_for_current_user_base`,
+   2026-07-30). And the per-keystroke rows-read figure (§2.6) scales with *use*, not with data — it is
+   already 170,540 rows per keystroke on day one.
+
+**The concession, and it is real:** §8.3 means S3's benefit for the Scotland trial specifically is modest,
+because most of those places fall through to the geocoder regardless. **If the PO's priority is the
+Scotland trial rather than the product generally, the honest sequencing is S0 → S1 → BUG-71 fix → *pause*,
+and revisit S2/S3 afterwards.** S1 closes the BUG-30 class and improves BUG-75 on its own; S0 fixes a live
+defect. Those two deliver real value with no dependency on the contested half — which is ADL-48 §11's own
+argument, and it survives this spike intact.
+
+---
+
+*Spike complete. No schema change was made, no migration was generated, no remote database was written to,
+and `main` was not touched. The ~17 MB generated artifact is gitignored — 170,540 rows, 17,756,562 bytes,
+`sha256:26ea16ec6eed8dee06eb420147b6536f5f5c8af91edfc2fc0423aa1ca0475fd4` — regenerate with
+`node scripts/generate-gazetteer.mjs`.*

--- a/scripts/generate-gazetteer.mjs
+++ b/scripts/generate-gazetteer.mjs
@@ -1,0 +1,312 @@
+#!/usr/bin/env node
+/**
+ * Travel Tracker — gazetteer / subdivision generator  (ADL-48 §8.1, SPIKE)
+ *
+ * STATUS: SPIKE ARTEFACT. Nothing here ships without the COO adopting the
+ * feasibility spike's verdict (jobs/architect/tech/20260802-ADL48-feasibility-spike.md).
+ *
+ * Reads two upstream datasets and emits the committed build artifacts:
+ *   data/regions.json            — ISO 3166-2 subdivisions for region-tier countries
+ *   data/gazetteer-cities.json   — ~170k world cities  (NOT COMMITTED — gitignored)
+ *   data/gazetteer-meta.json     — provenance + content hash
+ *
+ * ---------------------------------------------------------------------------
+ * TWO REVIEW FINDINGS ARE IMPLEMENTED HERE. Both were blocking. Read before editing.
+ * ---------------------------------------------------------------------------
+ *
+ * F4 — empty ISO subdivision codes must be filtered.
+ *   `iso3166-2-db` ships subdivisions whose `iso` field is an empty string
+ *   (recently-created subdivisions that have a GeoNames `admin` code but no ISO
+ *   code assigned yet). Naive `${cc}-${r.iso}` turns those into `"ID-"` / `"PH-"`,
+ *   which are NOT NULL and distinct, so they pass every constraint on `regions`
+ *   and land as permanently-unmatchable garbage. They are dropped here and
+ *   reported by name, never silently.
+ *
+ * F2 — this generator emits data ONLY. It does not define the seed mechanism,
+ *   and the seed for `regions` must be an ADDITIVE UPSERT, never delete-and-reload:
+ *
+ *       INSERT INTO regions (...) VALUES (...) ON CONFLICT (iso_3166_2) DO NOTHING
+ *
+ *   `cities.region_id` REFERENCES `regions.id` (schema.ts), and `regions.id` is
+ *   AUTOINCREMENT. A DELETE + reload re-issues ids and silently repoints every
+ *   existing city at a different subdivision. The ADL-48 §8.1 delete-and-reload
+ *   pattern is safe ONLY for `gazetteer_cities`, because that is the only table
+ *   nothing references. Verified against schema.ts, not inherited from the review.
+ *
+ * ---------------------------------------------------------------------------
+ * INPUT RESOLUTION — deliberately not a package.json dependency.
+ * ---------------------------------------------------------------------------
+ * `iso3166-2-db` unpacks to 283 MB / 42,268 files and costs ~11.8 s of install
+ * time, for ONE 3.35 MB file. This repo installs node_modules per agent worktree
+ * and on every CI run, so that is paid over and over. The spike therefore does
+ * not add it to package.json; inputs are resolved from, in order:
+ *
+ *   1. --iso-db <path> / --cities <path>   (explicit)
+ *   2. $ISO3166_2_DB / $CITIES_JSON        (env)
+ *   3. data/vendor/iso3166-2.json          (the recommended end state)
+ *   4. node_modules/<pkg>/...              (ADL-48's stated devDependency design)
+ *
+ * Usage:
+ *   node scripts/generate-gazetteer.mjs --iso-db <path> --cities <path> [--out-dir data] [--dry-run]
+ */
+
+import { createHash } from 'node:crypto';
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.join(__dirname, '..');
+
+// ----------------------------------------------------------------
+// Arg parsing
+// ----------------------------------------------------------------
+const argv = process.argv.slice(2);
+const argOf = (flag) => {
+  const i = argv.indexOf(flag);
+  return i !== -1 && argv[i + 1] ? argv[i + 1] : null;
+};
+const DRY_RUN = argv.includes('--dry-run');
+const OUT_DIR = path.resolve(REPO_ROOT, argOf('--out-dir') ?? 'data');
+
+function resolveInput(label, explicit, envVar, vendorRel, nodeModulesRel) {
+  const candidates = [
+    explicit,
+    process.env[envVar],
+    path.join(REPO_ROOT, vendorRel),
+    path.join(REPO_ROOT, nodeModulesRel),
+  ].filter(Boolean);
+  for (const c of candidates) if (existsSync(c)) return c;
+  console.error(
+    `[GAZ] Could not resolve ${label}. Tried:\n` +
+      candidates.map((c) => `  - ${c}`).join('\n') +
+      `\nPass an explicit path or set $${envVar}.`,
+  );
+  process.exit(1);
+}
+
+const ISO_DB_PATH = resolveInput(
+  'iso3166-2-db data',
+  argOf('--iso-db'),
+  'ISO3166_2_DB',
+  'data/vendor/iso3166-2.json',
+  'node_modules/iso3166-2-db/data/iso3166-2.json',
+);
+const CITIES_PATH = resolveInput(
+  'cities.json data',
+  argOf('--cities'),
+  'CITIES_JSON',
+  'data/vendor/cities.json',
+  'node_modules/cities.json/cities.json',
+);
+
+// ----------------------------------------------------------------
+// Load
+// ----------------------------------------------------------------
+console.info(`[GAZ] iso3166-2-db : ${ISO_DB_PATH}`);
+console.info(`[GAZ] cities.json  : ${CITIES_PATH}`);
+
+const isoDb = JSON.parse(readFileSync(ISO_DB_PATH, 'utf8'));
+const allCities = JSON.parse(readFileSync(CITIES_PATH, 'utf8'));
+const countries = JSON.parse(readFileSync(path.join(REPO_ROOT, 'data/countries.json'), 'utf8'));
+const liveRegions = JSON.parse(readFileSync(path.join(REPO_ROOT, 'data/regions.json'), 'utf8'));
+
+const enabled = countries.filter((c) => c.region_tier_enabled === 1).map((c) => c.country_code);
+const enabledSet = new Set(enabled);
+console.info(`[GAZ] ${allCities.length} source cities · ${enabled.length} region-tier countries`);
+
+// ----------------------------------------------------------------
+// 1. Subdivisions  (S1 output)
+// ----------------------------------------------------------------
+const regionRows = [];
+const dropped = []; // F4
+const seenIso = new Set();
+const dupes = [];
+
+for (const cc of enabled) {
+  const entry = isoDb[cc];
+  if (!entry || !Array.isArray(entry.regions)) continue;
+  for (const r of entry.regions) {
+    const isoSuffix = (r.iso ?? '').trim();
+
+    // --- F4: drop empty-ISO subdivisions, loudly ---
+    if (isoSuffix === '') {
+      dropped.push({ country_code: cc, name: r.name, admin: r.admin ?? null, fips: r.fips ?? null });
+      continue;
+    }
+
+    const code = `${cc}-${isoSuffix}`;
+    if (seenIso.has(code)) {
+      dupes.push(code);
+      continue;
+    }
+    seenIso.add(code);
+    regionRows.push({ country_code: cc, name: r.name, iso_3166_2: code });
+  }
+}
+
+regionRows.sort((a, b) =>
+  a.country_code === b.country_code
+    ? a.iso_3166_2.localeCompare(b.iso_3166_2)
+    : a.country_code.localeCompare(b.country_code),
+);
+
+// ----------------------------------------------------------------
+// 2. Crosswalk: GeoNames admin1 -> ISO 3166-2   (ADL-48 §4.1)
+//    GeoNames admin1 codes are NOT ISO 3166-2 codes. `admin` is the join key.
+// ----------------------------------------------------------------
+const crosswalk = new Map(); // `${cc}|${adminCode}` -> ISO 3166-2
+for (const cc of Object.keys(isoDb)) {
+  const entry = isoDb[cc];
+  if (!entry || !Array.isArray(entry.regions)) continue;
+  for (const r of entry.regions) {
+    const isoSuffix = (r.iso ?? '').trim();
+    if (isoSuffix === '') continue; // F4 again — never crosswalk to a garbage code
+    const admin = r.admin == null ? '' : String(r.admin).trim();
+    if (admin === '') continue;
+    const key = `${cc}|${admin}`;
+    if (!crosswalk.has(key)) crosswalk.set(key, `${cc}-${isoSuffix}`);
+  }
+}
+
+// ----------------------------------------------------------------
+// 3. Gazetteer cities  (S2 output)
+// ----------------------------------------------------------------
+const gazRows = [];
+let joined = 0;
+let nullRegion = 0;
+
+for (const c of allCities) {
+  const cc = c.country;
+  const lat = Number(c.lat);
+  const lng = Number(c.lng);
+  if (!cc || !Number.isFinite(lat) || !Number.isFinite(lng)) continue;
+
+  let regionIso = null;
+  const admin1 = c.admin1 == null ? '' : String(c.admin1).trim();
+  if (admin1 !== '') regionIso = crosswalk.get(`${cc}|${admin1}`) ?? null;
+
+  if (enabledSet.has(cc)) {
+    if (regionIso) joined++;
+  }
+  if (regionIso === null) nullRegion++;
+
+  gazRows.push({
+    name: c.name,
+    country_code: cc,
+    region_iso: regionIso,
+    latitude: lat,
+    longitude: lng,
+  });
+}
+
+// ----------------------------------------------------------------
+// 4. Correctness proofs  (S1 safety — the point of the exercise)
+// ----------------------------------------------------------------
+const generatedByIso = new Map(regionRows.map((r) => [r.iso_3166_2, r]));
+
+const preserved = [];
+const missing = [];
+const renamed = [];
+for (const live of liveRegions) {
+  const gen = generatedByIso.get(live.iso_3166_2);
+  if (!gen) {
+    missing.push(live);
+  } else {
+    preserved.push(live.iso_3166_2);
+    if (gen.name !== live.name) {
+      renamed.push({ iso: live.iso_3166_2, live: live.name, generated: gen.name });
+    }
+    if (gen.country_code !== live.country_code) {
+      renamed.push({ iso: live.iso_3166_2, live: live.country_code, generated: gen.country_code });
+    }
+  }
+}
+
+const enabledCityRows = gazRows.filter((r) => enabledSet.has(r.country_code));
+const enabledJoined = enabledCityRows.filter((r) => r.region_iso !== null).length;
+
+// ----------------------------------------------------------------
+// 5. Report
+// ----------------------------------------------------------------
+console.info('\n=== SUBDIVISIONS (S1) ===');
+console.info(`  generated rows            : ${regionRows.length}`);
+console.info(`  dropped (F4, empty ISO)   : ${dropped.length}`);
+for (const d of dropped) console.info(`      DROP ${d.country_code} "${d.name}" (admin=${d.admin}, fips=${d.fips})`);
+console.info(`  duplicate iso_3166_2      : ${dupes.length} ${dupes.length ? dupes.join(',') : '(none)'}`);
+console.info(`  live regions.json rows    : ${liveRegions.length}`);
+console.info(`  PRESERVED byte-for-byte   : ${preserved.length} / ${liveRegions.length}`);
+console.info(`  MISSING from generated    : ${missing.length}`);
+for (const m of missing) console.info(`      MISSING ${m.iso_3166_2} "${m.name}"`);
+console.info(`  name/country mismatches   : ${renamed.length}`);
+for (const r of renamed) console.info(`      DIFF ${r.iso}: live="${r.live}" generated="${r.generated}"`);
+console.info(`  net NEW rows (additive)   : ${regionRows.length - preserved.length}`);
+
+console.info('\n=== GAZETTEER CITIES (S2) ===');
+console.info(`  rows                      : ${gazRows.length}`);
+console.info(`  rows in enabled countries : ${enabledCityRows.length}`);
+console.info(
+  `  joined to ISO subdivision : ${enabledJoined} (${((enabledJoined / enabledCityRows.length) * 100).toFixed(2)}%)`,
+);
+console.info(
+  `  NULL region (all rows)    : ${nullRegion} (${((nullRegion / gazRows.length) * 100).toFixed(2)}%)`,
+);
+
+const SAFE =
+  missing.length === 0 && renamed.length === 0 && dupes.length === 0 && regionRows.length >= liveRegions.length;
+console.info(`\n=== S1 SEED SAFETY: ${SAFE ? 'PASS' : 'FAIL'} ===`);
+console.info(
+  '  (additive upsert only — ON CONFLICT (iso_3166_2) DO NOTHING; never DELETE+reload, see F2 above)',
+);
+
+// ----------------------------------------------------------------
+// 6. Emit
+// ----------------------------------------------------------------
+const citiesJson = JSON.stringify(gazRows);
+const contentHash = createHash('sha256').update(citiesJson).digest('hex');
+
+const meta = {
+  generated_at: new Date().toISOString(),
+  sources: [
+    {
+      name: 'cities.json',
+      version: '1.1.61',
+      licence: 'CC-BY-4.0',
+      attribution: 'City data © GeoNames contributors, CC BY 4.0',
+      path: path.relative(REPO_ROOT, CITIES_PATH),
+    },
+    {
+      name: 'iso3166-2-db',
+      version: '2.3.11',
+      licence: 'MIT',
+      attribution: 'ISO 3166-2 subdivision data — iso3166-2-db',
+      path: path.relative(REPO_ROOT, ISO_DB_PATH),
+    },
+  ],
+  regions_row_count: regionRows.length,
+  regions_dropped_empty_iso: dropped.length,
+  cities_row_count: gazRows.length,
+  cities_content_hash: `sha256:${contentHash}`,
+  cities_bytes: Buffer.byteLength(citiesJson),
+};
+
+console.info(`\n=== ARTIFACT ===`);
+console.info(`  gazetteer-cities.json bytes : ${meta.cities_bytes} (${(meta.cities_bytes / 1024 / 1024).toFixed(2)} MB)`);
+console.info(`  content hash                : ${meta.cities_content_hash}`);
+
+if (DRY_RUN) {
+  console.info('\n[GAZ] --dry-run: nothing written.');
+  process.exit(SAFE ? 0 : 1);
+}
+
+writeFileSync(path.join(OUT_DIR, 'gazetteer-cities.json'), citiesJson);
+writeFileSync(path.join(OUT_DIR, 'gazetteer-meta.json'), JSON.stringify(meta, null, 2) + '\n');
+writeFileSync(
+  path.join(OUT_DIR, 'regions.generated.json'),
+  JSON.stringify(regionRows, null, 2) + '\n',
+);
+console.info(`\n[GAZ] wrote gazetteer-cities.json, gazetteer-meta.json, regions.generated.json -> ${OUT_DIR}`);
+console.info('[GAZ] NOTE: regions.generated.json is written alongside, NOT over, data/regions.json.');
+console.info('[GAZ]       Promoting it is a separate, reviewed step (S1).');
+
+process.exit(SAFE ? 0 : 1);

--- a/scripts/spike/gazetteer-bench.mjs
+++ b/scripts/spike/gazetteer-bench.mjs
@@ -1,0 +1,314 @@
+#!/usr/bin/env node
+/**
+ * Travel Tracker — ADL-48 gazetteer search benchmark  (SPIKE, Q1/Q2)
+ *
+ * STATUS: SPIKE ARTEFACT. Measurement harness only — ships nothing.
+ *
+ * Answers, with real timings against the real 170,540-row dataset in local libSQL:
+ *
+ *   Q1  Which query shape can serve city search at 170k rows, and what does each
+ *       cost SEMANTICALLY (not just in milliseconds)?
+ *          - leading-wildcard LIKE '%q%'   (today's behaviour, cities.ts:48)
+ *          - prefix LIKE 'q%'              (indexable, but "york" stops finding "New York")
+ *          - FTS5                          (token-prefix; finds "New York" from "york")
+ *          - FTS5 substring via trigram    (full substring parity, larger index)
+ *   Q1b Minimum query length — where does the cost curve actually bite?
+ *   Q1c Result caps.
+ *   Q2  Narrowing by the trip's declared countries: hard WHERE filter vs ORDER BY rank.
+ *
+ * Every timing here is LOCAL libSQL (a file database) — CPU and disk only, no
+ * network. The Turso/remote regime is measured separately in gazetteer-turso-probe.mjs;
+ * the two must be read together, because if the network term dominates then query
+ * shape is the wrong lever entirely.
+ *
+ * Usage:
+ *   node scripts/spike/gazetteer-bench.mjs [--db <path>] [--rebuild]
+ */
+
+import { createClient } from '@libsql/client';
+import { existsSync, readFileSync, rmSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.join(__dirname, '../..');
+
+const argv = process.argv.slice(2);
+const argOf = (f) => {
+  const i = argv.indexOf(f);
+  return i !== -1 && argv[i + 1] ? argv[i + 1] : null;
+};
+const DB_PATH = path.resolve(REPO_ROOT, argOf('--db') ?? 'spike-gazetteer.db');
+const REBUILD = argv.includes('--rebuild');
+
+const GAZ_PATH = path.join(REPO_ROOT, 'data/gazetteer-cities.json');
+if (!existsSync(GAZ_PATH)) {
+  console.error(`[BENCH] ${GAZ_PATH} not found — run scripts/generate-gazetteer.mjs first.`);
+  process.exit(1);
+}
+
+if (REBUILD && existsSync(DB_PATH)) {
+  for (const suffix of ['', '-shm', '-wal']) {
+    try { rmSync(DB_PATH + suffix); } catch { /* absent */ }
+  }
+}
+
+const db = createClient({ url: `file:${DB_PATH}` });
+const ms = () => Number(process.hrtime.bigint() / 1000n) / 1000;
+
+/** Median + p95 of n timed runs. Median is the honest headline; p95 catches cliff behaviour. */
+async function timeIt(label, fn, runs = 7) {
+  await fn(); // warm
+  const samples = [];
+  for (let i = 0; i < runs; i++) {
+    const t0 = ms();
+    await fn();
+    samples.push(ms() - t0);
+  }
+  samples.sort((a, b) => a - b);
+  return {
+    label,
+    median: samples[Math.floor(samples.length / 2)],
+    min: samples[0],
+    max: samples[samples.length - 1],
+  };
+}
+const f = (n) => n.toFixed(1).padStart(8);
+
+// ================================================================
+// 1. Build
+// ================================================================
+const existing = await db
+  .execute("SELECT name FROM sqlite_master WHERE type='table' AND name='gazetteer_cities'")
+  .then((r) => r.rows.length > 0)
+  .catch(() => false);
+
+if (!existing) {
+  console.info('[BENCH] building gazetteer_cities …');
+  const rows = JSON.parse(readFileSync(GAZ_PATH, 'utf8'));
+  console.info(`[BENCH] ${rows.length} rows to load`);
+
+  await db.execute(`CREATE TABLE gazetteer_cities (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL,
+    country_code TEXT NOT NULL,
+    region_iso TEXT,
+    latitude REAL NOT NULL,
+    longitude REAL NOT NULL
+  )`);
+
+  const t0 = ms();
+  const BATCH = 2000;
+  for (let i = 0; i < rows.length; i += BATCH) {
+    const chunk = rows.slice(i, i + BATCH);
+    const placeholders = chunk.map(() => '(?,?,?,?,?)').join(',');
+    const args = [];
+    for (const r of chunk) args.push(r.name, r.country_code, r.region_iso, r.latitude, r.longitude);
+    await db.execute({
+      sql: `INSERT INTO gazetteer_cities (name,country_code,region_iso,latitude,longitude) VALUES ${placeholders}`,
+      args,
+    });
+  }
+  const insertMs = ms() - t0;
+
+  const t1 = ms();
+  await db.execute('CREATE INDEX idx_gaz_name_nocase ON gazetteer_cities (name COLLATE NOCASE)');
+  await db.execute('CREATE INDEX idx_gaz_country ON gazetteer_cities (country_code)');
+  await db.execute(
+    'CREATE INDEX idx_gaz_name_country ON gazetteer_cities (name COLLATE NOCASE, country_code)',
+  );
+  const indexMs = ms() - t1;
+
+  // FTS5 — token prefix. Finds "New York" from "york" (unlike LIKE 'york%').
+  const t2 = ms();
+  await db.execute(
+    "CREATE VIRTUAL TABLE gaz_fts USING fts5(name, content='gazetteer_cities', content_rowid='id', tokenize='unicode61')",
+  );
+  await db.execute("INSERT INTO gaz_fts(gaz_fts) VALUES('rebuild')");
+  const ftsMs = ms() - t2;
+
+  // FTS5 trigram — true substring parity with LIKE '%q%' (needs >=3 chars).
+  let trigramMs = -1;
+  try {
+    const t3 = ms();
+    await db.execute(
+      "CREATE VIRTUAL TABLE gaz_trigram USING fts5(name, content='gazetteer_cities', content_rowid='id', tokenize='trigram')",
+    );
+    await db.execute("INSERT INTO gaz_trigram(gaz_trigram) VALUES('rebuild')");
+    trigramMs = ms() - t3;
+  } catch (e) {
+    console.warn(`[BENCH] trigram tokenizer unavailable: ${e.message}`);
+  }
+
+  console.info(`[BENCH] insert ${insertMs.toFixed(0)} ms · b-tree idx ${indexMs.toFixed(0)} ms · fts5 ${ftsMs.toFixed(0)} ms · trigram ${trigramMs.toFixed(0)} ms`);
+}
+
+const [{ n: total }] = (await db.execute('SELECT COUNT(*) AS n FROM gazetteer_cities')).rows;
+console.info(`\n[BENCH] gazetteer_cities rows: ${total}`);
+console.info(`[BENCH] db file: ${(await import('node:fs')).statSync(DB_PATH).size / 1024 / 1024} MB\n`);
+
+// ================================================================
+// 2. Q1 — DOES THE INDEX ACTUALLY GET USED? (verify, don't infer)
+// ================================================================
+console.info('='.repeat(78));
+console.info('Q1a — EXPLAIN QUERY PLAN: is a leading wildcard really unindexable?');
+console.info('='.repeat(78));
+for (const [label, sql, args] of [
+  ["today: LIKE '%york%'", 'SELECT id FROM gazetteer_cities WHERE name LIKE ?', ['%york%']],
+  ["prefix: LIKE 'york%'", 'SELECT id FROM gazetteer_cities WHERE name LIKE ?', ['york%']],
+  [
+    "prefix + COLLATE NOCASE",
+    'SELECT id FROM gazetteer_cities WHERE name LIKE ? COLLATE NOCASE',
+    ['york%'],
+  ],
+  [
+    "prefix + country",
+    'SELECT id FROM gazetteer_cities WHERE name LIKE ? AND country_code = ?',
+    ['york%', 'GB'],
+  ],
+  ['fts5 MATCH', "SELECT rowid FROM gaz_fts WHERE gaz_fts MATCH ?", ['york*']],
+]) {
+  try {
+    const plan = await db.execute({ sql: `EXPLAIN QUERY PLAN ${sql}`, args });
+    console.info(`  ${label.padEnd(26)} → ${plan.rows.map((r) => r.detail).join(' | ')}`);
+  } catch (e) {
+    console.info(`  ${label.padEnd(26)} → ERROR ${e.message}`);
+  }
+}
+
+// ================================================================
+// 3. Q1 — query shape comparison
+// ================================================================
+const TERMS = ['york', 'lond', 'paris', 'newp', 'springf', 'san', 'glas', 'inver'];
+const LIMIT = 50;
+
+console.info('\n' + '='.repeat(78));
+console.info(`Q1b — QUERY SHAPE, median ms over ${TERMS.length} terms (LIMIT ${LIMIT}, local libSQL)`);
+console.info('='.repeat(78));
+console.info('  shape                          median      min      max   rows(ex)');
+
+const shapes = [
+  {
+    label: "LIKE '%q%'  (TODAY)",
+    run: (q) => db.execute({ sql: `SELECT id,name,country_code,region_iso,latitude,longitude FROM gazetteer_cities WHERE name LIKE ? ORDER BY name LIMIT ${LIMIT}`, args: [`%${q}%`] }),
+  },
+  {
+    label: "LIKE 'q%'   (prefix)",
+    run: (q) => db.execute({ sql: `SELECT id,name,country_code,region_iso,latitude,longitude FROM gazetteer_cities WHERE name LIKE ? ORDER BY name LIMIT ${LIMIT}`, args: [`${q}%`] }),
+  },
+  {
+    label: 'FTS5 MATCH  (token pfx)',
+    run: (q) => db.execute({ sql: `SELECT g.id,g.name,g.country_code,g.region_iso,g.latitude,g.longitude FROM gaz_fts JOIN gazetteer_cities g ON g.id=gaz_fts.rowid WHERE gaz_fts MATCH ? LIMIT ${LIMIT}`, args: [`${q}*`] }),
+  },
+  {
+    label: 'FTS5 trigram (substring)',
+    run: (q) => db.execute({ sql: `SELECT g.id,g.name,g.country_code,g.region_iso,g.latitude,g.longitude FROM gaz_trigram JOIN gazetteer_cities g ON g.id=gaz_trigram.rowid WHERE gaz_trigram MATCH ? LIMIT ${LIMIT}`, args: [`"${q}"`] }),
+  },
+];
+
+const shapeResults = {};
+for (const s of shapes) {
+  const meds = [];
+  let exampleRows = 0;
+  for (const q of TERMS) {
+    try {
+      const r = await timeIt(q, () => s.run(q), 5);
+      meds.push(r.median);
+      if (q === 'york') exampleRows = (await s.run(q)).rows.length;
+    } catch (e) {
+      console.info(`  ${s.label.padEnd(28)} ERROR ${e.message}`);
+      meds.length = 0;
+      break;
+    }
+  }
+  if (!meds.length) continue;
+  meds.sort((a, b) => a - b);
+  shapeResults[s.label] = meds[Math.floor(meds.length / 2)];
+  console.info(
+    `  ${s.label.padEnd(28)}${f(meds[Math.floor(meds.length / 2)])}${f(meds[0])}${f(meds[meds.length - 1])}   ${exampleRows}`,
+  );
+}
+
+// ================================================================
+// 4. Q1 — SEMANTIC cost. The part a speed table hides.
+// ================================================================
+console.info('\n' + '='.repeat(78));
+console.info('Q1c — SEMANTIC COST: what each shape FINDS for the same typed text');
+console.info('='.repeat(78));
+const semanticProbes = ['york', 'orleans', 'angeles', 'vegas', 'sur', 'ness'];
+console.info('  typed      LIKE %q%   LIKE q%    FTS5 tok   FTS5 trig   example miss');
+for (const q of semanticProbes) {
+  const sub = (await db.execute({ sql: 'SELECT COUNT(*) n FROM gazetteer_cities WHERE name LIKE ?', args: [`%${q}%`] })).rows[0].n;
+  const pfx = (await db.execute({ sql: 'SELECT COUNT(*) n FROM gazetteer_cities WHERE name LIKE ?', args: [`${q}%`] })).rows[0].n;
+  let fts = 0, tri = 0;
+  try { fts = (await db.execute({ sql: 'SELECT COUNT(*) n FROM gaz_fts WHERE gaz_fts MATCH ?', args: [`${q}*`] })).rows[0].n; } catch {}
+  try { tri = (await db.execute({ sql: 'SELECT COUNT(*) n FROM gaz_trigram WHERE gaz_trigram MATCH ?', args: [`"${q}"`] })).rows[0].n; } catch {}
+  // A concrete name the prefix shape loses
+  const miss = (await db.execute({ sql: 'SELECT name FROM gazetteer_cities WHERE name LIKE ? AND name NOT LIKE ? LIMIT 1', args: [`%${q}%`, `${q}%`] })).rows[0]?.name ?? '—';
+  console.info(`  ${q.padEnd(10)}${String(sub).padStart(8)}${String(pfx).padStart(11)}${String(fts).padStart(11)}${String(tri).padStart(12)}   ${miss}`);
+}
+
+// ================================================================
+// 5. Q1d — minimum query length
+// ================================================================
+console.info('\n' + '='.repeat(78));
+console.info('Q1d — MIN QUERY LENGTH: cost and result count vs typed characters');
+console.info('='.repeat(78));
+console.info('  chars  sample   LIKE %q% ms   rows matched   FTS5 ms   note');
+for (const q of ['s', 'sa', 'san', 'sant', 'santa']) {
+  const t = await timeIt('x', () => db.execute({ sql: `SELECT id,name FROM gazetteer_cities WHERE name LIKE ? ORDER BY name LIMIT ${LIMIT}`, args: [`%${q}%`] }), 5);
+  const n = (await db.execute({ sql: 'SELECT COUNT(*) n FROM gazetteer_cities WHERE name LIKE ?', args: [`%${q}%`] })).rows[0].n;
+  let ft = -1;
+  try { const r = await timeIt('y', () => db.execute({ sql: `SELECT rowid FROM gaz_fts WHERE gaz_fts MATCH ? LIMIT ${LIMIT}`, args: [`${q}*`] }), 5); ft = r.median; } catch {}
+  console.info(`  ${String(q.length).padStart(5)}  ${q.padEnd(8)}${f(t.median)}   ${String(n).padStart(12)}${f(ft)}`);
+}
+
+// ================================================================
+// 6. Q2 — narrowing by trip country: FILTER vs RANK
+// ================================================================
+console.info('\n' + '='.repeat(78));
+console.info('Q2 — NARROWING BY TRIP COUNTRY: hard WHERE filter vs ORDER BY rank');
+console.info('='.repeat(78));
+const TRIP_SETS = [
+  { label: '1 country  (GB)', ccs: ['GB'] },
+  { label: '2 countries (GB,FR)', ccs: ['GB', 'FR'] },
+  { label: '4 countries', ccs: ['GB', 'FR', 'ES', 'IT'] },
+];
+console.info('  scenario                         unnarrowed   WHERE filt   ORDER BY rank');
+for (const { label, ccs } of TRIP_SETS) {
+  const inList = ccs.map(() => '?').join(',');
+  const meds = { base: [], filt: [], rank: [] };
+  for (const q of TERMS) {
+    meds.base.push((await timeIt('b', () => db.execute({ sql: `SELECT id,name,country_code FROM gazetteer_cities WHERE name LIKE ? ORDER BY name LIMIT ${LIMIT}`, args: [`%${q}%`] }), 5)).median);
+    meds.filt.push((await timeIt('f', () => db.execute({ sql: `SELECT id,name,country_code FROM gazetteer_cities WHERE name LIKE ? AND country_code IN (${inList}) ORDER BY name LIMIT ${LIMIT}`, args: [`%${q}%`, ...ccs] }), 5)).median);
+    meds.rank.push((await timeIt('r', () => db.execute({ sql: `SELECT id,name,country_code FROM gazetteer_cities WHERE name LIKE ? ORDER BY (country_code IN (${inList})) DESC, name LIMIT ${LIMIT}`, args: [`%${q}%`, ...ccs] }), 5)).median);
+  }
+  const med = (a) => { a.sort((x, y) => x - y); return a[Math.floor(a.length / 2)]; };
+  console.info(`  ${label.padEnd(32)}${f(med(meds.base))}${f(med(meds.filt))}${f(med(meds.rank))}`);
+}
+
+// Q2 — what does a hard filter COST the user? Cross-border cities lost.
+console.info('\n  What a hard WHERE filter removes (trip declares GB only):');
+for (const q of ['calais', 'newport', 'bergen']) {
+  const all = (await db.execute({ sql: 'SELECT name,country_code FROM gazetteer_cities WHERE name LIKE ? LIMIT 200', args: [`%${q}%`] })).rows;
+  const gb = all.filter((r) => r.country_code === 'GB').length;
+  console.info(`    "${q}": ${all.length} rows worldwide, ${gb} in GB → filter hides ${all.length - gb}`);
+}
+
+// ================================================================
+// 7. Q1e — result caps and ambiguity detectability
+// ================================================================
+console.info('\n' + '='.repeat(78));
+console.info('Q1e — RESULT CAPS: can ambiguity stay detectable under a cap?');
+console.info('='.repeat(78));
+console.info('  A cap truncates ROWS. A separate COUNT(*)/GROUP BY keeps ambiguity visible.');
+console.info('  term         total rows   distinct (cc,region)   capped@50?   COUNT cost ms');
+for (const q of ['springfield', 'newport', 'san', 'york']) {
+  const n = (await db.execute({ sql: 'SELECT COUNT(*) n FROM gazetteer_cities WHERE name LIKE ?', args: [`%${q}%`] })).rows[0].n;
+  const g = (await db.execute({ sql: 'SELECT COUNT(*) n FROM (SELECT DISTINCT country_code, region_iso FROM gazetteer_cities WHERE name LIKE ?)', args: [`%${q}%`] })).rows[0].n;
+  const t = await timeIt('c', () => db.execute({ sql: 'SELECT COUNT(*) n FROM gazetteer_cities WHERE name LIKE ?', args: [`%${q}%`] }), 5);
+  console.info(`  ${q.padEnd(13)}${String(n).padStart(10)}${String(g).padStart(22)}${(n > 50 ? '  YES' : '   no').padStart(13)}${f(t.median)}`);
+}
+
+console.info('\n[BENCH] done.');
+await db.close();

--- a/scripts/spike/gazetteer-bug75-scenarios.mjs
+++ b/scripts/spike/gazetteer-bug75-scenarios.mjs
@@ -1,0 +1,154 @@
+#!/usr/bin/env node
+/**
+ * Travel Tracker — BUG-75 identity-key collision analysis, done properly.  (SPIKE, Q6)
+ *
+ * STATUS: SPIKE ARTEFACT.
+ *
+ * WHY THIS FILE EXISTS SEPARATELY. A first pass grouped gazetteer rows by their raw
+ * `region_iso`, which is WRONG as a model of the application: `cities.region_id` is
+ * forced NULL for every country with `region_tier_enabled = 0`, regardless of what
+ * subdivision the gazetteer knows about (cities.ts POST rejects a region_id for such
+ * countries; schema.ts documents the invariant). Grouping by raw region_iso therefore
+ * invents a discriminator the app does not have, and UNDERCOUNTS collisions.
+ *
+ * The identity key really is:
+ *     (name COLLATE NOCASE, country_code, COALESCE(region_id, 0))
+ * where region_id is NON-NULL only when BOTH:
+ *     - the country has region_tier_enabled = 1, AND
+ *     - a matching `regions` row is actually seeded.
+ *
+ * That second clause is what makes the answer time-dependent, so three scenarios are
+ * measured, not one:
+ *     A  TODAY          — only US/AU/CA/GB have any regions seeded (76 rows)
+ *     B  POST-S1        — all 26 region-tier countries seeded (714 rows)
+ *     C  POST-S1 + coordinate bucket — the candidate repair
+ *
+ * Usage: node scripts/spike/gazetteer-bug75-scenarios.mjs
+ */
+
+import { createClient } from '@libsql/client';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.join(__dirname, '../..');
+const db = createClient({ url: `file:${path.join(REPO_ROOT, 'spike-gazetteer.db')}` });
+
+const countries = JSON.parse(readFileSync(path.join(REPO_ROOT, 'data/countries.json'), 'utf8'));
+const liveRegions = JSON.parse(readFileSync(path.join(REPO_ROOT, 'data/regions.json'), 'utf8'));
+const enabled = new Set(countries.filter((c) => c.region_tier_enabled === 1).map((c) => c.country_code));
+const seededToday = new Set(liveRegions.map((r) => r.iso_3166_2));
+
+const rows = (await db.execute('SELECT name, country_code, region_iso, latitude, longitude FROM gazetteer_cities')).rows;
+console.info(`[BUG-75] ${rows.length} gazetteer rows loaded\n`);
+
+/** Great-circle-ish separation in km (equirectangular; fine at these scales). */
+function sep(a, b) {
+  const dLat = (a.lat - b.lat) * 111;
+  const dLng = (a.lng - b.lng) * 111 * Math.cos(((a.lat + b.lat) / 2 * Math.PI) / 180);
+  return Math.sqrt(dLat * dLat + dLng * dLng);
+}
+
+/**
+ * @param label   scenario name
+ * @param regionOf  (row) => the region discriminator the APP would store, or null
+ * @param extraKey  (row) => additional key component (coordinate bucket), or ''
+ */
+function analyse(label, regionOf, extraKey = () => '') {
+  const groups = new Map();
+  for (const r of rows) {
+    const region = regionOf(r);
+    // COALESCE(region_id, 0) — NULL collapses to the sentinel 0
+    const k = `${String(r.name).toLowerCase()}|${r.country_code}|${region ?? 0}|${extraKey(r)}`;
+    if (!groups.has(k)) groups.set(k, []);
+    groups.get(k).push({ lat: Number(r.latitude), lng: Number(r.longitude), name: r.name, cc: r.country_code });
+  }
+  let unrep = 0, colliding = 0, over10 = 0, over50 = 0, maxSep = 0, maxName = '';
+  for (const [, g] of groups) {
+    if (g.length < 2) continue;
+    colliding++;
+    unrep += g.length - 1;
+    let m = 0;
+    for (let i = 0; i < g.length; i++) for (let j = i + 1; j < g.length; j++) m = Math.max(m, sep(g[i], g[j]));
+    if (m > 10) over10++;
+    if (m > 50) over50++;
+    if (m > maxSep) { maxSep = m; maxName = `${g[0].name}, ${g[0].cc}`; }
+  }
+  const pct = ((unrep / rows.length) * 100).toFixed(2);
+  console.info(`${label}`);
+  console.info(`    distinct identity keys      : ${groups.size}`);
+  console.info(`    colliding groups            : ${colliding}`);
+  console.info(`    UNREPRESENTABLE rows        : ${unrep}  (${pct}% of ${rows.length})`);
+  console.info(`    colliding groups > 10 km    : ${over10}`);
+  console.info(`    colliding groups > 50 km    : ${over50}`);
+  console.info(`    largest separation          : ${maxSep.toFixed(0)} km  (${maxName})\n`);
+  return { unrep, colliding, over10, over50, maxSep };
+}
+
+console.info('='.repeat(78));
+console.info('BUG-75 — how many real places can the shipped identity key NOT represent?');
+console.info('='.repeat(78));
+console.info('Key: (name COLLATE NOCASE, country_code, COALESCE(region_id,0))');
+console.info('region_id is non-NULL only where the country is region-tier AND the region is seeded.\n');
+
+// --- Scenario A: TODAY ---
+const A = analyse(
+  'A — TODAY (76 regions seeded: US, AU, CA, GB only)',
+  (r) => (enabled.has(r.country_code) && r.region_iso && seededToday.has(r.region_iso) ? r.region_iso : null),
+);
+
+// --- Scenario B: POST-S1 ---
+const B = analyse(
+  'B — POST-S1 (714 regions seeded across all 26 region-tier countries)',
+  (r) => (enabled.has(r.country_code) && r.region_iso ? r.region_iso : null),
+);
+
+// --- Scenario C: POST-S1 + coordinate bucket repair ---
+const C = analyse(
+  'C — POST-S1 + 0.1 degree coordinate bucket added to the key (~11 km)',
+  (r) => (enabled.has(r.country_code) && r.region_iso ? r.region_iso : null),
+  (r) => `${Number(r.latitude).toFixed(1)},${Number(r.longitude).toFixed(1)}`,
+);
+
+const D = analyse(
+  'D — POST-S1 + 0.01 degree coordinate bucket (~1.1 km)',
+  (r) => (enabled.has(r.country_code) && r.region_iso ? r.region_iso : null),
+  (r) => `${Number(r.latitude).toFixed(2)},${Number(r.longitude).toFixed(2)}`,
+);
+
+console.info('='.repeat(78));
+console.info('READING THIS');
+console.info('='.repeat(78));
+console.info(`  S1 makes the problem BETTER, not worse: ${A.unrep} → ${B.unrep} unrepresentable rows,`);
+console.info(`  because seeding 638 more subdivisions gives the key a real discriminator in`);
+console.info(`  the 22 region-tier countries that currently have none.`);
+console.info(`  A coordinate bucket then removes ${(((B.unrep - C.unrep) / B.unrep) * 100).toFixed(1)}% of what remains`);
+console.info(`  (${B.unrep} → ${C.unrep} at 0.1 deg, → ${D.unrep} at 0.01 deg).`);
+console.info('');
+console.info('  ON THE OP-27 REVIEW\'S FIGURE: it reported 5,024 unrepresentable rows (2.95%),');
+console.info('  3,765 groups > 10 km, and Valverde/ES at 1,921 km. Scenario B reproduces all');
+console.info('  of those EXACTLY and independently. The review is correct — and it models the');
+console.info('  POST-S1 world. What it does not report is scenario A, the state shipped TODAY,');
+console.info('  which is materially worse (8,876 rows / 5.20%, worst case 8,092 km). So the');
+console.info('  defect is live now, it is not created by the gazetteer, and S1 IMPROVES it.');
+
+// Concrete GB examples under scenario B
+console.info('\n  Concrete GB collisions that survive S1 (scenario B):');
+const gb = new Map();
+for (const r of rows) {
+  if (r.country_code !== 'GB') continue;
+  const k = `${String(r.name).toLowerCase()}|${r.region_iso ?? 0}`;
+  if (!gb.has(k)) gb.set(k, []);
+  gb.get(k).push({ lat: Number(r.latitude), lng: Number(r.longitude), name: r.name, iso: r.region_iso });
+}
+const gbList = [...gb.values()].filter((g) => g.length > 1).map((g) => {
+  let m = 0;
+  for (let i = 0; i < g.length; i++) for (let j = i + 1; j < g.length; j++) m = Math.max(m, sep(g[i], g[j]));
+  return { name: g[0].name, iso: g[0].iso, n: g.length, km: m };
+}).sort((a, b) => b.km - a.km).slice(0, 10);
+for (const g of gbList) {
+  console.info(`    ${String(g.name).padEnd(16)} ${String(g.iso ?? 'NULL').padEnd(8)} ${g.n} rows, ${g.km.toFixed(0)} km apart`);
+}
+
+await db.close();

--- a/scripts/spike/gazetteer-identity-analysis.mjs
+++ b/scripts/spike/gazetteer-identity-analysis.mjs
@@ -1,0 +1,257 @@
+#!/usr/bin/env node
+/**
+ * Travel Tracker — ADL-48 identity-key + query-equivalence analysis  (SPIKE, Q1/Q2/Q6)
+ *
+ * STATUS: SPIKE ARTEFACT. Analysis only.
+ *
+ *  Q1f  EQUIVALENCE PROOF — is FTS5 trigram a drop-in for LIKE '%q%', or does it
+ *       change what the user finds? A speed win that quietly changes results is
+ *       not a speed win. Compared over many terms, set-equality, not counts.
+ *  Q1g  STORAGE COST of each index option.
+ *  Q1h  ROWS SCANNED per keystroke — the cost dimension a latency number hides,
+ *       and the one Turso bills on.
+ *  Q2b  IS COUNTRY THE LAST AVAILABLE SIGNAL? Tests the PO's claim rather than
+ *       accepting it — enumerates what is actually in hand at search time.
+ *  Q6   BUG-75 — the D13 identity key `(name COLLATE NOCASE, country_code,
+ *       COALESCE(region_id,0))` against real gazetteer data. Derived here, not
+ *       inherited from the OP-27 review.
+ *
+ * Usage: node scripts/spike/gazetteer-identity-analysis.mjs
+ */
+
+import { createClient } from '@libsql/client';
+import { existsSync, readFileSync, statSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.join(__dirname, '../..');
+const DB_PATH = path.join(REPO_ROOT, 'spike-gazetteer.db');
+const db = createClient({ url: `file:${DB_PATH}` });
+const ms = () => Number(process.hrtime.bigint() / 1000n) / 1000;
+
+// ================================================================
+// Q1f — trigram / LIKE equivalence
+// ================================================================
+console.info('='.repeat(78));
+console.info("Q1f — EQUIVALENCE: is FTS5 trigram a DROP-IN for LIKE '%q%'?");
+console.info('='.repeat(78));
+
+const EQ_TERMS = [
+  'york', 'orleans', 'angeles', 'vegas', 'ness', 'sur', 'ton', 'ville', 'burg', 'ford',
+  'san', 'new', 'port', 'chester', 'shire', 'dale', 'wick', 'beach', 'grand', 'saint',
+  'mouth', 'stone', 'bury', 'field', 'haven', 'ridge', 'brook', 'wood', 'hill', 'lake',
+];
+
+let identical = 0, differing = 0;
+const diffs = [];
+for (const q of EQ_TERMS) {
+  const a = (await db.execute({ sql: 'SELECT id FROM gazetteer_cities WHERE name LIKE ? ORDER BY id', args: [`%${q}%`] })).rows.map((r) => r.id);
+  const b = (await db.execute({ sql: 'SELECT rowid AS id FROM gaz_trigram WHERE gaz_trigram MATCH ? ORDER BY rowid', args: [`"${q}"`] })).rows.map((r) => r.id);
+  const sa = new Set(a), sb = new Set(b);
+  const onlyA = a.filter((x) => !sb.has(x));
+  const onlyB = b.filter((x) => !sa.has(x));
+  if (onlyA.length === 0 && onlyB.length === 0) identical++;
+  else { differing++; diffs.push({ q, n: a.length, onlyA: onlyA.length, onlyB: onlyB.length }); }
+}
+console.info(`  terms compared        : ${EQ_TERMS.length}`);
+console.info(`  IDENTICAL result sets : ${identical}`);
+console.info(`  differing             : ${differing}`);
+for (const d of diffs) console.info(`      DIFF "${d.q}": LIKE=${d.n} onlyLIKE=${d.onlyA} onlyTRIGRAM=${d.onlyB}`);
+
+// The known boundary: trigram needs >= 3 characters.
+console.info('\n  Boundary — queries shorter than 3 characters:');
+for (const q of ['y', 'yo']) {
+  const a = (await db.execute({ sql: 'SELECT COUNT(*) n FROM gazetteer_cities WHERE name LIKE ?', args: [`%${q}%`] })).rows[0].n;
+  let b = 'ERROR';
+  try { b = (await db.execute({ sql: 'SELECT COUNT(*) n FROM gaz_trigram WHERE gaz_trigram MATCH ?', args: [`"${q}"`] })).rows[0].n; } catch (e) { b = `unsupported (${e.message.slice(0, 40)})`; }
+  console.info(`    "${q}" (${q.length} ch): LIKE=${a}  trigram=${b}`);
+}
+
+// Case-insensitivity parity
+console.info('\n  Case parity (LIKE is ASCII-case-insensitive by default in SQLite):');
+for (const q of ['YORK', 'York', 'york']) {
+  const a = (await db.execute({ sql: 'SELECT COUNT(*) n FROM gazetteer_cities WHERE name LIKE ?', args: [`%${q}%`] })).rows[0].n;
+  const b = (await db.execute({ sql: 'SELECT COUNT(*) n FROM gaz_trigram WHERE gaz_trigram MATCH ?', args: [`"${q}"`] })).rows[0].n;
+  console.info(`    "${q}": LIKE=${a}  trigram=${b}`);
+}
+
+// ================================================================
+// Q1g — storage cost
+// ================================================================
+console.info('\n' + '='.repeat(78));
+console.info('Q1g — STORAGE COST of each option');
+console.info('='.repeat(78));
+const sizes = await db.execute(`
+  SELECT name, SUM(pgsize) AS bytes FROM dbstat GROUP BY name ORDER BY bytes DESC
+`).catch(() => null);
+if (sizes) {
+  for (const r of sizes.rows.slice(0, 12)) {
+    console.info(`  ${String(r.name).padEnd(34)}${(Number(r.bytes) / 1024 / 1024).toFixed(2).padStart(8)} MB`);
+  }
+} else {
+  console.info('  dbstat unavailable in this build — reporting whole-file size only.');
+}
+console.info(`  ${'TOTAL db file'.padEnd(34)}${(statSync(DB_PATH).size / 1024 / 1024).toFixed(2).padStart(8)} MB`);
+
+// ================================================================
+// Q1h — rows scanned per keystroke
+// ================================================================
+console.info('\n' + '='.repeat(78));
+console.info('Q1h — ROWS SCANNED per keystroke (the cost a latency number hides)');
+console.info('='.repeat(78));
+console.info('  Turso bills on rows read. A full index scan reads every row, every keystroke.');
+const [{ n: totalRows }] = (await db.execute('SELECT COUNT(*) AS n FROM gazetteer_cities')).rows;
+console.info('  term        LIKE %q% rows scanned   trigram rows matched   ratio');
+for (const q of ['york', 'newport', 'glas', 'plock']) {
+  const matched = (await db.execute({ sql: 'SELECT COUNT(*) n FROM gazetteer_cities WHERE name LIKE ?', args: [`%${q}%`] })).rows[0].n;
+  const ratio = Math.round(Number(totalRows) / Math.max(Number(matched), 1));
+  console.info(
+    `  ${q.padEnd(12)}${String(totalRows).padStart(18)}${String(matched).padStart(23)}${String(ratio).padStart(8)}x`,
+  );
+}
+
+// ================================================================
+// Q2b — is country genuinely the last signal?
+// ================================================================
+console.info('\n' + '='.repeat(78));
+console.info('Q2b — IS COUNTRY THE LAST AVAILABLE SIGNAL AT SEARCH TIME?');
+console.info('='.repeat(78));
+console.info('  Testing the PO\'s claim rather than accepting it. What narrowing power');
+console.info('  would each candidate signal actually buy, measured on real data?');
+
+const liveRegions = JSON.parse(readFileSync(path.join(REPO_ROOT, 'data/regions.json'), 'utf8'));
+const countries = JSON.parse(readFileSync(path.join(REPO_ROOT, 'data/countries.json'), 'utf8'));
+const enabled = countries.filter((c) => c.region_tier_enabled === 1);
+const withRegions = new Set(liveRegions.map((r) => r.country_code));
+
+console.info(`\n  Signal 1 — trip's declared countries (trip_countries). AVAILABLE.`);
+for (const q of ['newport', 'springfield', 'york']) {
+  const all = (await db.execute({ sql: 'SELECT COUNT(*) n FROM gazetteer_cities WHERE name LIKE ?', args: [`%${q}%`] })).rows[0].n;
+  const gb = (await db.execute({ sql: "SELECT COUNT(*) n FROM gazetteer_cities WHERE name LIKE ? AND country_code='GB'", args: [`%${q}%`] })).rows[0].n;
+  console.info(`      "${q}": ${all} worldwide → ${gb} in GB  (${(100 - (Number(gb) / Number(all)) * 100).toFixed(0)}% reduction)`);
+}
+
+console.info(`\n  Signal 2 — region/state. NOT available: the user types the city BEFORE`);
+console.info(`      the region is known. This is the asymmetry the PO identified.`);
+console.info(`      TODAY it is doubly unavailable: of ${enabled.length} region-tier countries,`);
+console.info(`      only ${withRegions.size} have ANY regions seeded (${[...withRegions].join(',')}) —`);
+console.info(`      ${enabled.length - withRegions.size} enabled countries have ZERO regions, so region_id is`);
+console.info(`      invariantly NULL there and cannot narrow anything even in principle.`);
+
+console.info(`\n  Signal 3 — the trip's ALREADY-ADDED places. Let's size it:`);
+console.info(`      If a trip already has a place, its country AND region are known. A second`);
+console.info(`      city is disproportionately likely to be near the first (a trip is a`);
+console.info(`      geographic cluster). Measured proximity narrowing, "newport" in GB:`);
+const npGb = (await db.execute({ sql: "SELECT name, region_iso, latitude, longitude FROM gazetteer_cities WHERE name LIKE 'newport' AND country_code='GB'", args: [] })).rows;
+console.info(`      ${npGb.length} exact "Newport" rows in GB:`);
+for (const r of npGb) console.info(`        ${String(r.name).padEnd(10)} ${String(r.region_iso ?? 'null').padEnd(8)} ${Number(r.latitude).toFixed(3)},${Number(r.longitude).toFixed(3)}`);
+// How much would a 100km anchor narrow it?
+if (npGb.length > 1) {
+  const anchor = npGb[0];
+  const near = npGb.filter((r) => {
+    const dLat = (Number(r.latitude) - Number(anchor.latitude)) * 111;
+    const dLng = (Number(r.longitude) - Number(anchor.longitude)) * 111 * Math.cos((Number(anchor.latitude) * Math.PI) / 180);
+    return Math.sqrt(dLat * dLat + dLng * dLng) <= 100;
+  });
+  console.info(`      An anchor at the first row + 100 km radius narrows ${npGb.length} → ${near.length}.`);
+}
+
+console.info(`\n  Signal 4 — the user's PREVIOUS trips' cities. Available in principle`);
+console.info(`      (cities table is global, trips are per-user). Weak and biased: it`);
+console.info(`      ranks toward where they have been, not where they are going.`);
+
+// ================================================================
+// Q6 — BUG-75 identity key collisions
+// ================================================================
+console.info('\n' + '='.repeat(78));
+console.info('Q6 — BUG-75: D13 identity key vs real gazetteer data');
+console.info('='.repeat(78));
+console.info('  Key: (name COLLATE NOCASE, country_code, COALESCE(region_id,0))');
+console.info('  region_iso is the gazetteer proxy for region_id (S1 maps one to one).\n');
+
+// Collisions under the key AS IT WOULD BEHAVE POST-S1 (all 26 countries have regions)
+const collide = await db.execute(`
+  SELECT lower(name) AS k, country_code, COALESCE(region_iso,'~') AS r,
+         COUNT(*) AS n,
+         MIN(latitude) AS mnla, MAX(latitude) AS mxla,
+         MIN(longitude) AS mnlo, MAX(longitude) AS mxlo
+  FROM gazetteer_cities
+  GROUP BY lower(name), country_code, COALESCE(region_iso,'~')
+  HAVING COUNT(*) > 1
+`);
+let unrepresentable = 0, groupsOver10 = 0, groupsOver50 = 0, maxSep = 0, maxSepName = '';
+for (const g of collide.rows) {
+  unrepresentable += Number(g.n) - 1;
+  const dLat = (Number(g.mxla) - Number(g.mnla)) * 111;
+  const dLng = (Number(g.mxlo) - Number(g.mnlo)) * 111 * Math.cos((Number(g.mnla) * Math.PI) / 180);
+  const sep = Math.sqrt(dLat * dLat + dLng * dLng);
+  if (sep > 10) groupsOver10++;
+  if (sep > 50) groupsOver50++;
+  if (sep > maxSep) { maxSep = sep; maxSepName = `${g.k} ${g.country_code}`; }
+}
+console.info(`  gazetteer rows                    : ${totalRows}`);
+console.info(`  colliding identity groups         : ${collide.rows.length}`);
+console.info(`  ROWS UNREPRESENTABLE in cities    : ${unrepresentable} (${((unrepresentable / Number(totalRows)) * 100).toFixed(2)}%)`);
+console.info(`  colliding groups > 10 km apart    : ${groupsOver10}`);
+console.info(`  colliding groups > 50 km apart    : ${groupsOver50}`);
+console.info(`  largest separation                : ${maxSep.toFixed(0)} km (${maxSepName})`);
+
+console.info('\n  Worst offenders in GB (a PO would hit these):');
+const gbWorst = await db.execute(`
+  SELECT name, COALESCE(region_iso,'~') AS r, COUNT(*) AS n,
+         MIN(latitude) mnla, MAX(latitude) mxla, MIN(longitude) mnlo, MAX(longitude) mxlo
+  FROM gazetteer_cities WHERE country_code='GB'
+  GROUP BY lower(name), COALESCE(region_iso,'~') HAVING COUNT(*) > 1
+  ORDER BY COUNT(*) DESC LIMIT 8
+`);
+for (const g of gbWorst.rows) {
+  const dLat = (Number(g.mxla) - Number(g.mnla)) * 111;
+  const dLng = (Number(g.mxlo) - Number(g.mnlo)) * 111 * Math.cos((Number(g.mnla) * Math.PI) / 180);
+  console.info(`    ${String(g.name).padEnd(14)} ${String(g.r).padEnd(8)} ${g.n} rows, ${Math.sqrt(dLat * dLat + dLng * dLng).toFixed(0)} km apart`);
+}
+
+// THE COO'S CLAIM: today, 22 of 26 enabled countries have zero regions, so the
+// whole country is one identity bucket. Verify it, don't inherit it.
+console.info('\n  COO claim — "22 of 26 region-tier countries hold zero regions, so the');
+console.info('  entire country is one identity bucket TODAY". Verified against real data:');
+const noRegionCountries = enabled.filter((c) => !withRegions.has(c.country_code)).map((c) => c.country_code);
+console.info(`    region-tier countries          : ${enabled.length}`);
+console.info(`    with >=1 seeded region         : ${withRegions.size} (${[...withRegions].join(',')})`);
+console.info(`    with ZERO seeded regions       : ${noRegionCountries.length} → ${noRegionCountries.join(',')}`);
+
+const collideNoRegion = await db.execute({
+  sql: `SELECT lower(name) k, country_code, COUNT(*) n
+        FROM gazetteer_cities
+        WHERE country_code IN (${noRegionCountries.map(() => '?').join(',')})
+        GROUP BY lower(name), country_code HAVING COUNT(*) > 1`,
+  args: noRegionCountries,
+});
+let noRegionUnrep = 0;
+for (const g of collideNoRegion.rows) noRegionUnrep += Number(g.n) - 1;
+console.info(`    → in those ${noRegionCountries.length} countries the key degenerates to (name, country_code):`);
+console.info(`      colliding groups ${collideNoRegion.rows.length}, unrepresentable rows ${noRegionUnrep}`);
+console.info(`      CLAIM CONFIRMED: with region_id invariantly NULL, COALESCE(region_id,0)=0`);
+console.info(`      for every city in those countries, so the whole country is one bucket.`);
+
+// Option costing
+console.info('\n  Option costing — how much does each repair actually buy?');
+const withAdmin2 = await db.execute(`
+  SELECT COUNT(*) n FROM (
+    SELECT lower(name) k, country_code, COALESCE(region_iso,'~') r,
+           ROUND(latitude,1) la, ROUND(longitude,1) lo, COUNT(*) c
+    FROM gazetteer_cities GROUP BY 1,2,3,4,5 HAVING COUNT(*) > 1)
+`);
+let coordBucketUnrep = 0;
+const cb = await db.execute(`
+  SELECT COUNT(*) - COUNT(DISTINCT lower(name)||'|'||country_code||'|'||COALESCE(region_iso,'~')||'|'||ROUND(latitude,1)||'|'||ROUND(longitude,1)) AS n
+  FROM gazetteer_cities
+`);
+coordBucketUnrep = Number(cb.rows[0].n);
+console.info(`    (a) key + 0.1° coordinate bucket → unrepresentable drops ${unrepresentable} → ${coordBucketUnrep}`);
+console.info(`        (0.1° ≈ 11 km; resolves ${(((unrepresentable - coordBucketUnrep) / unrepresentable) * 100).toFixed(1)}% of collisions)`);
+console.info(`    (b) accept conflation            → ${unrepresentable} rows silently mis-pin, up to ${maxSep.toFixed(0)} km`);
+console.info(`    (c) hide colliding rows          → ${unrepresentable} places become unselectable`);
+
+await db.close();
+console.info('\n[ANALYSIS] done.');

--- a/scripts/spike/gazetteer-turso-probe.mjs
+++ b/scripts/spike/gazetteer-turso-probe.mjs
@@ -1,0 +1,188 @@
+#!/usr/bin/env node
+/**
+ * Travel Tracker — ADL-48 Turso cold-seed / latency-regime probe  (SPIKE, Q3)
+ *
+ * STATUS: SPIKE ARTEFACT. Measurement only.
+ *
+ * Two questions, and they are different:
+ *
+ *  Q3a  WHICH REGIME ARE WE IN? If the network round-trip dominates, then tuning
+ *       the query shape (Q1) is optimising the wrong term. Measured by timing the
+ *       SAME trivial query locally and against Turso staging.
+ *
+ *  Q3b  COLD-SEED COST. ADL-48 §8.3 calls this UNVERIFIED and gates rollout on it.
+ *
+ * ---------------------------------------------------------------------------
+ * CREDENTIAL CONSTRAINT — read this before concluding anything from the output.
+ * ---------------------------------------------------------------------------
+ * The only Turso credentials in this environment are in `.env.agent-diagnostics`,
+ * and ADL-33 §5 makes them READ-ONLY BY DESIGN. The COO's brief authorised
+ * creating a throwaway `spike_gazetteer_probe` table — but authorisation is not
+ * capability. This probe ATTEMPTS the write anyway, deliberately, because the
+ * rejection is itself the second probe confirming the token is read-only rather
+ * than my inheriting that from ADL-33's text.
+ *
+ * Consequence: INSERT throughput against Turso is NOT measurable from here. What
+ * IS measurable is the network round-trip term, which is the thing ADL-48 §8.3
+ * was actually worried about ("86 batches over a WAN could plausibly be tens of
+ * seconds to minutes"). Read the output with that boundary in mind.
+ *
+ * Usage:
+ *   node scripts/spike/gazetteer-turso-probe.mjs [--env <path to .env.agent-diagnostics>]
+ */
+
+import { createClient } from '@libsql/client';
+import { config } from 'dotenv';
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.join(__dirname, '../..');
+
+const argv = process.argv.slice(2);
+const argOf = (f) => {
+  const i = argv.indexOf(f);
+  return i !== -1 && argv[i + 1] ? argv[i + 1] : null;
+};
+
+const ENV_PATH =
+  argOf('--env') ??
+  [
+    path.join(REPO_ROOT, '.env.agent-diagnostics'),
+    '/workspace/.env.agent-diagnostics',
+  ].find((p) => existsSync(p));
+
+if (!ENV_PATH || !existsSync(ENV_PATH)) {
+  console.error('[TURSO] .env.agent-diagnostics not found. Pass --env <path>.');
+  process.exit(1);
+}
+config({ path: ENV_PATH });
+console.info(`[TURSO] credentials: ${ENV_PATH} (read-only by design, ADL-33 §5)`);
+
+const url = process.env.TURSO_STAGING_URL;
+const authToken = process.env.TURSO_STAGING_TOKEN;
+if (!url || !authToken) {
+  console.error('[TURSO] TURSO_STAGING_URL / _TOKEN missing.');
+  process.exit(1);
+}
+
+const remote = createClient({ url, authToken });
+const local = createClient({ url: `file:${path.join(REPO_ROOT, 'spike-gazetteer.db')}` });
+const ms = () => Number(process.hrtime.bigint() / 1000n) / 1000;
+
+async function timed(fn, runs = 9) {
+  const s = [];
+  for (let i = 0; i < runs; i++) {
+    const t = ms();
+    try { await fn(); } catch (e) { return { err: e.message }; }
+    s.push(ms() - t);
+  }
+  s.sort((a, b) => a - b);
+  return { median: s[Math.floor(s.length / 2)], min: s[0], max: s[s.length - 1] };
+}
+const f = (n) => (n == null ? '     n/a' : n.toFixed(1).padStart(8));
+
+console.info('\n' + '='.repeat(74));
+console.info('Q3a — LATENCY REGIME: is this CPU-bound or network-bound?');
+console.info('='.repeat(74));
+
+const trivialRemote = await timed(() => remote.execute('SELECT 1'));
+const trivialLocal = await timed(() => local.execute('SELECT 1'));
+console.info(`  SELECT 1        local ${f(trivialLocal.median)} ms   |   Turso staging ${f(trivialRemote.median)} ms  (min ${f(trivialRemote.min)} max ${f(trivialRemote.max)})`);
+
+const countRemote = await timed(() => remote.execute('SELECT COUNT(*) FROM cities'));
+console.info(`  COUNT(*) cities                       |   Turso staging ${f(countRemote.median)} ms`);
+const cityRows = await remote.execute('SELECT COUNT(*) AS n FROM cities');
+const regionRows = await remote.execute('SELECT COUNT(*) AS n FROM regions');
+const countryRows = await remote.execute('SELECT COUNT(*) AS n FROM countries');
+console.info(`  staging today: cities=${cityRows.rows[0].n} regions=${regionRows.rows[0].n} countries=${countryRows.rows[0].n}`);
+
+console.info('\n  READ THIS: the local Q1 benchmark measured 8.7 ms for the leading-wildcard');
+console.info('  scan. Compare that against the round-trip number above to see which term');
+console.info('  dominates once the app talks to Turso rather than a local file.');
+
+// ---------------------------------------------------------------
+// Batch behaviour — does batch() cost one round trip or N?
+// ---------------------------------------------------------------
+console.info('\n' + '='.repeat(74));
+console.info('Q3b — BATCH ROUND-TRIP BEHAVIOUR (reads — see credential constraint)');
+console.info('='.repeat(74));
+console.info('  batch size    median ms    ms/statement');
+for (const n of [1, 10, 100, 500, 2000]) {
+  const stmts = Array.from({ length: n }, () => 'SELECT 1');
+  const r = await timed(() => remote.batch(stmts, 'read'), 5);
+  if (r.err) { console.info(`  ${String(n).padStart(10)}    ERROR ${r.err}`); continue; }
+  console.info(`  ${String(n).padStart(10)}${f(r.median)}${f(r.median / n)}`);
+}
+
+// A single statement carrying a large payload — the shape a real seed batch uses.
+console.info('\n  Single statement carrying a large VALUES payload (the real seed shape):');
+for (const n of [500, 2000]) {
+  const vals = Array.from({ length: n }, (_, i) => `(${i})`).join(',');
+  const r = await timed(() => remote.execute(`SELECT COUNT(*) FROM (VALUES ${vals})`), 5);
+  console.info(`    ${String(n).padStart(5)} VALUES rows → ${f(r?.median)} ms`);
+}
+
+// ---------------------------------------------------------------
+// The authorised write attempt — expected to be REJECTED.
+// ---------------------------------------------------------------
+console.info('\n' + '='.repeat(74));
+console.info('Q3c — WRITE CAPABILITY (authorised scratch table, expected to be refused)');
+console.info('='.repeat(74));
+let writeCapable = false;
+try {
+  await remote.execute('CREATE TABLE IF NOT EXISTS spike_gazetteer_probe (id INTEGER PRIMARY KEY, name TEXT)');
+  writeCapable = true;
+  console.info('  CREATE TABLE spike_gazetteer_probe → SUCCEEDED (token is write-capable)');
+} catch (e) {
+  console.info(`  CREATE TABLE spike_gazetteer_probe → REJECTED: ${e.message}`);
+  console.info('  → Confirms ADL-33 §5 by a second, independent probe (attempted write, not just');
+  console.info('    the documentation). Turso INSERT throughput is NOT measurable from here.');
+}
+
+if (writeCapable) {
+  // Only reachable if a write-capable token is ever supplied. Measure, then DROP.
+  console.info('\n  Write-capable token detected — measuring real INSERT batches.');
+  try {
+    for (const n of [500, 2000]) {
+      const ph = Array.from({ length: n }, () => '(?,?)').join(',');
+      const args = [];
+      for (let i = 0; i < n; i++) args.push(i, `name-${i}`);
+      const t = ms();
+      await remote.execute({ sql: `INSERT INTO spike_gazetteer_probe (id,name) VALUES ${ph}`, args });
+      const took = ms() - t;
+      console.info(`    INSERT ${String(n).padStart(5)} rows → ${took.toFixed(1)} ms  (extrapolated 170,540 rows: ${((took * 170540) / n / 1000).toFixed(1)} s)`);
+      await remote.execute('DELETE FROM spike_gazetteer_probe');
+    }
+  } finally {
+    await remote.execute('DROP TABLE IF EXISTS spike_gazetteer_probe');
+    const still = await remote.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='spike_gazetteer_probe'");
+    console.info(`  DROP spike_gazetteer_probe → ${still.rows.length === 0 ? 'CONFIRMED GONE' : 'STILL PRESENT — MANUAL CLEANUP REQUIRED'}`);
+  }
+} else {
+  // Prove we left nothing behind even though the write was refused.
+  const still = await remote.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='spike_gazetteer_probe'");
+  console.info(`  Post-check: spike_gazetteer_probe present on staging? ${still.rows.length === 0 ? 'NO — nothing was created, nothing to clean up' : 'YES — MANUAL CLEANUP REQUIRED'}`);
+}
+
+// ---------------------------------------------------------------
+// Storage headroom
+// ---------------------------------------------------------------
+console.info('\n' + '='.repeat(74));
+console.info('Q3d — STORAGE HEADROOM');
+console.info('='.repeat(74));
+try {
+  const pc = await remote.execute('PRAGMA page_count');
+  const ps = await remote.execute('PRAGMA page_size');
+  const pages = Number(Object.values(pc.rows[0])[0]);
+  const size = Number(Object.values(ps.rows[0])[0]);
+  console.info(`  staging DB today: ${pages} pages × ${size} B = ${((pages * size) / 1024 / 1024).toFixed(2)} MB`);
+} catch (e) {
+  console.info(`  PRAGMA page_count/page_size unavailable: ${e.message}`);
+}
+console.info('  Local measured gazetteer footprint is reported by gazetteer-bench.mjs.');
+
+await remote.close();
+await local.close();
+console.info('\n[TURSO] done.');


### PR DESCRIPTION
## SPIKE — DO NOT MERGE

Draft so CI runs and the diff is reviewable, with no risk of merge. **Nothing here ships.**
Commissioned by the PO, who declined to commit to ADL-48 on design alone.

Report: `jobs/architect/tech/20260802-ADL48-feasibility-spike.md`

This is the first ADL-48 work in which code was written and run. ADL-48's own §15.1 item 7
states *"No code was written and no test was run"*; its OP-27 review was likewise probe
scripts against package data. Every number below came from the real 170,540-row dataset in a
real libSQL database, or from Turso staging over the wire.

## Verdict: GO — WITH FOUR CHANGES

ADL-48's central decision (gazetteer-first, geocoder for the tail) survived being built.
G1/G2/G3/G5/G6/G8/G9/G10 all stand. Three stated mechanisms must change, and one inherited
defect is live in shipped code today.

1. **Search is FTS5 trigram — not `LIKE`, and NOT prefix.** ADL-48 §5.3's "exact then prefix"
   is a silent product regression: "vegas" stops finding Las Vegas, "orleans" stops finding
   New Orleans. Trigram returns a **provably identical** result set to today's `LIKE '%q%'`
   (30/30 terms, full id-set equality, full case parity) at 0.2 ms vs 8.7 ms, and it
   *replaces* three b-tree indexes.
2. **`regions` is seeded by additive upsert, never delete-and-reload** (review F2 — verified
   independently in `schema.ts`, not inherited).
3. **Vendor the 3.35 MB crosswalk; drop `iso3166-2-db`** — it costs **11.8 s of install time**
   (a number the review did not have; it measured disk only), paid per worktree and per CI run.
4. **BUG-75 is decoupled and fixed on its own merits** — it is live now.

## Headline measurements

| Question | Finding |
|---|---|
| Search at 170k rows | `LIKE '%q%'` = 8.7 ms, reads **all 170,540 rows per keystroke**. Trigram = 0.2 ms, identical results |
| Latency regime | **Network-dominated.** Turso RTT 29.5 ms vs 8.7 ms CPU → real win is **~22%, not 40×**. The true argument is **rows read: 4,264× fewer** |
| Narrow by country | Under `LIKE`, filter wins 25×, rank buys nothing. **Under trigram the performance case dissolves → rank, don't filter** |
| Is country the last signal? | **No.** The trip's existing places narrow 6 GB "Newport"s → **1** (country only gets 32 → 8) |
| Turso cold seed | `batch(2000)` = 156 ms as one round trip; 2,000-row `VALUES` = **33 ms** (5× better). Full seed 2.8–13.4 s wire time. Not a blocker |
| S1 correctness | **714 rows, 76/76 preserved byte-for-byte** (names too), 0 missing, 0 dup ISO, +638 additive; F4's 2 malformed rows dropped and named |
| BUG-75 | Live **today** at 8,876 rows / 5.20% (worst case 8,092 km). **S1 improves it** to 5,024 / 2.95% — reproducing the review exactly. A 0.1° bucket fixes **98.2%** |

## Two findings that change what should be briefed

**Trigram silently returns zero rows below 3 characters** — not an error. The route must
enforce min-3 as a validated precondition, or it ships a silent empty-results bug.

**Nominatim (Q4) remains UNVERIFIED, and the risk changed shape.** It is unreachable from this
devcontainer (two independent probes; `WebFetch` was also non-functional this session,
confirmed against a control host). The OSM-presence proxy says all nine tail villages exist.
But `nominatim-client.ts:81` filters every result to `SETTLEMENT_TYPES`, and Torridon,
Gairloch, Applecross and Braemar denote *features* as well as settlements — so the real risk is
"Nominatim returns it and **our own filter drops it**". **Whoever closes this must check the
returned `type` field, not merely that rows came back — testing presence alone gives a false pass.**

## Scope discipline

- No schema change, no migration generated, no `db:migrate` anywhere, no remote write.
- **Turso INSERT throughput is UNVERIFIED** — the diagnostic token is read-only. The authorised
  scratch-table write was attempted *deliberately* so the refusal would be an independent second
  probe. Rejected; post-check confirmed **nothing created, nothing to clean up, no user table touched**.
- No `package.json` change — a spike should not impose a 283 MB install on every CI run.
- **ADL-48 and its OP-27 review were not edited**, and no BRD or tracker entries were made.
  Findings are filed for COO adjudication (OP-28; same convention the OP-27 review used).
- The ~17 MB generated artifact is **gitignored** — 170,540 rows, 17,756,562 bytes,
  `sha256:26ea16ec6eed8dee06eb420147b6536f5f5c8af91edfc2fc0423aa1ca0475fd4`. Whether that blob
  belongs in git history is an open decision this spike deliberately does not settle by accident.

## Concession, stated plainly

The NW Highlands hold **45** gazetteer rows total, so for the Scotland dogfood trial the
gazetteer is the *minority* path. If that trial is the priority, the honest sequencing is
**S0 → S1 → BUG-71 fix → pause**, revisiting S2/S3 after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
