### PR TITLE
chore(ENV-01): reopen — an "accepted" constraint became an argument

### DIFF
--- a/.planning/drift-ledger.jsonl
+++ b/.planning/drift-ledger.jsonl
@@ -2774,3 +2774,4 @@
 {"ts":"2026-08-03T20:20:09Z","action":"edit","file":"/workspace/.claude/worktrees/agent-ad106d83bf1cd62c0/jobs/COO/inbox/20260803_1500-ARCHITECT-adl49-geocoder-allowlist.txt","agent_type":"architect"}
 {"ts":"2026-08-03T20:22:55Z","action":"subagent_stop","agent_id":"ad106d83bf1cd62c0"}
 {"ts":"2026-08-03T20:26:35Z","action":"edit","file":"/workspace/_project/tracker.json"}
+{"ts":"2026-08-03T20:41:14Z","action":"edit","file":"/workspace/_project/tracker.json"}

--- a/_project/STATUS.md
+++ b/_project/STATUS.md
@@ -17,7 +17,7 @@ _Tracker last updated: 2026-07-28 (B9 merged — QUAL-03 + QUAL-11 done, PR #292
 | PHASE-5 | Integrations — Notification Engine | ⬜ Pending |
 | PHASE-6 | v3 Planning-First Delivery | ⬜ Pending |
 
-## Open work (80)
+## Open work (81)
 
 ### P0 — Blockers (1)
 
@@ -36,10 +36,11 @@ _Tracker last updated: 2026-07-28 (B9 merged — QUAL-03 + QUAL-11 done, PR #292
 | QUAL-18 | E2E serves the frontend from vite preview, not Express — so no CSP header is ever under test | qa | ⬜ Pending |
 | UX-12 | GE-16 correction-by-re-point has no UI — a user cannot fix a wrong city (UX spec MVP) | frontend | ⬜ Pending |
 
-### P2 — Important (45)
+### P2 — Important (46)
 
 | ID | Title | Owner | Status |
 |---|---|---|---|
+| ENV-01 | Geocoding retry queue stuck — Nominatim blocked by devcontainer firewall | coo | ⬜ Pending |
 | FUTURE-03 | Companion model — linked/unlinked users with invite flow | coo | ⬜ Pending |
 | BRD-IT0809 | Rating sort and filter in item list views, cross-trip by city (IT-08/09) | frontend | done_pending_uat |
 | BRD-AD09 | Categories/activities are global seeded defaults; deactivation is owner-only (AD-09) | backend | ◐ Partial |
@@ -125,12 +126,12 @@ _Tracker last updated: 2026-07-28 (B9 merged — QUAL-03 + QUAL-11 done, PR #292
 |---|---|---|---|---|
 | feature | `██████████▓░░░░░░░░░` 29/58 | 29 | 29 | 3 |
 | requirement | `███████████████████░` 32/33 | 32 | 1 | 6 |
-| bug | `████████████░░░░░░░░` 44/71 | 44 | 27 | 4 |
+| bug | `████████████░░░░░░░░` 44/72 | 44 | 28 | 3 |
 | task | `████████████████████` 9/9 | 9 | 0 | 0 |
 | chore | `████████▓░░░░░░░░░░░` 14/34 | 14 | 20 | 1 |
 
 <details>
-<summary>Deferred (10)</summary>
+<summary>Deferred (9)</summary>
 
 | ID | Title | Owner |
 |---|---|---|
@@ -141,7 +142,6 @@ _Tracker last updated: 2026-07-28 (B9 merged — QUAL-03 + QUAL-11 done, PR #292
 | NR-12 | Archive instead of hard delete for structured lists | architect |
 | NR-13 | Global settings risk control — owner/admin only for destructive changes | architect |
 | UX-05 | Photos — full implementation | frontend |
-| ENV-01 | Geocoding retry queue stuck — Nominatim blocked by devcontainer firewall | coo |
 | BRD-PL0104 | Planning core — idea pool → booked across all item types (PL-01–04) | fullstack |
 | BRD-CU0103 | Shell trips — fast historic catch-up entry (CU-01–03) | fullstack |
 
@@ -161,4 +161,4 @@ _Tracker last updated: 2026-07-28 (B9 merged — QUAL-03 + QUAL-11 done, PR #292
 
 ---
 
-_136 done · 10 deferred · 4 closed · 80 open — 230 tracked items_
+_136 done · 9 deferred · 4 closed · 81 open — 230 tracked items_

--- a/_project/tracker.json
+++ b/_project/tracker.json
@@ -1039,12 +1039,12 @@
       "id": "ENV-01",
       "type": "bug",
       "title": "Geocoding retry queue stuck — Nominatim blocked by devcontainer firewall",
-      "status": "accepted",
+      "status": "pending",
       "owner": "coo",
-      "priority": "P3",
+      "priority": "P2",
       "brdRefs": [],
       "phase": 4,
-      "notes": "PO noted 5 items stuck in geocoding pending queue. Root cause: devcontainer firewall only allows GitHub/npm/Anthropic — Nominatim (external geocoding API) is blocked. Not a code bug. Accepted constraint for dev environment. Queue will resolve when app runs outside devcontainer. No fix needed."
+      "notes": "PO noted 5 items stuck in geocoding pending queue. Root cause: devcontainer firewall only allows GitHub/npm/Anthropic — Nominatim (external geocoding API) is blocked. Not a code bug. Accepted constraint for dev environment. Queue will resolve when app runs outside devcontainer. No fix needed. || REOPENED 2026-08-03, P3 -> P2, on PO direction and at the ADL-49 author's explicit request. THE ORIGINAL RESOLUTION WAS THE PROBLEM. Marking this 'accepted / no fix needed' was locally reasonable — the queue really does drain in a deployed environment — but it converted a one-line config gap into a standing architectural constraint, and over the following weeks that constraint was cited as an argument FOR bundling a 170,540-row dataset. ADL-48 §14 point 4 called the untestability of the primary path 'the strongest single reason' for the gazetteer, and the COO repeated it to the PO. PO ruling 2026-08-03: 'because the firewall blocks the geocoder isn't a good argument because we should be whitelisting services we need access to in local dev.' Correct — .devcontainer/init-firewall.sh is repo-controlled and adding a host is one entry in its `for domain in \\` list. THE COO ALSO HAD THE REBUTTAL ON DISK AND DID NOT CONNECT IT: open dialogue D-21, raised 2026-08-01, already recommended exactly this allowlist plus recorded fixtures. Memory: feedback_arguments_for_are_absence_claims_too. RESOLUTION PATH NOW EXISTS: ADL-49 (PR #376, merged) amends ADL-33 to allowlist nominatim.openstreetmap.org, quotes the exact init-firewall.sh diff rather than applying it, and designs recorded-fixture capture/replay so tests are deterministic without CI calling a free public service live. Two gates before it takes effect: an OP-27 fresh-eyes review of ADL-49, and a container rebuild (init-firewall.sh runs at container start, so no change helps an in-flight session). GENERAL LESSON WORTH KEEPING BEYOND THIS ENTRY: an 'accepted' environment constraint is not inert. It becomes a premise, and premises get built on. When accepting one, record what it would cost to remove — otherwise the next design pays that cost many times over without anyone re-pricing it."
     },
     {
       "id": "FUTURE-02",


### PR DESCRIPTION
Tracker only. Requested explicitly by the ADL-49 author, and it's the sharpest observation in that deliverable.

## Why this matters more than a status flip

ENV-01 was marked **"accepted / no fix needed"**. That was locally reasonable — the geocoding queue really does drain in a deployed environment. But it converted a one-line config gap into a *standing architectural constraint*, and over the following weeks that constraint was cited as **"the strongest single reason"** for bundling a 170,540-row dataset (ADL-48 §14 point 4). I repeated it to the PO.

PO ruling: *"because the firewall blocks the geocoder isn't a good argument because we should be whitelisting services we need access to in local dev."* Correct — `.devcontainer/init-firewall.sh` is repo-controlled and adding a host is one entry in its `for domain in \` list.

And I had the rebuttal on disk: open dialogue D-21, raised two days earlier, already recommended exactly this allowlist plus recorded fixtures. Having it written down isn't the same as connecting it.

## Resolution path now exists

ADL-49 (#376, merged) amends ADL-33 to allowlist the geocoder, quotes the exact `init-firewall.sh` diff rather than applying it, and designs recorded-fixture capture/replay so tests stay deterministic without CI calling a free public service live.

Two gates before it takes effect: an OP-27 fresh-eyes review, and a container rebuild (`init-firewall.sh` runs at container start).

## The general lesson, recorded in the entry

> An "accepted" environment constraint is not inert. It becomes a premise, and premises get built on. When accepting one, record what it would cost to remove — otherwise the next design pays that cost many times over without anyone re-pricing it.

## Checks

`check`, `type:check:all`, `test:backend` (679), `test:frontend` (249). 19 JSONC headers intact.