### PR TITLE
chore(QUAL-20): automated post-deploy shakedown

### DIFF
--- a/.github/workflows/post-deploy-shakedown.yml
+++ b/.github/workflows/post-deploy-shakedown.yml
@@ -1,0 +1,72 @@
+name: Post-Deploy Shakedown
+
+# QUAL-20 / OP-32 — the mechanical half of the deployment shakedown: confirms the DEPLOYED
+# staging build behaves like main before a PO UAT round finds otherwise. See
+# jobs/qa/tech/20260804-post-deploy-shakedown.md for the full design and the honest account
+# of what this suite does and does not cover.
+#
+# WHY THIS RUNS HERE AND NOT AS A DEVCONTAINER SCRIPT: the devcontainer's own firewall
+# blocks the app's public Railway domains (confirmed by two independent probes this session
+# — a direct curl timeout, and grep of .devcontainer/init-firewall.sh's domain list coming up
+# empty for travel-tracker-staging.up.railway.app; this mirrors the same block already
+# recorded against the production domain in jobs/COO/open-dialogues.md D-06). A GitHub-hosted
+# runner has no such restriction, so this is the only place in the project that can actually
+# reach the deployed app directly.
+#
+# TWO TRIGGERS, DELIBERATELY ASYMMETRIC IN HOW MUCH THEY ARE TRUSTED:
+#
+#   workflow_dispatch — COO-invoked, the PRIMARY way this is meant to be run today. Run it
+#   right after confirming (via scripts/agent-diagnostics/railway-query.sh staging status)
+#   that a new deployment reached SUCCESS. No ambiguity about which build is under test.
+#
+#   push to main — automatic, using ADL-32's existing staging-watches-main auto-deploy as
+#   the natural hook the QUAL-20 brief asked to use. This is WEAKER evidence than the manual
+#   trigger: Railway's rollout is not instantaneous and /health carries no build/commit
+#   marker, so this run cannot prove it tested the NEW deploy rather than the previous one
+#   still serving traffic during the rollout window (stated plainly in the tech doc rather
+#   than glossed over). The /health check's own retry/backoff absorbs the common case
+#   (rollout still in progress), but does not close the gap entirely. Treat a red run here as
+#   authoritative; treat a green run here as a good sign, not a substitute for a
+#   workflow_dispatch run before a UAT round that matters.
+on:
+  workflow_dispatch:
+    inputs:
+      base_url:
+        description: "Override target URL (defaults to staging)"
+        required: false
+        type: string
+  push:
+    branches: [main]
+
+jobs:
+  shakedown:
+    name: Shakedown staging
+    runs-on: ubuntu-latest
+    # Give the ADL-32 auto-deploy a head start on a push-triggered run before the suite's
+    # own /health retry/backoff takes over — this is a coarse grace period, not a
+    # deploy-completion signal (no such signal exists today, see comment above).
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: "22"
+          cache: "npm"
+      - run: npm ci
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+      - name: Grace period for in-flight deploy (push trigger only)
+        if: github.event_name == 'push'
+        run: sleep 60
+      - name: Run shakedown
+        run: npm run shakedown:staging
+        env:
+          SHAKEDOWN_BASE_URL: ${{ inputs.base_url || 'https://travel-tracker-staging.up.railway.app' }}
+      - name: Upload shakedown report
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: shakedown-results
+          path: |
+            shakedown-results/
+            shakedown-results.json
+          retention-days: 14

--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,11 @@ e2e.db
 playwright-report/
 test-results/
 
+# Post-deploy shakedown (QUAL-20) artefacts — playwright.shakedown.config.ts's own
+# outputDir/reporter output, separate from the pre-merge E2E suite's above.
+shakedown-results/
+shakedown-results.json
+
 # Personal Claude Code overrides — machine-specific permissions, notification hooks
 .claude/settings.local.json
 

--- a/jobs/COO/inbox/20260804_1200-QA-qual20-post-deploy-shakedown-complete.txt
+++ b/jobs/COO/inbox/20260804_1200-QA-qual20-post-deploy-shakedown-complete.txt
@@ -1,0 +1,75 @@
+QUAL-20 — Automated post-deploy shakedown · Branch chore/qual20-post-deploy-shakedown
+Tracker: QUAL-20 (implements). Related: QUAL-18, QUAL-19, ENV-02, ADL-49, BUG-76.
+BRD: none (OP-32 tooling, no BRD requirement ID).
+
+WHAT WAS BUILT
+A Playwright suite (src/e2e-shakedown/shakedown.spec.ts, playwright.shakedown.config.ts)
+that runs against the ALREADY-DEPLOYED staging URL from GitHub Actions
+(.github/workflows/post-deploy-shakedown.yml), not from the devcontainer, which cannot
+reach the staging domain (confirmed by two probes: curl timeout, allowlist grep — same
+block ADL-49/D-06 already documented for the prod domain).
+
+CHECKS BUILT (5, all on the anonymous/unauthenticated surface):
+  1. App loads and returns a document
+  2. Browser console is free of errors on load
+  3. No 5xx in the page's network lifecycle — retries once, classifies a clearing 5xx as
+     ENV-02-class transient rather than a false product-bug fail
+  4. Deployed document carries a Content-Security-Policy header (proves the QUAL-18
+     topology gap is real, i.e. this deploy genuinely differs from pre-merge E2E)
+  5. /health answers within a deploy-propagation window (backoff for the automatic trigger)
+
+SCOPE LIMIT — READ THIS BEFORE ASSUMING BUG-76-CLASS COVERAGE: none of the brief's
+evidence checks (denver, springfield/newport, plockton, map, admin region list) are
+built. All require an authenticated session; staging's BYPASS_AUTH is fail-closed under
+NODE_ENV=production, and ADL-33 §4 already declined the Clerk credential that would let
+CI mint one (checked directly against .env.agent-diagnostics — Railway/Turso tokens only,
+no Clerk secret/testing-token). Faking auth to get these checks green would repeat
+QUAL-22's shape one level up. THIS IS A PO/ARCHITECT DECISION (dedicated test account or
+Clerk Testing Token), flagged in the tech doc, not solved here.
+
+TRIGGER: workflow_dispatch (primary, COO-invoked, zero ambiguity) + push-to-main
+(automatic, weaker — no build-version signal exists yet, so it can't prove it tested the
+NEW deploy vs. one still rolling out; 60s grace + /health backoff mitigate but don't close
+this). Reasoning in tech doc §6.
+
+PASS/FAIL — WHAT I HAVE ACTUALLY SEEN, NOT INFERRED:
+  Never run against real staging — firewall-blocked from here (two probes, tech doc §2).
+  Validated instead against the closest reachable topology: a local build running
+  NODE_ENV=production with helmet CSP genuinely live, no BYPASS_AUTH.
+    PASS (seen, 4/5): app loads · no 5xx · CSP header present · /health w/ backoff.
+    FAIL (seen, 2x, RIG causes not defects): console-clean check — 1st run used a local-
+      only VITE_BYPASS_AUTH shortcut that fired 401'ing API calls (rig mismatch); 2nd run
+      used a real-shaped (non-secret) Clerk publishable key with no bypass and hit
+      net::ERR_ADDRESS_UNREACHABLE on Clerk's CDN subdomains, which aren't in this
+      devcontainer's allowlist. Check logic confirmed correct both times; a genuinely
+      clean pass was never observed. Marked UNVERIFIED against real staging in the tech
+      doc, with circumstantial support only (tracker already records live prod sign-in
+      working).
+  First real evidence comes from a workflow_dispatch run post-merge, not from this report.
+
+BUGS FOUND: none — this thread built tooling, not a feature/fix verification pass.
+
+CI: gh pr checks pending at time of writing — will confirm green (or fix) before this
+report is considered final; see PR comments / re-check if this note precedes ci-wait.sh.
+
+DECLARATIONS PER STANDING RULES:
+  - No source file rewritten wholesale — all changes are new files or small additive
+    edits (package.json +1 script line, .gitignore +1 block).
+  - jobs/qa/context/current.txt and this inbox entry are additive (Edit/new file), never
+    a rewrite.
+  - No scanner suppression added, none needed.
+  - No BRD or tracker.json edit made (COO's job per brief).
+
+OPEN ISSUES / FOLLOW-ONS (all named in the tech doc §5, not tracker entries — COO's call
+on whether to log them):
+  1. PO/Architect decision on an automated staging test-account mechanism — blocks the
+     denver/plockton/map/region-list checks entirely.
+  2. Embed the deployed commit SHA in /health (cheap Backend follow-on) — closes the
+     "which build actually answered" gap on the automatic trigger.
+  3. If a Railway token is ever added as a GH Actions secret for other reasons, revisit
+     gating the automatic trigger on a real deployment-status poll instead of a fixed
+     grace sleep.
+
+Full design, per-check proves/does-not-prove table, cost, and residual PO scope:
+jobs/qa/tech/20260804-post-deploy-shakedown.md
+Park doc: jobs/qa/park-docs/20260804-QA-park.txt

--- a/jobs/COO/inbox/20260804_1200-QA-qual20-post-deploy-shakedown-complete.txt
+++ b/jobs/COO/inbox/20260804_1200-QA-qual20-post-deploy-shakedown-complete.txt
@@ -1,4 +1,5 @@
-QUAL-20 — Automated post-deploy shakedown · Branch chore/qual20-post-deploy-shakedown
+QUAL-20 — Automated post-deploy shakedown · GitHub issue #384 · PR #385
+Branch chore/qual20-post-deploy-shakedown
 Tracker: QUAL-20 (implements). Related: QUAL-18, QUAL-19, ENV-02, ADL-49, BUG-76.
 BRD: none (OP-32 tooling, no BRD requirement ID).
 
@@ -49,8 +50,13 @@ PASS/FAIL — WHAT I HAVE ACTUALLY SEEN, NOT INFERRED:
 
 BUGS FOUND: none — this thread built tooling, not a feature/fix verification pass.
 
-CI: gh pr checks pending at time of writing — will confirm green (or fix) before this
-report is considered final; see PR comments / re-check if this note precedes ci-wait.sh.
+CI: scripts/ci-wait.sh pr 385 → PASS, all 18 checks green (Biome, Type Check, Backend
+Tests, Frontend Tests, Contract Tests, E2E Tests, Gitleaks, Semgrep, Dependency Scan) @
+ef443849da7034c77c8f254aaf14be623d56d126. Note: the new post-deploy-shakedown.yml workflow
+itself does NOT run on this PR by design (workflow_dispatch + push-to-main only, since it
+targets real staging) — it has not executed anywhere yet. Its first real run is whatever
+happens after merge; see the "PASS/FAIL" section above for what has and hasn't been
+observed to work.
 
 DECLARATIONS PER STANDING RULES:
   - No source file rewritten wholesale — all changes are new files or small additive

--- a/jobs/qa/context/current.txt
+++ b/jobs/qa/context/current.txt
@@ -171,3 +171,46 @@ NEXT STEPS (for incoming QA)
   NEXT: Backend stage (S1-S4) implements against this file as part of its
   definition-of-done, including the owner-access.test.ts HC-06 gap this
   thread surfaced.
+
+================================================================================
+2026-08-04 — QUAL-20 AUTOMATED POST-DEPLOY SHAKEDOWN
+================================================================================
+
+  Branch: chore/qual20-post-deploy-shakedown. Built the mechanical half of
+  OP-32's deployment-shakedown rule: a Playwright suite
+  (src/e2e-shakedown/shakedown.spec.ts, playwright.shakedown.config.ts) that
+  runs against the ALREADY-DEPLOYED staging URL from GitHub Actions
+  (.github/workflows/post-deploy-shakedown.yml — workflow_dispatch primary,
+  push-to-main automatic secondary), not from this devcontainer, which cannot
+  reach the staging domain (two probes: curl timeout, allowlist grep — same
+  block ADL-49/open-dialogues D-06 already documented against the prod
+  domain).
+
+  FIVE CHECKS, ALL ON THE ANONYMOUS SURFACE: app loads, console clean, no 5xx
+  (ENV-02-aware retry so a known transient edge dial-timeout doesn't read as
+  a false product bug), CSP header present (the literal topology difference
+  QUAL-18 documents E2E as unable to observe), /health answers with backoff.
+
+  LOAD-BEARING SCOPE LIMIT, STATED NOT HIDDEN: none of the brief's evidence
+  checks (denver auto-fill, springfield/newport narrowing, plockton, map,
+  admin region list) are built. All require an authenticated session;
+  staging's BYPASS_AUTH is fail-closed under NODE_ENV=production
+  (src/backend/middleware/auth.ts) and ADL-33 §4 already declined the Clerk
+  credential that would let CI mint one. Faking auth to get these checks
+  green would be the QUAL-22 mistake one level up. Flagged as a PO/Architect
+  decision (dedicated test account or Clerk Testing Token), not solved here.
+
+  HONEST STATUS (do not upgrade past what was actually observed): 4 of 5
+  checks seen passing against a production-shaped LOCAL build (NODE_ENV=
+  production, helmet CSP live, real CLERK_ISSUER, no BYPASS_AUTH — the
+  closest topology reachable from this sandbox). The console-clean check
+  failed twice locally for two RIG reasons (VITE_BYPASS_AUTH mismatch, then
+  this devcontainer's firewall blocking Clerk's CDN subdomains) — logic
+  confirmed correct (it caught both), but never observed to pass cleanly.
+  THE WHOLE SUITE HAS NEVER RUN AGAINST REAL STAGING — blocked by the same
+  firewall. First real evidence comes from whoever runs workflow_dispatch
+  from Actions after merge.
+
+  Full design + per-check proves/does-not-prove table + trigger reasoning +
+  cost: jobs/qa/tech/20260804-post-deploy-shakedown.md
+  Completion report: jobs/COO/inbox/

--- a/jobs/qa/park-docs/20260804-QA-park.txt
+++ b/jobs/qa/park-docs/20260804-QA-park.txt
@@ -117,9 +117,11 @@ npm run status:check    → STATUS.md up to date
 npx playwright test --config playwright.shakedown.config.ts --list
                          → all 5 checks register correctly
 
-PR CI (test-e2e, test-backend, test-frontend, test-contract, biome, typecheck)
-— status recorded in the completion report; this file is written before that
-resolves, per template order. See jobs/COO/inbox/ for the confirmed result.
+PR CI: scripts/ci-wait.sh pr 385 → PASS, all 18 checks green (Biome, Type
+Check, Backend/Frontend/Contract/E2E Tests, Gitleaks, Semgrep, Dependency
+Scan) @ ef443849da7034c77c8f254aaf14be623d56d126. GitHub issue #384, PR #385.
+Note: post-deploy-shakedown.yml itself does not run on PRs by design
+(workflow_dispatch + push-to-main only) — it has not executed anywhere yet.
 
 ---
 

--- a/jobs/qa/park-docs/20260804-QA-park.txt
+++ b/jobs/qa/park-docs/20260804-QA-park.txt
@@ -1,0 +1,139 @@
+QA PARK DOCUMENT — 2026-08-04
+PROJECT: Travel Tracker
+THREAD: QUAL-20 — automated post-deploy shakedown
+
+---
+
+WORK COMPLETED THIS THREAD
+
+Built the mechanical half of OP-32's "deployment shakedown before UAT" rule as a
+runnable, CI-triggerable Playwright suite that exercises the DEPLOYED staging
+build directly, so the PO stops being the first person to discover a broken
+deploy. Did not touch any product/application source (auth.ts, server.ts,
+geocode.ts etc. were read, not edited).
+
+Branch: chore/qual20-post-deploy-shakedown.
+
+---
+
+FILES CHANGED (all new; nothing rewritten)
+
+New:
+  playwright.shakedown.config.ts        — separate Playwright config, baseURL
+                                           = deployed staging URL (overridable
+                                           via SHAKEDOWN_BASE_URL), no webServer
+  src/e2e-shakedown/shakedown.spec.ts   — the 5 checks, each with an inline
+                                           "proves / does not prove" comment
+  .github/workflows/post-deploy-shakedown.yml
+                                         — workflow_dispatch (primary) + push
+                                           to main (automatic, weaker signal,
+                                           documented as such)
+  jobs/qa/tech/20260804-post-deploy-shakedown.md
+                                         — full design doc
+
+Edited (Edit, not Write — append-only per OP-28):
+  package.json          — added "shakedown:staging" script
+  .gitignore             — added shakedown-results/ + shakedown-results.json
+  jobs/qa/context/current.txt — appended 2026-08-04 entry
+
+No source file was rewritten wholesale. No BRD or tracker.json edit (out of
+scope per brief — COO's job).
+
+---
+
+THE SCOPE-DEFINING FINDING: AN AUTH WALL, NOT A CHOICE TO SKIP CHECKS
+
+The brief's evidence list (denver, springfield/newport, plockton, map, admin
+region list) all require an authenticated session against staging's real
+Clerk instance. Two things close that off today, established by code read +
+a direct check of the one credential store this session has:
+  1. src/backend/middleware/auth.ts's BYPASS_AUTH guard is fail-closed under
+     NODE_ENV=production (staging's actual mode per ADL-32) — there is no
+     bypass to reach for on a hosted environment.
+  2. ADL-33 §4 already declined Clerk API access; .env.agent-diagnostics
+     (checked directly, not inferred) holds Railway/Turso tokens only, no
+     Clerk secret key or Testing Token.
+Faking either would repeat QUAL-22's shape one level up (a check green
+against a mocked/bypassed environment it never actually touched). Documented
+as a PO/Architect decision to make (dedicated test account or Clerk Testing
+Token), not solved unilaterally inside this brief — this IS the "infra/auth-
+topology change needs Architect ADL" guardrail firing correctly, not a QA
+agent skipping hard work.
+
+Consequence: all 5 built checks run against the anonymous surface only (app
+loads, console clean, no 5xx w/ ENV-02-aware retry, CSP header present,
+/health w/ backoff). Full reasoning + what would unblock it: the tech doc §1
+and §5.
+
+---
+
+HONEST PASS/FAIL ACCOUNTING — READ BEFORE TRUSTING THIS SUITE
+
+THE SUITE HAS NEVER RUN AGAINST REAL STAGING. This devcontainer's firewall
+blocks the staging domain (two probes: curl timeout exit 7; grep of
+.devcontainer/init-firewall.sh's domain list — zero matches), the same block
+ADL-49/open-dialogues D-06 already documented for the prod domain. This is
+why the deliverable is a GitHub Actions workflow, not a local script — per
+QUAL-20's own tracker note, a runner has no such restriction.
+
+Validated locally instead against the closest reachable topology: a real
+`npm run build` + `tsx src/backend/server.ts` with NODE_ENV=production, real
+CLERK_ISSUER/CLERK_JWKS_URI, no BYPASS_AUTH (so helmet's CSP is genuinely
+live, matching production's gate condition at server.ts:233).
+
+  SEEN PASS locally (4/5): app loads; no 5xx; CSP header present; /health
+  with backoff.
+
+  SEEN FAIL locally, twice, for RIG reasons not product/check defects (the
+  5th check, console-clean):
+    1st attempt — VITE_BYPASS_AUTH=true (local-only shortcut) made the
+      frontend skip the sign-in gate and fire authenticated API calls that
+      401'd. Rig mismatch with staging's real topology, not a finding.
+    2nd attempt — used a real-shaped Clerk publishable key (pk_test_ + the
+      known CLERK_ISSUER host, Clerk's own public encoding, not a secret) and
+      no bypass; the sign-in page rendered correctly, but Clerk's CDN
+      subdomains (scdn.clerk.com etc.) aren't in this devcontainer's
+      allowlist (only the JWKS endpoint is, for backend diagnostics) —
+      net::ERR_ADDRESS_UNREACHABLE, a network-level block, not a CSP
+      violation.
+  The check's LOGIC is confirmed correct (caught real errors both times).
+  What was NOT observed is a genuinely clean pass — marked UNVERIFIED against
+  real staging specifically, with circumstantial support only (tracker
+  records Clerk sign-in already working live on production).
+
+First real evidence of this suite's actual behaviour against its actual
+target comes from whoever runs `workflow_dispatch` from GitHub Actions after
+this PR merges — not from anything in this park doc or the tech doc.
+
+---
+
+CI / VERIFICATION (local, pre-push)
+
+npm run check           → clean, 215 files, no fixes needed
+npm run type:check:all  → clean (src/e2e-shakedown/ isn't covered by either
+                           tsconfig, same as the existing src/e2e/ — not a
+                           new gap, matches precedent)
+npm run status:check    → STATUS.md up to date
+npx playwright test --config playwright.shakedown.config.ts --list
+                         → all 5 checks register correctly
+
+PR CI (test-e2e, test-backend, test-frontend, test-contract, biome, typecheck)
+— status recorded in the completion report; this file is written before that
+resolves, per template order. See jobs/COO/inbox/ for the confirmed result.
+
+---
+
+NEXT STEPS FOR WHOEVER PICKS THIS UP
+
+1. Run `workflow_dispatch` on post-deploy-shakedown.yml from Actions after
+   merge — this is the first genuine test of the suite against its actual
+   target. Read the result as new information, not a formality.
+2. PO/Architect decision needed on an automated staging test-account
+   mechanism before the denver/plockton/map/region-list checks can be built
+   — tech doc §5 item 1. Until then those checks stay a PO/UAT-only surface.
+3. Cheap Backend follow-on, not built here: embed the deployed commit SHA in
+   /health's response body, closing the "which build actually answered" gap
+   on the automatic (push) trigger — tech doc §5 item 2.
+4. If a Railway token is ever added as a GitHub Actions secret for other
+   reasons, revisit gating the automatic trigger on an actual deployment-
+   status poll (tech doc §6.3) rather than the current fixed grace sleep.

--- a/jobs/qa/tech/20260804-post-deploy-shakedown.md
+++ b/jobs/qa/tech/20260804-post-deploy-shakedown.md
@@ -1,0 +1,285 @@
+# QUAL-20 — Automated post-deploy shakedown
+
+**Date:** 2026-08-04
+**Tracker:** QUAL-20 (implements). Siblings: QUAL-18 (E2E topology), QUAL-19 (CSP allowlist static
+test), ENV-02 (staging edge 502s), ADL-49 (geocoder allowlist/fixtures), BUG-76 (denver/settlement
+filter).
+**Branch:** `chore/qual20-post-deploy-shakedown`
+
+---
+
+## 0. What this is, in one paragraph
+
+A Playwright suite (`src/e2e-shakedown/shakedown.spec.ts`, run via `playwright.shakedown.config.ts`)
+that hits the **already-deployed staging URL** directly and checks five things: the app loads, the
+console is clean, nothing in the page's network lifecycle 5xxs (with an ENV-02-aware retry), the
+document actually carries a CSP header, and `/health` answers. It runs from GitHub Actions
+(`.github/workflows/post-deploy-shakedown.yml`), not from this devcontainer, because the
+devcontainer's own firewall cannot reach the staging domain (§2). **It does not replace UAT and does
+not test product behaviour** — it tests whether the deployment itself is intact, which is the
+mechanical half of OP-32's shakedown rule and the half a PO should never have to do by hand.
+
+---
+
+## 1. Why the scope stops where it does — the auth wall
+
+This is the single most consequential design decision in this document, so it goes first rather than
+being discovered halfway through the checks table.
+
+The brief's evidence list asks for checks that need a logged-in session: `denver` auto-populating its
+country, `springfield`/`newport` narrowing to multiple regions, `plockton` resolving, the map
+rendering, a region-tier country's admin regions list being non-empty. Every one of those requires
+reaching `/api/geocode`, `/api/admin/*`, or the authenticated app shell, and **all three sit behind
+`requireAuth`** (`src/backend/server.ts:198`, applied globally to `/api/*`).
+
+Staging has no way to satisfy `requireAuth` short of a real Clerk session:
+
+- **`BYPASS_AUTH` is fail-closed on a hosted environment.** `src/backend/middleware/auth.ts`'s guard
+  throws at startup if `BYPASS_AUTH=true` and `NODE_ENV=production` — this is deliberate
+  (`jobs/COO/park-docs/20260721_1918-COO-park.txt` names it "the BYPASS_AUTH fatal-guard"), and staging
+  runs `NODE_ENV=production` per ADL-32. There is no bypass to reach for.
+- **This project has explicitly declined the credential that would make automated Clerk auth
+  possible.** ADL-33 §4 records that Clerk API access was declined and "no read-only credential exists
+  for it." A Clerk Testing Token (the standard mechanism for minting an automated session in CI)
+  requires the Clerk *secret* key — the same credential class ADL-33 already said no to, for reasons
+  that pre-date this brief and are not this brief's to relitigate.
+- **A hand-rolled workaround would repeat the QUAL-22 mistake at one remove.** A mocked session, a
+  forged cookie, or a second BYPASS_AUTH-shaped carve-out for CI would make the authenticated checks
+  pass without them ever touching the real Clerk-gated path staging actually runs — a check green for
+  the wrong reason, on an environment it never touched. That is exactly the shape QUAL-22 already cost
+  this project once (a mock exporting the wrong function name, passing without exercising anything).
+
+**Two independent probes, since this is a load-bearing absence claim:**
+
+1. **Code read.** `auth.ts`'s guard and its own comment naming the NODE_ENV=production fatal case;
+   `server.ts:198`'s global `app.use('/api/', requireAuth)`; ADL-33 §4's text declining Clerk access.
+2. **Live check of the credential store this session actually has access to.** `.env.agent-diagnostics`
+   (the file `railway-query.sh`/`turso-query.mjs` source from) holds Railway and Turso tokens only — no
+   Clerk secret key, no Clerk Testing Token, checked directly rather than inferred from the ADL text.
+
+Both agree: no accepted mechanism exists today. **This is a decision for the PO/Architect, not
+something to route around inside a QA brief** — provisioning a dedicated automated test account (or a
+Clerk Testing Token) is a new credential and a new call to reachable staging/prod identity, which is
+exactly the class of change CLAUDE.md's infra guardrail (Architect ADL before COO acts) and the shared
+Clerk-user-pool open topology question (`jobs/COO/open-dialogues.md`) already govern.
+
+**What this means concretely:** every check in §3 runs against the **anonymous surface** — the sign-in
+screen and its own asset/CSP/health chain. None of them can be the `denver`/`plockton`/map/region-list
+checks the brief's evidence section leads with. That is stated as a scope limit, not hidden as a
+silent omission — see §5 for the recommendation on what would unblock it.
+
+---
+
+## 2. Why this runs in CI, not the devcontainer
+
+Confirmed by **two independent probes**, mirroring the same block ADL-49 §2.1 already documented
+against the production Railway domain and `jobs/COO/open-dialogues.md` D-06:
+
+| Probe | Result |
+|---|---|
+| Direct network: `curl -m 5 https://travel-tracker-staging.up.railway.app/health` | `curl: (7) Failed to connect … after 54 ms` |
+| Allowlist config: `grep railway.app .devcontainer/init-firewall.sh` | No match — the domain is not in the allowlist |
+
+A GitHub-hosted runner has no such restriction (confirmed by CI's own `test-e2e` job already
+downloading Playwright's browser binaries and reaching the npm registry from the same runner class —
+ADL-49 §6.2 makes the identical argument for Nominatim reachability). This is why QUAL-20's own tracker
+note says the check "belongs in CI, not in a COO-run script," and why the deliverable is a GitHub
+Actions workflow rather than a script this devcontainer could run directly.
+
+---
+
+## 3. The checks — what each proves and does not prove
+
+All five live in one file, `src/e2e-shakedown/shakedown.spec.ts`; the table below is reproduced in
+that file's own comments so it travels with the code rather than living only here.
+
+| # | Check | Proves | Does not prove |
+|---|---|---|---|
+| 1 | **App loads and returns a document** | DNS/TLS/Railway-edge/Express chain is intact end to end for an anonymous GET — the exact request class BUG-59 (CORS misconfig) and the BRD-NF09 shakedown's five sequential blockers broke, each differently | The app is *usable* — this is the sign-in screen, not the product |
+| 2 | **Browser console is free of errors on load** | No CSP violation, uncaught exception, or failed-resource error is reported by a real browser against the real origin with helmet's CSP actually applied — the specific observation QUAL-18 says the pre-merge E2E suite structurally cannot make (vite preview carries no CSP header at all) | The console stays clean *past sign-in* — BUG-55 and BUG-68's violations both fired from authenticated actions this suite cannot reach (§1) |
+| 3 | **No 5xx in the page's network lifecycle (ENV-02-aware)** | The static asset pipeline and Express aren't 500ing an anonymous request, on a first attempt or a same-minute retry | Absence of 5xx on authenticated-only routes (`/api/geocode`, `/api/cities`, `/api/admin/*`) — unreachable without a session |
+| 4 | **The document carries a Content-Security-Policy header** | This deployed process is genuinely running the production code path (`NODE_ENV=production`, helmet mounted) — i.e. the exact topology difference QUAL-18 names is real, not a header-value duplicate of that suite's own test | The allowlist is *correct or complete* — that's QUAL-19's static source-level job, deliberately not re-implemented here so the two checks don't drift pretending to test the same thing two ways |
+| 5 | **`/health` answers within a deploy-propagation window** | The Express process is up and answering its own liveness endpoint; absorbs Railway rollout lag for the automatic trigger | That the *new* deploy is what answered, not the previous one still serving traffic — there is no version/commit marker in the response (§5) |
+
+### 3.1 Checks considered and argued against, per the brief's instruction not to implement the list blindly
+
+- **`denver` / `springfield` / `newport` / `plockton` (geocoder)** — argued against building *today*:
+  blocked by the auth wall (§1), not by anything cheap to route around. Building it would either fake
+  the auth (QUAL-22-shaped risk) or require a PO/Architect credential decision this brief cannot make
+  unilaterally.
+- **Map render** — same auth wall; the map only renders inside the authenticated shell.
+- **Reference data (region-tier country → non-empty region list)** — same auth wall
+  (`/api/admin/countries/:code/regions`).
+- **Bounding Nominatim request volume** — turned out to be moot rather than solved: none of this
+  suite's checks call Nominatim (directly or via the app), because none of them can reach an
+  authenticated surface that would trigger a geocode call. If the auth wall is ever lifted (§5), this
+  constraint becomes live again and must be re-applied — ADL-49 §4.3's rules (serialize, refuse under
+  `CI` without an explicit opt-in, never from a test suite) would bind whatever's built then.
+
+---
+
+## 4. Distinguishing product failure from environment failure (requirement #3)
+
+Two mechanisms, both already evidenced by tracker history rather than invented for this brief:
+
+1. **The 5xx check retries once before failing (§3, check 3).** ENV-02 recorded Railway edge
+   "connection dial timeout" 502s against this exact single-replica staging service — self-resolving on
+   refresh, with app-side causes (crash, OOM, CPU saturation) ruled out by direct log and metric
+   evidence at the time. A shakedown that hard-fails on the first sighting of that signature would
+   manufacture a false product bug, which is precisely what OP-32 exists to prevent. So: a 5xx clears on
+   retry → the check **passes**, annotated `ENVIRONMENT-TRANSIENT (ENV-02 class)` rather than a silent,
+   unqualified green. A 5xx that persists across the retry is **not** consistent with ENV-02's own
+   evidence (a per-connection edge timeout, not a sustained condition) and is reported as a probable
+   product/deployment defect.
+2. **`/health`'s retry/backoff (§3, check 5) exists for the same reason on the automatic trigger** — a
+   push-triggered run racing Railway's rollout should not report "staging is down" for a deploy that is
+   still in flight.
+
+What this does **not** do: retry the console-error or CSP-header checks. Those are not the ENV-02
+failure shape (a one-off edge timeout) — a CSP header is either present or it isn't, and a console
+error is either logged or it isn't, on any given load. Retrying those would just be reducing the
+chance of catching a real, intermittent problem, not correcting for a known transient one.
+
+---
+
+## 5. What this suite is honest about not covering
+
+Stated plainly, in the same spirit as QUAL-18/ADL-49's own scope-limit sections, and because a
+shakedown whose own status is overstated is worse than not having one (the brief's own words):
+
+1. **Every authenticated product surface** — §1. This is the largest gap and the one the brief's
+   evidence section most wants closed. **Recommendation:** the PO/Architect decide whether a dedicated,
+   narrowly-scoped automated test account (or a Clerk Testing Token) is worth the new credential and
+   the shared-Clerk-user-pool question it touches. Until that decision is made, this class of defect
+   (BUG-76-shaped: something that only breaks for an authenticated user hitting a real external
+   dependency) stays something only a human UAT pass or a PO report can catch on staging — which this
+   document does not pretend otherwise about.
+2. **Which build answered.** `/health` has no version/commit marker, so an automatic (push-triggered)
+   run cannot prove it tested the *new* deploy rather than the previous one still serving traffic during
+   Railway's rollout (§6.2 names this explicitly rather than glossing over it). **Cheap follow-on,
+   flagged for Backend, not built here:** embed the deployed commit SHA in `/health`'s response body.
+   This is a one-line, low-risk change to a route this brief has no mandate to touch.
+3. **Third-party correctness.** These checks prove *our* deployment is intact, never that Nominatim,
+   Clerk, or MapTiler are behaving correctly today — same boundary ADL-49 §5.8 draws for the
+   replay-fixture design.
+4. **Anything that only manifests under real traffic patterns or over time** — a slow memory leak, a
+   connection-pool exhaustion under load. This is a shakedown, not a soak test.
+
+---
+
+## 6. Trigger recommendation
+
+**Both, sequenced — `workflow_dispatch` as the trusted primary today, `push`-to-`main` as a weaker
+automatic signal layered on top, not a replacement for it.**
+
+### 6.1 `workflow_dispatch` (COO-invoked) — primary
+
+Run this right after confirming (`scripts/agent-diagnostics/railway-query.sh staging status`) that a
+new deployment reached `SUCCESS`. Zero ambiguity about which build is under test, zero new
+infrastructure, usable immediately. This is the trigger to treat as authoritative before a UAT round
+that matters — exactly the workflow QUAL-20's own tracker note anticipates ("a staging deploy that
+serves a CSP-broken or otherwise non-functional build fails the check").
+
+### 6.2 `push` to `main` — automatic, secondary, with a stated gap
+
+ADL-32 already makes staging watch `main` continuously, which the brief calls out as "a natural hook."
+Wiring it costs nothing extra (the same workflow, a second trigger) and it means a badly broken deploy
+gets flagged without anyone having to remember to invoke it. But it is **weaker evidence than the
+manual trigger**, for a reason worth stating rather than hiding: Railway's rollout is not instantaneous,
+and (per §5.2) `/health` carries no build marker, so a push-triggered run cannot prove it tested the new
+build rather than the previous one still answering during the rollout window. The workflow adds a
+60-second grace sleep before starting (crude, not a completion signal) and `/health`'s own
+retry/backoff absorbs the common case, but the gap is not fully closed. **Treat a red run here as
+real; treat a green run here as a good sign, not a substitute for a `workflow_dispatch` run before a
+UAT round.**
+
+### 6.3 What was considered and rejected
+
+- **Gating the automatic trigger on a Railway deployment-status poll** (via
+  `railway-query.sh`'s GraphQL pattern) would close the §5.2 gap properly, but it requires a Railway
+  token as a *GitHub Actions* secret — a new secret in a new location, not something to add
+  unilaterally inside a QA brief. Flagged as the correct fix for anyone revisiting this, not built here.
+- **A scheduled (`cron`) run** was not added. Nothing in this suite reaches a rate-limited third party
+  (§3.1), so ADL-49 §5.7's "why not a scheduled Action" reasoning doesn't directly transfer — but there
+  is also no standing need for a time-based run distinct from "after every deploy," so it would add a
+  third trigger for no evidenced benefit.
+
+---
+
+## 7. Cost
+
+- **Runtime:** ~15–20s of actual check time (5 short Playwright tests, mostly waiting on one page
+  load's `networkidle` + a 1.5s settle window) plus fixed CI overhead — `npm ci`, Playwright browser
+  install (~30–60s, same cost the existing `test-e2e` job already pays), and the push-trigger's 60s
+  grace sleep. Call it **~2 minutes wall-clock for a `workflow_dispatch` run, ~3 minutes for the
+  automatic one.**
+- **Request count:** a handful of HTTP requests per run (one page navigation with its asset
+  sub-requests, one direct CSP-header fetch, up to 10 `/health` polls at 6s spacing in the worst case).
+  Nowhere near any rate-limited surface — see §3.1 on why Nominatim exposure is moot here, not merely
+  bounded.
+- **Flakiness risk:** the two places most likely to flake are exactly the two given explicit
+  retry/backoff handling — 5xx (ENV-02) and `/health` (rollout lag). The console-error and CSP-header
+  checks are not retried and are expected to be either reliably green or a real finding; if either
+  starts flaking in practice, that is itself signal (an intermittent CSP misconfiguration is worth
+  knowing about, not worth suppressing).
+
+---
+
+## 8. What this leaves to the PO — stated plainly, not implied
+
+This is **not** a UAT replacement, and it does not claim to be:
+
+- **Every judgment call** — "the caption should be bolder," "the state list should narrow like the UK
+  one" — stays entirely the PO's, exactly as the brief frames it. Nothing here attempts to automate
+  taste or product feel.
+- **Every authenticated product behaviour** — §1's whole scope limit. Until an auth mechanism is
+  decided, a human is still the only thing that can catch a BUG-76-shaped defect on staging before it
+  ships to a UAT round.
+- **Whether the *right* thing was built**, only whether the *deployed* thing matches what CI already
+  approved. A shakedown that passes says "this is safe to UAT," not "this is correct."
+
+What it *does* free the PO from: being the first person to discover a white screen, a CSP
+misconfiguration, a CORS regression, or a dead process — the class of defect that has cost this
+project real UAT time at least twice (BRD-NF09, BUG-55) before this existed.
+
+---
+
+## 9. What I have actually seen pass, versus what is written but unproven
+
+Stated exactly as the brief asked, because this document exists in a thread about checks being green
+for the wrong reason:
+
+**Run locally against a production-shaped build** (`NODE_ENV=production`, real `CLERK_ISSUER`/
+`CLERK_JWKS_URI`, no `BYPASS_AUTH`, helmet applied — the closest topology reachable from this
+devcontainer, itself firewalled from the real staging URL per §2):
+
+- ✅ **Seen pass:** "the app loads and returns a document," "no 5xx in the page network lifecycle,"
+  "the deployed document carries a Content-Security-Policy header," "`/health` answers within the
+  deploy-propagation window."
+- ⚠️ **Seen fail, and why it does not indict the check:** "browser console is free of errors on load"
+  failed twice locally, for two different **rig** reasons, neither of which is evidence about staging
+  itself:
+  1. With `VITE_BYPASS_AUTH=true` (a local-only rig shortcut, not present on staging), the frontend
+     skipped the sign-in gate and fired authenticated API calls that 401'd — a mismatch between my test
+     rig and staging's real topology, not a defect the check found.
+  2. With a real-shaped Clerk publishable key (`pk_test_` + base64 of the known `CLERK_ISSUER` host —
+     Clerk's own documented encoding, not a secret) and no bypass, the sign-in page correctly rendered,
+     but Clerk's CDN subdomains (`scdn.clerk.com` and similar) are **not** in this devcontainer's
+     firewall allowlist (only the JWKS endpoint is, for backend diagnostics) — `net::ERR_ADDRESS_UNREACHABLE`,
+     a network-level block, not a CSP violation. This is the same class of environment limitation §2
+     documents for the staging URL itself, just hitting a different allowlisted-subset boundary.
+
+  **This check's logic is confirmed working** — it correctly detected and reported real console errors
+  in both cases. **What I have not been able to do is observe it pass against a genuinely clean,
+  unauthenticated Clerk sign-in load**, because this sandbox cannot reach the full set of hosts that
+  load requires. Circumstantial evidence this would be clean on real staging: the tracker's own record
+  confirms Clerk sign-in already renders correctly on live production
+  (`_project/tracker.json`, ADL-32's entry: "CONFIRMED WORKING 2026-07-21 (Ryan, live on prod): sign-in
+  … render correctly"). That is evidence, not proof — **marked UNVERIFIED against the real staging URL
+  specifically**, with the two probes and their blind spot stated above, per the standing rule.
+
+**Never run against the real staging URL at all** — blocked by §2's firewall, confirmed by the same two
+probes. **This entire suite is therefore unproven against its actual target as of this report.** The
+first genuine evidence of a pass/fail against real staging will be whoever (COO, most likely) runs
+`workflow_dispatch` from a GitHub Actions runner after this PR merges. That run, not this document,
+is the first real test of this shakedown.

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "test:contract:coverage": "vitest run --config vitest.config.contract.ts --coverage",
     "test:e2e": "SQLITE_PATH=file:./e2e.db npm run db:migrate && playwright test",
     "test:e2e:clean": "rm -f ./e2e.db",
+    "shakedown:staging": "playwright test --config playwright.shakedown.config.ts",
     "lint": "biome lint src/",
     "format": "biome format --write src/",
     "check": "biome ci src/"

--- a/playwright.shakedown.config.ts
+++ b/playwright.shakedown.config.ts
@@ -1,0 +1,59 @@
+/**
+ * Post-deploy shakedown — Playwright config — Travel Tracker (QUAL-20)
+ *
+ * This is deliberately a SEPARATE config from playwright.config.ts, not a project inside it.
+ * The two suites test different things against different topologies and must never be
+ * confused with each other:
+ *
+ *   playwright.config.ts        — pre-merge E2E. Runs against a LOCAL build (vite preview +
+ *                                  a fresh sqlite e2e.db), BYPASS_AUTH=true, proves product
+ *                                  BEHAVIOUR against source-controlled code. See QUAL-18 for
+ *                                  the CSP blind spot this topology has (no webServer here
+ *                                  fixes that — this config doesn't serve anything at all).
+ *
+ *   playwright.shakedown.config.ts (this file) — post-deploy. Runs against the ALREADY
+ *                                  DEPLOYED staging URL, no BYPASS_AUTH (there is no bypass
+ *                                  on a hosted environment — src/backend/middleware/auth.ts's
+ *                                  guard is fail-closed there), no webServer block at all
+ *                                  because there is nothing local to start. Proves the
+ *                                  DEPLOYMENT is intact — same build reachable, same CSP
+ *                                  applied, no 5xx on the anonymous surface — not product
+ *                                  behaviour. See jobs/qa/tech/20260804-post-deploy-shakedown.md
+ *                                  for what this suite does and does not cover, and why.
+ *
+ * Usage:
+ *   npm run shakedown:staging                              # defaults to staging
+ *   SHAKEDOWN_BASE_URL=<url> npm run shakedown:staging      # override (e.g. a preview env)
+ */
+
+import { defineConfig } from '@playwright/test';
+
+const DEFAULT_STAGING_URL = 'https://travel-tracker-staging.up.railway.app';
+
+export default defineConfig({
+  testDir: './src/e2e-shakedown',
+
+  // One run, no retries baked into the runner — retry semantics for transient platform
+  // errors (ENV-02's single-replica edge dial-timeouts) are handled EXPLICITLY inside the
+  // checks themselves, so the report can say "cleared on retry, environment-transient"
+  // rather than Playwright silently re-running the whole test and reporting a bare pass.
+  retries: 0,
+  workers: 1,
+  timeout: 60_000,
+
+  use: {
+    baseURL: process.env.SHAKEDOWN_BASE_URL || DEFAULT_STAGING_URL,
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+    video: 'off',
+    // A named UA so this is identifiable in Railway's http logs as the shakedown, not an
+    // anonymous crawler — same courtesy this project already extends to Nominatim (ADL-49 §4.1).
+    userAgent: 'TravelTrackerShakedown/1.0 (+https://github.com/ryanv11/travel-tracker)',
+  },
+
+  // No webServer block — deliberately. The whole point is testing something already
+  // running elsewhere; starting a local server here would defeat it.
+
+  reporter: [['list'], ['json', { outputFile: 'shakedown-results.json' }]],
+  outputDir: 'shakedown-results/',
+});

--- a/src/e2e-shakedown/shakedown.spec.ts
+++ b/src/e2e-shakedown/shakedown.spec.ts
@@ -1,0 +1,239 @@
+/**
+ * Post-deploy shakedown — Travel Tracker (QUAL-20 / OP-32)
+ *
+ * WHAT THIS FILE IS. The mechanical half of OP-32's "deployment shakedown before UAT" rule:
+ * confirms the DEPLOYED build behaves like main, before a PO UAT round finds otherwise. It
+ * runs against the real staging URL (playwright.shakedown.config.ts's baseURL), never a local
+ * server. See jobs/qa/tech/20260804-post-deploy-shakedown.md for the full design, the
+ * per-check "what this proves / does not prove" table (reproduced in each test's comment
+ * below so it travels with the code), the trigger recommendation, and — the part that matters
+ * most given why QUAL-20 exists — an explicit, honest list of what this suite does NOT cover
+ * and why, rather than silently omitting it.
+ *
+ * WHAT THIS FILE DELIBERATELY DOES NOT DO. It does not sign in. Staging runs with no
+ * BYPASS_AUTH (src/backend/middleware/auth.ts's guard is fail-closed on a hosted
+ * environment — there is no bypass to reach for), and this project has no accepted
+ * mechanism to mint an automated Clerk session for CI (ADL-33 §4 declined Clerk API
+ * access; no read-only or testing-token credential exists for it). So every check here is
+ * necessarily on the ANONYMOUS surface — the sign-in page and its own asset/CSP/health
+ * chain. The checks the QUAL-20 brief's evidence most wants (denver auto-fills its country,
+ * springfield/newport narrow, plockton resolves, the map paints, admin regions return data)
+ * all require an authenticated session and are NOT built here — see the tech doc's "What
+ * this does not cover" section for the reasoning and what would unblock it.
+ *
+ * NEVER add BYPASS_AUTH, a hand-rolled auth cookie, or a mocked Clerk session to make an
+ * authenticated check pass here. That would be indistinguishable from the QUAL-22 failure
+ * mode this whole ADL-49/QUAL-20 thread exists to avoid — a check green for the wrong
+ * reason, on an environment it never actually touched.
+ */
+
+import { expect, type Page, test } from '@playwright/test';
+
+/** A response is treated as a genuine 5xx signal only above this. 3xx/4xx are not this
+ * check's concern (4xx on `/` would be a real product surprise, but this suite's job is the
+ * environment/deployment layer — see the tech doc for why 4xx isn't gated here). */
+const SERVER_ERROR_FLOOR = 500;
+
+type CapturedResponse = { url: string; status: number };
+
+/** Navigates to `path` and collects every console message, uncaught page error, and
+ * response status seen during that single navigation + a short settle window. Shared by
+ * every check below so "what counts as an error" is defined exactly once. */
+async function loadAndObserve(page: Page, path: string) {
+  const consoleErrors: string[] = [];
+  const pageErrors: string[] = [];
+  const responses: CapturedResponse[] = [];
+
+  page.on('console', (msg) => {
+    if (msg.type() === 'error') consoleErrors.push(msg.text());
+  });
+  page.on('pageerror', (err) => {
+    pageErrors.push(err.message);
+  });
+  page.on('response', (res) => {
+    responses.push({ url: res.url(), status: res.status() });
+  });
+
+  const navResponse = await page.goto(path, { waitUntil: 'networkidle', timeout: 30_000 });
+
+  // Give any deferred/lazy work (chunked JS, a font, a late Clerk SDK call) a moment to
+  // finish and report — networkidle from Playwright fires on the request graph, not on
+  // "everything the page will ever do", and a console error logged 200ms after networkidle
+  // would otherwise be silently missed.
+  await page.waitForTimeout(1500);
+
+  return { navResponse, consoleErrors, pageErrors, responses };
+}
+
+/**
+ * CHECK — App loads and returns a real document.
+ *
+ * PROVES: DNS/TLS/Railway-edge/Express chain is intact end to end for an anonymous GET of
+ * the SPA document — the same request class BUG-59's CORS misconfiguration and the
+ * BRD-NF09 shakedown's five sequential blockers all broke in different ways.
+ *
+ * DOES NOT PROVE: that the app is usable. This is the sign-in screen, not the product —
+ * reaching product surfaces needs auth this suite does not have (see file header).
+ */
+test('the app loads and returns a document', async ({ page }) => {
+  const { navResponse } = await loadAndObserve(page, '/');
+  expect(
+    navResponse,
+    'navigation produced no response at all (DNS/TLS/connection failure)',
+  ).not.toBeNull();
+  expect(navResponse?.status(), `document request returned ${navResponse?.status()}`).toBeLessThan(
+    400,
+  );
+  await expect(page).toHaveTitle(/.+/);
+});
+
+/**
+ * CHECK — Browser console is clean on the anonymous landing surface.
+ *
+ * PROVES: no CSP violation, no uncaught JS exception, no failed-resource console error is
+ * reported by a REAL browser hitting the REAL deployed origin with helmet's CSP actually
+ * applied. This is precisely the observation QUAL-18 documents as structurally impossible
+ * in the pre-merge E2E suite (vite preview serves the document with no CSP header at all)
+ * — this check is the reason this file exists as a separate topology rather than a fourth
+ * project bolted onto playwright.config.ts.
+ *
+ * DOES NOT PROVE: the console stays clean past sign-in. BUG-55's connect-src violation and
+ * BUG-68's clerk-telemetry.com violation both fired from authenticated, in-product actions
+ * (adding a place) that this suite cannot reach. QUAL-19's static allowlist test is the
+ * complementary check for that class of defect from source instead of from a browser.
+ */
+test('browser console is free of errors on load', async ({ page }) => {
+  const { consoleErrors, pageErrors } = await loadAndObserve(page, '/');
+  const allErrors = [...consoleErrors, ...pageErrors];
+  expect(allErrors, `console/page errors on load:\n${allErrors.join('\n')}`).toHaveLength(0);
+});
+
+/**
+ * CHECK — Nothing in the page's network lifecycle 5xxs, with one environment-aware retry.
+ *
+ * PROVES: the static asset pipeline and Express aren't 500ing (or worse) for an anonymous
+ * request, either on the first attempt or on a same-minute retry.
+ *
+ * DOES NOT PROVE: absence of 5xx on authenticated-only routes (/api/geocode, /api/cities,
+ * /api/admin/*) — unreachable without a session (see file header).
+ *
+ * WHY THE RETRY, AND WHY IT IS NOT A SILENT PASS: ENV-02 recorded Railway edge "connection
+ * dial timeout" 502s against this exact single-replica staging service, self-resolving on
+ * refresh, with app-side causes (crash, OOM, CPU) ruled out by direct log/metric evidence.
+ * A shakedown that fails outright on that signature would be manufacturing a false product
+ * bug — exactly what OP-32 exists to prevent. So: a 5xx on the first load is retried once
+ * after a short delay; if it clears, the check PASSES but is annotated as
+ * ENVIRONMENT-TRANSIENT (ENV-02 class) rather than reported as a silent, unqualified green.
+ * If it persists across the retry, that is no longer consistent with ENV-02's own evidence
+ * (a per-connection edge timeout, not a sustained condition) and the check FAILS as a
+ * probable product/deployment defect.
+ */
+test('no 5xx in the page network lifecycle (ENV-02-aware)', async ({ page }, testInfo) => {
+  const attempt = async () => {
+    const { responses } = await loadAndObserve(page, '/');
+    return responses.filter((r) => r.status >= SERVER_ERROR_FLOOR);
+  };
+
+  const first = await attempt();
+  if (first.length === 0) return;
+
+  testInfo.annotations.push({
+    type: 'note',
+    description: `5xx on first attempt (${first.map((r) => `${r.status} ${r.url}`).join(', ')}) — retrying once per ENV-02's known transient-edge-timeout signature before treating as a failure.`,
+  });
+  await page.waitForTimeout(5_000);
+  const second = await attempt();
+
+  if (second.length === 0) {
+    testInfo.annotations.push({
+      type: 'note',
+      description:
+        'PASSED ON RETRY — classify as ENVIRONMENT-TRANSIENT (ENV-02 class: Railway edge dial-timeout against a single-replica service), not a product defect. Re-run if this repeats across consecutive shakedowns; a persistent pattern is evidence ENV-02 needs the replica-count fix, not a new investigation.',
+    });
+    return;
+  }
+
+  throw new Error(
+    `5xx persisted across a retry — NOT the ENV-02 transient signature (that clears on refresh). ` +
+      `Treat as a probable product/deployment defect, not a platform blip: ${second
+        .map((r) => `${r.status} ${r.url}`)
+        .join(', ')}`,
+  );
+});
+
+/**
+ * CHECK — The deployed document is actually served with a Content-Security-Policy header.
+ *
+ * PROVES: this deployed process is running the production code path (NODE_ENV=production,
+ * helmet's CSP middleware mounted) — i.e. the topology QUAL-18 says the pre-merge E2E suite
+ * can never observe (vite preview, no CSP header, two origins) is genuinely different from
+ * what's live. A missing header here would mean either the build isn't what we think it is,
+ * or helmet's gate condition (server.ts:233's NODE_ENV/dist check) isn't true in production
+ * the way it's assumed to be.
+ *
+ * DOES NOT PROVE: that the CSP allowlist is CORRECT or complete — only that one exists.
+ * Whether every origin the frontend fetches is actually in it is QUAL-19's job (a static
+ * source-level test), deliberately not duplicated here so the two checks don't drift apart
+ * pretending to test the same thing two different ways.
+ */
+test('the deployed document carries a Content-Security-Policy header', async ({
+  request,
+  baseURL,
+}) => {
+  const res = await request.get(baseURL ?? '/');
+  const csp = res.headers()['content-security-policy'];
+  expect(
+    csp,
+    'no content-security-policy header on the deployed document — see comment above',
+  ).toBeTruthy();
+});
+
+/**
+ * CHECK — /health answers, with backoff — the readiness gate the automatic (post-push)
+ * trigger relies on.
+ *
+ * PROVES: the Express process is up and answering its own liveness endpoint. Also
+ * absorbs deploy-propagation lag when this suite is triggered automatically right after a
+ * merge to main (ADL-32's staging auto-deploy) — Railway's rollout is not instantaneous,
+ * and this is the one check designed to retry across that window rather than report a
+ * false failure for a deploy still in flight.
+ *
+ * DOES NOT PROVE: that /health reflects the NEW deploy specifically rather than the
+ * previous one still running — there is no version/commit marker in the response to tell
+ * the difference (see the tech doc's "what this does not cover" — a cheap Backend follow-on,
+ * not built here). A manual (COO-invoked) run after confirming the deployment in
+ * `railway-query.sh staging status` does not have this ambiguity; the automatic trigger
+ * does, and that residual gap is stated rather than hidden.
+ */
+test('/health answers within the deploy-propagation window', async ({ request, baseURL }) => {
+  const url = `${baseURL}/health`;
+  const maxAttempts = 10;
+  const delayMs = 6_000;
+  let lastStatus: number | undefined;
+  let lastBody: string | undefined;
+
+  for (let i = 0; i < maxAttempts; i++) {
+    const res = await request.get(url, { failOnStatusCode: false });
+    lastStatus = res.status();
+    lastBody = await res.text();
+    if (res.ok()) {
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(lastBody);
+      } catch {
+        parsed = undefined;
+      }
+      expect(parsed, `/health returned 200 but an unexpected body: ${lastBody}`).toMatchObject({
+        status: 'ok',
+      });
+      return;
+    }
+    if (i < maxAttempts - 1) await new Promise((r) => setTimeout(r, delayMs));
+  }
+
+  throw new Error(
+    `/health never returned 200 after ${maxAttempts} attempts over ~${
+      (maxAttempts * delayMs) / 1000
+    }s (last: ${lastStatus} ${lastBody})`,
+  );
+});


### PR DESCRIPTION
Closes #384

Implements QUAL-20 — the mechanical half of OP-32's deployment-shakedown rule.

## What this is

A Playwright suite (`src/e2e-shakedown/shakedown.spec.ts`, run via
`playwright.shakedown.config.ts`) that hits the **already-deployed staging URL** directly
from GitHub Actions (`.github/workflows/post-deploy-shakedown.yml`) — not from the
devcontainer, which cannot reach the staging domain (two independent probes: a direct
connection timeout, and the domain's absence from `.devcontainer/init-firewall.sh`'s
allowlist).

Five checks, all on the anonymous surface:
1. App loads and returns a document
2. Browser console is free of errors on load
3. No 5xx in the page's network lifecycle (retries once, ENV-02-aware, so a known transient
   Railway edge dial-timeout doesn't read as a false product bug)
4. The deployed document carries a Content-Security-Policy header (proves the QUAL-18
   topology gap is real — this deploy genuinely differs from pre-merge E2E)
5. `/health` answers within a deploy-propagation window (backoff for the automatic trigger)

## What this deliberately does not cover

None of the brief's authenticated-surface checks (an unambiguous city auto-populating its
country, an ambiguous one narrowing, a long-tail village resolving, the map, admin
reference data) are built. All require a logged-in session against staging's real Clerk
instance; staging's auth bypass is fail-closed in a hosted environment, and this project
has already declined the Clerk credential (ADL-33 §4) that would let CI mint one. Faking
that would repeat the QUAL-22 mistake one level up (a check green against an environment it
never actually touched). This is flagged as a PO/Architect decision, not solved here — full
reasoning in the tech doc.

## Trigger

`workflow_dispatch` (primary, COO-invoked, zero ambiguity about which build is under test)
+ `push` to `main` (automatic, using ADL-32's existing staging-watches-main deploy as the
natural hook, but explicitly weaker — no build-version signal exists yet, so it can't prove
it tested the new deploy vs. one still rolling out).

## Honesty about what's actually been observed

This suite has **never run against real staging** — blocked by the same firewall named
above. Validated instead against the closest reachable topology (a local production-mode
build, real Clerk issuer, no auth bypass, helmet CSP genuinely live): 4/5 checks seen
passing; the console-clean check's logic is confirmed correct (it caught two real rig-level
issues) but a clean pass was never observed locally, for reasons specific to this sandbox
rather than the check itself. Full accounting: `jobs/qa/tech/20260804-post-deploy-shakedown.md` §9.

## Deliverables
- `jobs/qa/tech/20260804-post-deploy-shakedown.md` — design, per-check proves/does-not-prove
  table, trigger reasoning, cost, residual PO scope
- `jobs/qa/park-docs/20260804-QA-park.txt`
- `jobs/COO/inbox/20260804_1200-QA-qual20-post-deploy-shakedown-complete.txt`

BRD: none (OP-32 tooling item, no requirement ID).