### PR TITLE
fix(BUG-80): surface the region on saved places across all city payloads (#388)

### DIFF
--- a/jobs/COO/inbox/20260803_1600-BACKEND-bug80-region-on-saved-places-complete.txt
+++ b/jobs/COO/inbox/20260803_1600-BACKEND-bug80-region-on-saved-places-complete.txt
@@ -1,0 +1,67 @@
+TO: COO
+FROM: BACKEND
+DATE: 2026-08-03 16:00
+RE: BUG-80 — surface region on every city-shaped payload and saved-place surface
+
+Tracker: BUG-80 · GitHub #388 (PR not yet numbered — see below) · BRD GE-16/GE-17
+Branch: fix/bug80-region-on-saved-places
+
+WHAT WAS BUILT
+PO UAT finding: two saved places for same-named cities in different regions
+("Newport" in Scotland vs Wales) rendered identically as "Newport United
+Kingdom" — display-only (the identity key already kept them as distinct
+rows). Extended region_iso/region_name across every city-shaped backend
+payload that was missing one or both (GET/POST /api/trips + nested places,
+GET /api/cities/:id — 6 route handlers, 3 files, no schema change), lifted
+BUG-72's formatCitySubtitle() into a shared frontend util, and wired it into
+every saved-place-rendering surface named in the brief plus 2 more found by
+audit (GET/POST /api/trips/:tripId/places, previously unjoined entirely).
+
+ACCEPTANCE CRITERIA
+1. Two same-named cities in different regions visually distinguishable on
+   every surface that renders a saved place — PASS (PlaceSection,
+   PlaceDateForm, ReviewPanel, TripCard, CityMarkers, DesktopTripsLayout/
+   MobileTripsLayout map-filter label, CityItemsPage).
+2. Region-tier country with no region set renders that fact explicitly —
+   PASS (formatCitySubtitle's "(no <label> set)" branch, unit-tested).
+3. Non-region-tier country renders unchanged, no empty separator/undefined —
+   PASS (unit-tested, including the "region_name absent from object
+   entirely" variant).
+4. One formatter, shared, not two — PASS. formatCitySubtitle.ts is the only
+   implementation; every surface (including CityItemsPage, which consumes a
+   pre-computed subtitle via router state rather than recomputing) reuses it.
+5. Tests cover regioned / region-tier-no-region / non-region-tier /
+   payload-never-joined — PASS, 9-case unit suite plus 7 new backend
+   integration tests reproducing the exact PO scenario.
+
+SECURITY CHECKLIST (6 routes modified, 0 added)
+1. Auth middleware — unchanged on all 6 (blanket requireAuth via server.ts;
+   no requireOwner added/removed; GET /api/cities* intentionally ungated,
+   pre-existing).
+2. userId scoping — unchanged; only joins/columns added, no WHERE-clause or
+   ownership-check logic touched (tripRepository.getPlaces,
+   placeRepository.findByTrip both re-verified scoped exactly as before).
+3. New user-data FK columns — none; no migration, no schema.ts edit.
+   `regions` has no userId column (confirmed by direct schema read; same
+   tier-1 classification BUG-72 already established).
+
+CI: gh pr checks <PR#> — to be confirmed after PR is opened (see below).
+
+OPEN ISSUES / BLOCKERS
+- Deferred (not blocking): PlaceSection's Remove-place ConfirmDialog shows
+  neither country nor region — a pre-existing, wider ambiguity than this
+  brief's "region" scope, and touching it risks a documented Playwright
+  substring-matching fragility on that exact dialog. Flagged in the park doc
+  for a future, separately-scoped brief if wanted.
+- POST /api/cities and PATCH /api/cities/:id (serializeCity) deliberately
+  left as the "never joined regions" case — audited (two probes: full read
+  of AddPlaceFlow's use of the created city object, and a repo-wide grep for
+  other consumers) to confirm nothing renders their region fields today.
+
+WHAT'S NOW UNBLOCKED
+Nothing else was waiting on this specifically — closes the backend+frontend
+half of BUG-72's original design the brief described as already the
+strongest section of a larger identity design still blocked elsewhere.
+
+Full detail: jobs/backend/park-docs/20260803-BACKEND-bug80-park.txt
+Context: jobs/backend/context/current.txt (2026-08-03 entry)

--- a/jobs/backend/context/current.txt
+++ b/jobs/backend/context/current.txt
@@ -1,3 +1,76 @@
+BACKEND CONTEXT — 2026-08-03 (BUG-80 thread, latest)
+PROJECT: Travel Tracker
+CURRENT STATUS: implemented BUG-80 (GitHub #388, BRD GE-16/GE-17) — region
+  now surfaced on every city-shaped payload and saved-place surface, not just
+  GET /api/cities (BUG-72). Branch fix/bug80-region-on-saved-places off main,
+  PR to be opened this thread.
+  1. Backend (no schema change, no new join beyond what already existed on
+     trips.ts; one new join each on cities.ts GET /:id and places.ts POST):
+     - repositories/trips.ts getPlaces() and repositories/places.ts
+       findByTrip() both already LEFT JOIN regions for region_iso; both now
+       also select region_name off the same join.
+     - routes/trips.ts: list (buildTripResponse) was missing region_name;
+       detail (GET /:id) was missing BOTH region_iso and region_name — the
+       exact dropped-join defect the brief described.
+     - routes/places.ts: GET /api/trips/:tripId/places (standalone, confirmed
+       via two probes — grep + full read of usePlaces.ts — to have NO current
+       frontend consumer) now passes through region_iso/region_name from the
+       repo. POST /api/trips/:tripId/places built its own inline city object
+       with no join at all; added one.
+     - routes/cities.ts: GET /api/cities/:id (BUG-29) had no region fields at
+       all; added the same LEFT JOIN pattern as GET /api/cities (BUG-72).
+     - POST /api/cities and PATCH /api/cities/:id (serializeCity) deliberately
+       NOT touched — audited (traced AddPlaceFlow's handleSelectCity and
+       geocodeRetryQueue; neither reads region fields off these responses)
+       and left as the documented "never joined" case on the City type.
+  2. Frontend: lifted BUG-72's formatCitySubtitle() out of AddPlaceFlow.tsx
+     into src/frontend/utils/formatCitySubtitle.ts — one shared formatter,
+     generalized with an optional countryDisplay param (defaults to
+     country_code, matching BUG-72's original behaviour) so PlaceSection's
+     full-country-name contract (D-04) and AddPlaceFlow/ReviewPanel's
+     country-code convention both work off the same function. Honors the
+     region_name null-vs-undefined distinction (types/api.ts) — a payload
+     that never joined regions renders as country-only, never a false "no
+     region set" claim.
+     Wired into: PlaceSection.tsx (main subtitle line + PlaceDateForm modal
+     title via a new optional citySubtitle prop), ReviewPanel.tsx,
+     DesktopTripsLayout.tsx/MobileTripsLayout.tsx (map-filter chip label —
+     now derives the full city object, not just its name), CityMarkers.tsx
+     (map pin labels — subtitle only appended when two rendered pins share a
+     name, a coordinate-based dedup that's separate from BUG-33/34's
+     same-location dedup), TripCard.tsx (place badges — same collision-only
+     rule as CityMarkers, to avoid growing every badge on every trip
+     regardless of ambiguity), and CityItemsPage.tsx (via a pre-formatted
+     citySubtitle passed through router state — this page has no `countries`
+     list of its own).
+  3. Deliberately NOT touched (found during audit, judged out of scope):
+     PlaceSection's Remove-place ConfirmDialog ("Remove {name}?") never showed
+     country/region even before this fix and touching it risks the documented
+     Playwright substring-matching fragility (PlaceSection.tsx's own comment
+     on the Remove button's accessible name) — same defect *class* but a
+     wider blast radius than this brief's "surface the region" scope.
+  4. Tests: new src/frontend/utils/__tests__/formatCitySubtitle.test.ts (9
+     cases — regioned, region-tier-no-region with and without a custom label,
+     non-region-tier with both null and absent region_name, the critical
+     undefined-vs-null distinction, empty-countries-list fallback, and the
+     countryDisplay override). Backend: new integration tests in
+     trips.crud.test.ts (list + detail, reproducing the exact
+     Newport-Scotland-vs-Wales scenario), cities.get-by-id.test.ts, and
+     places.test.ts (both GET and POST) — 6 new backend tests total.
+  Full detail: jobs/backend/park-docs/20260803-BACKEND-bug80-park.txt.
+  No schema change, no new user-data columns. Security checklist: all
+  touched routes' auth middleware unchanged (blanket requireAuth via
+  server.ts, no owner gates added or removed); all repository queries
+  touching user data (getPlaces, findByTrip) remain scoped exactly as
+  before — only a join and two selected columns were added, no scoping
+  logic changed; regions has no userId column (tier-1 global reference
+  data, same classification BUG-72 already established with its own two
+  probes, re-confirmed here by reading schema.ts directly).
+ACTIVE TASKS: None — PR to be opened this thread, awaiting CI + COO
+  review/merge.
+PENDING MESSAGES TO COO: completion report in jobs/COO/inbox/ (this
+  thread).
+
 BACKEND CONTEXT — 2026-08-01 (BUG-72 thread, latest)
 PROJECT: Travel Tracker
 CURRENT STATUS: implemented BUG-72 (GitHub #351, BRD GE-16) — GET /api/cities

--- a/jobs/backend/park-docs/20260803-BACKEND-bug80-park.txt
+++ b/jobs/backend/park-docs/20260803-BACKEND-bug80-park.txt
@@ -1,0 +1,246 @@
+BACKEND PARK DOC — 2026-08-03
+BRIEF: BUG-80 (GitHub #388) — BRD GE-16/GE-17
+BRANCH: fix/bug80-region-on-saved-places
+CLASS (OP-32): gap in shipped behaviour (display-only; not a regression —
+  the brief explicitly ruled out git-history hunting).
+
+TASK
+PO UAT on staging: "Once I save two different newports as two different
+places in a trip, they display identically 'Newport United Kingdom'. Should
+be Newport, Scotland and Newport, Wales." Two distinct city rows already
+existed (Newport GB-SCT, Newport GB-WLS) — the ADL-46 identity key did its
+job; this was purely a missing-field display defect. Scope: extend region
+display to every city-shaped payload and saved-place surface, reusing
+BUG-72's formatCitySubtitle() rather than writing a second formatter.
+Explicitly out of scope (per brief): the `cities` identity key,
+findOrUpgradeCity, classifyCandidates, ambiguity classification — all live
+open questions on a separate thread.
+
+WHAT WAS CHANGED — BACKEND
+
+1. src/backend/repositories/trips.ts — getPlaces(): added `cityRegionName:
+   regions.name` to the existing select (the LEFT JOIN onto `regions` was
+   already there for cityRegionIso — one more column, no new join).
+
+2. src/backend/repositories/places.ts — findByTrip(): this repository's own
+   city query had NEVER joined `regions` at all (a separate query path from
+   tripRepository.getPlaces, easy to miss without an explicit audit). Added
+   `leftJoin(regions, eq(regions.id, cities.regionId))` and selected both
+   cityRegionIso/cityRegionName. Updated the PlaceWithCity interface's
+   `city` shape to add region_iso/region_name (both `string | null`, never
+   optional here — this repository always joins).
+
+3. src/backend/routes/trips.ts:
+   - buildTripResponse (list, GET /api/trips): city object had region_iso
+     already (prior work) but not region_name — added.
+   - GET /api/trips/:id (detail): city object was missing BOTH region_iso
+     AND region_name — the core defect the brief described. Added both.
+
+4. src/backend/routes/places.ts:
+   - GET /api/trips/:tripId/places (standalone list): the route just does
+     `city: p.city` — once the repository (see #2) started returning the
+     two fields, this endpoint got them for free. No route-level edit
+     needed beyond confirming the passthrough.
+   - POST /api/trips/:tripId/places: built its OWN inline city object from a
+     bare `db.select().from(cities)...` with no join whatsoever. Changed the
+     query to select the same shape as GET /api/cities/:id (LEFT JOIN
+     regions, select regionName/regionIso) and added both fields to the
+     response.
+
+5. src/backend/routes/cities.ts — GET /api/cities/:id (BUG-29): had NO
+   region fields at all (not even region_id was joined — region_id was a
+   bare column, region_name/region_iso weren't in the shape). Added the
+   same LEFT JOIN pattern GET /api/cities (search, BUG-72) already
+   established. LEFT, not INNER — a NULL region_id must still 200, not 404.
+
+6. NOT touched: POST /api/cities and PATCH /api/cities/:id (serializeCity's
+   four call sites). AUDIT (two probes, per the negative-findings rule):
+   (a) read AddPlaceFlow.tsx's handleSelectCity/handleCreateCity in full —
+   the created `city` object is only used for `city.id`/`city.geocode_status`
+   (geocodeRetryQueue.add) and to call handleSelectCity; no region field is
+   read or rendered from it anywhere in this flow. (b) grepped the entire
+   frontend for other consumers of `useCreateCity` / `apiPatch.*cities` — none
+   found beyond AddPlaceFlow. Conclusion: these two responses are the
+   documented "never joined regions" case on the City type and stay that
+   way; fixing them would mean restructuring findOrUpgradeCity's return
+   shape or adding a follow-up query on every code path in POST /api/cities
+   (four call sites, three of which return raw `cities` rows from different
+   insert/select statements) for zero rendering benefit — not worth the
+   risk of touching code adjacent to the explicitly-out-of-scope
+   find-or-create logic.
+
+WHAT WAS CHANGED — FRONTEND
+
+7. src/frontend/utils/formatCitySubtitle.ts (NEW) — lifted verbatim-in-
+   behaviour from AddPlaceFlow.tsx's module-local function, generalized with
+   a third optional parameter `countryDisplay` (defaults to
+   `city.country_code`, so AddPlaceFlow's call site and its existing tests
+   are unaffected). This is what let ONE formatter serve both:
+     - AddPlaceFlow/ReviewPanel's convention (country CODE, e.g. "Illinois, US")
+     - PlaceSection's D-04 contract (full country NAME, e.g. "Scotland,
+       United Kingdom") — pass `city.country_name ?? city.country_code`
+   Preserves BUG-72's three-state behaviour (regioned / region-tier-no-region
+   / non-region-tier) and adds explicit handling for the fourth state this
+   brief calls out: `region_name === undefined` (payload never joined
+   `regions`) renders as country-only, NEVER "(no state set)" — that would
+   be a lie the payload never checked. See the file's own doc comment for
+   the full reasoning; see types/api.ts's City.region_name doc comment for
+   the contract this honors.
+
+8. src/frontend/components/TripDetail/AddPlaceFlow.tsx — removed the
+   module-local formatCitySubtitle, imports the shared one instead. Call
+   site (`formatCitySubtitle(city, countries)`) unchanged — 2-arg form,
+   defaults countryDisplay to country_code, byte-identical behaviour.
+   Existing AddPlaceFlow.bug72.test.tsx passes unmodified (verified).
+
+9. src/frontend/components/TripDetail/PlaceSection.tsx — this IS the exact
+   surface the PO looked at. Replaced
+   `{place.city.country_name ?? place.city.country_code}` with a computed
+   `citySubtitle = formatCitySubtitle(place.city, countries, place.city.
+   country_name ?? place.city.country_code)`. Added `useCountries()`.
+   Also threads `citySubtitle` through to:
+     - the `/cities/:id` Link's router state (for CityItemsPage, #12)
+     - PlaceDateForm's new optional `citySubtitle` prop (#10)
+   Deliberately did NOT touch the Remove-place ConfirmDialog's "Remove
+   {name}?" title/message — see "DEFERRED FINDING" below.
+
+10. src/frontend/components/TripDetail/PlaceDateForm.tsx — added optional
+    `citySubtitle?: string` prop; when present, the modal title becomes
+    "Dates — Newport, Scotland" instead of just "Dates — Newport". Optional
+    so the prop isn't load-bearing for the date-editing logic itself.
+
+11. src/frontend/components/PostTripReview/ReviewPanel.tsx — was
+    `{place.city.name} · {place.city.country_code}`, the same bug pattern
+    one panel over. Now `{place.city.name} · {formatCitySubtitle(place.city,
+    countries)}` (2-arg form — this panel already showed the code, not the
+    full name, so that convention is preserved). Added `useCountries()`.
+
+12. src/frontend/pages/CityItemsPage.tsx — `CityLinkState` gained an
+    optional `citySubtitle` field; the page renders it in preference to the
+    old bare `countryName`, falling back to `countryName` for a state-less
+    direct visit or an older link shape. Deliberately does NOT call
+    useCountries()/formatCitySubtitle itself — PlaceSection (the only
+    producer of this router state) already computed the subtitle once;
+    duplicating the computation here would be exactly the "two formatters"
+    the brief said not to write.
+
+13. src/frontend/components/TripList/TripCard.tsx — place badges
+    (`{p.city.name}`) previously showed no country/region at all, ever.
+    Rather than growing every badge on every trip card, added a per-render
+    name-collision check (`nameCounts`): a region/country suffix is appended
+    ONLY when two places on THAT trip share a city name — the actual
+    ambiguity a viewer can hit. The common case (all unique names) is
+    visually unchanged. Added `useCountries()`.
+
+14. src/frontend/components/Map/CityMarkers.tsx — `buildCityGeoJSON` dedupes
+    pins by COORDINATE (BUG-34), not name, so two different-location
+    same-named cities (the Newport case) already render as two separate
+    pins — just both labeled plain "Newport". Applied the same
+    collision-only rule as TripCard: a name-count pass over the deduped
+    feature list appends the region/country suffix only where a collision
+    exists among the pins actually being rendered. `buildCityGeoJSON` and
+    `CityMarkers` both gained an optional `countries` param/prop (default
+    `[]`) — kept optional so the existing CityMarkers.test.ts pure-function
+    tests (single-arg calls) needed no changes.
+
+15. src/frontend/components/Map/MapView.tsx — added `useCountries()`, passes
+    `countries` down to `<CityMarkers>`.
+
+16. src/frontend/components/TripList/DesktopTripsLayout.tsx /
+    MobileTripsLayout.tsx — the map-filter chip ("City: Newport") derives
+    from a SPECIFIC city_id click, so it's already unambiguous by
+    selection — but the LABEL wasn't. Changed `cityName` (string) to
+    `cityInfo` (the full city object) so the label can always show
+    "City: Newport, Scotland" rather than "City: Newport" regardless of
+    collision (this is a single selected city, not a list of badges, so the
+    TripCard/CityMarkers collision-only rule doesn't apply here — always
+    showing it is the more informative default). Added `useCountries()` to
+    both.
+
+17. src/frontend/components/TripDetail/TripDetail.tsx — corrected a stale
+    module-doc line ("D-04: Country code shown in PlaceSection subtitle" —
+    it was actually the full country NAME even before this brief; now also
+    notes the region prefix).
+
+18. src/frontend/types/api.ts — City.region_name's doc comment updated to
+    list the now-much-larger set of endpoints that join `regions`, and to
+    name the two that deliberately still don't (POST/PATCH /api/cities).
+
+DEFERRED FINDING (audited, not fixed)
+PlaceSection.tsx's Remove-place ConfirmDialog ("Remove {city.name}?" / "This
+permanently removes {city.name} from the trip...") shows NEITHER country NOR
+region — a pre-existing, broader ambiguity than this brief's "surface the
+region" scope (this bug is specifically about region being dropped where
+country WAS already shown; the Remove dialog never showed country in the
+first place). PlaceSection.tsx's own comment documents a real, previously-hit
+Playwright substring-matching fragility on this exact dialog's accessible
+name (fixture city names "EditCity"/"DeleteCity" collided with
+"Edit"/"Delete" button name matching). Given that documented fragility and
+that this dialog is outside the brief's explicit surface list, left
+unchanged and flagged here rather than risking an E2E regression for a
+finding that's a different, wider defect than the one being fixed.
+
+SCOPE AUDIT — SURFACES BEYOND THE BRIEF'S STARTING LIST
+The brief named 6 known city-shaped payloads (5 frontend components + GET
+/api/cities/:id) and asked for a fresh audit on top. Found and fixed 2 more
+not on that list:
+  - GET /api/trips/:tripId/places (standalone; repositories/places.ts never
+    joined `regions` at all — a separate code path from tripRepository).
+  - POST /api/trips/:tripId/places (built its own unjoined inline city
+    object).
+Both confirmed to have NO current frontend rendering consumer (two probes
+each: grep + full read of the relevant hook file) but fixed anyway for
+payload consistency, matching the brief's explicit rationale for including
+GET /api/cities/:id despite it also lacking a direct region-rendering
+consumer today.
+
+SECURITY CHECKLIST (routes modified, none added)
+1. Auth middleware — unchanged on every touched route. All six remain under
+   the blanket `app.use('/api/', requireAuth)` (server.ts), confirmed by
+   reading each route file's mount/nosemgrep comments; none of this brief's
+   changes touch route registration, middleware chains, or add/remove a
+   `requireOwner` gate. GET /api/cities/:id and GET /api/cities (search)
+   both intentionally have no owner gate (cities are global reference data)
+   — unchanged, pre-existing.
+2. userId scoping — unchanged. tripRepository.getPlaces(tripId) and
+   placeRepository.findByTrip(userId, tripId) both scope exactly as they
+   did before; this brief added a join and selected columns, never touched
+   a WHERE clause or an ownership check. routes/places.ts POST's city
+   lookup is intentionally NOT userId-scoped (cities are global reference
+   data — the ownership check that matters, trip ownership, lives in
+   placeRepository.create(), untouched).
+3. New user-data columns — none. No migration, no schema.ts edit anywhere
+   in this brief. `regions` (the table every new join targets) has no
+   userId/createdByUserId column — confirmed by reading schema.ts directly
+   (positive finding, self-verifying) and consistent with BUG-72's own
+   two-probe classification of `regions` as tier-1 global reference data.
+
+TEST RESULTS
+- New: src/frontend/utils/__tests__/formatCitySubtitle.test.ts (9 tests).
+- New backend integration tests: trips.crud.test.ts (+3: list region_name,
+  detail region_id/iso/name distinguishing two same-named cities — the
+  exact PO scenario — and a non-region-tier null-fields case),
+  cities.get-by-id.test.ts (+1, plus updated the existing exact-shape
+  toEqual to include the two new always-present null fields),
+  places.test.ts (+3: GET regioned, GET region-less, POST regioned).
+- Full suites: test:backend 696 passed (0 skipped); test:frontend 266
+  passed; type:check:all clean; biome check clean (2 files needed
+  `biome check --write` for line-length formatting on lines I wrote,
+  applied before the final commit); status:check clean (no STATUS.md
+  regeneration needed).
+
+DECLARED FULL-FILE REWRITES
+None. Every change is a targeted edit (Edit tool) to an existing file, or a
+genuinely new file (formatCitySubtitle.ts and its test). No source file was
+replaced wholesale.
+
+OPEN ISSUES / BLOCKERS
+None. The Remove-place ConfirmDialog finding above is deferred, not
+blocking — it's a pre-existing, differently-shaped ambiguity gap, not a
+regression from this fix.
+
+WHAT'S NOW UNBLOCKED
+Nothing downstream is waiting on this specifically; it closes out the
+"other half" of BUG-72's original design that the brief describes as
+already the strongest section of a larger identity design whose remaining
+sections stay blocked on a separate PO decision.

--- a/jobs/backend/tech/20260307-api-reference.md
+++ b/jobs/backend/tech/20260307-api-reference.md
@@ -180,6 +180,8 @@ List all trips with their associations.
           "name": "Paris",
           "country_code": "FR",
           "region_id": null,
+          "region_iso": null,
+          "region_name": null,
           "latitude": 48.8566,
           "longitude": 2.3522,
           "geocode_status": "resolved"
@@ -191,6 +193,14 @@ List all trips with their associations.
 ```
 
 > **Note on `places` in list response:** The list endpoint includes a minimal `places` array (city coordinates only — no `activities` or `items`) to support map city-pin rendering without requiring a full trip detail fetch.
+
+> **`region_name` on `places[].city` (BUG-80, GitHub #388, 2026-08-03):** the joined
+> `regions` row's `name`, alongside the pre-existing `region_iso`. Both `null` when
+> `region_id` is `null` (LEFT JOIN — a region-less city is never dropped). Before this fix,
+> two saved places for same-named cities in different regions of one country (e.g. "Newport"
+> in Scotland vs Wales) rendered identically — `tripRepository.getPlaces()` already joined
+> `regions`, but this route never surfaced the result. See also `GET /api/cities` (BUG-72),
+> which added the same two fields to search results.
 
 Returns an empty array `[]` if no trips match.
 
@@ -289,7 +299,10 @@ Get a single trip with full nested data (places, cities, items).
         "id": 1,
         "name": "Paris",
         "country_code": "FR",
+        "country_name": "France",
         "region_id": null,
+        "region_iso": null,
+        "region_name": null,
         "latitude": 48.8566,
         "longitude": 2.3522,
         "geocode_status": "resolved"
@@ -317,6 +330,16 @@ Get a single trip with full nested data (places, cities, items).
   ]
 }
 ```
+
+> **`region_iso` / `region_name` on `places[].city` (BUG-80, GitHub #388, 2026-08-03):** both
+> were entirely missing from this endpoint's `city` object before this fix — unlike the list
+> endpoint (`GET /api/trips`), which already had `region_iso`. `tripRepository.getPlaces()`
+> (shared by both endpoints) already LEFT JOINs `regions` and selected `region_iso`; this
+> route's response assembly just never included either field. `country_name` was already
+> present and is included in this example for completeness — see the PO UAT finding
+> reproduced by the fix: two saved places for same-named cities in different regions of one
+> country (e.g. "Newport" in Scotland vs Wales) rendered identically with nothing in the
+> payload to distinguish them.
 
 > **`arrived_on` / `departed_on` on each place (ADL-24 / BUG-31):** `null` when
 > not explicitly set on the place. These drive `resolvePlaceDateRange`'s
@@ -472,6 +495,8 @@ List all places on a trip with their city details and activity tags.
       "name": "Paris",
       "country_code": "FR",
       "region_id": null,
+      "region_name": null,
+      "region_iso": null,
       "latitude": 48.8566,
       "longitude": 2.3522,
       "geocode_status": "resolved"
@@ -483,6 +508,11 @@ List all places on a trip with their city details and activity tags.
   }
 ]
 ```
+
+`region_name` / `region_iso` (BUG-80, GitHub #388, 2026-08-03) — same `LEFT JOIN` onto
+`regions` as every other city-shaped payload touched by this fix. This endpoint has no
+current frontend consumer (the trip detail page uses `GET /api/trips/:id` instead), added
+here for payload consistency.
 
 **Errors:**
 - `404` — trip not found
@@ -518,6 +548,8 @@ Add a city to a trip as a place.
     "name": "Paris",
     "country_code": "FR",
     "region_id": null,
+    "region_name": null,
+    "region_iso": null,
     "latitude": 48.8566,
     "longitude": 2.3522,
     "geocode_status": "resolved"
@@ -525,6 +557,10 @@ Add a city to a trip as a place.
   "activities": []
 }
 ```
+
+`region_name` / `region_iso` (BUG-80, GitHub #388, 2026-08-03) — same as `GET
+/api/trips/:tripId/places` above. The frontend's `useAddPlace` only reads `id`/`warnings`
+off this response and re-fetches trip detail for display; added for payload consistency.
 
 **Errors:**
 - `400` — validation failure
@@ -1111,6 +1147,43 @@ To clear the region:
 **Errors:**
 - `400` — validation failure, or `region_id` does not exist in regions table
 - `404` — city not found
+
+---
+
+### GET /api/cities/:id
+
+Read-only single-city fetch (BUG-29, GitHub #155). Used by the frontend geocode retry queue
+to poll `geocode_status` without issuing a write. Never triggers geocoding (ADL-10) — the
+backend queue owns re-resolution. Readable by any authenticated user, same as `GET /api/cities`
+(no owner gate — cities are global reference data).
+
+**Path Parameters:**
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `id` | integer | City ID |
+
+**Response: `200 OK`**
+```json
+{
+  "id": 5,
+  "name": "Newport",
+  "country_code": "GB",
+  "region_id": 9,
+  "region_name": "Wales",
+  "region_iso": "GB-WLS",
+  "latitude": 51.5842,
+  "longitude": -2.9977,
+  "geocode_status": "resolved"
+}
+```
+
+`region_name` / `region_iso` (BUG-80, GitHub #388, 2026-08-03) — same `LEFT JOIN` onto
+`regions` as `GET /api/cities` (search, BUG-72). Both `null` when `region_id` is `null`.
+This endpoint itself (and this doc section) predates BUG-80; it was undocumented before
+this fix — added here as part of the same brief that touched its response shape.
+
+**Errors:**
+- `404` — city not found, or `id` is not numeric
 
 ---
 

--- a/src/backend/repositories/places.ts
+++ b/src/backend/repositories/places.ts
@@ -11,6 +11,7 @@ import {
   cities,
   getDb,
   items,
+  regions,
   tripPlaceActivitiesMap,
   tripPlaces,
   trips,
@@ -33,6 +34,16 @@ export interface PlaceWithCity {
     name: string | null;
     country_code: string | null;
     region_id: number | null;
+    // BUG-80: this standalone endpoint (GET /api/trips/:tripId/places) had no
+    // frontend consumer at the time of the fix (confirmed by two probes — a
+    // repo-wide grep for a hook wrapping this path, and a full read of
+    // usePlaces.ts) — added anyway, for the same reason GET /api/cities/:id
+    // was fixed despite also having no direct region-rendering consumer: it
+    // is a city-shaped payload, and the whole point of this brief is that
+    // every one of them carries the same fields consistently rather than
+    // some silently lagging until the next bug report.
+    region_iso: string | null;
+    region_name: string | null;
     latitude: number | null;
     longitude: number | null;
     geocode_status: string | null;
@@ -70,12 +81,15 @@ export const placeRepository = {
         cityName: cities.name,
         cityCountryCode: cities.countryCode,
         cityRegionId: cities.regionId,
+        cityRegionIso: regions.iso3166_2,
+        cityRegionName: regions.name,
         cityLatitude: cities.latitude,
         cityLongitude: cities.longitude,
         cityGeocodeStatus: cities.geocodeStatus,
       })
       .from(tripPlaces)
       .leftJoin(cities, eq(cities.id, tripPlaces.cityId))
+      .leftJoin(regions, eq(regions.id, cities.regionId))
       .where(eq(tripPlaces.tripId, tripId));
 
     const placeIds = placesRows.map((p) => p.id);
@@ -103,6 +117,8 @@ export const placeRepository = {
         name: p.cityName,
         country_code: p.cityCountryCode,
         region_id: p.cityRegionId,
+        region_iso: p.cityRegionIso ?? null,
+        region_name: p.cityRegionName ?? null,
         latitude: p.cityLatitude,
         longitude: p.cityLongitude,
         geocode_status: p.cityGeocodeStatus,

--- a/src/backend/repositories/trips.ts
+++ b/src/backend/repositories/trips.ts
@@ -343,6 +343,10 @@ export const tripRepository = {
         cityCountryName: countries.name,
         cityRegionId: cities.regionId,
         cityRegionIso: regions.iso3166_2,
+        // BUG-80: human-readable region name (e.g. "Scotland") off the SAME
+        // LEFT JOIN onto `regions` already used for cityRegionIso two lines
+        // below — no new join, one more column selected from it.
+        cityRegionName: regions.name,
         cityLatitude: cities.latitude,
         cityLongitude: cities.longitude,
         cityGeocodeStatus: cities.geocodeStatus,

--- a/src/backend/routes/__tests__/cities.get-by-id.test.ts
+++ b/src/backend/routes/__tests__/cities.get-by-id.test.ts
@@ -1,5 +1,5 @@
 /**
- * Integration tests for GET /api/cities/:id (BUG-29).
+ * Integration tests for GET /api/cities/:id (BUG-29; BUG-80 region fields).
  *
  * The frontend geocode retry queue polls this endpoint to check whether a
  * pending city has been geocoded — replacing the previous empty-PATCH poll
@@ -9,6 +9,10 @@
  *   2. Return 404 for an unknown city id (drives queue entry removal)
  *   3. Return 404 for a non-numeric id
  *   4. Not modify the row (no updated_at bump — it is a pure read)
+ *   5. (BUG-80) LEFT JOIN `regions` so this city-shaped payload also carries
+ *      region_name/region_iso — same pattern as GET /api/cities (search,
+ *      BUG-72) and the trip list/detail city objects. A NULL region_id must
+ *      still return the row (LEFT, not INNER).
  *
  * Uses an in-memory libSQL database, schema derived from the real migrations
  * via createTestDb() (QUAL-17 — see repositories/__tests__/test-db.ts).
@@ -110,10 +114,37 @@ describe('GET /api/cities/:id — BUG-29 read-based geocode status poll', () => 
       name: 'Dublin',
       country_code: 'IE',
       region_id: null,
+      // BUG-80: LEFT JOIN regions — a NULL region_id must resolve to
+      // region_name/region_iso both null, not undefined/omitted (that would
+      // be the "never joined" case this route no longer is in).
+      region_name: null,
+      region_iso: null,
       latitude: null,
       longitude: null,
       geocode_status: 'pending',
     });
+  });
+
+  it('BUG-80: returns region_name/region_iso when the city has a region_id', async () => {
+    // Country row must exist before the region FK — seedCity would normally
+    // create it, but the region needs to be inserted first here so the city
+    // can reference it, so it's created explicitly (onConflictDoNothing
+    // matches seedCity's own idempotent insert).
+    await testDb!
+      .insert(schema.countries)
+      .values({ countryCode: 'IE', name: 'Ireland' })
+      .onConflictDoNothing();
+    const [region] = await testDb!
+      .insert(schema.regions)
+      .values({ countryCode: 'IE', name: 'Leinster', iso3166_2: 'IE-L' })
+      .returning();
+    const city = await seedCity(testDb!, { regionId: region.id });
+
+    const res = await supertest(app).get(`/api/cities/${city.id}`).expect(200);
+
+    expect(res.body.region_id).toBe(region.id);
+    expect(res.body.region_name).toBe('Leinster');
+    expect(res.body.region_iso).toBe('IE-L');
   });
 
   it('returns a resolved city with coordinates', async () => {

--- a/src/backend/routes/__tests__/places.test.ts
+++ b/src/backend/routes/__tests__/places.test.ts
@@ -82,12 +82,30 @@ async function seedCountry(db: TestDb, countryCode: string, name: string) {
   await db.insert(schema.countries).values({ countryCode, name }).onConflictDoNothing();
 }
 
-async function seedCity(db: TestDb, countryCode: string, name: string) {
+async function seedCity(
+  db: TestDb,
+  countryCode: string,
+  name: string,
+  overrides: Partial<typeof schema.cities.$inferInsert> = {},
+) {
   const [city] = await db
     .insert(schema.cities)
-    .values({ name, countryCode, geocodeStatus: 'resolved' })
+    .values({ name, countryCode, geocodeStatus: 'resolved', ...overrides })
     .returning();
   return city;
+}
+
+// BUG-80 (#388): seeds a region row for a country already inserted via
+// seedCountry — used to prove both the standalone GET /api/trips/:tripId/places
+// list and the POST create response carry region_name/region_iso, not just
+// region_id (repositories/places.ts's findByTrip and this route's POST both
+// previously omitted the two fields entirely).
+async function seedRegion(db: TestDb, countryCode: string, name: string, iso: string) {
+  const [region] = await db
+    .insert(schema.regions)
+    .values({ countryCode, name, iso3166_2: iso })
+    .returning();
+  return region;
 }
 
 async function seedTrip(db: TestDb, overrides: Partial<typeof schema.trips.$inferInsert> = {}) {
@@ -171,6 +189,42 @@ describe('GET /api/trips/:tripId/places', () => {
 
     expect(res.body).toHaveProperty('error');
   });
+
+  // BUG-80 (#388): repositories/places.ts's findByTrip already joined `cities`
+  // but never `regions` — region_id was present, region_iso/region_name were
+  // not. This endpoint has no current frontend consumer (confirmed by grep +
+  // a full read of usePlaces.ts), but it's still a city-shaped payload the
+  // brief calls out for consistency.
+  it('BUG-80: place.city carries region_name/region_iso for a regioned city', async () => {
+    const db = testDb!;
+    const region = await seedRegion(db, 'FR', 'Île-de-France', 'FR-IDF');
+    const city = await seedCity(db, 'FR', 'Paris', { regionId: region.id });
+    const trip = await seedTrip(db);
+    await db
+      .insert(schema.tripPlaces)
+      .values({ tripId: trip.id, cityId: city.id, userId: TEST_USER_ID });
+
+    const res = await supertest(app).get(`/api/trips/${trip.id}/places`).expect(200);
+
+    expect(res.body[0].city.region_id).toBe(region.id);
+    expect(res.body[0].city.region_name).toBe('Île-de-France');
+    expect(res.body[0].city.region_iso).toBe('FR-IDF');
+  });
+
+  it('BUG-80: place.city has null region_name/region_iso for a region-less city', async () => {
+    const db = testDb!;
+    const city = await seedCity(db, 'FR', 'Lyon');
+    const trip = await seedTrip(db);
+    await db
+      .insert(schema.tripPlaces)
+      .values({ tripId: trip.id, cityId: city.id, userId: TEST_USER_ID });
+
+    const res = await supertest(app).get(`/api/trips/${trip.id}/places`).expect(200);
+
+    expect(res.body[0].city.region_id).toBeNull();
+    expect(res.body[0].city.region_name).toBeNull();
+    expect(res.body[0].city.region_iso).toBeNull();
+  });
 });
 
 // ----------------------------------------------------------------
@@ -204,6 +258,28 @@ describe('POST /api/trips/:tripId/places', () => {
     expect(res.body.city.name).toBe('Lyon');
     expect(res.body).toHaveProperty('activities');
     expect(Array.isArray(res.body.activities)).toBe(true);
+  });
+
+  // BUG-80 (#388): this route built its own inline city object (a bare
+  // `cities` select, no join at all) — region_id was present, region_iso/
+  // region_name were entirely absent from the shape. The frontend doesn't
+  // render this response's city fields directly today (useAddPlace
+  // invalidates and re-fetches trip detail instead — confirmed by reading
+  // usePlaces.ts in full), but it's still a city-shaped payload.
+  it('BUG-80: created place.city carries region_name/region_iso for a regioned city', async () => {
+    const db = testDb!;
+    const region = await seedRegion(db, 'FR', 'Île-de-France', 'FR-IDF');
+    const city = await seedCity(db, 'FR', 'Paris', { regionId: region.id });
+    const trip = await seedTrip(db);
+
+    const res = await supertest(app)
+      .post(`/api/trips/${trip.id}/places`)
+      .send({ city_id: city.id })
+      .expect(201);
+
+    expect(res.body.city.region_id).toBe(region.id);
+    expect(res.body.city.region_name).toBe('Île-de-France');
+    expect(res.body.city.region_iso).toBe('FR-IDF');
   });
 
   it('returns 201 with arrived_on and departed_on when provided', async () => {

--- a/src/backend/routes/__tests__/trips.crud.test.ts
+++ b/src/backend/routes/__tests__/trips.crud.test.ts
@@ -97,6 +97,34 @@ async function seedTrip(db: TestDb, overrides: Partial<typeof schema.trips.$infe
   return trip;
 }
 
+// BUG-80 (#388): a city in a region-tier country, optionally with a region
+// assigned. Used to reproduce the PO's exact UAT finding — two saved places
+// for same-named cities in different UK regions ("Newport, Scotland" vs
+// "Newport, Wales") rendering identically because region_name/region_iso
+// were dropped when the places array was assembled (repositories/trips.ts
+// already LEFT JOINs `regions` and selects both — the route just never
+// surfaced them).
+async function seedCityWithRegion(
+  db: TestDb,
+  cityName: string,
+  regionName: string,
+  regionIso: string,
+) {
+  await db
+    .insert(schema.countries)
+    .values({ countryCode: 'GB', name: 'United Kingdom', regionTierEnabled: 1 })
+    .onConflictDoNothing();
+  const [region] = await db
+    .insert(schema.regions)
+    .values({ countryCode: 'GB', name: regionName, iso3166_2: regionIso })
+    .returning();
+  const [city] = await db
+    .insert(schema.cities)
+    .values({ countryCode: 'GB', name: cityName, regionId: region.id })
+    .returning();
+  return city;
+}
+
 // ----------------------------------------------------------------
 // GET /api/trips
 // ----------------------------------------------------------------
@@ -182,6 +210,23 @@ describe('GET /api/trips', () => {
     const res = await supertest(app).get('/api/trips?status=bogus').expect(400);
 
     expect(res.body).toHaveProperty('error');
+  });
+
+  // BUG-80 (#388): the list endpoint (buildTripResponse) already carried
+  // region_iso — region_name was the missing field here.
+  it('BUG-80: list place.city carries region_name for a regioned city', async () => {
+    const db = testDb!;
+    const trip = await seedTrip(db, { name: 'UK Trip' });
+    const city = await seedCityWithRegion(db, 'Newport', 'Wales', 'GB-WLS');
+    await db
+      .insert(schema.tripPlaces)
+      .values({ tripId: trip.id, cityId: city.id, userId: TEST_USER_ID });
+
+    const res = await supertest(app).get('/api/trips').expect(200);
+
+    const place = res.body[0].places[0];
+    expect(place.city.region_name).toBe('Wales');
+    expect(place.city.region_iso).toBe('GB-WLS');
   });
 
   it('returns trips ordered by start_date descending (QUAL-02 finding 2)', async () => {
@@ -338,6 +383,66 @@ describe('GET /api/trips/:id', () => {
 
     expect(res.body.places[0].arrived_on).toBe('2025-07-10');
     expect(res.body.places[0].departed_on).toBe('2025-07-14');
+  });
+
+  // BUG-80 (#388) — PO UAT: "Once I save two different newports as two
+  // different places in a trip, they display identically 'Newport United
+  // Kingdom'. Should be Newport, Scotland and Newport, Wales." The two rows
+  // already existed as distinct cities (the identity key did its job — this
+  // was display-only); repositories/trips.ts's getPlaces() already LEFT
+  // JOINs regions and selects region_iso, but this route's city object never
+  // included region_iso OR region_name. Reproduces the exact scenario.
+  it('BUG-80: detail place.city carries region_id/region_iso/region_name, distinguishing two same-named cities', async () => {
+    const db = testDb!;
+    const trip = await seedTrip(db, { name: 'UK Trip' });
+    const newportScotland = await seedCityWithRegion(db, 'Newport', 'Scotland', 'GB-SCT');
+    const newportWales = await seedCityWithRegion(db, 'Newport', 'Wales', 'GB-WLS');
+    await db
+      .insert(schema.tripPlaces)
+      .values({ tripId: trip.id, cityId: newportScotland.id, userId: TEST_USER_ID });
+    await db
+      .insert(schema.tripPlaces)
+      .values({ tripId: trip.id, cityId: newportWales.id, userId: TEST_USER_ID });
+
+    const res = await supertest(app).get(`/api/trips/${trip.id}`).expect(200);
+
+    expect(res.body.places).toHaveLength(2);
+    const byRegion = Object.fromEntries(
+      res.body.places.map((p: { city: { region_iso: string; region_name: string } }) => [
+        p.city.region_iso,
+        p.city,
+      ]),
+    );
+    expect(byRegion['GB-SCT']).toMatchObject({
+      name: 'Newport',
+      region_id: newportScotland.regionId,
+      region_name: 'Scotland',
+      region_iso: 'GB-SCT',
+    });
+    expect(byRegion['GB-WLS']).toMatchObject({
+      name: 'Newport',
+      region_id: newportWales.regionId,
+      region_name: 'Wales',
+      region_iso: 'GB-WLS',
+    });
+    // The actual defect: both used to render "Newport United Kingdom" with
+    // nothing in the payload to tell them apart.
+    expect(byRegion['GB-SCT'].region_name).not.toBe(byRegion['GB-WLS'].region_name);
+  });
+
+  it('trip detail place.city has null region_name/region_iso for a non-region-tier city', async () => {
+    const db = testDb!;
+    const trip = await seedTrip(db);
+    const city = await seedCityForPlace(db); // Italy — non-region-tier, no region_id
+    await db
+      .insert(schema.tripPlaces)
+      .values({ tripId: trip.id, cityId: city.id, userId: TEST_USER_ID });
+
+    const res = await supertest(app).get(`/api/trips/${trip.id}`).expect(200);
+
+    expect(res.body.places[0].city.region_id).toBeNull();
+    expect(res.body.places[0].city.region_name).toBeNull();
+    expect(res.body.places[0].city.region_iso).toBeNull();
   });
 });
 

--- a/src/backend/routes/cities.ts
+++ b/src/backend/routes/cities.ts
@@ -414,7 +414,26 @@ citiesRouter.get(
 
     const db = getDb();
 
-    const rows = await db.select().from(cities).where(eq(cities.id, cityId)).limit(1);
+    // BUG-80: LEFT JOIN regions so this city-shaped payload also carries
+    // region_name/region_iso, matching GET /api/cities (search). LEFT, not
+    // INNER: a NULL region_id (non-region-tier country, or a region-tier city
+    // not yet assigned one) must still return the city row, not 404 it.
+    const rows = await db
+      .select({
+        id: cities.id,
+        name: cities.name,
+        countryCode: cities.countryCode,
+        regionId: cities.regionId,
+        regionName: regions.name,
+        regionIso: regions.iso3166_2,
+        latitude: cities.latitude,
+        longitude: cities.longitude,
+        geocodeStatus: cities.geocodeStatus,
+      })
+      .from(cities)
+      .leftJoin(regions, eq(regions.id, cities.regionId))
+      .where(eq(cities.id, cityId))
+      .limit(1);
     if (!rows.length) throw new NotFoundError('City');
 
     const city = rows[0];
@@ -423,6 +442,8 @@ citiesRouter.get(
       name: city.name,
       country_code: city.countryCode,
       region_id: city.regionId,
+      region_name: city.regionName,
+      region_iso: city.regionIso,
       latitude: city.latitude,
       longitude: city.longitude,
       geocode_status: city.geocodeStatus,

--- a/src/backend/routes/places.ts
+++ b/src/backend/routes/places.ts
@@ -14,7 +14,7 @@
 
 import { and, eq, inArray } from 'drizzle-orm';
 import { Router } from 'express';
-import { cities, getDb, items, tripPlaceActivitiesMap, tripPlaces } from '../db/index.js';
+import { cities, getDb, items, regions, tripPlaceActivitiesMap, tripPlaces } from '../db/index.js';
 import { ConflictError, NotFoundError, ValidationError } from '../errors.js';
 import { asyncHandler } from '../middleware/error-handler.js';
 import { validateBody } from '../middleware/validate.js';
@@ -73,8 +73,27 @@ placesRouter.post(
     const { city_id, arrived_on, departed_on } = req.body;
     const db = getDb();
 
-    // Verify city exists
-    const cityRows = await db.select().from(cities).where(eq(cities.id, city_id)).limit(1);
+    // Verify city exists. BUG-80: LEFT JOIN regions so this response's city
+    // object also carries region_name/region_iso — same city-shaped-payload
+    // consistency as every other route touched by this fix, even though (per
+    // usePlaces.ts's useAddPlace) the frontend only reads place.id/warnings
+    // off this response today and re-fetches trip detail for display.
+    const cityRows = await db
+      .select({
+        id: cities.id,
+        name: cities.name,
+        countryCode: cities.countryCode,
+        regionId: cities.regionId,
+        regionName: regions.name,
+        regionIso: regions.iso3166_2,
+        latitude: cities.latitude,
+        longitude: cities.longitude,
+        geocodeStatus: cities.geocodeStatus,
+      })
+      .from(cities)
+      .leftJoin(regions, eq(regions.id, cities.regionId))
+      .where(eq(cities.id, city_id))
+      .limit(1);
     if (!cityRows.length) throw new NotFoundError('City');
 
     // placeRepository.create verifies trip ownership + lock status + duplicate check
@@ -92,6 +111,8 @@ placesRouter.post(
         name: city.name,
         country_code: city.countryCode,
         region_id: city.regionId,
+        region_name: city.regionName,
+        region_iso: city.regionIso,
         latitude: city.latitude,
         longitude: city.longitude,
         geocode_status: city.geocodeStatus,

--- a/src/backend/routes/trips.ts
+++ b/src/backend/routes/trips.ts
@@ -82,6 +82,10 @@ async function buildTripResponse(trip: {
       country_code: p.cityCountryCode,
       region_id: p.cityRegionId,
       region_iso: p.cityRegionIso ?? null,
+      // BUG-80: region_iso was already selected here; region_name (the
+      // human-readable "Scotland" vs the ISO "GB-SCT") was not — same LEFT
+      // JOIN in tripRepository.getPlaces, one more column.
+      region_name: p.cityRegionName ?? null,
       latitude: p.cityLatitude,
       longitude: p.cityLongitude,
       geocode_status: p.cityGeocodeStatus,
@@ -238,6 +242,15 @@ tripsRouter.get(
         country_code: p.cityCountryCode,
         country_name: p.cityCountryName,
         region_id: p.cityRegionId,
+        // BUG-80: this route already SELECTs regions.iso3166_2 and regions.name
+        // via tripRepository.getPlaces' LEFT JOIN onto `regions` (cityRegionIso /
+        // cityRegionName), but this response object never surfaced either —
+        // the dropped-join defect described in the brief. Two saved places for
+        // same-named cities in different regions ("Newport, Scotland" vs
+        // "Newport, Wales") rendered identically as "Newport United Kingdom"
+        // with nothing in the payload for the frontend to distinguish them by.
+        region_iso: p.cityRegionIso ?? null,
+        region_name: p.cityRegionName ?? null,
         latitude: p.cityLatitude,
         longitude: p.cityLongitude,
         geocode_status: p.cityGeocodeStatus,

--- a/src/frontend/components/Map/CityMarkers.tsx
+++ b/src/frontend/components/Map/CityMarkers.tsx
@@ -11,11 +11,19 @@
 import type { SymbolLayerSpecification } from 'maplibre-gl';
 import { useMemo } from 'react';
 import { Layer, Source } from 'react-map-gl/maplibre';
-import type { TripSummary } from '../../types/api';
+import type { Country, TripSummary } from '../../types/api';
+import { formatCitySubtitle } from '../../utils/formatCitySubtitle';
 
 interface CityMarkersProps {
   /** All loaded trip summaries — cities are extracted from their places. */
   trips: TripSummary[];
+  /**
+   * BUG-80: used to disambiguate two same-named pins (e.g. two "Newport"
+   * markers in different regions) with a region/country label suffix.
+   * Defaults to `[]` — same safe "country only, no false claims" fallback
+   * formatCitySubtitle already has when the country list hasn't loaded yet.
+   */
+  countries?: Country[];
 }
 
 /**
@@ -42,9 +50,13 @@ function coordKey(lat: number, lng: number): string {
  * DB or not — renders exactly one marker, restoring consistent treatment
  * across cities regardless of whether BUG-33's root cause has been fixed yet.
  */
-export function buildCityGeoJSON(trips: TripSummary[]): GeoJSON.FeatureCollection {
+export function buildCityGeoJSON(
+  trips: TripSummary[],
+  countries: Country[] = [],
+): GeoJSON.FeatureCollection {
   const seen = new Set<string>();
-  const features: GeoJSON.Feature[] = [];
+  type DedupedCity = NonNullable<TripSummary['places'][number]['city']>;
+  const deduped: DedupedCity[] = [];
 
   for (const trip of trips) {
     for (const place of trip.places) {
@@ -58,21 +70,40 @@ export function buildCityGeoJSON(trips: TripSummary[]): GeoJSON.FeatureCollectio
         const key = coordKey(city.latitude, city.longitude);
         if (seen.has(key)) continue;
         seen.add(key);
-        features.push({
-          type: 'Feature',
-          geometry: {
-            type: 'Point',
-            coordinates: [city.longitude!, city.latitude!],
-          },
-          properties: {
-            id: city.id,
-            // SEC-12: city name rendered via MapLibre text-field, not innerHTML
-            name: city.name,
-          },
-        });
+        deduped.push(city);
       }
     }
   }
+
+  // BUG-80: two distinct pins can legitimately share a name (two "Newport"
+  // rows in different regions, at different coordinates — not the BUG-33/34
+  // same-location duplicate this function already dedupes above). Only
+  // append the region/country suffix when a name collision actually exists
+  // among the markers being rendered, so the common case (every pin has a
+  // unique name) keeps its plain label.
+  const nameCounts = new Map<string, number>();
+  for (const city of deduped) {
+    nameCounts.set(city.name, (nameCounts.get(city.name) ?? 0) + 1);
+  }
+
+  const features: GeoJSON.Feature[] = deduped.map((city) => {
+    const isAmbiguous = (nameCounts.get(city.name) ?? 0) > 1;
+    const label = isAmbiguous
+      ? `${city.name}, ${formatCitySubtitle(city, countries, city.country_name ?? city.country_code)}`
+      : city.name;
+    return {
+      type: 'Feature',
+      geometry: {
+        type: 'Point',
+        coordinates: [city.longitude!, city.latitude!],
+      },
+      properties: {
+        id: city.id,
+        // SEC-12: name rendered via MapLibre text-field, not innerHTML
+        name: label,
+      },
+    };
+  });
 
   return { type: 'FeatureCollection', features };
 }
@@ -105,9 +136,11 @@ const citySymbolLayer: SymbolLayerSpecification = {
  * derived from the provided trips.
  *
  * @param trips - Array of trip summaries from which city coordinates are extracted.
+ * @param countries - Country tier config, used to disambiguate same-named
+ *   pins in different regions (BUG-80). Defaults to `[]`.
  */
-export function CityMarkers({ trips }: CityMarkersProps) {
-  const geojson = useMemo(() => buildCityGeoJSON(trips), [trips]);
+export function CityMarkers({ trips, countries = [] }: CityMarkersProps) {
+  const geojson = useMemo(() => buildCityGeoJSON(trips, countries), [trips, countries]);
 
   return (
     <Source id="cities-source" type="geojson" data={geojson}>

--- a/src/frontend/components/Map/MapView.tsx
+++ b/src/frontend/components/Map/MapView.tsx
@@ -13,6 +13,7 @@ import { useCallback, useRef, useState } from 'react';
 import MapGL, { type MapLayerMouseEvent, type MapRef } from 'react-map-gl/maplibre';
 import 'maplibre-gl/dist/maplibre-gl.css';
 import { useNavigate } from 'react-router-dom';
+import { useCountries } from '../../hooks/useAdmin';
 import { useMapShading, useRegionShading } from '../../hooks/useMapShading';
 import type { TripSummary } from '../../types/api';
 import { LoadingSpinner } from '../shared/LoadingSpinner';
@@ -50,6 +51,7 @@ export function MapView({ trips, onCountryClick }: MapViewProps) {
   const navigate = useNavigate();
 
   const { data: shadingData, isLoading: shadingLoading } = useMapShading();
+  const { data: countries = [] } = useCountries();
   // Lazy-load region shading only when zoomed in enough
   const { data: regionData } = useRegionShading(
     zoom >= REGION_ZOOM_THRESHOLD ? visibleCountryCode : undefined,
@@ -157,7 +159,7 @@ export function MapView({ trips, onCountryClick }: MapViewProps) {
         )}
 
         {/* City pins — only for geocoded cities */}
-        <CityMarkers trips={trips} />
+        <CityMarkers trips={trips} countries={countries} />
       </MapGL>
 
       {/* Shading colour legend — bottom-left, clear of the MapLibre attribution

--- a/src/frontend/components/PostTripReview/ReviewPanel.tsx
+++ b/src/frontend/components/PostTripReview/ReviewPanel.tsx
@@ -6,9 +6,11 @@
  * and a "Complete Review & Lock Trip" button with confirmation.
  */
 import { useState } from 'react';
+import { useCountries } from '../../hooks/useAdmin';
 import { useUpdateItem } from '../../hooks/useItems';
 import { useLockTrip, useUpdateTripStatus } from '../../hooks/useTrips';
 import type { Item, ItemStatus, TripDetail } from '../../types/api';
+import { formatCitySubtitle } from '../../utils/formatCitySubtitle';
 import { ConfirmDialog } from '../shared/ConfirmDialog';
 import { ErrorMessage } from '../shared/ErrorMessage';
 import { ReviewItemRow } from './ReviewItemRow';
@@ -34,6 +36,7 @@ export function ReviewPanel({ trip, onClose }: ReviewPanelProps) {
   const lockTrip = useLockTrip();
   const returnToPlanning = useUpdateTripStatus();
   const updateItem = useUpdateItem();
+  const { data: countries = [] } = useCountries();
 
   const handleLock = async () => {
     await lockTrip.mutateAsync(trip.id);
@@ -112,7 +115,11 @@ export function ReviewPanel({ trip, onClose }: ReviewPanelProps) {
               paddingBottom: '6px',
             }}
           >
-            {place.city.name} · {place.city.country_code}
+            {/* BUG-80: was `{name} · {country_code}` — identical for two
+                same-named cities in different regions. Keep the compact
+                country_code display (this panel's existing convention), just
+                add the region ahead of it via the shared formatter. */}
+            {place.city.name} · {formatCitySubtitle(place.city, countries)}
           </h3>
           {place.items.length === 0 ? (
             <p style={{ margin: 0, color: '#9CA3AF', fontSize: '13px' }}>No items at this place.</p>

--- a/src/frontend/components/PostTripReview/__tests__/ReviewPanel.test.tsx
+++ b/src/frontend/components/PostTripReview/__tests__/ReviewPanel.test.tsx
@@ -59,6 +59,16 @@ vi.mock('../../../hooks/useItems.js', () => ({
   useUpdateItem: () => mockUpdateItem,
 }));
 
+// BUG-80: ReviewPanel now calls useCountries() (formatCitySubtitle's tier
+// lookup) — mocked so this file doesn't need a real QueryClientProvider,
+// same reasoning as the mocks above. Empty by default: none of these tests
+// exercise region-tier disambiguation (that's formatCitySubtitle's own unit
+// tests); every fixture city here is a non-listed country, so the tier
+// lookup safely falls through to "show the country as before" either way.
+vi.mock('../../../hooks/useAdmin.js', () => ({
+  useCountries: () => ({ data: [] }),
+}));
+
 // ----------------------------------------------------------------
 // Test data builders
 // ----------------------------------------------------------------

--- a/src/frontend/components/TripDetail/AddPlaceFlow.tsx
+++ b/src/frontend/components/TripDetail/AddPlaceFlow.tsx
@@ -20,35 +20,16 @@ import {
 } from '../../hooks/useCities';
 import { useAddPlace } from '../../hooks/usePlaces';
 import { geocodeRetryQueue } from '../../services/geocodeRetryQueue';
-import type { City, Country } from '../../types/api';
+import type { City } from '../../types/api';
 import { resolveDefaultDate } from '../../utils/dateDefaults';
+// BUG-80: formatCitySubtitle used to live here (BUG-72, PR #353) as a
+// module-local function. Lifted to a shared util so every saved-place
+// surface reuses the same formatter instead of a second one drifting out of
+// sync — see formatCitySubtitle.ts's doc comment for the full behaviour.
+import { formatCitySubtitle } from '../../utils/formatCitySubtitle';
 import { capitalizeFirst } from '../../utils/textFormat';
 import { CarryForwardModal } from '../CarryForward/CarryForwardModal';
 import { ErrorMessage } from '../shared/ErrorMessage';
-
-/**
- * BUG-72: the search dropdown used to render only `{name} {country_code}`
- * ("Springfield US"), which is visually identical for two same-named cities
- * in different regions — selecting one silently binds the trip to specific
- * coordinates with nothing on screen distinguishing which one. Renders:
- *   - region-tier country, region known:   "Illinois, US"
- *   - region-tier country, region missing: "US (no state set)" — explicit,
- *     not indistinguishable from a regioned row (surfaces catalogue rows
- *     that are missing data users should be able to notice)
- *   - non-region-tier country:             "US" (unchanged from before)
- * `region_name` comes straight off the GET /api/cities response (BUG-72
- * backend half, PR #353's LEFT JOIN onto `regions`) — no new network call.
- */
-function formatCitySubtitle(
-  city: { country_code: string; region_name?: string | null },
-  countries: Country[],
-): string {
-  const country = countries.find((c) => c.country_code === city.country_code);
-  if (!country?.region_tier_enabled) return city.country_code;
-  if (city.region_name) return `${city.region_name}, ${city.country_code}`;
-  const label = (country.region_tier_label ?? 'region').toLowerCase();
-  return `${city.country_code} (no ${label} set)`;
-}
 
 interface AddPlaceFlowProps {
   tripId: number;

--- a/src/frontend/components/TripDetail/PlaceDateForm.tsx
+++ b/src/frontend/components/TripDetail/PlaceDateForm.tsx
@@ -15,6 +15,15 @@ interface PlaceDateFormProps {
   tripId: number;
   placeId: number;
   cityName: string;
+  /**
+   * BUG-80: optional region/country subtitle (from formatCitySubtitle),
+   * appended to the modal title so two same-named cities in different
+   * regions ("Newport, Scotland" vs "Newport, Wales") aren't both titled
+   * just "Dates — Newport". Optional so a caller without region context
+   * (there are none left in this codebase after BUG-80, but the prop isn't
+   * load-bearing for the form's actual date logic) degrades to the old title.
+   */
+  citySubtitle?: string;
   currentArrivedOn: string | null;
   currentDepartedOn: string | null;
   onClose: () => void;
@@ -26,6 +35,7 @@ interface PlaceDateFormProps {
  * @param tripId - Parent trip ID.
  * @param placeId - Place ID to patch.
  * @param cityName - City name — shown in the modal title.
+ * @param citySubtitle - Optional region/country suffix for the title (BUG-80).
  * @param currentArrivedOn - Existing arrived_on value (null if not set).
  * @param currentDepartedOn - Existing departed_on value (null if not set).
  * @param onClose - Called when the modal should close.
@@ -34,6 +44,7 @@ export function PlaceDateForm({
   tripId,
   placeId,
   cityName,
+  citySubtitle,
   currentArrivedOn,
   currentDepartedOn,
   onClose,
@@ -94,7 +105,10 @@ export function PlaceDateForm({
         className="bg-white rounded-lg p-6 w-[400px] max-w-[95vw] shadow-2xl"
         onClick={(e) => e.stopPropagation()}
       >
-        <h2 className="m-0 mb-4 text-lg font-bold text-gray-900">Dates — {cityName}</h2>
+        <h2 className="m-0 mb-4 text-lg font-bold text-gray-900">
+          Dates — {cityName}
+          {citySubtitle && <span className="font-normal text-gray-500">, {citySubtitle}</span>}
+        </h2>
 
         {/* Backend warnings callout */}
         {warnings.length > 0 && (

--- a/src/frontend/components/TripDetail/PlaceSection.tsx
+++ b/src/frontend/components/TripDetail/PlaceSection.tsx
@@ -32,6 +32,7 @@
  */
 import { useState } from 'react';
 import { Link } from 'react-router-dom';
+import { useCountries } from '../../hooks/useAdmin';
 import {
   applyRatingSortFilter,
   DEFAULT_RATING_SORT_FILTER,
@@ -39,6 +40,7 @@ import {
 } from '../../hooks/useItems';
 import { useRemovePlace } from '../../hooks/usePlaces';
 import type { Item, TripPlace } from '../../types/api';
+import { formatCitySubtitle } from '../../utils/formatCitySubtitle';
 import { formatDate } from '../../utils/formatDate';
 import { resolvePlaceDateRange } from '../../utils/resolvePlaceDateRange';
 import { ConfirmDialog } from '../shared/ConfirmDialog';
@@ -98,6 +100,20 @@ export function PlaceSection({
   );
 
   const removePlace = useRemovePlace();
+  const { data: countries = [] } = useCountries();
+
+  // BUG-80: D-04's "full country name" contract stays intact — countryDisplay
+  // is place.city.country_name (falling back to the code only when the name
+  // itself is unavailable, e.g. list/map-shaped City objects), region info is
+  // layered on top of it via the shared formatter rather than a bespoke
+  // string here. Two saved places named "Newport" in different UK regions
+  // used to both render exactly "United Kingdom" on this line with nothing to
+  // tell them apart (PO UAT finding, BUG-80/#388).
+  const citySubtitle = formatCitySubtitle(
+    place.city,
+    countries,
+    place.city.country_name ?? place.city.country_code,
+  );
 
   const handleEditItem = (item: Item) => setEditingItem(item);
   const handleCloseForm = () => {
@@ -143,15 +159,20 @@ export function PlaceSection({
               IT-09: links to the cross-trip rated-items view for this city. */}
           <Link
             to={`/cities/${place.city.id}`}
-            state={{ cityName: place.city.name, countryName: place.city.country_name }}
+            state={{
+              cityName: place.city.name,
+              countryName: place.city.country_name,
+              citySubtitle,
+            }}
             className="font-display font-semibold text-[17px] max-md:text-[16px] text-wp-ink hover:text-wp-primary hover:underline no-underline"
           >
             {place.city.name}
           </Link>
 
-          {/* D-03/UX-02: Country name · date range on single subtitle line */}
+          {/* D-03/UX-02/BUG-80: region (when applicable) + country name · date
+              range on single subtitle line */}
           <p className="mt-0.5 font-ui text-[12px] text-wp-ink-muted">
-            {place.city.country_name ?? place.city.country_code}
+            {citySubtitle}
             {dateRangeDisplay && (
               <>
                 {' · '}
@@ -300,6 +321,7 @@ export function PlaceSection({
           currentArrivedOn={place.arrived_on ?? null}
           currentDepartedOn={place.departed_on ?? null}
           cityName={place.city.name}
+          citySubtitle={citySubtitle}
           onClose={() => setShowEditDates(false)}
         />
       )}

--- a/src/frontend/components/TripDetail/TripDetail.tsx
+++ b/src/frontend/components/TripDetail/TripDetail.tsx
@@ -12,7 +12,8 @@
  *   D-01: Companion names in meta row below title
  *   D-02: Category + activity badges in meta row
  *   D-03: Per-place date range derived from hotel check-in/check-out
- *   D-04: Country code shown in PlaceSection subtitle
+ *   D-04: Full country name shown in PlaceSection subtitle (BUG-80: region
+ *         name, when applicable, now shown ahead of it — formatCitySubtitle)
  *   F-04/TR-12: Persistent status transition control (now the stepper)
  *   PH-03/F-08: Photos button placeholder (non-functional, shows "Coming soon")
  *   C2: Unlock button/flow preserved as new stepper-card chrome (mockup has no

--- a/src/frontend/components/TripDetail/__tests__/PlaceSection.test.tsx
+++ b/src/frontend/components/TripDetail/__tests__/PlaceSection.test.tsx
@@ -49,6 +49,17 @@ vi.mock('../../../hooks/usePlaces.js', () => ({
   useRemovePlace: () => mockRemovePlace,
 }));
 
+// BUG-80: PlaceSection now calls useCountries() (formatCitySubtitle needs the
+// country's region-tier config) — mocked so this file doesn't need a real
+// QueryClientProvider wired up, same reasoning as the useItems mock below.
+// Empty by default: none of these tests exercise region-tier disambiguation
+// (that's formatCitySubtitle's own unit tests) — every fixture city here is a
+// non-region-tier / unlisted country, so formatCitySubtitle's tier lookup
+// safely falls through to "show the country as before" either way.
+vi.mock('../../../hooks/useAdmin.js', () => ({
+  useCountries: () => ({ data: [] }),
+}));
+
 // ItemCard (rendered per item) depends on useDeleteItem — stub it so tests that
 // include items don't need a real QueryClient wired up. applyRatingSortFilter/
 // DEFAULT_RATING_SORT_FILTER (IT-08) are pure helpers PlaceSection imports

--- a/src/frontend/components/TripList/DesktopTripsLayout.tsx
+++ b/src/frontend/components/TripList/DesktopTripsLayout.tsx
@@ -22,8 +22,10 @@
  */
 import { useCallback, useMemo, useState } from 'react';
 import { Outlet, useNavigate, useParams, useSearchParams } from 'react-router-dom';
+import { useCountries } from '../../hooks/useAdmin';
 import { type TripFilters, useDeleteTrip, useTrips } from '../../hooks/useTrips';
 import type { TripStatus } from '../../types/api';
+import { formatCitySubtitle } from '../../utils/formatCitySubtitle';
 import { ErrorMessage } from '../shared/ErrorMessage';
 import { LoadingSpinner } from '../shared/LoadingSpinner';
 import { TripForm } from '../TripDetail/TripForm';
@@ -72,6 +74,7 @@ export function DesktopTripsLayout() {
 
   const { data: trips, isLoading, error } = useTrips(filters);
   const { data: allTrips = [] } = useTrips(); // no filters — for counts only
+  const { data: countries = [] } = useCountries();
   const deleteTrip = useDeleteTrip();
 
   const handleFormClose = () => {
@@ -88,23 +91,36 @@ export function DesktopTripsLayout() {
     [trips, searchText, sortBy, countryFilter, regionFilter, cityFilter],
   );
 
-  // Derive city name for display when city filter is active
-  const cityName = useMemo(() => {
+  // BUG-80: this filter already targets one specific city_id (unambiguous by
+  // definition), but the label used to show only the bare name — two
+  // different "Newport" pins on the map would both read "City: Newport"
+  // after being clicked. Derive the full city object (not just its name) so
+  // the label can carry the same region/country subtitle every other
+  // saved-place surface now shows.
+  const cityInfo = useMemo(() => {
     if (cityFilter === null) return null;
     for (const trip of trips ?? []) {
       for (const place of trip.places) {
-        if (place.city_id === cityFilter) return place.city.name;
+        if (place.city_id === cityFilter) return place.city;
       }
     }
-    return String(cityFilter);
+    return null;
   }, [trips, cityFilter]);
 
   const mapFilterLabel = useMemo(() => {
-    if (cityFilter !== null) return `City: ${cityName ?? cityFilter}`;
+    if (cityFilter !== null) {
+      if (!cityInfo) return `City: ${cityFilter}`;
+      const subtitle = formatCitySubtitle(
+        cityInfo,
+        countries,
+        cityInfo.country_name ?? cityInfo.country_code,
+      );
+      return `City: ${cityInfo.name}, ${subtitle}`;
+    }
     if (regionFilter) return `Region: ${regionFilter}`;
     if (countryFilter) return `Country: ${countryFilter}`;
     return null;
-  }, [cityFilter, regionFilter, countryFilter, cityName]);
+  }, [cityFilter, regionFilter, countryFilter, cityInfo, countries]);
 
   const tripCount = displayedTrips.length;
 

--- a/src/frontend/components/TripList/MobileTripsLayout.tsx
+++ b/src/frontend/components/TripList/MobileTripsLayout.tsx
@@ -22,9 +22,11 @@
  */
 import { useCallback, useMemo, useState } from 'react';
 import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
+import { useCountries } from '../../hooks/useAdmin';
 import { useMe } from '../../hooks/useMe';
 import { type TripFilters, useDeleteTrip, useTrip, useTrips } from '../../hooks/useTrips';
 import type { TripStatus } from '../../types/api';
+import { formatCitySubtitle } from '../../utils/formatCitySubtitle';
 import { AdminIcon, LocationPinIcon, SuitcaseIcon } from '../icons';
 import { ReviewPanel } from '../PostTripReview/ReviewPanel';
 import { ErrorMessage } from '../shared/ErrorMessage';
@@ -76,6 +78,7 @@ export function MobileTripsLayout() {
   const { data: trips, isLoading, error } = useTrips(filters);
   const { data: allTrips = [] } = useTrips();
   const deleteTrip = useDeleteTrip();
+  const { data: countries = [] } = useCountries();
 
   // Detail-view data — fetched directly (no <Outlet/>, see module doc comment).
   const numericSelectedId = selectedId ? Number(selectedId) : undefined;
@@ -95,22 +98,34 @@ export function MobileTripsLayout() {
     [trips, searchText, sortBy, countryFilter, regionFilter, cityFilter],
   );
 
-  const cityName = useMemo(() => {
+  // BUG-80: same fix as DesktopTripsLayout — derive the full city object (not
+  // just its name) so the map-filter label can carry a region/country
+  // subtitle; two different "Newport" pins used to both label this chip
+  // "City: Newport" once clicked.
+  const cityInfo = useMemo(() => {
     if (cityFilter === null) return null;
     for (const trip of trips ?? []) {
       for (const place of trip.places) {
-        if (place.city_id === cityFilter) return place.city.name;
+        if (place.city_id === cityFilter) return place.city;
       }
     }
-    return String(cityFilter);
+    return null;
   }, [trips, cityFilter]);
 
   const mapFilterLabel = useMemo(() => {
-    if (cityFilter !== null) return `City: ${cityName ?? cityFilter}`;
+    if (cityFilter !== null) {
+      if (!cityInfo) return `City: ${cityFilter}`;
+      const subtitle = formatCitySubtitle(
+        cityInfo,
+        countries,
+        cityInfo.country_name ?? cityInfo.country_code,
+      );
+      return `City: ${cityInfo.name}, ${subtitle}`;
+    }
     if (regionFilter) return `Region: ${regionFilter}`;
     if (countryFilter) return `Country: ${countryFilter}`;
     return null;
-  }, [cityFilter, regionFilter, countryFilter, cityName]);
+  }, [cityFilter, regionFilter, countryFilter, cityInfo, countries]);
 
   const tripCount = displayedTrips.length;
 

--- a/src/frontend/components/TripList/TripCard.tsx
+++ b/src/frontend/components/TripList/TripCard.tsx
@@ -1,5 +1,7 @@
 import { useNavigate } from 'react-router-dom';
+import { useCountries } from '../../hooks/useAdmin';
 import type { TripSummary } from '../../types/api';
+import { formatCitySubtitle } from '../../utils/formatCitySubtitle';
 import { formatDate } from '../../utils/formatDate';
 import { StatusBadge } from '../shared/StatusBadge';
 
@@ -48,12 +50,22 @@ export function TripCard({
   density = 'desktop',
 }: TripCardProps) {
   const navigate = useNavigate();
+  const { data: countries = [] } = useCountries();
 
   const places = trip.places ?? [];
   const visiblePlaces = places.slice(0, MAX_PLACE_BADGES);
   const extraCount = places.length - MAX_PLACE_BADGES;
   const isLocked = trip.status === 'locked';
   const isMobile = density === 'mobile';
+
+  // BUG-80: badges stay compact ("Newport") for the common case — a region
+  // suffix is only appended when two places on THIS trip share a city name
+  // (the actual ambiguity a viewer can hit), rather than growing every badge
+  // on every trip card regardless of whether anything on it is ambiguous.
+  const nameCounts = new Map<string, number>();
+  for (const p of places) {
+    nameCounts.set(p.city.name, (nameCounts.get(p.city.name) ?? 0) + 1);
+  }
 
   const handleClick = () => {
     if (selectionMode) {
@@ -117,14 +129,19 @@ export function TripCard({
       {/* D-06: Place name badges — wrap, never scroll horizontally */}
       {places.length > 0 && (
         <div className="mt-2 flex flex-wrap gap-1">
-          {visiblePlaces.map((p) => (
-            <span
-              key={p.id}
-              className={`inline-block rounded-[7px] px-2.5 py-1 text-[11px] font-ui bg-wp-bg-subtle text-wp-ink-muted ${isMobile ? 'rounded-[8px]' : ''}`}
-            >
-              {p.city.name}
-            </span>
-          ))}
+          {visiblePlaces.map((p) => {
+            const isAmbiguous = (nameCounts.get(p.city.name) ?? 0) > 1;
+            return (
+              <span
+                key={p.id}
+                className={`inline-block rounded-[7px] px-2.5 py-1 text-[11px] font-ui bg-wp-bg-subtle text-wp-ink-muted ${isMobile ? 'rounded-[8px]' : ''}`}
+              >
+                {p.city.name}
+                {isAmbiguous &&
+                  `, ${formatCitySubtitle(p.city, countries, p.city.country_name ?? p.city.country_code)}`}
+              </span>
+            );
+          })}
           {extraCount > 0 && (
             <span className="inline-block rounded-[7px] px-2.5 py-1 text-[11px] font-ui bg-wp-bg-subtle text-wp-ink-faint">
               +{extraCount} more

--- a/src/frontend/pages/CityItemsPage.tsx
+++ b/src/frontend/pages/CityItemsPage.tsx
@@ -35,6 +35,14 @@ import { formatDate } from '../utils/formatDate';
 interface CityLinkState {
   cityName?: string;
   countryName?: string | null;
+  /**
+   * BUG-80: pre-formatted region+country subtitle (formatCitySubtitle,
+   * computed by PlaceSection at link-creation time — this page has no
+   * `countries` list of its own and deliberately doesn't fetch one just to
+   * duplicate that formatting here). Falls back to `countryName` alone when
+   * absent (direct/refreshed visit with no router state, or an older link).
+   */
+  citySubtitle?: string;
 }
 
 /** Derives the display label and effective rating for a city item, per its type. */
@@ -105,10 +113,15 @@ export function CityItemsPage() {
       <h1 className="font-display font-semibold text-2xl text-wp-ink mb-0.5">
         {state.cityName ?? 'This city'}
       </h1>
-      {state.countryName && (
-        <p className="font-ui text-sm text-wp-ink-muted mb-4">{state.countryName}</p>
+      {/* BUG-80: prefer the pre-formatted region+country subtitle passed from
+          PlaceSection's link; fall back to the bare country name for an older
+          link shape or a state-less direct visit. */}
+      {(state.citySubtitle ?? state.countryName) && (
+        <p className="font-ui text-sm text-wp-ink-muted mb-4">
+          {state.citySubtitle ?? state.countryName}
+        </p>
       )}
-      {!state.countryName && <div className="mb-4" />}
+      {!(state.citySubtitle ?? state.countryName) && <div className="mb-4" />}
 
       <p className="font-ui text-xs text-wp-ink-faint mb-4">
         Completed restaurants, hotels, and experiences across every trip that visited this city.

--- a/src/frontend/types/api.ts
+++ b/src/frontend/types/api.ts
@@ -139,11 +139,15 @@ export interface City {
   /**
    * Human-readable region name (e.g. "Illinois"). Optional (not just
    * nullable): present on GET /api/cities search results (BUG-72, PR #353's
-   * LEFT JOIN onto `regions`), but genuinely absent from every other City
-   * shape in this codebase today — serializeCity (cities.ts) and the
-   * trip-detail/map City shapes never select it. Null means "joined, but this
-   * city has no region_id"; undefined means "this response never joined
-   * `regions` at all" — callers must not conflate the two into "no region."
+   * LEFT JOIN onto `regions`), and — as of BUG-80 — also on the city objects
+   * nested in trip list/detail responses (GET /api/trips, GET /api/trips/:id)
+   * and on GET /api/cities/:id, all via the same LEFT JOIN pattern. Still
+   * genuinely absent from POST /api/cities and PATCH /api/cities/:id
+   * (serializeCity, cities.ts) — audited for BUG-80 and left unjoined because
+   * nothing renders those responses' region fields (see BUG-80 park doc).
+   * Null means "joined, but this city has no region_id"; undefined means
+   * "this response never joined `regions` at all" — callers must not conflate
+   * the two into "no region" (see formatCitySubtitle, utils/formatCitySubtitle.ts).
    */
   region_name?: string | null;
   latitude: number | null;

--- a/src/frontend/utils/__tests__/formatCitySubtitle.test.ts
+++ b/src/frontend/utils/__tests__/formatCitySubtitle.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Unit tests for formatCitySubtitle (BUG-80, GitHub #388).
+ *
+ * Covers the four states the brief's success criteria call out explicitly:
+ *   1. Regioned city in a region-tier country.
+ *   2. Region-tier country, region genuinely not set (joined, region_name null).
+ *   3. Non-region-tier country (region_name null or absent — must render unchanged).
+ *   4. The "payload never joined `regions`" case (region_name undefined) —
+ *      must NOT be conflated with case 2's "no region set" (see the module's
+ *      doc comment and City.region_name's doc comment in types/api.ts).
+ *
+ * Plus the `countryDisplay` override this function added on top of BUG-72's
+ * original AddPlaceFlow-local version, which is what lets every saved-place
+ * surface reuse one formatter instead of writing a second one (PlaceSection
+ * needs the full country name per D-04; AddPlaceFlow's dropdown needs the code).
+ *
+ * Source: src/frontend/utils/formatCitySubtitle.ts
+ */
+import { describe, expect, it } from 'vitest';
+import type { Country } from '../../types/api.js';
+import { formatCitySubtitle } from '../formatCitySubtitle.js';
+
+const usRegionTier: Country = {
+  country_code: 'US',
+  name: 'United States',
+  region_tier_enabled: true,
+  region_tier_label: 'State',
+};
+
+const gbRegionTier: Country = {
+  country_code: 'GB',
+  name: 'United Kingdom',
+  region_tier_enabled: true,
+  region_tier_label: null, // no custom label — falls back to "region"
+};
+
+const frNonRegionTier: Country = {
+  country_code: 'FR',
+  name: 'France',
+  region_tier_enabled: false,
+  region_tier_label: null,
+};
+
+const countries: Country[] = [usRegionTier, gbRegionTier, frNonRegionTier];
+
+describe('formatCitySubtitle', () => {
+  it('regioned: renders "region, country" for a region-tier country with a region set', () => {
+    const city = { country_code: 'US', region_name: 'Illinois' };
+    expect(formatCitySubtitle(city, countries)).toBe('Illinois, US');
+  });
+
+  it('region-tier-with-no-region: renders an explicit "(no <label> set)" — distinct from a regioned row', () => {
+    const city = { country_code: 'US', region_name: null };
+    expect(formatCitySubtitle(city, countries)).toBe('US (no state set)');
+  });
+
+  it('region-tier-with-no-region: falls back to the generic label "region" when the country has none', () => {
+    const city = { country_code: 'GB', region_name: null };
+    expect(formatCitySubtitle(city, countries)).toBe('GB (no region set)');
+  });
+
+  it('non-region-tier: renders the country alone, never an empty separator or "undefined"', () => {
+    const cityWithNull = { country_code: 'FR', region_name: null };
+    const cityWithoutField: { country_code: string; region_name?: string | null } = {
+      country_code: 'FR',
+    };
+    expect(formatCitySubtitle(cityWithNull, countries)).toBe('FR');
+    expect(formatCitySubtitle(cityWithoutField, countries)).toBe('FR');
+  });
+
+  it('payload-never-joined: region_name undefined on a region-tier country shows the country only, NOT "(no state set)"', () => {
+    // The critical case the brief calls out: this response never checked
+    // whether a region exists, so it must not claim there isn't one.
+    const city: { country_code: string; region_name?: string | null } = { country_code: 'US' };
+    expect(formatCitySubtitle(city, countries)).toBe('US');
+  });
+
+  it('payload-never-joined vs region-tier-with-no-region: undefined and null must render differently', () => {
+    const neverJoined = formatCitySubtitle({ country_code: 'US' }, countries);
+    const joinedNoRegion = formatCitySubtitle({ country_code: 'US', region_name: null }, countries);
+    expect(neverJoined).not.toBe(joinedNoRegion);
+    expect(neverJoined).toBe('US');
+    expect(joinedNoRegion).toBe('US (no state set)');
+  });
+
+  it('falls back to country-only when the country list has not loaded yet (empty array)', () => {
+    const city = { country_code: 'US', region_name: 'Illinois' };
+    expect(formatCitySubtitle(city, [])).toBe('US');
+  });
+
+  it('countryDisplay override: shows a full country name in place of the code, region logic unaffected', () => {
+    const city = { country_code: 'US', region_name: 'Illinois' };
+    expect(formatCitySubtitle(city, countries, 'United States')).toBe('Illinois, United States');
+  });
+
+  it('countryDisplay override: non-region-tier country renders the override alone', () => {
+    const city = { country_code: 'FR', region_name: null };
+    expect(formatCitySubtitle(city, countries, 'France')).toBe('France');
+  });
+});

--- a/src/frontend/utils/formatCitySubtitle.ts
+++ b/src/frontend/utils/formatCitySubtitle.ts
@@ -1,0 +1,70 @@
+/**
+ * formatCitySubtitle — the one shared "where is this city" formatter.
+ *
+ * Originally written for BUG-72 (AddPlaceFlow's city search dropdown, PR
+ * #353) and lifted here for BUG-80 (GitHub #388) so every saved-place surface
+ * reuses one formatter instead of a second one drifting out of sync — see the
+ * BUG-80 brief's explicit "reuse, do not rewrite" instruction.
+ *
+ * Renders three real states plus one deliberately-not-a-fourth:
+ *   - region-tier country, region known:    "Illinois, US"   (or your own
+ *     `countryDisplay` in place of "US" — see below)
+ *   - region-tier country, region missing:  "US (no state set)" — explicit,
+ *     never indistinguishable from a regioned row
+ *   - non-region-tier country:              "US" (or `countryDisplay`) — unchanged
+ *   - the response never joined `regions` at all: same as non-region-tier —
+ *     country only, NEVER "(no state set)". Conflating "never checked" with
+ *     "checked, and there isn't one" would render a claim the payload never
+ *     verified (see City.region_name's doc comment in types/api.ts and the
+ *     project's negative-findings rule — the same "don't upgrade absence of
+ *     evidence into evidence of absence" principle applies to a UI string,
+ *     not just an investigation finding).
+ *
+ * `countryDisplay` decouples "which country's tier config do we look up"
+ * (always `city.country_code` — regions/tier config is keyed by ISO code)
+ * from "what do we print for the country" (defaults to the same ISO code,
+ * matching BUG-72's original AddPlaceFlow dropdown behaviour, but callers
+ * that want the full country name — e.g. PlaceSection's existing "Full
+ * country name shown in subtitle" contract, D-04 — pass it explicitly).
+ * This is what lets one formatter serve both a compact code-based subtitle
+ * and a full-name-based one without a second implementation.
+ */
+import type { Country } from '../types/api';
+
+/**
+ * Builds a human-readable region/country subtitle for a city.
+ *
+ * @param city - Must carry `country_code` (used to look up tier config) and
+ *   `region_name` (optional/nullable — see the module doc comment above for
+ *   why the undefined/null distinction matters).
+ * @param countries - The full country list (GET /api/admin/countries), used
+ *   to determine whether the city's country shows a region tier at all and,
+ *   if so, its localised label (e.g. "State" vs "Province").
+ * @param countryDisplay - What to print for the country itself. Defaults to
+ *   `city.country_code`. Pass `city.country_name` (or any other string) to
+ *   show a full name instead.
+ * @returns The formatted subtitle. Never empty.
+ */
+export function formatCitySubtitle(
+  city: { country_code: string; region_name?: string | null },
+  countries: Country[],
+  countryDisplay: string = city.country_code,
+): string {
+  const country = countries.find((c) => c.country_code === city.country_code);
+
+  // Non-region-tier country (or the country list hasn't loaded yet — same
+  // safe fallback as before this function existed): country only, no empty
+  // separator, nothing that could render as "undefined".
+  if (!country?.region_tier_enabled) return countryDisplay;
+
+  // Never joined `regions` at all — genuinely unknown, not "no region set".
+  // Showing the country alone here (rather than a false claim of absence) is
+  // the entire point of keeping this branch distinct from the null branch.
+  if (city.region_name === undefined) return countryDisplay;
+
+  if (city.region_name) return `${city.region_name}, ${countryDisplay}`;
+
+  // Joined, and this row genuinely has no region_id.
+  const label = (country.region_tier_label ?? 'region').toLowerCase();
+  return `${countryDisplay} (no ${label} set)`;
+}


### PR DESCRIPTION
Closes #388
BRD GE-16/GE-17

## Summary

PO UAT on staging: *"Once I save two different newports as two different places in a trip, they display identically 'Newport United Kingdom'. Should be Newport, Scotland and Newport, Wales."* Two distinct city rows already existed (the identity key did its job) — this was purely a display defect: `region_iso`/`region_name` were dropped or never joined on several city-shaped payloads.

- **Backend** (no schema change): added/completed the `LEFT JOIN regions` → `region_iso`/`region_name` pattern (established by BUG-72 for `GET /api/cities`) across six route handlers: `GET /api/trips` (list), `GET /api/trips/:id` (detail — was missing region_iso AND region_name entirely), `GET /api/trips/:tripId/places`, `POST /api/trips/:tripId/places` (previously unjoined), and `GET /api/cities/:id` (BUG-29, had no region fields at all).
- **Frontend**: lifted BUG-72's `formatCitySubtitle()` out of `AddPlaceFlow.tsx` into a shared `src/frontend/utils/formatCitySubtitle.ts`, generalized with an optional `countryDisplay` param so both the country-code convention (AddPlaceFlow, ReviewPanel) and the full-country-name contract (PlaceSection, D-04) reuse the same formatter. Wired into `PlaceSection`, `PlaceDateForm`, `ReviewPanel`, `TripCard` (badges), `CityMarkers` (map pins), `DesktopTripsLayout`/`MobileTripsLayout` (map-filter chip label), and `CityItemsPage`.
- Honors the `region_name` null-vs-undefined contract documented on the `City` type — a payload that never joined `regions` renders as country-only, never a false "no region set" claim.
- Two additional surfaces found during audit, beyond the brief's starting list: `GET`/`POST /api/trips/:tripId/places` (fixed for payload consistency, though neither currently has a frontend consumer that reads the region fields).
- Deliberately **not** touched: the `cities` identity key, `findOrUpgradeCity`, `classifyCandidates`, `POST`/`PATCH /api/cities` (audited — nothing renders their region fields today).

## Test plan
- [x] `npm run test:backend` — 696 passed, incl. 7 new integration tests reproducing the exact Newport-Scotland-vs-Wales scenario
- [x] `npm run test:frontend` — 266 passed, incl. new 9-case `formatCitySubtitle` unit suite
- [x] `npm run type:check:all` — clean
- [x] `npm run check` (biome) — clean
- [x] `npm run status:check` — clean
- [x] No schema/migration changes generated

Full detail: `jobs/backend/park-docs/20260803-BACKEND-bug80-park.txt`