### PR TITLE
fix(QUAL-20): drop push-to-main trigger — the shakedown was blocking all deploys

### DIFF
--- a/.github/workflows/post-deploy-shakedown.yml
+++ b/.github/workflows/post-deploy-shakedown.yml
@@ -35,8 +35,23 @@ on:
         description: "Override target URL (defaults to staging)"
         required: false
         type: string
-  push:
-    branches: [main]
+  # push-to-main REMOVED 2026-08-04 — it blocked every deployment. Railway's staging
+  # service sets `checkSuites: true`, i.e. it gates deploys on GitHub's check suite for
+  # the commit. This workflow runs against the ALREADY-DEPLOYED app, so a failure here
+  # means "the deployed build has a problem" — but Railway reads it as "this commit's
+  # checks failed" and SKIPS the deploy. The result was a deadlock: the console check
+  # failed deterministically, main's check suite went red, and five consecutive commits
+  # (including the BUG-80 fix the PO was testing) were never deployed. Staging silently
+  # served a build five commits stale while every PR showed green.
+  #
+  # The category error is structural, not a bad value: a post-deploy check must never be
+  # part of the pre-deploy gate. Re-adding this trigger re-creates the deadlock — if an
+  # automatic run is wanted, it must report somewhere Railway does not read as a gate
+  # (a separate status context excluded from checkSuites, an issue, or a notification).
+  #
+  # workflow_dispatch was already the primary trigger by design: this workflow's own
+  # header notes that a push-triggered run cannot prove which build it tested, because
+  # /health carries no commit marker and Railway's rollout is not instantaneous.
 
 jobs:
   shakedown:

--- a/.planning/drift-ledger.jsonl
+++ b/.planning/drift-ledger.jsonl
@@ -2895,3 +2895,4 @@
 {"ts":"2026-08-04T00:19:40Z","action":"subagent_stop","agent_id":"a2c24716b7b1ebd1f"}
 {"ts":"2026-08-04T00:23:25Z","action":"edit","file":"/workspace/_project/tracker.json"}
 {"ts":"2026-08-04T00:23:37Z","action":"edit","file":"/workspace/_project/tracker.json"}
+{"ts":"2026-08-04T01:04:15Z","action":"edit","file":"/workspace/.github/workflows/post-deploy-shakedown.yml"}


### PR DESCRIPTION
**Urgent.** Staging has been serving a build five commits stale.

## What happened

Railway's staging service sets `checkSuites: true` — it gates deploys on the GitHub check suite for each commit.

The shakedown runs against the **already-deployed** app, so a failure means *"the deployed build has a problem."* Railway reads it as *"this commit's checks failed"* and skips the deploy.

Deadlock:

1. The shakedown merged with a `push: branches: [main]` trigger
2. Its console check fails deterministically
3. main's check suite goes red on every push
4. **Railway skipped every deployment since** — `aac8323` is the last SUCCESS
5. Five commits never deployed, including the **BUG-80 fix the PO was testing**

Staging silently served stale code while every PR showed green.

## How it surfaced

The PO reported that Newport still displayed wrongly on staging after the fix merged. **That report is the only reason this was found** — nothing in CI could have caught it, because CI was green throughout. The deploy was skipped, not failed.

## The fix, and why not just fix the check

Trigger reduced to `workflow_dispatch` only.

The category error is structural, not a bad value: **a post-deploy check must never be part of the pre-deploy gate.** Fixing the console assertion would clear today's symptom and leave the deadlock armed for the next legitimate shakedown failure — which is exactly when you least want deploys frozen.

Re-adding the trigger re-creates it. If an automatic run is wanted, it must report somewhere Railway doesn't read as a gate.

`workflow_dispatch` was already the primary trigger by design — the workflow's own header notes a push-triggered run can't prove which build it tested, since `/health` carries no commit marker.

## After merge

Railway should deploy `main` normally again and pick up the five stale commits, BUG-80 among them.