### PR TITLE
chore: bridge gh CLI auth to the live dev-container git credential (survives rebuilds)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -56,5 +56,6 @@
   "workspaceFolder": "/workspace",
   "postCreateCommand": "npm ci",
   "postStartCommand": "sudo /usr/local/bin/init-firewall.sh; echo '{\"permissions\":{\"defaultMode\":\"bypassPermissions\"}}' > /home/node/.claude/settings.json",
+  "postAttachCommand": "bash .devcontainer/gh-auth-bridge.sh",
   "waitFor": "postStartCommand"
 }

--- a/.devcontainer/gh-auth-bridge.sh
+++ b/.devcontainer/gh-auth-bridge.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Bridge the gh CLI's auth to the LIVE VS Code dev-container git credential helper.
+#
+# Why this exists (diagnosed 2026-08-05):
+#   - git works in this container via VS Code's dev-container credential helper
+#     (/tmp/vscode-remote-containers-*.js), which VS Code re-injects on every attach and
+#     which forwards to the host live.
+#   - gh has a SEPARATE auth source: GH_TOKEN (empty — devcontainer.json sets it from
+#     ${localEnv:GH_TOKEN}, but the host uses interactive `gh auth login`, not an env var,
+#     so it resolves empty) or ~/.config/gh/hosts.yml. The gh config dir is NOT on the
+#     persistent volume (only /home/node/.claude is), so it is wiped on every rebuild.
+#   - Net effect: git keeps working, gh silently loses its token on rebuild.
+#
+# This mints a token from the same live git credential helper and logs gh in with it, so gh
+# survives rebuilds with no manual re-login. Wired to devcontainer.json postAttachCommand,
+# which re-runs on every attach (self-healing after a rebuild).
+#
+# Fail-open by design: if the helper is unavailable or returns nothing, gh simply stays
+# logged out and callers can bridge inline — this must never break container attach.
+set +e
+
+TOKEN=$(printf 'protocol=https\nhost=github.com\n\n' | git credential fill 2>/dev/null | sed -n 's/^password=//p')
+
+if [ -n "$TOKEN" ]; then
+  printf '%s' "$TOKEN" | gh auth login --with-token >/dev/null 2>&1 \
+    && echo "gh-auth-bridge: gh authenticated from the git credential helper." \
+    || echo "gh-auth-bridge: token minted but 'gh auth login' failed — gh left logged out."
+else
+  echo "gh-auth-bridge: no token from git credential helper — gh left logged out (bridge inline if needed)."
+fi
+
+exit 0


### PR DESCRIPTION
## Problem
`gh` silently loses its token on every container rebuild, while `git push` keeps working. Diagnosed from the config itself:
- `gh` auth lives in `~/.config/gh/hosts.yml`, which is **not** on the persistent volume (only `/home/node/.claude` is) → wiped on rebuild.
- devcontainer.json's `GH_TOKEN=${localEnv:GH_TOKEN}` resolves **empty** because the host authenticates via interactive `gh auth login` (a config file), not an exported env var.
- `git` survives because VS Code re-injects its own dev-container credential helper on every attach.

## Fix
- `.devcontainer/gh-auth-bridge.sh` mints a token from that same live git credential helper and runs `gh auth login --with-token`.
- Wired to a new `postAttachCommand`, so it re-runs on every attach — **self-healing after a rebuild**, no manual re-login.
- **Fail-open**: if the helper is unavailable it leaves gh logged out and never breaks attach.

## Verified
Bridge authenticates gh as `ryanv11` from the git credential helper; devcontainer.json is valid JSON; Biome/typecheck/status clean. Only `.devcontainer/` changed — no `src/`, so the test suites are unaffected (CI confirms).

Low-risk fail-open infra convenience; implemented on PO approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)