### PR TITLE
feat(BUG-75/UX-12): picker-precedence reorder + Change-city entry point

### DIFF
--- a/jobs/COO/inbox/20260807_0930-QA-bug75-pickerprecedence-ux12-red-atdd-complete.md
+++ b/jobs/COO/inbox/20260807_0930-QA-bug75-pickerprecedence-ux12-red-atdd-complete.md
@@ -1,0 +1,178 @@
+# QA completion — BUG-75 picker-precedence + UX-12: RED ATDD suite (OP-35)
+
+**From:** QA · **Date:** 2026-08-07 · **Branch:** `feat/bug75-pickerprecedence-and-ux12`
+**Role in the phase:** ATDD-first (OP-35) — I wrote the RED acceptance tests as the executable
+definition of done. I did NOT write product code. Frontend continues on THIS branch and turns it green.
+**Design under test:** `origin/feat/bug75-pickerprecedence-design` §11 + the OP-27 review
+(`origin/review/bug75-pickerprecedence-design`: MAJOR-1, MAJOR-2, AC-3 build-blocker), all folded in.
+
+---
+
+## TL;DR
+
+- **6 new files** on the branch: 5 test files + 1 shared fixtures module. All pushed.
+- **RED confirmed:** 5 test files fail; 10 individual assertions fail; **2 pass** and those two are the
+  intended paired *negative guards* (see "The two passing tests" below) — not false-greens.
+- **Every RED test fails for the RIGHT reason** — verified per test (region `<select>` fires instead of
+  the picker; country silently committed; no creation message; net-new units missing). Details below.
+- **Mock fidelity verified** against the real `lookupCityCountry` shape; the spanning fixture **includes
+  Wales** (the row the shipped suite omitted).
+- **AC-3 (Springfield) is `.skip` pending a real Nominatim capture** — NOT fabricated. Nominatim is
+  unreachable from this container (two prior probes + I did not re-probe; inherited-as-UNVERIFIED).
+- **biome ci clean** on all 6 files. **type:check** shows exactly 3 errors, all the intended
+  missing-module imports the Frontend build resolves.
+
+---
+
+## AC → test → RED-reason map
+
+| AC | Layer / file | RED reason (verified) |
+|---|---|---|
+| **AC-1** spanning (headline) | composition — `AddPlaceFlow.picker-precedence.test.tsx` | On main the spanning fixture triggers the region branch (DOM shows `Region — multiple matches found, please choose`); picker label `Multiple places match` and the `Newport, Isle of Wight` / `Cymru / Wales` rows never render. **The defect itself.** |
+| **AC-1** (pure) | `decideCityDisambiguation.test.ts` | returns `'picker'` not `'region'` for the spanning set — RED: unit not built. |
+| **AC-2** same-region twins | `decideCityDisambiguation.test.ts` | `'picker'` for two GB-ENG Newports — RED: unit not built. (At the *composition* layer this case is already green on main — the existing `AddPlaceFlow.city-picker.test.tsx` covers it — so AC-2's red gate is the pure-function layer, by design.) |
+| **AC-3** Springfield | `decideCityDisambiguation.test.ts` | **`it.skip` — PENDING real capture.** Structure authored; do NOT fabricate a Springfield fixture (that is the QUAL-22 vacuous-pass class). |
+| **AC-4** F1/F2 parity | `decideCityDisambiguation.test.ts` | `'region'` for multi-region no-osm; `'suggested'` for single-region no-osm; one-osm-across-two-regions → `'region'` (positive-evidence gate). RED: unit not built. |
+| **AC-5** single unambiguous (Denver) | `decideCityDisambiguation.test.ts` | `'suggested'` even with an osm_id; empty set → `'none'`. RED: unit not built. |
+| **AC-6** region_id alignment | `buildCreateCityDataFromCandidate.test.ts` | region_id derived from THAT candidate; incomplete-seed → undefined (never invented). RED: unit not built. |
+| **AC-7** truncation caveat | composition — `AddPlaceFlow.picker-precedence.test.tsx` | truncated *spanning* lookup: caveat must ride on the picker; RED because the picker never renders on main (region branch fires). |
+| **AC-8** Change-city control | `PlaceSection.change-city.test.tsx` | `button[name=/change city/i]` not found on unlocked resolved/pending places. RED: control absent. |
+| **AC-9** shared precedence (no drift) | `ChangeCityModal.test.tsx` | spanning fires the picker in Change-city too. RED: component missing. |
+| **AC-10** re-point preserves data (D11) | `ChangeCityModal.test.tsx` | selecting a candidate calls the re-point mutation `{tripId,placeId,cityId}` (→ PATCH `…/places/:id` `{city_id}`). RED: component missing. |
+| **AC-11** badge | `PlaceSection.change-city.test.tsx` | `Location not confirmed` badge absent for pending/failed; present-case fails. RED: badge absent. |
+| **AC-12** (MAJOR-1) identity carry once | `buildCreateCityDataFromCandidate.test.ts` (pure) + `ChangeCityModal.test.tsx` (cross-flow behavioural) | pure mapping unit missing; and Change-city must carry the SAME osm identity + region_id AddPlace carries. RED: unit + component missing. |
+| **AC-13** (MAJOR-2) country not silently committed | composition — `AddPlaceFlow.picker-precedence.test.tsx` | `Suggested: United Kingdom` (country tentative caption) not found — on main `AddPlaceFlow.tsx:360` silently commits the country; only the region ever gets a `Suggested:` caption. |
+| **AC-14** (MAJOR-2) creation-time messaging | composition — `AddPlaceFlow.picker-precedence.test.tsx` | `still confirming this location` (UX §3.4 pending copy) not found — main just closes/shows warnings. |
+
+Files:
+- `src/frontend/utils/__tests__/decideCityDisambiguation.test.ts`
+- `src/frontend/utils/__tests__/buildCreateCityDataFromCandidate.test.ts`
+- `src/frontend/components/TripDetail/__tests__/AddPlaceFlow.picker-precedence.test.tsx`
+- `src/frontend/components/TripDetail/__tests__/ChangeCityModal.test.tsx`
+- `src/frontend/components/TripDetail/__tests__/PlaceSection.change-city.test.tsx`
+- `src/frontend/components/TripDetail/__tests__/fixtures/newportGeocode.ts` (shared fixtures, not a test file)
+
+---
+
+## Mock-fidelity verification (QUAL-22 — mandatory)
+
+**How I verified the double matches the real dependency:**
+- Read `lookupCityCountry` at `src/frontend/hooks/useCities.ts:87-104`. Real return shape:
+  `{ countryCode: string|null, regionIso: string|null, candidates: GeocodeCandidate[], failed: boolean,
+  truncated: boolean }`. Every `mockLookupCityCountry.mockResolvedValue(...)` in the suite returns exactly
+  those five keys — no missing field the code reads (a missing field inside the swallowing `.then/.catch`
+  is precisely how the original bug hid).
+- Read `useCreateCity`/`useAddPlace` (useMutation results) — doubles return `{mutateAsync, isPending,
+  error}`; `useAddPlace` resolves `{id, warnings:[]}`. Matches the real hook surface.
+- The candidates carry `osm_type`/`osm_id` — the code's REAL disambiguation signal
+  (`AddPlaceFlow.tsx:389-393` computes `distinctOsmIds` from exactly these). A fixture without them
+  specifies nothing.
+- **The spanning fixture includes Wales.** `spanningRegionNewports()` = IoW (GB-ENG) + Telford (GB-ENG) +
+  **Newport city (GB-WLS, node 26700977)**. This is the row `AddPlaceFlow.city-picker.test.tsx`'s
+  `sameRegionNewports()` omitted; its presence is what makes `sameCountryRegionIsos.length > 1` and thus
+  what turns the composition test red on the region-first order. Anti-vacuous by construction.
+
+**Honest qualification (per OP-35):** writing these first stops them being bent to fit the code; it does
+not by itself make them perfect. The composition tests assert *observable* behaviour (which control
+renders, what `createCity` is called with) — they do not, and cannot at this layer, prove Nominatim's real
+`newport` response carries these exact osm_ids (that is the backend/UAT layer's job — same documented
+limitation the existing suite carries).
+
+---
+
+## Fixture provenance — real-captured vs pending
+
+**Real captured (safe to gate on now):**
+- `26700978` GB-ENG Newport, Isle of Wight — captured; already in `cities.identity-carry.test.ts:149`.
+- `27459103` GB-ENG Newport, Telford and Wrekin — captured; design §5.2 verbatim + identity-carry:159.
+- `26700977` GB-WLS Newport (city), `Cymru / Wales` — captured; design §5.2 verbatim
+  (`"Newport, Cymru / Wales, NP20 1GF, …"`) and referenced as `N26700977` in identity-carry:54.
+  This is the previously-omitted Wales row.
+
+Per-osm_id provenance is documented in `fixtures/newportGeocode.ts`. **No osm_id is invented.**
+`latitude`/`longitude` on each candidate are plausible real coordinates included only to satisfy the
+required type field — they are **never asserted** and are marked as filler in the fixture. The load-bearing,
+captured fields are `osm_type`/`osm_id`/`region_iso`/`country_code` and the region token in `display_name`.
+
+**Pending real capture (NOT fabricated):**
+- **AC-3 Springfield** is `it.skip` with the fixture placeholder commented out. Nominatim is unreachable
+  from this container (firewall-regressed; connection-refused on two prior probes recorded in the design
+  §5.2/§13 — I did **not** re-probe this session, so I inherit that as **UNVERIFIED**, blind spot: a single
+  network state I did not re-establish). A post-rebuild session must capture a real Springfield `/lookup`
+  response, drop it into the fixtures module, and un-skip. AC-1 + AC-2 (real captured Newport) are the RED
+  gate in the meantime, exactly as the review's build-blocker directs.
+
+---
+
+## The two passing tests (why they are correct, not false-greens)
+
+The run is `10 failed | 2 passed`. The two that pass are the **paired negative-space guards**:
+1. `AC-8 … is hidden when the trip is locked` — passes because no Change-city control exists on main, so
+   it is trivially absent when locked. It must STAY green after the build (control hidden under `isLocked`).
+2. `AC-11 … shows NO badge for a resolved place` — passes because no badge exists on main. Must stay green
+   after the build (resolved → no badge).
+
+Both are the negative half of a positive/negative pair; their positive siblings (control present when
+unlocked; badge present when not resolved) correctly FAIL now. This is intended coverage, not a test aimed
+at the wrong thing.
+
+---
+
+## Precise handoff to Frontend — what to build to turn this green
+
+Sequenced A → B (design §10). **The tests are the contract; signatures below are pinned by the test imports.**
+
+**Brief A — precedence fix + shared extraction:**
+1. Create `src/frontend/utils/decideCityDisambiguation.ts` — the pure decision function. Signature
+   (MINOR-1: `regionIso` is a SEPARATE input, not derivable from candidates):
+   `decideCityDisambiguation(candidatesForCountry: GeocodeCandidate[], regionIso: string | null): CityDisambiguation`
+   with `CityDisambiguation = {mode:'picker',candidates} | {mode:'region',regionIsos} | {mode:'suggested',regionIso} | {mode:'none'}`.
+   The reorder is the point: evaluate `distinctOsmIds.size > 1` (picker) BEFORE `sameCountryRegionIsos.length > 1` (region).
+2. Create `src/frontend/utils/buildCreateCityDataFromCandidate.ts` (MAJOR-1 anti-drift) —
+   `(candidate, cityName, regions, fallbackCountryCode?) => CreateCityData | null`. Lifts the identity
+   carry out of `AddPlaceFlow.handleSelectPickerCandidate` so it exists ONCE. Must forward
+   osm_type/osm_id/display_name and derive region_id from the candidate's own region_iso (incomplete-seed → undefined).
+3. Rewire `AddPlaceFlow` to consume both (extraction + reorder, NOT a rewrite — no-wholesale-rewrite rule).
+4. AC-13/AC-14 (MAJOR-2): country as a tentative `Suggested: <country> — from "<name>"` caption
+   (UX §3.2) instead of the silent commit at line 360; and the geocode_status-keyed creation message
+   (UX §3.4 — pending copy is verbatim in the AC-14 test).
+
+**Brief B — UX-12 (reuse-only):**
+5. `src/frontend/components/TripDetail/ChangeCityModal.tsx` — `{tripId, placeId, onClose}`. Reuses the
+   extracted search step + shared precedence unit + shared identity carry; on select/create calls the
+   D11 re-point. The AC-10 test targets a `useChangeCity()` seam calling `{tripId, placeId, cityId}`
+   (→ PATCH `…/places/:placeId` `{city_id}`) — a thin sibling of `useUpdatePlaceDates`. If you instead
+   extend `useUpdatePlaceDates` with an optional cityId, retarget that one mock; the observable contract
+   (a PATCH with city_id) is what AC-10 pins.
+6. `PlaceSection` — a standing `aria-label="Change city"` button on every unlocked place regardless of
+   `geocode_status`, hidden under the same `isLocked` rule as Remove (AC-8); and a single
+   `Location not confirmed` badge (existing `locked` hue) whenever `geocode_status !== 'resolved'` (AC-11).
+
+Also required by the review's MINOR-2 (not a test I can author — it's a lifecycle stamp): the build PR must
+stamp `ADL-46 §4.3.2` with the §7 SUPERSEDED banner.
+
+---
+
+## Findings to flag (two probes / marked UNVERIFIED as noted)
+
+1. **GeocodeStatus type/enum mismatch (real, verified two probes).** Frontend
+   `src/frontend/types/api.ts:22` declares `type GeocodeStatus = 'pending' | 'resolved' | 'failed'`, but
+   the backend DB CHECK (`src/backend/db/schema.ts:144`) is `IN ('pending','resolved','unresolvable')`.
+   The frontend has **no `'unresolvable'`** and the backend has **no `'failed'`**. The AC-11 badge rule
+   (`!== 'resolved'`) is unaffected, but **UX §3.4's `unresolvable` creation message can never match the
+   frontend type** — AC-14 as authored covers only the `pending` message for that reason. This is a latent
+   defect the Frontend/COO should decide on (reconcile the type to the backend enum, or map at the boundary).
+   Not mine to fix; flagged. (Probe 1: read the frontend type. Probe 2: read the backend schema CHECK.)
+2. **AC-2 composition is green on main** (the existing same-region test already covers it) — so AC-2's red
+   gate is the pure-function layer only. Stated so nobody reads "AC-2 passes at the flow layer" as a miss.
+3. **`unresolvable` badge case** in AC-11 is authored as `'failed'` (the frontend's valid terminal value)
+   to stay type-sound — see the inline comment in `PlaceSection.change-city.test.tsx`.
+
+## What I could not verify
+- **Real Springfield `/lookup` data** (AC-3) — Nominatim unreachable; inherited UNVERIFIED (blind spot: I
+  did not re-run the network probe this session). Gated as `.skip`.
+- **The exact in-modal chrome / hook name of `ChangeCityModal`** — Frontend's build detail. The tests pin
+  the observable contract (search step present, picker fires, PATCH with city_id), not the internal shape;
+  the `useChangeCity` seam is a recommendation, retarget note included above.
+
+CI note: this branch is RED by design and must NOT be merged to main until Frontend turns it green — no PR opened.

--- a/jobs/COO/inbox/20260807_1712-FRONTEND-bug75-pickerprecedence-ux12-build-complete.md
+++ b/jobs/COO/inbox/20260807_1712-FRONTEND-bug75-pickerprecedence-ux12-build-complete.md
@@ -1,0 +1,169 @@
+# Frontend completion — BUG-75 picker-precedence + UX-12: RED suite turned GREEN (OP-35)
+
+**From:** Frontend · **Date:** 2026-08-07 · **Branch:** `feat/bug75-pickerprecedence-and-ux12`
+**PR:** [#413](https://github.com/ryanv11/travel-tracker/pull/413) — CI fully green, 18/18 checks
+(`scripts/ci-wait.sh pr 413` confirmed, including E2E). Not merged — COO reviews/merges.
+**Role in the phase:** ATDD-first (OP-35) implementer. QA's RED suite (branch continuation, same
+lineage) is the executable definition of done. I wrote zero new acceptance tests; every AC below is
+QA's own test, now green.
+
+---
+
+## Worktree note (procedural, not a deviation from the brief's intent)
+
+The brief said "check out QA's branch INTO your worktree, do NOT start a new branch." QA's own
+worktree (`agent-acc03c5dc1ab6c856`) still had `feat/bug75-pickerprecedence-and-ux12` checked out
+(stale registration, not cleaned up) — git refuses the same branch in two worktrees. Rather than touch
+another agent's worktree, I checked out the identical commit (`81a046b`, verified matching
+`origin/feat/bug75-pickerprecedence-and-ux12`) under a locally-scoped branch name
+(`feat/bug75-pickerprecedence-and-ux12--fe-worktree`) tracking the same remote ref, then pushed back
+to `HEAD:feat/bug75-pickerprecedence-and-ux12` — same history, same remote branch, no new lineage
+created. Flagging so it's not mistaken for a rule deviation.
+
+---
+
+## AC status — all green except the deliberately-skipped AC-3
+
+| AC | Status |
+|---|---|
+| AC-1 spanning-region (headline, pure + composition) | GREEN |
+| AC-2 same-region twins | GREEN |
+| AC-3 Springfield | `.skip` — **left skipped**, not unskipped, not fabricated (see below) |
+| AC-4 F1/F2 parity | GREEN |
+| AC-5 single unambiguous (Denver) | GREEN |
+| AC-6 region_id alignment | GREEN |
+| AC-7 truncation caveat on picker | GREEN |
+| AC-8 Change-city control | GREEN (incl. the locked-hides-it guard, was already green, stays green) |
+| AC-9 shared precedence (no drift) | GREEN |
+| AC-10 re-point preserves data (D11) | GREEN |
+| AC-11 badge | GREEN (incl. the resolved-shows-no-badge guard, was already green, stays green) |
+| AC-12 identity carry once | GREEN (both the pure-function test and the cross-flow behavioural test) |
+| AC-13 country tentative suggestion (MAJOR-2) | GREEN |
+| AC-14 creation-time messaging (MAJOR-2) | GREEN |
+
+Full suite: `npm run test:frontend` → **300 passed | 1 skipped (301)**, up from the RED baseline's
+285 total (275 passing + 10 failing). The 2 negative guards QA called out (AC-8 locked-hides-it,
+AC-11 resolved-shows-none) are unchanged and still pass. AC-3 Springfield is `it.skip` exactly as
+QA left it — I did not touch it, did not fabricate a fixture, did not re-probe Nominatim (still the
+documented firewall-regressed state).
+
+## Did NOT wholesale-rewrite AddPlaceFlow
+
+`AddPlaceFlow.tsx`'s diff is an extraction + reorder, per the brief's hard rule:
+- The if/else branch order in `handleOpenNewCityForm`'s `.then` callback was replaced by one call to
+  the new `decideCityDisambiguation()` + a `switch` on its `mode` — the actual reorder is now owned by
+  the pure function, not re-derived inline.
+- `handleSelectPickerCandidate`'s inline mapping became a call to
+  `buildCreateCityDataFromCandidate()`.
+- Two new pieces of state (`countryIsSuggested`, `creationStatusMessage`) and their render blocks were
+  added for AC-13/AC-14 (MAJOR-2), mirroring the existing `regionIsSuggested`/`placeWarnings` patterns
+  exactly rather than inventing a new mechanism.
+- Every other piece of state, every existing effect, the whole JSX structure, and all six
+  BUG-specific behaviours (BUG-71/72/73/78/79, F1/F2 parity) are untouched. `AddPlaceFlow.test.tsx`,
+  `.bug71`, `.bug72`, `.bug73`(geocodeFailure), `.bug78-79`, `.city-picker` all still pass unmodified
+  in logic (two of them needed a one-line regex narrowing, see below — not a logic change).
+
+No source file was replaced wholesale. `ChangeCityModal.tsx` is a **new** file (net-new component, not
+a rewrite of anything).
+
+## Reuse confirmation (standing PO preference)
+
+- **`CityPicker`** — reused as-is by both `AddPlaceFlow` and `ChangeCityModal`. Not modified.
+- **D11 PATCH re-point** (`PATCH /api/trips/:tripId/places/:placeId` with `city_id`) — reused as-is.
+  No backend route added or modified (confirmed: `git diff --stat` against `origin/main` for this PR
+  touches zero files under `src/backend/`; grep of the diff for `src/backend` returns nothing — two
+  probes, both positive/mechanical, not an absence claim needing a second kind of check). The new
+  `useChangeCity` hook (`usePlaces.ts`) is a thin frontend wrapper issuing the identical PATCH shape
+  `useUpdatePlaceDates` already uses — no new endpoint, no new backend security surface. Per the
+  brief's security checklist: **this PR adds/modifies no backend routes**, so the Backend security
+  checklist (auth middleware / userId scoping / FK notNull) does not apply — confirmed, not assumed.
+
+## MAJOR-1 (identity-carry, "exists in exactly one place") — how I read the review's intent
+
+The review's suggested shape was a hook owning `POST /api/cities` and handing callers a resolved
+`city_id`. QA's own ATDD contract (`buildCreateCityDataFromCandidate.test.ts`) pins it as a **plain,
+non-hook utility function** — no React, imported and asserted directly. I built it exactly to that
+signature and both `AddPlaceFlow` and `ChangeCityModal` call it directly, each against their own
+`useCreateCity()`. The actual drift risk MAJOR-1 flags — the mapping logic (osm forwarding, region_id
+derivation) being reimplemented per call site — is eliminated: it exists in exactly one function,
+consumed identically (AC-12's cross-flow test asserts this directly). I judged this satisfies
+MAJOR-1's intent without introducing a hook shape the ATDD contract didn't call for.
+
+Separately, I did build `useCityDisambiguation.ts` (owns the geocode lookup + runs
+`decideCityDisambiguation`) — used by `ChangeCityModal` (brand new, no legacy tests to risk).
+`AddPlaceFlow` calls `decideCityDisambiguation`/`buildCreateCityDataFromCandidate` **inline**, within
+its existing `.then()` structure, rather than adopting the hook wrapper — a deliberate choice to avoid
+restructuring a heavily-regression-tested file's effect/promise timing (six BUG-specific suites) for a
+change whose real drift-risk (the decision + identity-carry *logic*) is already eliminated by both
+flows calling the identical pure functions. The plumbing differs; the logic that can silently diverge
+does not. Flagging this explicitly as an interpretation call, not silently deciding it was in-scope.
+
+## GeocodeStatus type fix — blast radius verified
+
+Changed `src/frontend/types/api.ts`'s `GeocodeStatus` from `'pending' | 'resolved' | 'failed'` to
+`'pending' | 'resolved' | 'unresolvable'`, matching the backend CHECK
+(`chk_cities_geocode_status`, `src/backend/db/schema.ts:144`) exactly. Two probes, both positive:
+- Grepped `'failed'` as a literal across `src/frontend` — one hit outside the type declaration itself:
+  `PlaceSection.change-city.test.tsx`'s `makePlace('failed')` (QA's own comment there already flagged
+  the mismatch and used `'failed'` to stay type-valid under the *old*, wrong type).
+- Read the backend CHECK constraint directly (`schema.ts:144`).
+No other frontend code compared against `'failed'` (confirmed by the same grep — zero other hits).
+**Necessitated test edit:** changed that one literal to `'unresolvable'` and updated the adjacent
+comment — the assertion itself (badge fires for any non-resolved status) is unchanged, only the value
+used to reach it.
+
+## Other necessitated test edits (not weakenings — flagging per the brief)
+
+MAJOR-2's new country-suggested caption ("Suggested: <country> — from ...") is unavoidably a NEW match
+for any pre-existing broad `/suggested:/i` absence-check once a country is auto-detected — three
+pre-existing regression tests (unrelated to QA's suite) asserted "no Suggested: caption anywhere"
+using that broad regex, written before a second field could ever carry one:
+- `AddPlaceFlow.bug71.test.tsx` (2 assertions) — narrowed to the specific region name(s) the test is
+  actually about (`/suggested: virginia/i`, `/suggested: (missouri|colorado)/i`-equivalent as two
+  separate checks).
+- `AddPlaceFlow.bug78-79.test.tsx` (1 assertion) — same narrowing, three region names.
+- `AddPlaceFlow.picker-precedence.test.tsx` (QA's own AC-14 test) — its own wait condition
+  `findByText(/Suggested: United Kingdom|United Kingdom/i)` became genuinely ambiguous once the AC-13
+  caption it's testing FOR actually renders (the country `<option>` element's plain "United Kingdom"
+  text also matches the same regex, and once both match, `findByText` throws "found multiple
+  elements" instead of waiting). Narrowed to the specific, more-precise alternate
+  (`/Suggested: United Kingdom/i`) that the surrounding comment already said was the real intent.
+
+Each of these is a one-line regex narrowing that preserves the exact regression each test protects
+(verified by re-reading each test's own stated purpose before touching it) — none had their assertion
+*semantics* weakened. All are called out here per the brief's "flag, don't silently weaken" rule, even
+though I judge these necessitated by an explicitly-authorized behavior change (MAJOR-2) rather than
+QA-suite weakening.
+
+## D14 stamp (MINOR-2)
+
+`jobs/architect/tech/20260307-architecture-decisions-log.md` — appended (via `Edit`, old text
+untouched) a SUPERSEDED-in-part banner directly under D14's paragraph (item 14), per design §7's exact
+text. Also recorded the open-questions closure check inline: two probes (grep of the BRD's Open
+Questions table for anything D14/picker-related; grep of ADL-46 itself for a "resolves OQ-" tied to
+D14) found neither, so there's no open BRD question this stamp closes — D14 was PO-raised with both
+answers explicitly permitted, not an answer to a standing open question.
+
+## What I could not verify / inherited as UNVERIFIED
+
+- **AC-3 Springfield** — unchanged from QA's handoff: Nominatim unreachable this session too (did not
+  re-probe; inheriting QA's/the design's UNVERIFIED marker rather than silently upgrading it).
+- **Real Nominatim shape for the AC-13/AC-14 messaging copy** — the exact wording of UX spec §3.4 was
+  not available to me directly (only referenced via QA's test, which pins the substring "still
+  confirming this location" as the DoD). I wrote copy satisfying that substring; if the full UX spec
+  §3.4 text differs in ways UAT catches, that's a copy-polish follow-up, not a functional gap.
+
+## Files touched
+
+New: `src/frontend/utils/decideCityDisambiguation.ts`,
+`src/frontend/utils/buildCreateCityDataFromCandidate.ts`,
+`src/frontend/hooks/useCityDisambiguation.ts`,
+`src/frontend/components/TripDetail/ChangeCityModal.tsx`
+
+Modified: `src/frontend/components/TripDetail/AddPlaceFlow.tsx`,
+`src/frontend/components/TripDetail/PlaceSection.tsx`, `src/frontend/hooks/usePlaces.ts`,
+`src/frontend/types/api.ts`, `jobs/architect/tech/20260307-architecture-decisions-log.md`,
+plus the three test-file edits listed above.
+
+Pre-push: all green (`npm run check`, `type:check:all`, `test:backend` 740 passed,
+`test:frontend` 300 passed | 1 skipped, `status:check`). PR #413 CI: 18/18 green.

--- a/jobs/architect/tech/20260307-architecture-decisions-log.md
+++ b/jobs/architect/tech/20260307-architecture-decisions-log.md
@@ -3701,6 +3701,25 @@ consequence six days later.
     usable `pending` record. The smaller alternative (auto-accept the top candidate) is recorded as
     the first thing to cut if the release must shrink.
 
+    > **SUPERSEDED (2026-08-06) in part** — ADL-46 §4.3.2 (D14) established that ambiguous city
+    > disambiguation is **region-first** (narrow the region `<select>` to the candidate regions). For
+    > the branch where the geocode lookup returns **positive identity evidence** (≥2 candidates carrying
+    > distinct `(osm_type, osm_id)`), the place-level `CityPicker` is now **primary** and the region
+    > `<select>` no longer pre-empts it. D14's region-narrowing `<select>` is **retained unchanged** as
+    > the fallback for the **no-`osm_id`** case (legacy / partial responses / ADL-46 F1/F2 parity).
+    > Rationale and evidence:
+    > `jobs/architect/tech/20260806-BUG75-pickerprecedence-and-ux12-entry.md` §5–§6, reviewed
+    > `jobs/architect/tech/20260806-BUG75-pickerprecedence-design-review.md`. Region-first was
+    > structurally unable to separate two distinct places sharing one region (the two GB-ENG Newports),
+    > which is the BUG-75 defect. The reorder shipped in the PR that lands this stamp (BUG-75/UX-12
+    > build) as `src/frontend/utils/decideCityDisambiguation.ts`. Retained for history.
+    >
+    > **Open-questions closure check (document-lifecycle rule, item 4):** two probes run — a grep of
+    > `_project/travel-tracker-BRD.md`'s Open Questions table (OQ-01..OQ-05) for any entry referencing
+    > D14/picker-precedence, and a grep of this ADL-46 section for a "resolves OQ-" note tied to D14 —
+    > neither found one. D14 was PO-raised with both answers explicitly permitted (see above), not an
+    > answer to an open BRD question, so there is no open-questions section for this stamp to close.
+
 **Framing correction adopted 2026-07-30 (PO: *"I don't want to be architecting based on the current
 user base"*).** "Acceptable at two users" had been used to justify at least four judgements in this
 ADL; the justification is withdrawn wherever it appeared. Each was re-weighed to either a real fix

--- a/src/frontend/components/TripDetail/AddPlaceFlow.tsx
+++ b/src/frontend/components/TripDetail/AddPlaceFlow.tsx
@@ -21,7 +21,13 @@ import {
 import { useAddPlace } from '../../hooks/usePlaces';
 import { geocodeRetryQueue } from '../../services/geocodeRetryQueue';
 import type { City, GeocodeCandidate } from '../../types/api';
+// BUG-75/UX-12 (design §9/§6, review MAJOR-1/MINOR-1): the shared
+// precedence decision and the shared candidate->city identity-carry mapping,
+// each extracted to exactly one place so AddPlace and ChangeCityModal cannot
+// drift. See each module's doc comment for the full rationale.
+import { buildCreateCityDataFromCandidate } from '../../utils/buildCreateCityDataFromCandidate';
 import { resolveDefaultDate } from '../../utils/dateDefaults';
+import { decideCityDisambiguation } from '../../utils/decideCityDisambiguation';
 // BUG-80: formatCitySubtitle used to live here (BUG-72, PR #353) as a
 // module-local function. Lifted to a shared util so every saved-place
 // surface reuses the same formatter instead of a second one drifting out of
@@ -113,6 +119,15 @@ export function AddPlaceFlow({
   // regionIsSuggested still can't and shouldn't be narrowed to "only when
   // truncated."
   const [regionIsSuggested, setRegionIsSuggested] = useState(false);
+  // BUG-75/UX-12 (MAJOR-2, AC-13, UX spec §3.2/§12.2 item 3): the country
+  // field used to be silently committed the moment the lookup resolved one
+  // (line below, now removed) — the only field with the BUG-71 "Suggested:"
+  // tentative treatment was the region. A wrong auto-detected country is
+  // exactly the "confidently-wrong-result" class §3.2 exists to prevent, so
+  // the country now gets the identical tentative treatment as the region:
+  // pre-filled but visibly a suggestion, cleared the moment the user
+  // explicitly picks a country themselves (tier 1, same rule as region).
+  const [countryIsSuggested, setCountryIsSuggested] = useState(false);
   // BUG-79 (#379): true only when the geocode lookup's raw upstream response
   // may have had more matches than `candidates` shows (nominatim-client.ts's
   // pre-filter count hit the requested limit) — see useCities.ts/geocode.ts.
@@ -145,6 +160,12 @@ export function AddPlaceFlow({
   );
   const [dateValidationError, setDateValidationError] = useState<string | null>(null);
   const [placeWarnings, setPlaceWarnings] = useState<string[]>([]);
+  // BUG-75/UX-12 (MAJOR-2, AC-14, UX spec §3.4/§12.2 item 4): status-conditional
+  // guidance shown once a place is created for a city that isn't resolved yet
+  // — on `main` a successful non-resolved create just sat there (or closed)
+  // with no explanation. Mutually exclusive with placeWarnings (set only when
+  // there are no backend warnings to show instead).
+  const [creationStatusMessage, setCreationStatusMessage] = useState<string | null>(null);
 
   const debounceTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -259,6 +280,14 @@ export function AddPlaceFlow({
       // NR-06: queue geocoding retry if city wasn't resolved yet
       if (city.geocode_status !== 'resolved') {
         geocodeRetryQueue.add(city);
+        // BUG-75/UX-12 (MAJOR-2, AC-14, UX spec §3.4): tell the user the
+        // location isn't confirmed yet rather than leaving them to guess why
+        // nothing further happened.
+        setCreationStatusMessage(
+          city.geocode_status === 'unresolvable'
+            ? "We couldn't automatically confirm this location. The place has still been added — you can try Change city later if this doesn't look right."
+            : "We're still confirming this location — it'll update automatically once it resolves. The place has been added.",
+        );
       }
     } catch {
       /* shown via addPlace.error */
@@ -294,23 +323,16 @@ export function AddPlaceFlow({
    */
   const handleSelectPickerCandidate = async (candidate: GeocodeCandidate) => {
     if (!newCityName.trim()) return;
-    const countryCode = candidate.country_code ?? newCityCountryCode;
-    if (!countryCode) return;
-    const regionId = candidate.region_iso
-      ? (countryRegions.find((r) => r.iso_3166_2 === candidate.region_iso)?.id ?? undefined)
-      : undefined;
-    const data: CreateCityData = {
-      name: newCityName.trim(),
-      country_code: countryCode,
-      region_id: regionId,
-      ...(candidate.osm_type && candidate.osm_id != null
-        ? {
-            osm_type: candidate.osm_type,
-            osm_id: candidate.osm_id,
-            display_name: candidate.display_name,
-          }
-        : {}),
-    };
+    // BUG-75/UX-12 (review MAJOR-1): the identity-carry mapping now lives in
+    // exactly one place, shared with ChangeCityModal — see the module doc
+    // comment on buildCreateCityDataFromCandidate.ts.
+    const data = buildCreateCityDataFromCandidate(
+      candidate,
+      newCityName.trim(),
+      countryRegions,
+      newCityCountryCode,
+    );
+    if (!data) return;
     try {
       const city = await createCity.mutateAsync(data);
       setPlacePickerCandidates(null);
@@ -338,8 +360,10 @@ export function AddPlaceFlow({
     setCandidateRegionIsos(null);
     setPlacePickerCandidates(null);
     setRegionIsSuggested(false);
+    setCountryIsSuggested(false);
     setLookupTruncated(false);
     setGeocodeLookupFailed(false);
+    setCreationStatusMessage(null);
     if (cityName.trim().length >= 2) {
       setCountryLookupPending(true);
       lookupCityCountry(cityName.trim())
@@ -357,55 +381,46 @@ export function AddPlaceFlow({
           // false single survivor, and both need the same "don't claim
           // certainty" caveat.
           setLookupTruncated(truncated);
-          if (countryCode) setNewCityCountryCode(countryCode);
+          // BUG-75/UX-12 (MAJOR-2, AC-13): the country used to be committed
+          // here with no tentative signal at all. Now mirrors the region's
+          // BUG-71 treatment — pre-filled, but visibly a suggestion until the
+          // user explicitly confirms it (by leaving it as-is IS an implicit
+          // confirmation in the existing region pattern's spirit — the same
+          // stopgap trade-off BUG-71 already made, applied to a second field).
+          if (countryCode) {
+            setNewCityCountryCode(countryCode);
+            setCountryIsSuggested(true);
+          }
 
-          // D14: collect the distinct region_iso values among candidates that
-          // share the resolved country. More than one means the city name is
-          // ambiguous within that country (Springfield IL vs Springfield MO) —
-          // narrow the region selector to just those instead of auto-picking
-          // the top candidate's region.
+          // BUG-75/UX-12 (design §6/§9, review MINOR-1): the reordered
+          // precedence — positive osm_id identity evidence wins over region
+          // ambiguity — now lives in exactly one place, shared with
+          // ChangeCityModal. See decideCityDisambiguation.ts's doc comment
+          // for the full "why" (this is the actual BUG-75 headline fix).
           const candidatesForCountry = countryCode
             ? candidates.filter((c) => c.country_code === countryCode)
             : [];
-          const sameCountryRegionIsos = [
-            ...new Set(
-              candidatesForCountry.filter((c) => c.region_iso).map((c) => c.region_iso as string),
-            ),
-          ];
-
-          // BUG-75/UX-12 (v3 §B5 m1 REPLACE, ask-to-choose #4): region-only
-          // narrowing is insufficient when 2+ candidates carry DISTINCT OSM
-          // identity but share one region (or none) — a region selector
-          // would collapse them into a false single choice (the two GB-ENG
-          // Newports). This is gated on POSITIVE identity evidence
-          // (>=2 distinct osm_id) rather than raw candidate count so it does
-          // NOT fire for the ADL-46 F1/F2 parity case (AddPlaceFlow.test.tsx)
-          // where two Nominatim rows for the same real place at different
-          // granularities (no osm_id on either, by that fixture's design)
-          // legitimately collapse to one non-ambiguous region — the frontend
-          // has no signal there to say otherwise, and byte-for-byte matching
-          // the backend's classifyCandidates "ok" verdict for that shape is
-          // the settled contract (ADL-46 F1/F2 ruling), unchanged by this brief.
-          const distinctOsmIds = new Set(
-            candidatesForCountry
-              .filter((c) => c.osm_id != null)
-              .map((c) => `${c.osm_type ?? ''}:${c.osm_id}`),
-          );
-
-          if (sameCountryRegionIsos.length > 1) {
-            setCandidateRegionIsos(sameCountryRegionIsos);
-            // Ambiguous — leave newCityRegionId unset so the user must choose.
-          } else if (distinctOsmIds.size > 1) {
-            setPlacePickerCandidates(candidatesForCountry);
-            // Place-level ambiguity — leave newCityRegionId unset; the pick
-            // itself (handleSelectPickerCandidate) derives region_id.
-          } else if (regionIso) {
-            // BUG-71 stopgap: this branch cannot distinguish "genuinely one
-            // region" from "collapsed to one by truncation upstream" — mark
-            // every auto-fill from here as a tentative suggestion (see the
-            // regionIsSuggested declaration above) rather than assuming either.
-            setAutoRegionIso(regionIso);
-            setRegionIsSuggested(true);
+          const disambiguation = decideCityDisambiguation(candidatesForCountry, regionIso);
+          switch (disambiguation.mode) {
+            case 'picker':
+              setPlacePickerCandidates(disambiguation.candidates);
+              // Place-level ambiguity — leave newCityRegionId unset; the pick
+              // itself (handleSelectPickerCandidate) derives region_id.
+              break;
+            case 'region':
+              setCandidateRegionIsos(disambiguation.regionIsos);
+              // Ambiguous — leave newCityRegionId unset so the user must choose.
+              break;
+            case 'suggested':
+              // BUG-71 stopgap: this branch cannot distinguish "genuinely one
+              // region" from "collapsed to one by truncation upstream" — mark
+              // every auto-fill from here as a tentative suggestion (see the
+              // regionIsSuggested declaration above) rather than assuming either.
+              setAutoRegionIso(disambiguation.regionIso);
+              setRegionIsSuggested(true);
+              break;
+            case 'none':
+              break;
           }
           setCountryLookupPending(false);
         })
@@ -435,6 +450,35 @@ export function AddPlaceFlow({
         candidates={carryForwardCandidates}
         onClose={onClose}
       />
+    );
+  }
+
+  // BUG-75/UX-12 (AC-14): status-conditional guidance for a non-resolved
+  // create. Mutually exclusive with placeWarnings — handleSelectCity only
+  // sets this when there were no backend warnings to show instead.
+  if (creationStatusMessage) {
+    return (
+      <div
+        className="fixed inset-0 bg-black/45 flex items-center justify-center z-[700]"
+        onClick={onClose}
+      >
+        <div
+          className="bg-white rounded-lg p-6 w-[480px] max-w-[95vw] shadow-2xl"
+          onClick={(e) => e.stopPropagation()}
+        >
+          <h2 className="m-0 mb-4 text-lg font-bold text-gray-900">Place Added</h2>
+          <div className="mb-4 px-4 py-3 bg-blue-50 border border-blue-200 rounded-md text-blue-800 text-sm">
+            <p>{creationStatusMessage}</p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="px-4 py-2 bg-teal-600 text-white border-none rounded-md text-sm font-semibold hover:bg-teal-700 cursor-pointer"
+          >
+            OK
+          </button>
+        </div>
+      </div>
     );
   }
 
@@ -588,6 +632,11 @@ export function AddPlaceFlow({
                 value={newCityCountryCode}
                 onChange={(e) => {
                   setNewCityCountryCode(e.target.value);
+                  // BUG-71: an explicit user pick is never "just a suggestion" —
+                  // tier 1 (UX spec §1): explicit selection always wins and is
+                  // never treated as tentative again. Same rule now applied to
+                  // the country field (MAJOR-2, AC-13).
+                  setCountryIsSuggested(false);
                   setNewCityRegionId(null);
                   setAutoRegionIso(null);
                   setRegionIsSuggested(false);
@@ -611,6 +660,17 @@ export function AddPlaceFlow({
                   </option>
                 ))}
               </select>
+              {/* BUG-75/UX-12 (MAJOR-2, AC-13): country tentative caption,
+                  mirroring the region's BUG-71 "Suggested:" treatment exactly
+                  — see that block's doc comment below for the full rationale.
+                  Country name resolved via the countries list rather than a
+                  literal string so it always matches what the <select>'s own
+                  options render. */}
+              {countryIsSuggested && selectedCountry && (
+                <p className="mt-1 text-xs font-semibold text-gray-500">
+                  Suggested: {selectedCountry.name} — from "{newCityName}"
+                </p>
+              )}
               {/* BUG-73: non-blocking, visible failure state — retries are
                   already exhausted by the time this renders (lookupCityCountry
                   handles retry internally). The form stays fully usable;

--- a/src/frontend/components/TripDetail/ChangeCityModal.tsx
+++ b/src/frontend/components/TripDetail/ChangeCityModal.tsx
@@ -1,0 +1,368 @@
+/**
+ * ChangeCityModal — UX-12's "Change city" correction entry point (design §8.2,
+ * review MAJOR-1, BRD GE-16).
+ *
+ * Re-points an existing trip place to a different city via the D11 PATCH
+ * (`PATCH /api/trips/:tripId/places/:placeId` with `city_id`, already shipped
+ * on `main` — `useChangeCity`, `usePlaces.ts`), preserving the place's items,
+ * notes, and activity tags (server-side, already asserted by
+ * `place-repoint.test.ts`). This is a CORRECTION, never a new place.
+ *
+ * Reuses AddPlace's city search step (same "Search city name…" input, same
+ * `+ Add new: "…"` affordance) and the shared disambiguation seam
+ * (`useCityDisambiguation`, which itself runs candidates through
+ * `decideCityDisambiguation` — the single source of truth also consumed by
+ * `AddPlaceFlow`, so the two flows' picker-vs-region composition cannot
+ * drift, AC-9) plus the shared identity-carry mapping
+ * (`buildCreateCityDataFromCandidate`, review MAJOR-1, AC-12). Deliberately
+ * has NO date fields and NO carry-forward chrome (UX spec §12.1) — this is a
+ * single-purpose city-correction surface, not a second AddPlaceFlow.
+ */
+import type React from 'react';
+import { useEffect, useRef, useState } from 'react';
+import { useCountries, useCountryRegions } from '../../hooks/useAdmin';
+import { type CreateCityData, useCitySearch, useCreateCity } from '../../hooks/useCities';
+import { useCityDisambiguation } from '../../hooks/useCityDisambiguation';
+import { useChangeCity } from '../../hooks/usePlaces';
+import type { City, GeocodeCandidate } from '../../types/api';
+import { buildCreateCityDataFromCandidate } from '../../utils/buildCreateCityDataFromCandidate';
+import { formatCitySubtitle } from '../../utils/formatCitySubtitle';
+import { capitalizeFirst } from '../../utils/textFormat';
+import { CityPicker } from '../shared/CityPicker';
+import { ErrorMessage } from '../shared/ErrorMessage';
+
+interface ChangeCityModalProps {
+  tripId: number;
+  placeId: number;
+  onClose: () => void;
+}
+
+const DEBOUNCE_MS = 300;
+
+export function ChangeCityModal({ tripId, placeId, onClose }: ChangeCityModalProps) {
+  const [query, setQuery] = useState('');
+  const [debouncedQuery, setDebouncedQuery] = useState('');
+  const [showNewCityForm, setShowNewCityForm] = useState(false);
+  const [newCityName, setNewCityName] = useState('');
+  const [newCityCountryCode, setNewCityCountryCode] = useState('');
+  const [newCityRegionId, setNewCityRegionId] = useState<number | null>(null);
+  const [countryIsSuggested, setCountryIsSuggested] = useState(false);
+  const [regionIsSuggested, setRegionIsSuggested] = useState(false);
+
+  const debounceTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const { data: searchResults = [], isLoading: searching } = useCitySearch(debouncedQuery);
+  const { data: countries = [] } = useCountries();
+  const selectedCountry = countries.find((c) => c.country_code === newCityCountryCode);
+  const showRegionDropdown = selectedCountry?.region_tier_enabled ?? false;
+  const regionLabel = selectedCountry?.region_tier_label ?? 'Region';
+  const { data: countryRegions = [] } = useCountryRegions(
+    showRegionDropdown ? newCityCountryCode : undefined,
+  );
+  const suggestedRegionName = countryRegions.find((r) => r.id === newCityRegionId)?.name;
+
+  // BUG-75/UX-12 (design §9): the shared lookup + precedence-decision seam —
+  // same decideCityDisambiguation output AddPlaceFlow consumes, so the two
+  // flows' picker/region/suggested composition cannot drift (AC-9).
+  const cityDisambig = useCityDisambiguation();
+  const createCity = useCreateCity();
+  const changeCity = useChangeCity();
+
+  // Debounce the search query
+  useEffect(() => {
+    if (debounceTimer.current) clearTimeout(debounceTimer.current);
+    debounceTimer.current = setTimeout(() => setDebouncedQuery(query), DEBOUNCE_MS);
+    return () => {
+      if (debounceTimer.current) clearTimeout(debounceTimer.current);
+    };
+  }, [query]);
+
+  // Sync the shared hook's resolved country/region onto this form's own
+  // controlled-input state (the hook owns lookup + decision; the <select>
+  // elements below still need component-owned state to be controlled).
+  useEffect(() => {
+    if (cityDisambig.countryCode) {
+      setNewCityCountryCode(cityDisambig.countryCode);
+      setCountryIsSuggested(true);
+    }
+  }, [cityDisambig.countryCode]);
+
+  useEffect(() => {
+    const d = cityDisambig.disambiguation;
+    if (d.mode === 'suggested' && countryRegions.length) {
+      const match = countryRegions.find((r) => r.iso_3166_2 === d.regionIso);
+      if (match) {
+        setNewCityRegionId(match.id);
+        setRegionIsSuggested(true);
+      }
+    }
+  }, [cityDisambig.disambiguation, countryRegions]);
+
+  /** Re-points the place to `city.id` via the D11 PATCH, then closes. */
+  const repointTo = async (city: City) => {
+    try {
+      await changeCity.mutateAsync({ tripId, placeId, cityId: city.id });
+      onClose();
+    } catch {
+      /* shown via changeCity.error */
+    }
+  };
+
+  const handleSelectExistingCity = async (city: City) => {
+    await repointTo(city);
+  };
+
+  const handleOpenNewCityForm = (cityName: string) => {
+    setShowNewCityForm(true);
+    setNewCityName(capitalizeFirst(cityName));
+    setNewCityCountryCode('');
+    setNewCityRegionId(null);
+    setCountryIsSuggested(false);
+    setRegionIsSuggested(false);
+    cityDisambig.reset();
+    cityDisambig.runLookup(cityName);
+  };
+
+  const handleSelectPickerCandidate = async (candidate: GeocodeCandidate) => {
+    if (!newCityName.trim()) return;
+    // BUG-75/UX-12 (review MAJOR-1, AC-12): the identity-carry mapping lives
+    // in exactly one place, shared with AddPlaceFlow.
+    const data = buildCreateCityDataFromCandidate(
+      candidate,
+      newCityName.trim(),
+      countryRegions,
+      newCityCountryCode,
+    );
+    if (!data) return;
+    try {
+      const city = await createCity.mutateAsync(data);
+      await repointTo(city);
+    } catch {
+      /* shown via createCity.error */
+    }
+  };
+
+  const handleCreateAndRepoint = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!newCityName.trim() || !newCityCountryCode) return;
+    const data: CreateCityData = {
+      name: newCityName.trim(),
+      country_code: newCityCountryCode,
+      region_id: newCityRegionId ?? undefined,
+    };
+    try {
+      const city = await createCity.mutateAsync(data);
+      await repointTo(city);
+    } catch {
+      /* shown via createCity.error */
+    }
+  };
+
+  const mutationError = createCity.error ?? changeCity.error;
+
+  const inputClass =
+    'w-full px-2.5 py-2 border border-gray-300 rounded-md text-sm bg-white focus:outline-none focus:ring-2 focus:ring-teal-500 box-border';
+  const labelClass = 'block text-xs font-semibold text-gray-700 mb-1';
+
+  const disambiguation = cityDisambig.disambiguation;
+
+  return (
+    <div
+      className="fixed inset-0 bg-black/45 flex items-center justify-center z-[700]"
+      onClick={onClose}
+    >
+      <div
+        className="bg-white rounded-lg p-6 w-[480px] max-w-[95vw] max-h-[85vh] overflow-y-auto shadow-2xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h2 className="m-0 mb-4 text-lg font-bold text-gray-900">Change City</h2>
+
+        {!showNewCityForm ? (
+          <>
+            <input
+              className={inputClass}
+              placeholder="Search city name…"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              autoFocus
+            />
+
+            {searching && query.length >= 2 && (
+              <div className="py-2 text-xs text-gray-500">Searching…</div>
+            )}
+
+            {debouncedQuery.length >= 2 && (
+              <div className="border border-gray-200 rounded-md mt-2 overflow-hidden">
+                {searchResults.map((city) => (
+                  <div
+                    key={city.id}
+                    data-testid={`city-search-result-${city.id}`}
+                    className="px-3 py-2.5 cursor-pointer border-b border-gray-100 text-sm hover:bg-gray-50"
+                    onClick={() => {
+                      void handleSelectExistingCity(city);
+                    }}
+                  >
+                    {city.name}{' '}
+                    <span className="text-gray-500">— {formatCitySubtitle(city, countries)}</span>
+                  </div>
+                ))}
+                <div
+                  className="px-3 py-2.5 cursor-pointer text-sm text-teal-600 font-semibold hover:bg-teal-50 border-b border-gray-100 last:border-b-0"
+                  onClick={() => handleOpenNewCityForm(query)}
+                >
+                  + Add new: "{query}"
+                </div>
+              </div>
+            )}
+          </>
+        ) : (
+          <form
+            onSubmit={(e) => {
+              void handleCreateAndRepoint(e);
+            }}
+          >
+            <div className="mb-3.5">
+              <label className={labelClass}>City Name</label>
+              <input
+                className={inputClass}
+                value={newCityName}
+                onChange={(e) => setNewCityName(capitalizeFirst(e.target.value))}
+                required
+              />
+            </div>
+            <div className="mb-4">
+              <label className={labelClass}>
+                Country{' '}
+                {cityDisambig.pending && (
+                  <span className="font-normal text-gray-400 text-xs">detecting…</span>
+                )}
+              </label>
+              <select
+                className={inputClass}
+                value={newCityCountryCode}
+                onChange={(e) => {
+                  setNewCityCountryCode(e.target.value);
+                  setCountryIsSuggested(false);
+                  setNewCityRegionId(null);
+                  setRegionIsSuggested(false);
+                }}
+                required
+              >
+                <option value="">Select country…</option>
+                {countries.map((c) => (
+                  <option key={c.country_code} value={c.country_code}>
+                    {c.name}
+                  </option>
+                ))}
+              </select>
+              {countryIsSuggested && selectedCountry && (
+                <p className="mt-1 text-xs font-semibold text-gray-500">
+                  Suggested: {selectedCountry.name} — from "{newCityName}"
+                </p>
+              )}
+              {cityDisambig.failed && (
+                <div className="mt-2 px-2.5 py-2 bg-amber-50 border border-amber-200 rounded-md text-amber-800 text-xs flex items-center justify-between gap-2">
+                  <span>Automatic lookup failed — you can select country and region manually.</span>
+                  <button
+                    type="button"
+                    onClick={() => handleOpenNewCityForm(newCityName)}
+                    className="shrink-0 text-teal-700 font-semibold underline hover:text-teal-800 cursor-pointer"
+                  >
+                    Retry
+                  </button>
+                </div>
+              )}
+            </div>
+
+            {disambiguation.mode === 'picker' ? (
+              <div className="mb-4">
+                <label className={labelClass}>
+                  Multiple places match "{newCityName}"
+                  <span className="font-normal text-amber-600 text-xs">
+                    {' '}
+                    — please choose the one you mean
+                  </span>
+                </label>
+                <CityPicker
+                  candidates={disambiguation.candidates}
+                  onSelect={(candidate) => {
+                    void handleSelectPickerCandidate(candidate);
+                  }}
+                  truncated={cityDisambig.truncated}
+                  disabled={createCity.isPending || changeCity.isPending}
+                />
+              </div>
+            ) : (
+              showRegionDropdown && (
+                <div className="mb-4">
+                  <label className={labelClass}>
+                    {regionLabel} <span className="font-normal text-gray-500">(optional)</span>
+                    {disambiguation.mode === 'region' && (
+                      <span className="font-normal text-amber-600 text-xs">
+                        {' '}
+                        — multiple matches found, please choose
+                        {cityDisambig.truncated && ' (there may be more not shown)'}
+                      </span>
+                    )}
+                  </label>
+                  <select
+                    className={inputClass}
+                    value={newCityRegionId ?? ''}
+                    onChange={(e) => {
+                      setNewCityRegionId(e.target.value ? Number(e.target.value) : null);
+                      setRegionIsSuggested(false);
+                    }}
+                  >
+                    <option value="">No {regionLabel.toLowerCase()} selected</option>
+                    {(disambiguation.mode === 'region'
+                      ? countryRegions.filter((r) =>
+                          disambiguation.regionIsos.includes(r.iso_3166_2),
+                        )
+                      : countryRegions
+                    ).map((r) => (
+                      <option key={r.id} value={r.id}>
+                        {r.name}
+                      </option>
+                    ))}
+                  </select>
+                  {regionIsSuggested &&
+                    disambiguation.mode === 'suggested' &&
+                    suggestedRegionName && (
+                      <p className="mt-1 text-xs font-semibold text-gray-500">
+                        Suggested: {suggestedRegionName} — from "{newCityName}"
+                        {cityDisambig.truncated && ' (other matches may exist)'}
+                      </p>
+                    )}
+                </div>
+              )
+            )}
+
+            {mutationError && <ErrorMessage error={mutationError} />}
+            <div className="flex gap-2.5 mt-1">
+              <button
+                type="button"
+                onClick={() => setShowNewCityForm(false)}
+                className="px-3.5 py-2 border border-gray-300 rounded-md bg-white text-sm text-gray-700 hover:bg-gray-50 cursor-pointer"
+              >
+                Back
+              </button>
+              <button
+                type="submit"
+                disabled={createCity.isPending || changeCity.isPending}
+                className="px-4.5 py-2 bg-teal-600 text-white border-none rounded-md text-sm font-semibold hover:bg-teal-700 disabled:opacity-60 cursor-pointer"
+              >
+                {createCity.isPending || changeCity.isPending
+                  ? 'Saving…'
+                  : mutationError
+                    ? 'Retry'
+                    : 'Change City'}
+              </button>
+            </div>
+          </form>
+        )}
+
+        {mutationError && !showNewCityForm && <ErrorMessage error={mutationError} />}
+      </div>
+    </div>
+  );
+}

--- a/src/frontend/components/TripDetail/PlaceSection.tsx
+++ b/src/frontend/components/TripDetail/PlaceSection.tsx
@@ -32,6 +32,7 @@
  */
 import { useState } from 'react';
 import { Link } from 'react-router-dom';
+import { BADGE_HUE_CLASSES, BADGE_SHAPE_CLASSES, BADGE_TEXT_CLASSES } from '../../design/badges';
 import { useCountries } from '../../hooks/useAdmin';
 import {
   applyRatingSortFilter,
@@ -43,8 +44,10 @@ import type { Item, TripPlace } from '../../types/api';
 import { formatCitySubtitle } from '../../utils/formatCitySubtitle';
 import { formatDate } from '../../utils/formatDate';
 import { resolvePlaceDateRange } from '../../utils/resolvePlaceDateRange';
+import { EditIcon } from '../icons';
 import { ConfirmDialog } from '../shared/ConfirmDialog';
 import { RatingSortFilterControls } from '../shared/RatingSortFilterControls';
+import { ChangeCityModal } from './ChangeCityModal';
 import { ItemCard } from './ItemCard';
 import { ItemForm } from './ItemForm';
 import { PlaceDateForm } from './PlaceDateForm';
@@ -93,6 +96,8 @@ export function PlaceSection({
   const [editingItem, setEditingItem] = useState<Item | null>(null);
   const [showEditDates, setShowEditDates] = useState(false);
   const [showRemoveConfirm, setShowRemoveConfirm] = useState(false);
+  // UX-12/BUG-75 (design §8.1): standing correction entry point.
+  const [showChangeCity, setShowChangeCity] = useState(false);
   // IT-08: local, per-place — see module doc for why this is client state
   // rather than a query param.
   const [ratingSortFilter, setRatingSortFilter] = useState<RatingSortFilterState>(
@@ -183,6 +188,19 @@ export function PlaceSection({
             )}
           </p>
 
+          {/* UX-12/BUG-75 (design §8.3, AC-11): "Location not confirmed"
+              badge — shown whenever the city's geocode hasn't resolved,
+              regardless of isLocked (a passive discoverability signal for
+              the Change-city control, not a write action). Reuses the
+              existing `locked` hue — no new hue (UX spec §12.2 MVP). */}
+          {place.city.geocode_status !== 'resolved' && (
+            <span
+              className={`mt-1.5 inline-block whitespace-nowrap ${BADGE_HUE_CLASSES.locked.bg} ${BADGE_HUE_CLASSES.locked.text} ${BADGE_SHAPE_CLASSES.chip} ${BADGE_TEXT_CLASSES}`}
+            >
+              Location not confirmed
+            </span>
+          )}
+
           {/* Activity tags */}
           {place.activities.length > 0 && (
             <div className="mt-1.5 flex flex-wrap gap-1">
@@ -208,6 +226,23 @@ export function PlaceSection({
               title="Edit arrival / departure dates"
             >
               {hasExplicitDates ? 'Edit dates' : 'Set dates'}
+            </button>
+          )}
+
+          {/* UX-12/BUG-75 (design §8.1, AC-8): standing correction control —
+              visible on every unlocked place regardless of geocode_status
+              (the correction right is not conditional on location status);
+              hidden under the same isLocked rule as Remove. */}
+          {!isLocked && (
+            <button
+              type="button"
+              onClick={() => setShowChangeCity(true)}
+              aria-label="Change city"
+              className="font-ui text-xs rounded-wp px-2.5 py-1.5 bg-wp-bg-surface text-wp-ink border border-wp-border hover:bg-wp-bg-subtle cursor-pointer inline-flex items-center gap-1.5"
+              title="Change the city for this place"
+            >
+              <EditIcon size={12} />
+              Change city
             </button>
           )}
 
@@ -323,6 +358,15 @@ export function PlaceSection({
           cityName={place.city.name}
           citySubtitle={citySubtitle}
           onClose={() => setShowEditDates(false)}
+        />
+      )}
+
+      {/* UX-12/BUG-75: Change-city correction modal (design §8.2) */}
+      {showChangeCity && (
+        <ChangeCityModal
+          tripId={tripId}
+          placeId={place.id}
+          onClose={() => setShowChangeCity(false)}
         />
       )}
 

--- a/src/frontend/components/TripDetail/__tests__/AddPlaceFlow.bug71.test.tsx
+++ b/src/frontend/components/TripDetail/__tests__/AddPlaceFlow.bug71.test.tsx
@@ -176,7 +176,13 @@ describe('AddPlaceFlow — BUG-71 stopgap: single-candidate region auto-fill is 
       .closest('select') as HTMLSelectElement;
     await user.selectOptions(regionSelect, 'Missouri');
 
-    expect(screen.queryByText(/suggested:/i)).not.toBeInTheDocument();
+    // BUG-75/UX-12 build note: the country field now ALSO gets a "Suggested:"
+    // tentative caption (MAJOR-2, AC-13) — a broad /suggested:/i check would
+    // now false-positive on that unrelated caption. Narrowed to the region's
+    // own caption (the thing this test actually regresses on) — the assertion
+    // this test protects (explicit region pick clears the REGION suggestion)
+    // is unchanged.
+    expect(screen.queryByText(/suggested: virginia/i)).not.toBeInTheDocument();
     expect(regionSelect).toHaveValue('2');
   });
 
@@ -212,7 +218,11 @@ describe('AddPlaceFlow — BUG-71 stopgap: single-candidate region auto-fill is 
     await waitFor(() => {
       expect(screen.getByText(/multiple matches found, please choose/i)).toBeInTheDocument();
     });
-    expect(screen.queryByText(/suggested:/i)).not.toBeInTheDocument();
+    // BUG-75/UX-12 build note: narrowed to the region-specific captions (see
+    // the sibling narrowing above) — the country field's own tentative
+    // caption is a separate, unrelated mechanism (MAJOR-2, AC-13).
+    expect(screen.queryByText(/suggested: missouri/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/suggested: colorado/i)).not.toBeInTheDocument();
   });
 
   it('shows no "Suggested:" caption when the lookup legitimately finds nothing (zero candidates — unrelated to the suggestion mechanism)', async () => {

--- a/src/frontend/components/TripDetail/__tests__/AddPlaceFlow.bug78-79.test.tsx
+++ b/src/frontend/components/TripDetail/__tests__/AddPlaceFlow.bug78-79.test.tsx
@@ -250,7 +250,12 @@ describe('AddPlaceFlow — BUG-78 (bold Suggested caption) + BUG-79 (US region n
       .getByRole('option', { name: /no state selected/i })
       .closest('select') as HTMLSelectElement;
     expect(regionSelect).toHaveValue('');
-    expect(screen.queryByText(/suggested:/i)).not.toBeInTheDocument();
+    // BUG-75/UX-12 build note: narrowed to the region-specific captions — the
+    // country field now also gets its own, unrelated tentative caption
+    // (MAJOR-2, AC-13), which would false-positive a broad /suggested:/i check.
+    expect(screen.queryByText(/suggested: illinois/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/suggested: missouri/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/suggested: massachusetts/i)).not.toBeInTheDocument();
   });
 
   it('BUG-79 regression check: ambiguous UK case ("newport") behaves exactly as it did before this fix — England/Wales narrowing + hint, unaffected', async () => {

--- a/src/frontend/components/TripDetail/__tests__/AddPlaceFlow.picker-precedence.test.tsx
+++ b/src/frontend/components/TripDetail/__tests__/AddPlaceFlow.picker-precedence.test.tsx
@@ -1,0 +1,283 @@
+/**
+ * BUG-75 / UX-12 / GE-16 — picker-precedence, RENDERED COMPOSITION layer.
+ *
+ * ATDD-first RED acceptance tests (OP-35). These are the HEADLINE red gate: they
+ * fail on `main`'s region-first order for the RIGHT reason — the place-level
+ * picker never fires for a spanning-region name, so the region <select> pre-empts
+ * it and a specific town silently auto-resolves to the wrong pin.
+ *
+ * ── WHY THE SHIPPED SUITE STAYED GREEN (mock-fidelity, QUAL-22) ───────────────
+ * AddPlaceFlow.city-picker.test.tsx's fixture was SAME-REGION (both GB-ENG) — it
+ * omitted the GB-WLS Newport, so `sameCountryRegionIsos.length` was 1 and the
+ * spanning path was never exercised. This file's fixture SPANS GB-ENG + GB-WLS
+ * (real captured node 26700977, Wales) — see fixtures/newportGeocode.ts for the
+ * per-osm_id provenance. That is the difference that turns the test red.
+ *
+ * ── MOCK FIDELITY ─────────────────────────────────────────────────────────────
+ * The lookup double returns the EXACT shape of `lookupCityCountry`
+ * (useCities.ts:87-104): { countryCode, regionIso, candidates, failed, truncated }.
+ * The candidates carry osm_type/osm_id (the code's real disambiguation signal),
+ * and the spanning fixture includes Wales. A double that omitted osm_id or Wales
+ * would specify nothing — that was the original bug.
+ */
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Country, Region } from '../../../types/api';
+import { AddPlaceFlow } from '../AddPlaceFlow';
+import { singleRegionNoOsm, spanningRegionNewports } from './fixtures/newportGeocode';
+
+const mockLookupCityCountry = vi.fn();
+const mockCreateCity = vi.fn();
+
+// FIDELITY: mirror useCities' real export surface — lookupCityCountry is a plain
+// async function, the hooks return { mutateAsync/isPending/error }.
+vi.mock('../../../hooks/useCities', () => ({
+  lookupCityCountry: (cityName: string) => mockLookupCityCountry(cityName),
+  useCitySearch: () => ({ data: [], isLoading: false }),
+  useCreateCity: () => ({ mutateAsync: mockCreateCity, isPending: false, error: null }),
+  useCarryForwardCandidates: () => ({ data: [], isFetched: false }),
+}));
+
+vi.mock('../../../hooks/usePlaces', () => ({
+  useAddPlace: () => ({
+    mutateAsync: vi.fn().mockResolvedValue({ id: 1, warnings: [] }),
+    isPending: false,
+    error: null,
+  }),
+}));
+
+const gbCountry: Country = {
+  country_code: 'GB',
+  name: 'United Kingdom',
+  region_tier_enabled: true,
+  region_tier_label: 'Region',
+};
+
+const gbRegions: Region[] = [
+  {
+    id: 5,
+    country_code: 'GB',
+    name: 'England',
+    iso_3166_2: 'GB-ENG',
+    created_at: '',
+    updated_at: '',
+  },
+  {
+    id: 6,
+    country_code: 'GB',
+    name: 'Wales',
+    iso_3166_2: 'GB-WLS',
+    created_at: '',
+    updated_at: '',
+  },
+];
+
+vi.mock('../../../hooks/useAdmin', () => ({
+  useCountries: () => ({ data: [gbCountry] }),
+  useCountryRegions: () => ({ data: gbRegions }),
+}));
+
+async function openNewCityForm(user: ReturnType<typeof userEvent.setup>, cityName: string) {
+  const input = screen.getByPlaceholderText('Search city name…');
+  await user.type(input, cityName);
+  const addNew = await screen.findByText(`+ Add new: "${cityName}"`, {}, { timeout: 2000 });
+  await user.click(addNew);
+}
+
+function renderFlow() {
+  return render(
+    <AddPlaceFlow
+      tripId={1}
+      onClose={vi.fn()}
+      tripStartDate="2026-01-01"
+      tripEndDate="2026-01-10"
+      isFirstPlace={false}
+    />,
+  );
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// AC-1 — spanning-region (headline). RED on main: region-first fires the region
+// <select>, so the picker never renders these display_names.
+// ────────────────────────────────────────────────────────────────────────────
+describe('AC-1 spanning-region — the picker fires, the region <select> does NOT', () => {
+  beforeEach(() => {
+    mockLookupCityCountry.mockReset();
+    mockCreateCity.mockReset();
+    mockCreateCity.mockResolvedValue({
+      id: 99,
+      name: 'Newport',
+      country_code: 'GB',
+      region_id: 5,
+      geocode_status: 'pending',
+    });
+    mockLookupCityCountry.mockResolvedValue({
+      countryCode: 'GB',
+      regionIso: 'GB-ENG',
+      candidates: spanningRegionNewports(),
+      failed: false,
+      truncated: false,
+    });
+  });
+
+  it('presents all three spanning candidates by region-qualified display_name', async () => {
+    const user = userEvent.setup();
+    renderFlow();
+    await openNewCityForm(user, 'Newport');
+
+    expect(
+      await screen.findByText(/Newport, Isle of Wight/i, {}, { timeout: 2000 }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Newport, Telford and Wrekin/i)).toBeInTheDocument();
+    // The GB-WLS row the shipped fixture omitted — its presence is the whole point.
+    expect(screen.getByText(/Cymru \/ Wales/i)).toBeInTheDocument();
+  });
+
+  it('does NOT collapse to the region <select> — the region-ambiguity hint is absent', async () => {
+    const user = userEvent.setup();
+    renderFlow();
+    await openNewCityForm(user, 'Newport');
+
+    // Picker fired (place-level label), NOT the region branch's hint.
+    expect(
+      await screen.findByText(/Multiple places match/i, {}, { timeout: 2000 }),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/multiple matches found, please choose/i)).not.toBeInTheDocument();
+  });
+
+  it('selecting Newport (Isle of Wight) carries its osm identity and region_id from GB-ENG — never Wales', async () => {
+    const user = userEvent.setup();
+    renderFlow();
+    await openNewCityForm(user, 'Newport');
+
+    const iow = await screen.findByText(/Newport, Isle of Wight/i, {}, { timeout: 2000 });
+    await user.click(iow);
+
+    await waitFor(() => expect(mockCreateCity).toHaveBeenCalled());
+    const body = mockCreateCity.mock.calls[0][0];
+    expect(body).toMatchObject({
+      name: 'Newport',
+      country_code: 'GB',
+      osm_type: 'node',
+      osm_id: 26700978,
+      display_name: 'Newport, Isle of Wight, England, PO30 1JU, UK',
+      region_id: 5, // GB-ENG => id 5
+    });
+    // Must never carry the Wales region_id (6) for an England pick.
+    expect(body.region_id).not.toBe(6);
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// AC-7 — truncation caveat rides on the PICKER (BUG-79). RED on main: for a
+// spanning lookup the picker never renders, so the caveat only ever appears on
+// the region-select branch.
+// ────────────────────────────────────────────────────────────────────────────
+describe('AC-7 truncation caveat on the picker (spanning lookup)', () => {
+  beforeEach(() => {
+    mockLookupCityCountry.mockReset();
+    mockCreateCity.mockReset();
+    mockLookupCityCountry.mockResolvedValue({
+      countryCode: 'GB',
+      regionIso: 'GB-ENG',
+      candidates: spanningRegionNewports(),
+      failed: false,
+      truncated: true,
+    });
+  });
+
+  it('a truncated spanning lookup shows the "more matches not shown" caveat on the picker', async () => {
+    const user = userEvent.setup();
+    renderFlow();
+    await openNewCityForm(user, 'Newport');
+
+    // Anti-vacuous guard: require the picker's candidates first, so the caveat
+    // can only be the picker's, not the legacy region-suggestion caption.
+    expect(
+      await screen.findByText(/Newport, Isle of Wight/i, {}, { timeout: 2000 }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Cymru \/ Wales/i)).toBeInTheDocument();
+    await waitFor(() =>
+      expect(
+        screen.getByText(/there may be more|other matches may exist|not shown/i),
+      ).toBeInTheDocument(),
+    );
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// AC-13 (MAJOR-2) — country is never silently auto-committed. RED on main:
+// AddPlaceFlow.tsx:360 does `if (countryCode) setNewCityCountryCode(countryCode)`
+// with NO visible tentative state; only the region ever gets a "Suggested:"
+// caption. UX spec §3.2 requires the country to be a visibly tentative
+// suggestion (e.g. `Suggested: United Kingdom — from "Newport"`).
+// ────────────────────────────────────────────────────────────────────────────
+describe('AC-13 country presented as a tentative suggestion, not silently committed', () => {
+  beforeEach(() => {
+    mockLookupCityCountry.mockReset();
+    mockCreateCity.mockReset();
+    mockLookupCityCountry.mockResolvedValue({
+      countryCode: 'GB',
+      regionIso: 'GB-ENG',
+      candidates: singleRegionNoOsm(),
+      failed: false,
+      truncated: false,
+    });
+  });
+
+  it('shows a visible tentative "Suggested:" state for the auto-detected country', async () => {
+    const user = userEvent.setup();
+    renderFlow();
+    await openNewCityForm(user, 'Newport');
+
+    // Country-specific tentative caption (mirrors the region's BUG-71 treatment).
+    // "United Kingdom" is the country name, distinct from the region's
+    // "Suggested: England ..." — so this cannot false-match the region caption.
+    expect(
+      await screen.findByText(/Suggested: United Kingdom/i, {}, { timeout: 2000 }),
+    ).toBeInTheDocument();
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// AC-14 (MAJOR-2) — creation-time messaging (UX spec §3.4 / §12.2 item 4). RED
+// on main: after a successful non-resolved create the modal just closes / shows
+// warnings; there is no status-conditional guidance line.
+// ────────────────────────────────────────────────────────────────────────────
+describe('AC-14 creation-time messaging keyed on geocode_status', () => {
+  beforeEach(() => {
+    mockLookupCityCountry.mockReset();
+    mockCreateCity.mockReset();
+    mockLookupCityCountry.mockResolvedValue({
+      countryCode: 'GB',
+      regionIso: 'GB-ENG',
+      candidates: singleRegionNoOsm(),
+      failed: false,
+      truncated: false,
+    });
+  });
+
+  it('a created "pending" city shows the §3.4 pending guidance line', async () => {
+    mockCreateCity.mockResolvedValue({
+      id: 99,
+      name: 'Newport',
+      country_code: 'GB',
+      region_id: 5,
+      geocode_status: 'pending',
+    });
+    const user = userEvent.setup();
+    renderFlow();
+    await openNewCityForm(user, 'Newport');
+
+    // Wait for the auto-filled country so the create submits cleanly.
+    await screen.findByText(/Suggested: United Kingdom|United Kingdom/i, {}, { timeout: 2000 });
+    const submit = screen.getByRole('button', { name: /Add City & Place/i });
+    await user.click(submit);
+
+    // UX spec §3.4 pending copy — verbatim DoD.
+    expect(
+      await screen.findByText(/still confirming this location/i, {}, { timeout: 2000 }),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/frontend/components/TripDetail/__tests__/AddPlaceFlow.picker-precedence.test.tsx
+++ b/src/frontend/components/TripDetail/__tests__/AddPlaceFlow.picker-precedence.test.tsx
@@ -271,7 +271,15 @@ describe('AC-14 creation-time messaging keyed on geocode_status', () => {
     await openNewCityForm(user, 'Newport');
 
     // Wait for the auto-filled country so the create submits cleanly.
-    await screen.findByText(/Suggested: United Kingdom|United Kingdom/i, {}, { timeout: 2000 });
+    // NOTE (Frontend, BUG-75/UX-12 build): narrowed from the original
+    // `/Suggested: United Kingdom|United Kingdom/i` alternation — now that
+    // AC-13 is implemented, the plain "United Kingdom" alternate is also
+    // matched by the country <option> element that's in the DOM from the
+    // moment the form opens (independent of the lookup completing), and once
+    // the AC-13 caption renders too, `findByText` throws "found multiple
+    // elements" instead of waiting. The caption text is the more precise
+    // condition this line always intended to wait for; no other change.
+    await screen.findByText(/Suggested: United Kingdom/i, {}, { timeout: 2000 });
     const submit = screen.getByRole('button', { name: /Add City & Place/i });
     await user.click(submit);
 

--- a/src/frontend/components/TripDetail/__tests__/ChangeCityModal.test.tsx
+++ b/src/frontend/components/TripDetail/__tests__/ChangeCityModal.test.tsx
@@ -1,0 +1,197 @@
+/**
+ * UX-12 / BUG-75 — the "Change city" re-point modal, RENDERED layer.
+ *
+ * ATDD-first RED acceptance tests (OP-35). RED now because ChangeCityModal does
+ * not exist on `main` (confirmed: grep for "ChangeCityModal" across src/frontend
+ * turns up only CityPicker.tsx's doc comment; no component).
+ *
+ * ── CONTRACT FRONTEND MUST BUILD (design §8.2, review MAJOR-1, UX spec §12.1) ──
+ * Frontend must create:
+ *
+ *   src/frontend/components/TripDetail/ChangeCityModal.tsx
+ *   export function ChangeCityModal(props: {
+ *     tripId: number;
+ *     placeId: number;
+ *     onClose: () => void;
+ *   }): JSX.Element;
+ *
+ * It reuses the EXTRACTED search step (city search + new-city name/country/region
+ * form) — same "Search city name…" input and `+ Add new: "…"` affordance as
+ * AddPlace, minus the date/carry-forward chrome (UX spec §12.1) — and consumes
+ * the SHARED precedence unit (decideCityDisambiguation) and the SHARED identity
+ * carry (buildCreateCityDataFromCandidate), so its disambiguation is byte-identical
+ * to AddPlace (AC-9). On select/create it re-points via the D11 PATCH:
+ *
+ *   useChangeCity() -> mutateAsync({ tripId, placeId, cityId })
+ *     => PATCH /api/trips/:tripId/places/:placeId  { city_id }
+ *
+ * `useChangeCity` is the specified re-point seam — a thin sibling of
+ * useUpdatePlaceDates (usePlaces.ts:101) issuing the same PATCH with `city_id`.
+ * (If Frontend instead extends useUpdatePlaceDates to take an optional cityId,
+ * retarget this mock accordingly — the observable contract, a PATCH with city_id,
+ * is what AC-10 pins.)
+ */
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Country, Region } from '../../../types/api';
+// RED: this component does not exist on `main`. Frontend creates it (see header).
+import { ChangeCityModal } from '../ChangeCityModal';
+import { spanningRegionNewports } from './fixtures/newportGeocode';
+
+const mockLookupCityCountry = vi.fn();
+const mockCreateCity = vi.fn();
+const mockChangeCity = vi.fn();
+
+vi.mock('../../../hooks/useCities', () => ({
+  lookupCityCountry: (cityName: string) => mockLookupCityCountry(cityName),
+  useCitySearch: () => ({ data: [], isLoading: false }),
+  useCreateCity: () => ({ mutateAsync: mockCreateCity, isPending: false, error: null }),
+  useCarryForwardCandidates: () => ({ data: [], isFetched: false }),
+}));
+
+vi.mock('../../../hooks/usePlaces', () => ({
+  // The re-point seam (see header). Called with { tripId, placeId, cityId }.
+  useChangeCity: () => ({ mutateAsync: mockChangeCity, isPending: false, error: null }),
+  useUpdatePlaceDates: () => ({ mutateAsync: vi.fn(), isPending: false, error: null }),
+  useAddPlace: () => ({ mutateAsync: vi.fn(), isPending: false, error: null }),
+}));
+
+const gbCountry: Country = {
+  country_code: 'GB',
+  name: 'United Kingdom',
+  region_tier_enabled: true,
+  region_tier_label: 'Region',
+};
+const gbRegions: Region[] = [
+  {
+    id: 5,
+    country_code: 'GB',
+    name: 'England',
+    iso_3166_2: 'GB-ENG',
+    created_at: '',
+    updated_at: '',
+  },
+  {
+    id: 6,
+    country_code: 'GB',
+    name: 'Wales',
+    iso_3166_2: 'GB-WLS',
+    created_at: '',
+    updated_at: '',
+  },
+];
+
+vi.mock('../../../hooks/useAdmin', () => ({
+  useCountries: () => ({ data: [gbCountry] }),
+  useCountryRegions: () => ({ data: gbRegions }),
+}));
+
+function renderModal() {
+  return render(
+    <MemoryRouter>
+      <ChangeCityModal tripId={1} placeId={7} onClose={vi.fn()} />
+    </MemoryRouter>,
+  );
+}
+
+async function openNewCityForm(user: ReturnType<typeof userEvent.setup>, cityName: string) {
+  const input = screen.getByPlaceholderText('Search city name…');
+  await user.type(input, cityName);
+  const addNew = await screen.findByText(`+ Add new: "${cityName}"`, {}, { timeout: 2000 });
+  await user.click(addNew);
+}
+
+beforeEach(() => {
+  mockLookupCityCountry.mockReset();
+  mockCreateCity.mockReset();
+  mockChangeCity.mockReset();
+  mockCreateCity.mockResolvedValue({
+    id: 99,
+    name: 'Newport',
+    country_code: 'GB',
+    region_id: 5,
+    geocode_status: 'pending',
+  });
+  mockChangeCity.mockResolvedValue({ id: 7 });
+  mockLookupCityCountry.mockResolvedValue({
+    countryCode: 'GB',
+    regionIso: 'GB-ENG',
+    candidates: spanningRegionNewports(),
+    failed: false,
+    truncated: false,
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// AC-9 — shared precedence (no drift): the SAME spanning scenario fires the
+// picker here exactly as it does in AddPlace.
+// ────────────────────────────────────────────────────────────────────────────
+describe('AC-9 shared precedence — spanning-region fires the picker in Change-city too', () => {
+  it('presents all spanning candidates by display_name, not a region <select>', async () => {
+    const user = userEvent.setup();
+    renderModal();
+    await openNewCityForm(user, 'Newport');
+
+    expect(
+      await screen.findByText(/Newport, Isle of Wight/i, {}, { timeout: 2000 }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Newport, Telford and Wrekin/i)).toBeInTheDocument();
+    expect(screen.getByText(/Cymru \/ Wales/i)).toBeInTheDocument();
+    expect(screen.queryByText(/multiple matches found, please choose/i)).not.toBeInTheDocument();
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// AC-10 — re-point preserves data (D11): select/create -> PATCH …/places/:id
+// with city_id. Backend already asserts items/tags survive (place-repoint.test.ts);
+// this is the frontend wiring.
+// ────────────────────────────────────────────────────────────────────────────
+describe('AC-10 re-point wiring — selecting a candidate PATCHes the place with the new city_id', () => {
+  it('routes the resolved city_id through the D11 re-point mutation for this placeId', async () => {
+    const user = userEvent.setup();
+    renderModal();
+    await openNewCityForm(user, 'Newport');
+
+    const iow = await screen.findByText(/Newport, Isle of Wight/i, {}, { timeout: 2000 });
+    await user.click(iow);
+
+    // The chosen candidate is created/resolved to a city_id, then the place is
+    // re-pointed — NOT a new place created (this is a correction, D11).
+    await waitFor(() => expect(mockChangeCity).toHaveBeenCalled());
+    expect(mockChangeCity.mock.calls[0][0]).toMatchObject({
+      tripId: 1,
+      placeId: 7,
+      cityId: 99,
+    });
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// AC-12 (MAJOR-1) — anti-drift: the identity carry is byte-identical across the
+// two flows. Selecting the same candidate here carries the same osm identity and
+// region_id AddPlace carries (asserted in AddPlaceFlow.picker-precedence AC-1).
+// A fork in ChangeCityModal that dropped osm_id or derived a stale region_id
+// would fail here.
+// ────────────────────────────────────────────────────────────────────────────
+describe('AC-12 identity carry does not fork in Change-city', () => {
+  it('carries osm_type/osm_id/display_name + region_id from the pick into createCity, same as AddPlace', async () => {
+    const user = userEvent.setup();
+    renderModal();
+    await openNewCityForm(user, 'Newport');
+
+    const iow = await screen.findByText(/Newport, Isle of Wight/i, {}, { timeout: 2000 });
+    await user.click(iow);
+
+    await waitFor(() => expect(mockCreateCity).toHaveBeenCalled());
+    expect(mockCreateCity.mock.calls[0][0]).toMatchObject({
+      name: 'Newport',
+      country_code: 'GB',
+      osm_type: 'node',
+      osm_id: 26700978,
+      display_name: 'Newport, Isle of Wight, England, PO30 1JU, UK',
+      region_id: 5,
+    });
+  });
+});

--- a/src/frontend/components/TripDetail/__tests__/PlaceSection.change-city.test.tsx
+++ b/src/frontend/components/TripDetail/__tests__/PlaceSection.change-city.test.tsx
@@ -110,14 +110,17 @@ describe('AC-11 "Location not confirmed" badge', () => {
     expect(screen.getAllByText(/Location not confirmed/i)).toHaveLength(1);
   });
 
-  it('shows the badge for a failed (terminal) place', () => {
-    // NOTE: the frontend GeocodeStatus type is 'pending' | 'resolved' | 'failed',
-    // while the backend DB CHECK uses 'unresolvable' for the terminal state — a
-    // real type/enum mismatch flagged to COO. The badge rule is `!== 'resolved'`,
-    // so it fires for any non-resolved value regardless; 'failed' is used here to
-    // stay valid under the frontend type.
+  it('shows the badge for an unresolvable (terminal) place', () => {
+    // NOTE (Frontend, BUG-75/UX-12 build): the frontend GeocodeStatus type has
+    // been corrected to 'pending' | 'resolved' | 'unresolvable', matching the
+    // backend DB CHECK exactly (see types/api.ts) — QA's original comment here
+    // flagged the mismatch and used 'failed' to stay type-valid under the
+    // then-current (wrong) frontend type; now that the type is fixed, this
+    // literal is updated to the real terminal value so the file still
+    // type-checks. The assertion itself (badge fires for any non-resolved
+    // status) is unchanged.
     renderPlaceSection(
-      <PlaceSection place={makePlace('failed')} isLocked={false} {...defaultProps} />,
+      <PlaceSection place={makePlace('unresolvable')} isLocked={false} {...defaultProps} />,
     );
     expect(screen.getByText(/Location not confirmed/i)).toBeInTheDocument();
   });

--- a/src/frontend/components/TripDetail/__tests__/PlaceSection.change-city.test.tsx
+++ b/src/frontend/components/TripDetail/__tests__/PlaceSection.change-city.test.tsx
@@ -1,0 +1,131 @@
+/**
+ * UX-12 — the standing "Change city" control + "Location not confirmed" badge on
+ * PlaceSection. ATDD-first RED acceptance tests (OP-35).
+ *
+ * RED now: no "Change city" control and no "Location not confirmed" badge exist
+ * anywhere in the frontend (confirmed by grep across src/frontend + reading
+ * PlaceSection.tsx — the header row carries only Set/Edit dates, Add Item, Remove).
+ *
+ * ── CONTRACT (design §8.1/§8.3, UX spec §12.2) ────────────────────────────────
+ * AC-8  A "Change city" control (aria-label "Change city", pencil glyph) is shown
+ *       on every UNLOCKED place REGARDLESS of geocode_status; hidden under the
+ *       SAME isLocked rule as Remove.
+ * AC-11 A single "Location not confirmed" badge shows whenever
+ *       place.city.geocode_status !== 'resolved' (existing `locked` hue, NO new
+ *       hue); a `resolved` place shows none.
+ */
+import { render, screen } from '@testing-library/react';
+import type { ReactElement } from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { GeocodeStatus, Item, TripPlace } from '../../../types/api';
+import { PlaceSection } from '../PlaceSection';
+
+function renderPlaceSection(ui: ReactElement) {
+  return render(<MemoryRouter>{ui}</MemoryRouter>);
+}
+
+vi.mock('../../../hooks/usePlaces', () => ({
+  useRemovePlace: () => ({ mutate: vi.fn(), isPending: false, error: null, reset: vi.fn() }),
+  // Safe stubs for the re-point seam a Change-city build may reference.
+  useChangeCity: () => ({ mutateAsync: vi.fn(), isPending: false, error: null }),
+  useUpdatePlaceDates: () => ({ mutateAsync: vi.fn(), isPending: false, error: null }),
+}));
+
+vi.mock('../../../hooks/useAdmin', () => ({
+  useCountries: () => ({ data: [] }),
+}));
+
+vi.mock('../../../hooks/useItems', async () => {
+  const actual =
+    await vi.importActual<typeof import('../../../hooks/useItems')>('../../../hooks/useItems');
+  return {
+    ...actual,
+    useDeleteItem: () => ({ mutateAsync: vi.fn(), isPending: false, error: null }),
+  };
+});
+
+function makePlace(geocodeStatus: GeocodeStatus, overrides: Partial<TripPlace> = {}): TripPlace {
+  return {
+    id: 1,
+    city_id: 5,
+    activities: [],
+    city: {
+      id: 5,
+      name: 'Newport',
+      country_code: 'GB',
+      country_name: 'United Kingdom',
+      region_id: null,
+      region_iso: null,
+      latitude: null,
+      longitude: null,
+      geocode_status: geocodeStatus,
+    },
+    items: [] as Item[],
+    created_at: '2024-01-01T00:00:00Z',
+    ...overrides,
+  } as TripPlace;
+}
+
+const defaultProps = { tripId: 10, tripStartDate: '2024-04-01', tripEndDate: '2024-04-14' };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// AC-8 — standing "Change city" control
+// ────────────────────────────────────────────────────────────────────────────
+describe('AC-8 "Change city" control', () => {
+  it('renders on an UNLOCKED, resolved place (correction right is not conditional on status)', () => {
+    renderPlaceSection(
+      <PlaceSection place={makePlace('resolved')} isLocked={false} {...defaultProps} />,
+    );
+    expect(screen.getByRole('button', { name: /change city/i })).toBeInTheDocument();
+  });
+
+  it('renders on an UNLOCKED, pending place too', () => {
+    renderPlaceSection(
+      <PlaceSection place={makePlace('pending')} isLocked={false} {...defaultProps} />,
+    );
+    expect(screen.getByRole('button', { name: /change city/i })).toBeInTheDocument();
+  });
+
+  it('is hidden when the trip is locked — same rule as Remove', () => {
+    renderPlaceSection(
+      <PlaceSection place={makePlace('pending')} isLocked={true} {...defaultProps} />,
+    );
+    expect(screen.queryByRole('button', { name: /change city/i })).not.toBeInTheDocument();
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// AC-11 — "Location not confirmed" badge
+// ────────────────────────────────────────────────────────────────────────────
+describe('AC-11 "Location not confirmed" badge', () => {
+  it('shows exactly one badge when geocode_status is not resolved (pending)', () => {
+    renderPlaceSection(
+      <PlaceSection place={makePlace('pending')} isLocked={false} {...defaultProps} />,
+    );
+    expect(screen.getAllByText(/Location not confirmed/i)).toHaveLength(1);
+  });
+
+  it('shows the badge for a failed (terminal) place', () => {
+    // NOTE: the frontend GeocodeStatus type is 'pending' | 'resolved' | 'failed',
+    // while the backend DB CHECK uses 'unresolvable' for the terminal state — a
+    // real type/enum mismatch flagged to COO. The badge rule is `!== 'resolved'`,
+    // so it fires for any non-resolved value regardless; 'failed' is used here to
+    // stay valid under the frontend type.
+    renderPlaceSection(
+      <PlaceSection place={makePlace('failed')} isLocked={false} {...defaultProps} />,
+    );
+    expect(screen.getByText(/Location not confirmed/i)).toBeInTheDocument();
+  });
+
+  it('shows NO badge for a resolved place', () => {
+    renderPlaceSection(
+      <PlaceSection place={makePlace('resolved')} isLocked={false} {...defaultProps} />,
+    );
+    expect(screen.queryByText(/Location not confirmed/i)).not.toBeInTheDocument();
+  });
+});

--- a/src/frontend/components/TripDetail/__tests__/fixtures/newportGeocode.ts
+++ b/src/frontend/components/TripDetail/__tests__/fixtures/newportGeocode.ts
@@ -1,0 +1,145 @@
+/**
+ * BUG-75 / UX-12 — shared geocode fixtures for the picker-precedence ATDD suite.
+ *
+ * ── PROVENANCE (mock-fidelity, QUAL-22 + this bug's own cause) ────────────────
+ * The shipped all-green suite hid the headline defect because
+ * AddPlaceFlow.city-picker.test.tsx's four-Newport fixture was SAME-REGION — it
+ * omitted Wales, so `sameCountryRegionIsos.length` was 1 and the spanning-region
+ * path (region-first pre-empts the picker) was never exercised. These fixtures
+ * exist to express the spanning-region reality the old one could not.
+ *
+ * Every osm_id below is REAL captured Nominatim data — none are invented:
+ *   • node 26700978  GB-ENG  Newport, Isle of Wight        — captured, already in
+ *     cities.identity-carry.test.ts:149 and AddPlaceFlow.city-picker.test.tsx.
+ *   • node 27459103  GB-ENG  Newport, Telford and Wrekin   — captured, design §5.2
+ *     verbatim (`node 27459103 | county=Telford and Wrekin | GB-ENG`) and
+ *     cities.identity-carry.test.ts:159.
+ *   • node 26700977  GB-WLS  Newport (city), Cymru / Wales  — captured, design §5.2
+ *     verbatim (`node 26700977 | county=Newport | GB-WLS | "Newport, Cymru /
+ *     Wales, NP20 1GF, …"`) and referenced in cities.identity-carry.test.ts:54
+ *     as the type-prefixed id 'N26700977'. THIS is the row the shipped fixture
+ *     omitted; adding it is what makes AC-1 span GB-ENG + GB-WLS.
+ *
+ * LOAD-BEARING vs FILLER: the assertions in the suite depend ONLY on
+ * `osm_type`, `osm_id`, `region_iso`, `country_code`, and the region-qualifying
+ * token inside `display_name` (all captured above). `latitude`/`longitude` are
+ * required by the GeocodeCandidate type but are NEVER asserted — they are
+ * plausible real coordinates included only to satisfy the type, marked here so
+ * a reader knows they are not the captured, load-bearing part. The Wales
+ * display_name tail (`, UK`) matches the sibling captured rows' format; its
+ * captured, load-bearing discriminator is `Cymru / Wales`.
+ */
+import type { GeocodeCandidate } from '../../../../types/api';
+
+/** Candidate carrying a guaranteed (osm_type, osm_id) — a real place identity. */
+export type PickCandidate = GeocodeCandidate & {
+  osm_type: 'node' | 'way' | 'relation';
+  osm_id: number;
+};
+
+/** GB-ENG — Newport, Isle of Wight (captured node 26700978). */
+export const NEWPORT_IOW: PickCandidate = {
+  name: 'Newport',
+  display_name: 'Newport, Isle of Wight, England, PO30 1JU, UK',
+  country_code: 'GB',
+  region_iso: 'GB-ENG',
+  latitude: 50.7, // filler — not asserted
+  longitude: -1.29, // filler — not asserted
+  osm_type: 'node',
+  osm_id: 26700978,
+};
+
+/** GB-ENG — Newport, Telford and Wrekin (captured node 27459103). */
+export const NEWPORT_TELFORD: PickCandidate = {
+  name: 'Newport',
+  display_name: 'Newport, Telford and Wrekin, England, TF10 7AG, UK',
+  country_code: 'GB',
+  region_iso: 'GB-ENG',
+  latitude: 52.77, // filler — not asserted
+  longitude: -2.38, // filler — not asserted
+  osm_type: 'node',
+  osm_id: 27459103,
+};
+
+/** GB-WLS — Newport (city), Wales (captured node 26700977). The row the shipped
+ *  fixture omitted; its presence is what makes the set span two regions. */
+export const NEWPORT_WALES: PickCandidate = {
+  name: 'Newport',
+  display_name: 'Newport, Cymru / Wales, NP20 1GF, UK',
+  country_code: 'GB',
+  region_iso: 'GB-WLS',
+  latitude: 51.588, // filler — not asserted
+  longitude: -2.997, // filler — not asserted
+  osm_type: 'node',
+  osm_id: 26700977,
+};
+
+/** AC-1 headline set: spanning GB-ENG + GB-WLS, three distinct osm_id. */
+export function spanningRegionNewports(): PickCandidate[] {
+  return [NEWPORT_IOW, NEWPORT_TELFORD, NEWPORT_WALES];
+}
+
+/** AC-2 set: two Newports, both GB-ENG, distinct osm_id — region-only narrowing
+ *  cannot separate them. */
+export function sameRegionNewports(): PickCandidate[] {
+  return [NEWPORT_IOW, NEWPORT_TELFORD];
+}
+
+/**
+ * AC-4 F1/F2 parity: two Nominatim rows for the SAME real place at different
+ * granularities carry NO osm_id (that fixture family's design, ADL-46 F1/F2) and
+ * span two regions — must resolve to the region <select> fallback, never the
+ * picker. Shape mirrors AddPlaceFlow.test.tsx's parity fixtures (no osm fields).
+ */
+export function multiRegionNoOsm(): GeocodeCandidate[] {
+  return [
+    {
+      name: 'Springfield',
+      display_name: 'Springfield, Illinois, United States',
+      country_code: 'US',
+      region_iso: 'US-IL',
+      latitude: 39.8, // filler — not asserted
+      longitude: -89.6, // filler — not asserted
+    },
+    {
+      name: 'Springfield',
+      display_name: 'Springfield, Missouri, United States',
+      country_code: 'US',
+      region_iso: 'US-MO',
+      latitude: 37.2, // filler — not asserted
+      longitude: -93.3, // filler — not asserted
+    },
+  ];
+}
+
+/** AC-4 F1/F2 parity, single-region no-osm variant → tentative "suggested". */
+export function singleRegionNoOsm(): GeocodeCandidate[] {
+  return [
+    {
+      name: 'Newport',
+      display_name: 'Newport, England, United Kingdom',
+      country_code: 'GB',
+      region_iso: 'GB-ENG',
+      latitude: 50.7, // filler — not asserted
+      longitude: -1.29, // filler — not asserted
+    },
+  ];
+}
+
+/** AC-5 single unambiguous (Denver): one real place, one region. Even carrying an
+ *  osm_id, a single distinct identity must NOT fire the picker — it is a tentative
+ *  suggestion (BUG-71). */
+export function singleUnambiguousDenver(): PickCandidate[] {
+  return [
+    {
+      name: 'Denver',
+      display_name: 'Denver, Colorado, United States',
+      country_code: 'US',
+      region_iso: 'US-CO',
+      latitude: 39.74, // filler — not asserted
+      longitude: -104.99, // filler — not asserted
+      osm_type: 'relation',
+      osm_id: 253750,
+    },
+  ];
+}

--- a/src/frontend/hooks/useCityDisambiguation.ts
+++ b/src/frontend/hooks/useCityDisambiguation.ts
@@ -1,0 +1,82 @@
+/**
+ * BUG-75 / UX-12 (design §9) — the shared lookup + precedence-decision seam.
+ *
+ * Owns the geocode lookup call (`lookupCityCountry`) and runs its result
+ * through `decideCityDisambiguation` (the single source of truth for
+ * picker-vs-region precedence, `utils/decideCityDisambiguation.ts`) so the
+ * decision itself cannot fork between call sites. Consumed by
+ * `ChangeCityModal` directly; `AddPlaceFlow` calls the same two pure
+ * functions (`decideCityDisambiguation` / `buildCreateCityDataFromCandidate`)
+ * inline within its own existing lookup effect rather than adopting this
+ * hook wrapper — a deliberate choice to avoid restructuring a
+ * heavily-regression-tested file's promise/effect timing (six BUG-specific
+ * suites: BUG-71/72/73/78/79, F1/F2 parity) for a change whose actual
+ * drift-risk (the decision + identity-carry LOGIC) is already eliminated by
+ * both flows calling the identical pure functions. See the Frontend
+ * completion report for the full reasoning.
+ *
+ * Does NOT own the candidate→city identity carry (that is
+ * `buildCreateCityDataFromCandidate`, a separate plain utility both flows
+ * call directly against their own `useCreateCity()` — review MAJOR-1) — this
+ * hook is lookup + decision only.
+ */
+import { useState } from 'react';
+import {
+  type CityDisambiguation,
+  decideCityDisambiguation,
+} from '../utils/decideCityDisambiguation';
+import { lookupCityCountry } from './useCities';
+
+export interface CityLookupState {
+  disambiguation: CityDisambiguation;
+  countryCode: string | null;
+  truncated: boolean;
+  /** True only when retries were exhausted without a successful response (BUG-73 contract). */
+  failed: boolean;
+  pending: boolean;
+}
+
+const IDLE_STATE: CityLookupState = {
+  disambiguation: { mode: 'none' },
+  countryCode: null,
+  truncated: false,
+  failed: false,
+  pending: false,
+};
+
+export function useCityDisambiguation() {
+  const [state, setState] = useState<CityLookupState>(IDLE_STATE);
+
+  /** Fires the geocode lookup for `cityName` and updates disambiguation state
+   *  once it resolves. A name under 2 characters resets to idle (mirrors
+   *  AddPlaceFlow's own `cityName.trim().length >= 2` gate). */
+  const runLookup = (cityName: string) => {
+    if (cityName.trim().length < 2) {
+      setState(IDLE_STATE);
+      return;
+    }
+    setState((s) => ({ ...s, pending: true, failed: false }));
+    lookupCityCountry(cityName.trim())
+      .then(({ countryCode, regionIso, candidates, failed, truncated }) => {
+        if (failed) {
+          setState({ ...IDLE_STATE, failed: true });
+          return;
+        }
+        const candidatesForCountry = countryCode
+          ? candidates.filter((c) => c.country_code === countryCode)
+          : [];
+        setState({
+          disambiguation: decideCityDisambiguation(candidatesForCountry, regionIso),
+          countryCode,
+          truncated,
+          failed: false,
+          pending: false,
+        });
+      })
+      .catch(() => setState({ ...IDLE_STATE, failed: true }));
+  };
+
+  const reset = () => setState(IDLE_STATE);
+
+  return { ...state, runLookup, reset };
+}

--- a/src/frontend/hooks/usePlaces.ts
+++ b/src/frontend/hooks/usePlaces.ts
@@ -123,6 +123,42 @@ export function useUpdatePlaceDates() {
 }
 
 /**
+ * Re-points a place to a corrected city via PATCH /api/trips/:tripId/places/:placeId
+ * (ADL-46 D11, city_id-only). UX-12's "Change city" correction path — a thin
+ * sibling of `useUpdatePlaceDates` issuing the same PATCH endpoint with only
+ * `city_id` in the body (items, notes, and activity tags are preserved
+ * server-side; already asserted by `place-repoint.test.ts`). Kept as a
+ * separate hook rather than overloading `useUpdatePlaceDates` with an
+ * optional `cityId` param — the two write intents (editing dates vs.
+ * correcting the city) are distinct call sites (`PlaceDateForm` vs.
+ * `ChangeCityModal`) and this keeps each hook's argument list to what its
+ * caller actually has in hand.
+ *
+ * @returns useMutation result. Call mutateAsync({ tripId, placeId, cityId }).
+ */
+export function useChangeCity() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      tripId,
+      placeId,
+      cityId,
+    }: {
+      tripId: number;
+      placeId: number;
+      cityId: number;
+    }) =>
+      apiPatch<UpdatePlaceDatesResult>(`/api/trips/${tripId}/places/${placeId}`, {
+        city_id: cityId,
+      }),
+    onSuccess: (_result, vars) => {
+      void qc.invalidateQueries({ queryKey: ['trips', vars.tripId] });
+      void qc.invalidateQueries({ queryKey: ['map', 'shading'] });
+    },
+  });
+}
+
+/**
  * Executes the carry-forward action for a place (AC-17, IT-07).
  * POST /api/trips/:tripId/places/:placeId/carry-forward
  *

--- a/src/frontend/types/api.ts
+++ b/src/frontend/types/api.ts
@@ -19,7 +19,18 @@ export type ItemType = 'restaurant' | 'hotel' | 'flight' | 'car_rental' | 'exper
 
 export type ItemStatus = 'consider' | 'confirmed' | 'completed' | 'cancelled' | 'next_time';
 
-export type GeocodeStatus = 'pending' | 'resolved' | 'failed';
+/**
+ * BUG-75/UX-12 build (COO-approved type-truth fix): aligned to the backend's
+ * actual CHECK constraint (`src/backend/db/schema.ts:144` —
+ * `chk_cities_geocode_status`, `IN ('pending', 'resolved', 'unresolvable')`).
+ * Previously said `'failed'`, a value the backend never sends — verified with
+ * two probes (grep across src/frontend for a `'failed'` literal compared
+ * against this type: none outside this declaration and one now-corrected test
+ * fixture; read of the backend CHECK constraint itself) that no frontend logic
+ * compared against `'failed'`, so the fix is a pure type-truth correction with
+ * zero runtime ripple.
+ */
+export type GeocodeStatus = 'pending' | 'resolved' | 'unresolvable';
 
 export type ShadingStateKey =
   | 'never_visited'

--- a/src/frontend/utils/__tests__/buildCreateCityDataFromCandidate.test.ts
+++ b/src/frontend/utils/__tests__/buildCreateCityDataFromCandidate.test.ts
@@ -1,0 +1,98 @@
+/**
+ * BUG-75 / UX-12 — the candidate->city identity-carry mapping, extracted ONCE.
+ *
+ * ATDD-first RED acceptance tests (OP-35). Pins AC-12 (MAJOR-1) and AC-6.
+ *
+ * ── WHY THIS EXISTS (review MAJOR-1, the anti-drift AC) ───────────────────────
+ * On `main` the candidate->CreateCityData identity carry lives inside
+ * `AddPlaceFlow.handleSelectPickerCandidate` (AddPlaceFlow.tsx:295-321) — a
+ * COMPONENT-LOCAL function. A second component (ChangeCityModal) cannot "reuse
+ * it unchanged"; left as-is it would be re-implemented, and a drift THERE
+ * (forgetting to forward osm_id, or deriving region_id from a stale selector)
+ * re-introduces the exact BUG-75 identity defect. The reviewer's fix: lift the
+ * mapping into a shared unit consumed by BOTH flows, so the identity carry
+ * exists in exactly one place.
+ *
+ * Frontend must create:
+ *
+ *   src/frontend/utils/buildCreateCityDataFromCandidate.ts
+ *
+ *   export function buildCreateCityDataFromCandidate(
+ *     candidate: GeocodeCandidate,
+ *     cityName: string,
+ *     regions: Region[],
+ *     fallbackCountryCode?: string,
+ *   ): CreateCityData | null;   // null when no country can be resolved
+ *
+ * Behaviour (must match handleSelectPickerCandidate:297-313 exactly):
+ *   • country_code = candidate.country_code ?? fallbackCountryCode (null if neither)
+ *   • region_id    = regions.find(r => r.iso_3166_2 === candidate.region_iso)?.id
+ *                    — derived from THIS candidate's region_iso, incomplete-seed
+ *                      leaves it undefined (NEVER invents an id)
+ *   • osm_type/osm_id/display_name forwarded only when the candidate carries a
+ *     real identity (osm_type present AND osm_id != null)
+ *
+ * RED now because the module does not exist (net-new shared unit).
+ */
+import { describe, expect, it } from 'vitest';
+import {
+  NEWPORT_IOW,
+  NEWPORT_WALES,
+} from '../../components/TripDetail/__tests__/fixtures/newportGeocode';
+import type { Region } from '../../types/api';
+// RED: this module does not exist on `main`. Frontend creates it (see header).
+import { buildCreateCityDataFromCandidate } from '../buildCreateCityDataFromCandidate';
+
+const ENGLAND: Region = {
+  id: 5,
+  country_code: 'GB',
+  name: 'England',
+  iso_3166_2: 'GB-ENG',
+  created_at: '',
+  updated_at: '',
+};
+const WALES: Region = {
+  id: 6,
+  country_code: 'GB',
+  name: 'Wales',
+  iso_3166_2: 'GB-WLS',
+  created_at: '',
+  updated_at: '',
+};
+
+describe('buildCreateCityDataFromCandidate — AC-12 identity carry (defined once)', () => {
+  it('forwards the chosen candidate osm_type/osm_id/display_name into CreateCityData', () => {
+    const data = buildCreateCityDataFromCandidate(NEWPORT_IOW, 'Newport', [ENGLAND, WALES]);
+    expect(data).toMatchObject({
+      name: 'Newport',
+      country_code: 'GB',
+      osm_type: 'node',
+      osm_id: 26700978,
+      display_name: 'Newport, Isle of Wight, England, PO30 1JU, UK',
+    });
+  });
+});
+
+describe('buildCreateCityDataFromCandidate — AC-6 region_id alignment (F4)', () => {
+  it('derives region_id from THAT candidate region_iso, never a sibling region', () => {
+    // The Wales pick must derive Wales (id 6), never England (id 5) — the exact
+    // "carried with a stale/wrong region_id" failure AC-6 guards against.
+    const data = buildCreateCityDataFromCandidate(NEWPORT_WALES, 'Newport', [ENGLAND, WALES]);
+    expect(data?.region_id).toBe(6);
+    expect(data?.osm_id).toBe(26700977);
+  });
+
+  it('leaves region_id undefined (NULL, not invented) when the pick region_iso is unseeded', () => {
+    // Incomplete-seed fallback: only England is seeded; a Wales pick must NOT
+    // borrow England's id and must NOT invent one.
+    const data = buildCreateCityDataFromCandidate(NEWPORT_WALES, 'Newport', [ENGLAND]);
+    expect(data?.region_id).toBeUndefined();
+    // ...but identity is still carried so the server can canonicalize by osm_id.
+    expect(data?.osm_id).toBe(26700977);
+  });
+
+  it('returns null when neither the candidate nor a fallback resolves a country', () => {
+    const noCountry = { ...NEWPORT_IOW, country_code: null };
+    expect(buildCreateCityDataFromCandidate(noCountry, 'Newport', [ENGLAND, WALES])).toBeNull();
+  });
+});

--- a/src/frontend/utils/__tests__/decideCityDisambiguation.test.ts
+++ b/src/frontend/utils/__tests__/decideCityDisambiguation.test.ts
@@ -1,0 +1,145 @@
+/**
+ * BUG-75 / UX-12 / GE-16 — `decideCityDisambiguation` pure-function decision table.
+ *
+ * ATDD-first RED acceptance tests (OP-35). Authored BEFORE the function exists,
+ * as the executable definition of done handed to Frontend.
+ *
+ * ── WHAT THIS UNIT IS (design §9, review MINOR-1) ─────────────────────────────
+ * The single source of truth for picker-vs-region precedence, extracted out of
+ * `AddPlaceFlow.tsx:389-409` so AddPlace and the UX-12 ChangeCityModal cannot
+ * drift. Frontend must create:
+ *
+ *   src/frontend/utils/decideCityDisambiguation.ts
+ *
+ *   export type CityDisambiguation =
+ *     | { mode: 'picker';    candidates: GeocodeCandidate[] }  // >=2 distinct osm_id
+ *     | { mode: 'region';    regionIsos: string[] }            // multi-region, no osm_id
+ *     | { mode: 'suggested'; regionIso: string }               // single candidate (BUG-71)
+ *     | { mode: 'none' };
+ *
+ *   // MINOR-1: `regionIso` is a SEPARATE resolved input (lookupCityCountry
+ *   // returns it top-level, useCities.ts:87-101) — it is NOT derivable from
+ *   // `candidatesForCountry`. A signature that drops it regresses AC-5.
+ *   export function decideCityDisambiguation(
+ *     candidatesForCountry: GeocodeCandidate[],
+ *     regionIso: string | null,
+ *   ): CityDisambiguation;
+ *
+ * ── THE REORDER THIS PINS (the defect) ────────────────────────────────────────
+ * On `main`, AddPlaceFlow evaluates the region branch FIRST
+ * (`sameCountryRegionIsos.length > 1`) and mutually-exclusively pre-empts the
+ * picker. This function must evaluate POSITIVE identity evidence
+ * (`distinctOsmIds.size > 1`) first. AC-1 is the test that a spanning-region set
+ * returns `mode: 'picker'`, NOT `mode: 'region'` — the exact behaviour region-first
+ * gets wrong. RED now because the unit does not exist; it must be red on the
+ * MISSING-UNIT reason (a net-new pure function is legitimately red-until-built),
+ * then green only once the reorder is correct.
+ */
+import { describe, expect, it } from 'vitest';
+import {
+  multiRegionNoOsm,
+  sameRegionNewports,
+  singleRegionNoOsm,
+  singleUnambiguousDenver,
+  spanningRegionNewports,
+} from '../../components/TripDetail/__tests__/fixtures/newportGeocode';
+import type { GeocodeCandidate } from '../../types/api';
+// RED: this module does not exist on `main`. Frontend creates it (see header).
+import { decideCityDisambiguation } from '../decideCityDisambiguation';
+
+describe('decideCityDisambiguation — AC-1 spanning-region (headline)', () => {
+  it('returns mode "picker" (NOT "region") for Newport spanning GB-ENG + GB-WLS with >=2 distinct osm_id', () => {
+    const result = decideCityDisambiguation(spanningRegionNewports(), 'GB-ENG');
+    // The precise failure of region-first: for this set it returns 'region'.
+    // Positive identity evidence must win.
+    expect(result.mode).toBe('picker');
+  });
+
+  it('carries every distinct-osm_id candidate into the picker set', () => {
+    const result = decideCityDisambiguation(spanningRegionNewports(), 'GB-ENG');
+    expect(result.mode).toBe('picker');
+    if (result.mode !== 'picker') return;
+    expect(result.candidates).toHaveLength(3);
+    const osmIds = result.candidates.map((c: GeocodeCandidate) => c.osm_id).sort();
+    expect(osmIds).toEqual([26700977, 26700978, 27459103]);
+  });
+});
+
+describe('decideCityDisambiguation — AC-2 same-region twins', () => {
+  it('returns mode "picker" for two GB-ENG Newports with distinct osm_id — a region select would collapse them', () => {
+    const result = decideCityDisambiguation(sameRegionNewports(), 'GB-ENG');
+    expect(result.mode).toBe('picker');
+    if (result.mode !== 'picker') return;
+    expect(result.candidates.map((c: GeocodeCandidate) => c.osm_id).sort()).toEqual([
+      26700978, 27459103,
+    ]);
+  });
+});
+
+describe('decideCityDisambiguation — AC-3 Springfield many-region (PENDING real capture)', () => {
+  // BUILD-BLOCKER (review): AC-3 must NOT be authored against an invented
+  // Springfield fixture — that reproduces exactly the QUAL-22 vacuous-pass class
+  // this suite exists to prevent. Nominatim is unreachable from this container
+  // (firewall-regressed; connection-refused on two prior probes), so a REAL
+  // captured Springfield /lookup response cannot be taken this session. A
+  // post-rebuild session must capture it, drop it into the fixtures module, and
+  // un-skip this test. Structure retained so the DoD is visible and enforceable.
+  it.skip('returns mode "picker" listing all N Springfields by region-qualified display_name — PENDING real Nominatim capture', () => {
+    // const springfields = capturedSpringfields(); // TODO: real capture, N>=2 distinct osm_id across N regions
+    // const result = decideCityDisambiguation(springfields, 'US-IL');
+    // expect(result.mode).toBe('picker');
+    // if (result.mode !== 'picker') return;
+    // expect(result.candidates).toHaveLength(springfields.length);
+  });
+});
+
+describe('decideCityDisambiguation — AC-4 F1/F2 parity (no false picker)', () => {
+  it('returns mode "region" for multi-region candidates that carry NO osm_id', () => {
+    // Positive-identity gate untouched: no osm_id => distinctOsmIds.size <= 1 =>
+    // the picker must NOT fire; the D14 region <select> fallback handles it.
+    const result = decideCityDisambiguation(multiRegionNoOsm(), null);
+    expect(result.mode).toBe('region');
+    if (result.mode !== 'region') return;
+    expect(result.regionIsos.sort()).toEqual(['US-IL', 'US-MO']);
+  });
+
+  it('returns mode "suggested" for a single-region no-osm candidate with a resolved regionIso', () => {
+    const result = decideCityDisambiguation(singleRegionNoOsm(), 'GB-ENG');
+    expect(result.mode).toBe('suggested');
+    if (result.mode !== 'suggested') return;
+    expect(result.regionIso).toBe('GB-ENG');
+  });
+
+  it('does NOT fire the picker when only ONE candidate carries a distinct osm_id even across two regions', () => {
+    // One osm-bearing candidate + one bare candidate in a different region:
+    // distinctOsmIds.size == 1 (not > 1), so this is region ambiguity, not
+    // place-level identity ambiguity. The picker must NOT pre-empt here.
+    const [iow] = sameRegionNewports();
+    const bareWales = {
+      name: 'Newport',
+      display_name: 'Newport, Wales, United Kingdom',
+      country_code: 'GB',
+      region_iso: 'GB-WLS',
+      latitude: 51.588,
+      longitude: -2.997,
+    };
+    const result = decideCityDisambiguation([iow, bareWales], 'GB-ENG');
+    expect(result.mode).toBe('region');
+  });
+});
+
+describe('decideCityDisambiguation — AC-5 single unambiguous (Denver)', () => {
+  it('returns mode "suggested" for one real place in one region, even carrying an osm_id (BUG-71 tentative)', () => {
+    const result = decideCityDisambiguation(singleUnambiguousDenver(), 'US-CO');
+    // A single distinct identity is NOT place-level ambiguity — it is a tentative
+    // suggestion, never a forced pick.
+    expect(result.mode).toBe('suggested');
+    if (result.mode !== 'suggested') return;
+    expect(result.regionIso).toBe('US-CO');
+  });
+
+  it('returns mode "none" for an empty candidate set with no resolved regionIso', () => {
+    const result = decideCityDisambiguation([], null);
+    expect(result.mode).toBe('none');
+  });
+});

--- a/src/frontend/utils/buildCreateCityDataFromCandidate.ts
+++ b/src/frontend/utils/buildCreateCityDataFromCandidate.ts
@@ -1,0 +1,51 @@
+/**
+ * BUG-75 / UX-12 — the candidate→city identity-carry mapping, extracted ONCE
+ * (review MAJOR-1, the anti-drift AC).
+ *
+ * On `main` this mapping lived inline inside `AddPlaceFlow.handleSelectPickerCandidate`
+ * (`:295-321`) — a component-local function a second component (`ChangeCityModal`)
+ * could not "reuse unchanged" (the design's original §1 reuse-table claim, corrected
+ * by the review). A drift here — forgetting to forward `osm_id`, or deriving
+ * `region_id` from a stale selector value instead of the pick's own `region_iso` —
+ * re-introduces the exact BUG-75 identity defect. Lifting it to a plain, shared
+ * utility means the mapping exists in exactly one place, consumed identically by
+ * AddPlace and Change-city (AC-12).
+ *
+ * Behaviour matches `handleSelectPickerCandidate:297-313` exactly:
+ *   - country_code = candidate.country_code ?? fallbackCountryCode (null → no
+ *     country resolvable → returns null, no city can be built)
+ *   - region_id = regions.find(r => r.iso_3166_2 === candidate.region_iso)?.id —
+ *     derived from THIS candidate's own region_iso; an unseeded region_iso
+ *     leaves region_id undefined (F4/incomplete-seed fallback — NEVER invents one)
+ *   - osm_type/osm_id/display_name forwarded only when the candidate carries a
+ *     real identity (osm_type present AND osm_id != null)
+ */
+import type { CreateCityData } from '../hooks/useCities';
+import type { GeocodeCandidate, Region } from '../types/api';
+
+export function buildCreateCityDataFromCandidate(
+  candidate: GeocodeCandidate,
+  cityName: string,
+  regions: Region[],
+  fallbackCountryCode?: string,
+): CreateCityData | null {
+  const countryCode = candidate.country_code ?? fallbackCountryCode ?? null;
+  if (!countryCode) return null;
+
+  const regionId = candidate.region_iso
+    ? (regions.find((r) => r.iso_3166_2 === candidate.region_iso)?.id ?? undefined)
+    : undefined;
+
+  return {
+    name: cityName,
+    country_code: countryCode,
+    region_id: regionId,
+    ...(candidate.osm_type && candidate.osm_id != null
+      ? {
+          osm_type: candidate.osm_type,
+          osm_id: candidate.osm_id,
+          display_name: candidate.display_name,
+        }
+      : {}),
+  };
+}

--- a/src/frontend/utils/decideCityDisambiguation.ts
+++ b/src/frontend/utils/decideCityDisambiguation.ts
@@ -1,0 +1,70 @@
+/**
+ * BUG-75 / UX-12 / GE-16 — the single source of truth for city-disambiguation
+ * precedence (design §9, review MINOR-1).
+ *
+ * Extracted from `AddPlaceFlow.tsx`'s `handleOpenNewCityForm` (pre-extraction:
+ * `:395-409`) so AddPlace and the UX-12 `ChangeCityModal` consume byte-identical
+ * logic and cannot drift (design §9 / review MAJOR-1's sibling concern for the
+ * *decision*, as opposed to MAJOR-1's own concern for the identity-carry
+ * mapping — see `buildCreateCityDataFromCandidate.ts`).
+ *
+ * THE REORDER (the actual BUG-75 fix, design §6): on `main`, the region branch
+ * (`sameCountryRegionIsos.length > 1`) was evaluated FIRST and mutually
+ * exclusively pre-empted the place-level picker — so a spanning-region name
+ * like "Newport" (GB-ENG + GB-WLS) never reached the picker, and the region
+ * `<select>` silently collapsed two distinct GB-ENG Newports (Isle of Wight vs
+ * Telford and Wrekin) into one indistinguishable choice. This function
+ * evaluates POSITIVE identity evidence (`distinctOsmIds.size > 1`) FIRST —
+ * positive `osm_id` evidence is strictly more specific than a region cut, so
+ * it always wins when present (design §6.4's completeness argument). The
+ * region `<select>` is preserved unchanged as the fallback for the no-`osm_id`
+ * case (legacy/partial responses, the ADL-46 F1/F2 parity fixture family).
+ */
+import type { GeocodeCandidate } from '../types/api';
+
+export type CityDisambiguation =
+  | { mode: 'picker'; candidates: GeocodeCandidate[] }
+  | { mode: 'region'; regionIsos: string[] }
+  | { mode: 'suggested'; regionIso: string }
+  | { mode: 'none' };
+
+/**
+ * Decides which disambiguation control (if any) should present the given
+ * candidates, per the reordered D14/BUG-75 precedence.
+ *
+ * @param candidatesForCountry - Geocode candidates already filtered to the
+ *   resolved country (the caller's job — this function is agnostic to how the
+ *   country was resolved).
+ * @param regionIso - The lookup's top-level resolved region ISO (MINOR-1: a
+ *   SEPARATE input from `lookupCityCountry`, `useCities.ts:87-101` — NOT
+ *   derivable from `candidatesForCountry`, since the single-candidate
+ *   `'suggested'` mode needs it even when candidates carry no `region_iso` of
+ *   their own).
+ */
+export function decideCityDisambiguation(
+  candidatesForCountry: GeocodeCandidate[],
+  regionIso: string | null,
+): CityDisambiguation {
+  const sameCountryRegionIsos = [
+    ...new Set(candidatesForCountry.filter((c) => c.region_iso).map((c) => c.region_iso as string)),
+  ];
+
+  // Positive identity evidence: candidates carrying a real, distinct
+  // (osm_type, osm_id) pair — the code's actual disambiguation signal.
+  const distinctOsmIds = new Set(
+    candidatesForCountry
+      .filter((c) => c.osm_id != null)
+      .map((c) => `${c.osm_type ?? ''}:${c.osm_id}`),
+  );
+
+  if (distinctOsmIds.size > 1) {
+    return { mode: 'picker', candidates: candidatesForCountry };
+  }
+  if (sameCountryRegionIsos.length > 1) {
+    return { mode: 'region', regionIsos: sameCountryRegionIsos };
+  }
+  if (regionIso) {
+    return { mode: 'suggested', regionIso };
+  }
+  return { mode: 'none' };
+}


### PR DESCRIPTION
## Summary

Turns QA's RED ATDD suite (`jobs/COO/inbox/20260807_0930-QA-bug75-pickerprecedence-ux12-red-atdd-complete.md`) GREEN by building the product code on the same branch — no new acceptance tests written by this PR.

**Brief A — BUG-75 headline fix** (design §6/§9, review MAJOR-1/MINOR-1/MAJOR-2):
- `src/frontend/utils/decideCityDisambiguation.ts` — the reordered precedence decision (positive `osm_id` identity evidence now wins over region ambiguity), extracted to a pure function shared by both flows so they cannot drift. AC-1..AC-5.
- `src/frontend/utils/buildCreateCityDataFromCandidate.ts` — the candidate→city identity-carry mapping (MAJOR-1), extracted once. AC-6, AC-12.
- `src/frontend/components/TripDetail/AddPlaceFlow.tsx` — consumes both via the reordered branch (extraction + ~3-line reorder, not a rewrite), plus MAJOR-2's country tentative "Suggested:" caption (AC-13) and geocode_status-keyed creation messaging (AC-14).
- `jobs/architect/tech/20260307-architecture-decisions-log.md` — ADL-46 §4.3.2 (D14) stamped SUPERSEDED-in-part (MINOR-2), append-only (`Edit`, old text retained).

**Brief B — UX-12 entry point** (reuse-only):
- `src/frontend/components/TripDetail/ChangeCityModal.tsx` — new re-point surface (no dates/carry-forward chrome), consumes the same shared precedence + identity-carry units (AC-9/AC-12) and the D11 PATCH re-point via a new `useChangeCity` hook (`usePlaces.ts`) (AC-10).
- `src/frontend/components/TripDetail/PlaceSection.tsx` — standing "Change city" control (AC-8) + single "Location not confirmed" badge reusing the existing `locked` hue, no new hue (AC-11).

**Also fixes** the `GeocodeStatus` type/enum mismatch QA flagged: frontend type now matches the backend CHECK exactly (`'pending' | 'resolved' | 'unresolvable'`), verified zero logic ripple.

**AC-3 (Springfield)** stays `.skip` pending a real Nominatim capture, per the review's build-blocker — not fabricated.

Closes BUG-75, UX-12 · BRD GE-16 §5.2

## Test plan
- [x] `npm run test:frontend` — 300 passed | 1 skipped (Springfield, correctly left skipped)
- [x] `npm run test:backend` — 740 passed (untouched, confirms zero backend surface change)
- [x] `npm run type:check:all` — clean
- [x] `npm run check` (biome) — clean (5 pre-existing infos in an untouched backend test file, exit 0)
- [x] `npm run status:check` — STATUS.md in sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)