### PR TITLE
test(BUG-75): un-skip AC-3 Springfield with real captured fixture

### DIFF
--- a/jobs/COO/inbox/20260807_1752-QA-bug75-ac3-springfield-unskip-complete.md
+++ b/jobs/COO/inbox/20260807_1752-QA-bug75-ac3-springfield-unskip-complete.md
@@ -1,0 +1,97 @@
+# QA completion report — BUG-75 AC-3 Springfield un-skip
+
+**Date:** 2026-08-07
+**Branch:** `test/bug75-ac3-springfield`
+**PR:** https://github.com/ryanv11/travel-tracker/pull/415 (all 18 CI checks green, not merged — COO merges)
+
+## Outcome
+
+**AC-3 is now green, running for real — no defect found.** The already-shipped
+picker-precedence logic (`src/frontend/utils/decideCityDisambiguation.ts`, PR #413) passed
+AC-3 as soon as it was un-skipped against a valid, real fixture. No product code was touched
+or needed to be.
+
+**Skipped-count: 0.** Repo-wide grep for `it.skip|describe.skip|xit(|xdescribe(` across
+`src/frontend` and `src/backend` returns exactly one hit before this PR (the AC-3 skip
+itself) and zero after. Full suites: frontend 43 files / 302 tests passed, 0 skipped;
+backend 42 files / 740 tests passed, 0 skipped.
+
+## What changed (test + fixture only, as scoped)
+
+- **New file** `src/frontend/components/TripDetail/__tests__/fixtures/springfieldGeocode.ts`
+  — reuses the `PickCandidate` shape/convention from `newportGeocode.ts` exactly (same field
+  set, same "load-bearing vs filler" provenance-comment convention). Exports the four
+  candidates plus a `capturedSpringfields()` factory, mirroring `spanningRegionNewports()`
+  etc.
+- **Un-skipped and extended** the AC-3 `describe` block in
+  `src/frontend/utils/__tests__/decideCityDisambiguation.test.ts`: removed the `it.skip`
+  stub, added two real tests — (1) picker mode fires, candidate count and region-qualified
+  `display_name`s all carry through unchanged; (2) selecting the Virginia candidate carries
+  *that* candidate's own distinct `(osm_type, osm_id)`, and that id is absent from every
+  other candidate in the set (guards against the picker silently collapsing distinct
+  places).
+- `_project/tracker.json` and product code (`decideCityDisambiguation.ts` etc.) — **not
+  touched**, per the brief.
+
+## Fixture provenance — two independent captures, zero discrepancy
+
+1. **COO capture** — pasted into the brief, taken via
+   `q=Springfield&countrycodes=us&format=json&addressdetails=1&limit=40` against
+   `nominatim.openstreetmap.org`, then the app's own `SETTLEMENT_TYPES` filter
+   (`{city,town,village,hamlet,municipality}`, `src/backend/services/nominatim-client.ts:116`).
+2. **QA independent re-capture** — I confirmed Nominatim is reachable from this worktree
+   (it was not, in the prior BUG-75 session) and ran the *identical* query directly via
+   `curl` against the live host, then applied the identical `SETTLEMENT_TYPES` filter myself
+   in a scratch script. Raw response: 32 rows. Post-filter: 4 rows.
+   **Result: byte-for-byte identical to the COO's paste** — same 4 `osm_id`
+   (158396042 / 157579394 / 153751916 / 153356201), same `type`s (city/hamlet/village/village),
+   same `display_name` strings, same coordinates.
+
+   This also gave me the raw `address['ISO3166-2-lvl4']` field the COO's paste didn't
+   include (it only had `address.state`) — `parseCandidate` in `nominatim-client.ts:293`
+   reads that exact field for `region_iso`, so I used it rather than inferring a
+   state→ISO mapping myself: **US-VA, US-WV, US-IN, US-WI**.
+
+Two independent probes agreeing is stronger than the mandatory minimum for a *negative*
+finding — this is a positive finding (data exists, is exactly 4 rows), but I ran the second
+probe anyway since mock-fidelity is explicitly part of ATDD/OP-35 and I wanted the fixture's
+`region_iso` field to be real, not guessed.
+
+**Springfield, Illinois is confirmed correctly absent**, not an oversight: it's OSM node/
+relation `126326`, `type: 'administrative'`, `class: 'boundary'` — visible in my own raw
+capture — and `SETTLEMENT_TYPES` does not include `administrative`, so the proxy drops it
+before the frontend ever sees it. This matches the brief's framing exactly; I did not add it
+and it would not survive the filter if I tried.
+
+## Pre-push checklist — all green
+
+- `npm run check` (Biome) — 0 errors on the changed files (1 format issue I introduced —
+  a stray single-quote-with-apostrophe in a test title — fixed before commit; the remaining
+  5 "info"-level Biome notes are pre-existing in files I did not touch,
+  `geocoding.resolveByOsmId.test.ts` and similar)
+- `npm run type:check:all` — clean, frontend + backend
+- `npm run test:backend` — 42 files / 740 tests passed
+- `npm run test:frontend` — 43 files / 302 tests passed, 0 skipped
+- `npm run status:check` — STATUS.md already in sync (this change doesn't touch tracker
+  facts)
+- PR #415 CI — 18/18 checks green (Backend Tests, Frontend Tests, Type Check, Biome, Contract
+  Tests, E2E Tests, Static Analysis/Semgrep, Dependency Vulnerability Scan, Secret Scanning —
+  all pass)
+
+## Not done (out of scope, flagging so it isn't silently dropped)
+
+- `_project/tracker.json` update — explicitly reserved for the COO this session per the
+  brief.
+- I did not touch `AddPlaceFlow.picker-precedence.test.tsx` — I grepped it for
+  `Springfield|AC-3|it.skip` and got zero hits (confirmed by `ls` + a repo-wide skip grep
+  as the second probe), so there was nothing there to un-skip. Two-probe: (1) targeted grep
+  on that one file for Springfield/AC-3/skip patterns — no hits; (2) repo-wide grep for
+  every skip-marker across all of `src/frontend` and `src/backend` — exactly one hit total,
+  the AC-3 test I closed. Both probes agree: the only AC-3 Springfield `.skip` in the repo
+  was the one in `decideCityDisambiguation.test.ts`.
+
+## Files touched
+
+- `src/frontend/components/TripDetail/__tests__/fixtures/springfieldGeocode.ts` (new)
+- `src/frontend/utils/__tests__/decideCityDisambiguation.test.ts` (modified — un-skip + 2 new
+  assertions)

--- a/src/frontend/components/TripDetail/__tests__/fixtures/springfieldGeocode.ts
+++ b/src/frontend/components/TripDetail/__tests__/fixtures/springfieldGeocode.ts
@@ -1,0 +1,108 @@
+/**
+ * BUG-75 / UX-12 — AC-3 Springfield many-region fixture.
+ *
+ * ── PROVENANCE (mock-fidelity, QUAL-22) ───────────────────────────────────────
+ * REAL captured Nominatim data — none invented. Captured 2026-08-07 via the
+ * exact query the geocode proxy issues (`nominatim-client.ts`'s `nominatimSearch`):
+ *
+ *   q=Springfield&countrycodes=us&format=json&addressdetails=1&limit=40
+ *
+ * then passed through the app's own `SETTLEMENT_TYPES` filter
+ * (`src/backend/services/nominatim-client.ts:116`, `{city,town,village,hamlet,
+ * municipality}`). The raw response carries ~32 rows; only 4 survive the
+ * filter. The famous Springfield, Illinois is an OSM **administrative
+ * relation** (`type: 'administrative'`, `class: 'boundary'`) — it does NOT
+ * survive `SETTLEMENT_TYPES` and is correctly absent here. That is
+ * pre-existing, correct proxy behaviour, not a gap this fixture works around.
+ *
+ * Captured TWICE independently (two-probe, per CLAUDE.md's negative/positive
+ * findings discipline even though this is a positive finding — mock-fidelity
+ * demands it match live behaviour, not just the COO's paste):
+ *   1. COO capture, pasted into the BUG-75 AC-3 close-out brief (2026-08-07).
+ *   2. QA capture, same session, direct `curl` against
+ *      `nominatim.openstreetmap.org/search` with the identical query string,
+ *      filtered through the identical `SETTLEMENT_TYPES` set in this repo.
+ * Both captures returned the SAME 4 osm_id, SAME types, SAME display_name
+ * strings, byte-for-byte — zero discrepancy. `region_iso` values below
+ * (`ISO3166-2-lvl4`) come from QA's own capture, since the COO's paste did not
+ * include that raw field (it only had `address.state`); the mapping
+ * (Virginia→US-VA, West Virginia→US-WV, Indiana→US-IN, Wisconsin→US-WI) is
+ * NOT a guess — it is Nominatim's own `address['ISO3166-2-lvl4']` field, the
+ * exact field `parseCandidate` reads (`nominatim-client.ts:293`).
+ *
+ * LOAD-BEARING vs FILLER, same convention as `newportGeocode.ts`: assertions
+ * depend only on `osm_type`, `osm_id`, `region_iso`, `country_code`, and the
+ * region-qualifying token inside `display_name`. `latitude`/`longitude` are
+ * real captured coordinates (not invented) but are not asserted on.
+ */
+import type { GeocodeCandidate } from '../../../../types/api';
+
+/** Candidate carrying a guaranteed (osm_type, osm_id) — a real place identity. */
+export type PickCandidate = GeocodeCandidate & {
+  osm_type: 'node' | 'way' | 'relation';
+  osm_id: number;
+};
+
+/** US-VA — Springfield, Fairfax County, Virginia (captured node 158396042). */
+export const SPRINGFIELD_VIRGINIA: PickCandidate = {
+  name: 'Springfield',
+  display_name: 'Springfield, Fairfax County, Virginia, 22150, United States',
+  country_code: 'US',
+  region_iso: 'US-VA',
+  latitude: 38.7791227,
+  longitude: -77.1861196,
+  osm_type: 'node',
+  osm_id: 158396042,
+};
+
+/** US-WV — Springfield, Hampshire County, West Virginia (captured node 157579394). */
+export const SPRINGFIELD_WEST_VIRGINIA: PickCandidate = {
+  name: 'Springfield',
+  display_name: 'Springfield, Hampshire County, West Virginia, 26763, United States',
+  country_code: 'US',
+  region_iso: 'US-WV',
+  latitude: 39.4506494,
+  longitude: -78.6936272,
+  osm_type: 'node',
+  osm_id: 157579394,
+};
+
+/** US-IN — Springfield, LaPorte County, Indiana (captured node 153751916). */
+export const SPRINGFIELD_INDIANA: PickCandidate = {
+  name: 'Springfield',
+  display_name: 'Springfield, LaPorte County, Indiana, United States',
+  country_code: 'US',
+  region_iso: 'US-IN',
+  latitude: 41.7153192,
+  longitude: -86.7775264,
+  osm_type: 'node',
+  osm_id: 153751916,
+};
+
+/** US-WI — Springfield, Town of Lyons, Walworth County, Wisconsin (captured node 153356201). */
+export const SPRINGFIELD_WISCONSIN: PickCandidate = {
+  name: 'Springfield',
+  display_name: 'Springfield, Town of Lyons, Walworth County, Wisconsin, 53176, United States',
+  country_code: 'US',
+  region_iso: 'US-WI',
+  latitude: 42.6416831,
+  longitude: -88.4120405,
+  osm_type: 'node',
+  osm_id: 153356201,
+};
+
+/**
+ * AC-3 set: the full realistic Springfield candidate set post-filter — 4
+ * distinct settlements, 4 distinct states/regions, 4 distinct osm_id. NOT the
+ * ~20 an earlier estimate guessed (that estimate predated a real capture and
+ * didn't account for the SETTLEMENT_TYPES filter dropping administrative
+ * relations like Springfield, IL).
+ */
+export function capturedSpringfields(): PickCandidate[] {
+  return [
+    SPRINGFIELD_VIRGINIA,
+    SPRINGFIELD_WEST_VIRGINIA,
+    SPRINGFIELD_INDIANA,
+    SPRINGFIELD_WISCONSIN,
+  ];
+}

--- a/src/frontend/utils/__tests__/decideCityDisambiguation.test.ts
+++ b/src/frontend/utils/__tests__/decideCityDisambiguation.test.ts
@@ -43,6 +43,7 @@ import {
   singleUnambiguousDenver,
   spanningRegionNewports,
 } from '../../components/TripDetail/__tests__/fixtures/newportGeocode';
+import { capturedSpringfields } from '../../components/TripDetail/__tests__/fixtures/springfieldGeocode';
 import type { GeocodeCandidate } from '../../types/api';
 // RED: this module does not exist on `main`. Frontend creates it (see header).
 import { decideCityDisambiguation } from '../decideCityDisambiguation';
@@ -76,20 +77,52 @@ describe('decideCityDisambiguation — AC-2 same-region twins', () => {
   });
 });
 
-describe('decideCityDisambiguation — AC-3 Springfield many-region (PENDING real capture)', () => {
-  // BUILD-BLOCKER (review): AC-3 must NOT be authored against an invented
-  // Springfield fixture — that reproduces exactly the QUAL-22 vacuous-pass class
-  // this suite exists to prevent. Nominatim is unreachable from this container
-  // (firewall-regressed; connection-refused on two prior probes), so a REAL
-  // captured Springfield /lookup response cannot be taken this session. A
-  // post-rebuild session must capture it, drop it into the fixtures module, and
-  // un-skip this test. Structure retained so the DoD is visible and enforceable.
-  it.skip('returns mode "picker" listing all N Springfields by region-qualified display_name — PENDING real Nominatim capture', () => {
-    // const springfields = capturedSpringfields(); // TODO: real capture, N>=2 distinct osm_id across N regions
-    // const result = decideCityDisambiguation(springfields, 'US-IL');
-    // expect(result.mode).toBe('picker');
-    // if (result.mode !== 'picker') return;
-    // expect(result.candidates).toHaveLength(springfields.length);
+describe('decideCityDisambiguation — AC-3 Springfield many-region', () => {
+  // Un-skipped 2026-08-07 (QA, BUG-75 close-out) against a REAL captured
+  // Nominatim response — see fixtures/springfieldGeocode.ts's provenance
+  // header for the two independent captures (COO's + QA's own, byte-for-byte
+  // identical). The realistic post-filter Springfield set is 4 settlements
+  // in 4 states — Springfield, Illinois is an OSM administrative relation
+  // and is correctly dropped by the app's own SETTLEMENT_TYPES filter before
+  // it ever reaches this function; it is deliberately NOT in the fixture.
+  it('returns mode "picker" listing all N Springfields by region-qualified display_name', () => {
+    const springfields = capturedSpringfields();
+    const result = decideCityDisambiguation(springfields, 'US-VA');
+    expect(result.mode).toBe('picker');
+    if (result.mode !== 'picker') return;
+    expect(result.candidates).toHaveLength(springfields.length);
+    const osmIds = result.candidates.map((c: GeocodeCandidate) => c.osm_id).sort();
+    expect(osmIds).toEqual([153356201, 153751916, 157579394, 158396042]);
+    // Row count == candidate count, and each candidate is independently
+    // selectable by its own region-qualified display_name (the picker UI's
+    // job downstream; this asserts the decision-table output it renders
+    // from carries every distinct region-qualified name, not a collapsed
+    // subset).
+    const displayNames = result.candidates.map((c: GeocodeCandidate) => c.display_name);
+    expect(displayNames).toEqual([
+      'Springfield, Fairfax County, Virginia, 22150, United States',
+      'Springfield, Hampshire County, West Virginia, 26763, United States',
+      'Springfield, LaPorte County, Indiana, United States',
+      'Springfield, Town of Lyons, Walworth County, Wisconsin, 53176, United States',
+    ]);
+  });
+
+  it("selecting one candidate (Springfield, Virginia) carries THAT candidate's own (osm_type, osm_id)", () => {
+    const springfields = capturedSpringfields();
+    const result = decideCityDisambiguation(springfields, 'US-VA');
+    expect(result.mode).toBe('picker');
+    if (result.mode !== 'picker') return;
+    const picked = result.candidates.find((c: GeocodeCandidate) => c.region_iso === 'US-VA');
+    expect(picked).toBeDefined();
+    expect(picked?.osm_type).toBe('node');
+    expect(picked?.osm_id).toBe(158396042);
+    // And it is distinct from every other candidate in the same set — the
+    // whole point of AC-3 is that these are 4 different real places, not
+    // one place with 4 name spellings.
+    const otherIds = result.candidates
+      .filter((c: GeocodeCandidate) => c.region_iso !== 'US-VA')
+      .map((c: GeocodeCandidate) => c.osm_id);
+    expect(otherIds).not.toContain(picked?.osm_id);
   });
 });
 


### PR DESCRIPTION
## Summary
Closes the last remaining ATDD `.skip` from the BUG-75 picker-precedence build (#413). AC-3 (Springfield many-region) was left `it.skip` in that build because Nominatim was unreachable from the container at the time. It is reachable again — this PR un-skips AC-3 against a **real captured** fixture, not a fabricated one.

## What changed
- **New fixture** `src/frontend/components/TripDetail/__tests__/fixtures/springfieldGeocode.ts`, following the exact `PickCandidate` shape/convention established by `newportGeocode.ts`. Built from a real Nominatim response captured twice, independently, with byte-for-byte identical results:
  1. COO capture, pasted into the close-out brief.
  2. QA capture — direct `curl` against `nominatim.openstreetmap.org/search` using the exact query the geocode proxy issues (`q=Springfield&countrycodes=us&format=json&addressdetails=1&limit=40`), filtered through the app's own `SETTLEMENT_TYPES` set (`src/backend/services/nominatim-client.ts:116`).
  - Result: 4 real settlements survive the filter (Springfield, VA / WV / IN / WI), 4 distinct `osm_id`. Springfield, Illinois is an OSM **administrative relation** and is correctly dropped by `SETTLEMENT_TYPES` — not included, by design, not omission.
  - `region_iso` values (`US-VA`/`US-WV`/`US-IN`/`US-WI`) come from Nominatim's own `address['ISO3166-2-lvl4']` field — the same field `parseCandidate` reads in production, not invented.
- **Un-skipped `decideCityDisambiguation.test.ts`**'s AC-3 describe block, extended with two tests: picker mode + full candidate/display_name carry-through, and that selecting one candidate carries its own distinct `(osm_type, osm_id)`.

## What did NOT change
Per brief: only test + fixture files touched. No product code, no `_project/tracker.json` (COO owns that update this session).

## Result
The already-shipped picker-precedence logic (`decideCityDisambiguation.ts`) passed AC-3 as soon as it was un-skipped — no defect found, no code change needed. Full frontend suite: 43 files / 302 tests passed, **0 skipped**. Backend: 42 files / 740 tests passed. Type-check clean (frontend + backend). `npm run check` (Biome) clean on the changed files.

Closes the AC-3 portion of #413's follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)