### PR TITLE
chore(DEP-03): npm audit fix — bump nanoid past high-severity advisory (unblock main)

### DIFF
--- a/_project/STATUS.md
+++ b/_project/STATUS.md
@@ -135,7 +135,7 @@ _Tracker last updated: 2026-07-28 (B9 merged — QUAL-03 + QUAL-11 done, PR #292
 | feature | `██████████▓░░░░░░░░░` 29/57 | 29 | 28 | 4 |
 | requirement | `███████████████████░` 32/33 | 32 | 1 | 6 |
 | bug | `████████████░░░░░░░░` 45/76 | 45 | 31 | 3 |
-| task | `████████████████████` 9/9 | 9 | 0 | 0 |
+| task | `████████████████████` 10/10 | 10 | 0 | 0 |
 | chore | `███████▓░░░░░░░░░░░░` 14/40 | 14 | 26 | 1 |
 
 <details>
@@ -170,4 +170,4 @@ _Tracker last updated: 2026-07-28 (B9 merged — QUAL-03 + QUAL-11 done, PR #292
 
 ---
 
-_137 done · 9 deferred · 5 closed · 89 open — 240 tracked items_
+_138 done · 9 deferred · 5 closed · 89 open — 241 tracked items_

--- a/_project/security-backlog.md
+++ b/_project/security-backlog.md
@@ -1,6 +1,6 @@
 # Travel Tracker — Security Backlog
-**Version:** 1.3
-**Date:** 2026-07-26
+**Version:** 1.4
+**Date:** 2026-08-07
 **Author:** COO
 **Source:** BACKEND security report (20260308_1000-BACKEND-security-report.txt)
 
@@ -108,6 +108,28 @@ went red on main again on a docs/tracker-only diff (advisories published post-DE
 Gate status after this pass: `npm audit --audit-level=high` exits 0 (6 moderate
 vulnerabilities remain — the 4 already-accepted esbuild/drizzle-kit findings plus the
 2 new, deferred react-router findings — both below the gate threshold).
+
+---
+
+## npm audit — DEP-03 (2026-08-07)
+
+Third occurrence of the DEP-01/DEP-02 pattern (tracker DEP-03). `npm audit --audit-level=high`
+went red on main again from an advisory published after the last green run — the same
+calendar-based mechanism ADL-40 documents: `Security Checks` was green on `main` at #418
+(21:06 UTC) and red at 22:12 UTC on the identical tree (the PR that caught it, #419, changed
+no dependencies). 1 fixed via `npm audit fix` (non-breaking):
+
+| Advisory | Package | Severity | Disposition |
+|----------|---------|----------|-------------|
+| GHSA-2v37-7h3g-55p8 | nanoid <3.3.8 (transitive) | High-gate-triggering | **FIXED** — 3.3.16 → 3.3.18, non-breaking transitive bump via `npm audit fix`. |
+| GHSA-67mh-4wv8-2f99, GHSA-g7r4-m6w7-qqqr | esbuild via drizzle-kit → @esbuild-kit chain | Moderate | **ACCEPTED (unchanged from DEP-01/DEP-02)** — dev-only, below the gate, drizzle-kit stays pinned 0.31.9 (ADL-15 patch). No new action. |
+| GHSA-wrjc-x8rr-h8h6, GHSA-337j-9hxr-rhxg | react-router / react-router-dom | Moderate | **DEFERRED (unchanged from DEP-02)** — still needs the react-router-dom@7 major bump + routing/e2e verification pass; below the gate, not blocking. Not yet scheduled. |
+
+Gate status after this pass: `npm audit --audit-level=high` exits 0 (6 moderate vulnerabilities
+remain — the already-accepted esbuild/drizzle-kit cluster plus the deferred react-router cluster,
+both below the gate threshold). Full verification: biome clean, type:check:all clean, backend
+740/740, frontend 302/302, status:check in sync. drizzle-kit stayed pinned at 0.31.9;
+react-router-dom not bumped.
 
 ---
 

--- a/_project/tracker.json
+++ b/_project/tracker.json
@@ -1351,6 +1351,17 @@
       "notes": "Found 2026-07-26 — Dependency Vulnerability Scan red on main again on an unrelated tracker-only diff (PR #248/#249), same symptom shape as DEP-01. GitHub issue #250. RESOLVED same day: npm audit fix (non-breaking) — body-parser 2.2.2→2.3.0 (GHSA-v422-hmwv-36x6, DoS via invalid limit value), postcss 8.5.16→8.5.23 (GHSA-r28c-9q8g-f849, high, path-traversal .map disclosure). Verified drizzle-kit stayed pinned at 0.31.9 (ADL-15 patch intact) and react-router-dom stayed at 6.30.4 — neither breaking upgrade taken. Full verification: type:check:all clean, backend tests 580/581 (1 pre-existing skip), frontend tests 154/154, npm audit --audit-level=high exits 0. Two moderate clusters remain, both below the CI gate: esbuild/drizzle-kit (re-affirmed ACCEPTED, unchanged from DEP-01 — fix would break ADL-15 patch) and react-router (newly DEFERRED — fix requires react-router-dom@7.18.1 major bump, needs its own routing/e2e verification pass before scheduling). security-backlog.md bumped to v1.2 with the DEP-02 section + updated change log, same PR. Issue #250 closed on merge."
     },
     {
+      "id": "DEP-03",
+      "type": "task",
+      "title": "npm audit — third calendar-based drift: nanoid high newly published, fixed non-breaking",
+      "status": "done",
+      "owner": "coo",
+      "priority": "P2",
+      "brdRefs": [],
+      "phase": 6,
+      "notes": "Found 2026-08-07 — Dependency Vulnerability Scan (required check) red on main again, same calendar-based mechanism as DEP-01/DEP-02/ADL-40: Security Checks was green on main at #418 (21:06 UTC) and red at 22:12 UTC on the identical dependency tree (caught on PR #419, a docs+fixtures diff that changed no dependencies), because GHSA-2v37-7h3g-55p8 (nanoid, high — custom generators can loop indefinitely when size is zero) published in between. RESOLVED same session: npm audit fix (non-breaking) bumped nanoid 3.3.16 → 3.3.18 (transitive), dropping the HIGH count to 0 so npm audit --audit-level=high exits 0. The 6 remaining moderates are the already-dispositioned clusters, both below the gate: esbuild/drizzle-kit (ACCEPTED, unchanged since DEP-01 — fix breaks the ADL-15 drizzle-kit 0.31.9 patch) and react-router (DEFERRED, unchanged since DEP-02 — needs the react-router-dom@7 major + routing/e2e pass). drizzle-kit stayed pinned 0.31.9; react-router-dom not bumped. Full verification: biome clean, type:check:all clean, backend 740/740, frontend 302/302, status:check in sync. security-backlog.md bumped to v1.4 with the DEP-03 section, same PR per document-lifecycle rule. No GitHub issue raised (fixed within the session that found it); PR carries the DEP-03 tag."
+    },
+    {
       "id": "OP-08",
       "type": "requirement",
       "title": "Security enforcement mechanisms for new work — regression suite + Semgrep rules",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5947,9 +5947,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
**Unblocks red main.** The required `Dependency Vulnerability Scan` (`npm audit --audit-level=high`) went newly-red — third occurrence of the DEP-01/DEP-02 calendar-based pattern (ADL-40): `Security Checks` was green on `main` at #418 (21:06 UTC) and red at 22:12 UTC on the **identical dependency tree** (caught on #419, a docs+fixtures diff that touched no deps), because GHSA-2v37-7h3g-55p8 (nanoid, high) published in between.

## Fix
- `npm audit fix` (non-breaking) → **nanoid 3.3.16 → 3.3.18** (transitive). HIGH count → 0, gate exits 0.
- The 6 remaining moderates are already-dispositioned and below the gate: esbuild/drizzle-kit (ACCEPTED since DEP-01 — fix breaks the ADL-15 patch) and react-router (DEFERRED since DEP-02 — needs the RRv7 major + routing/e2e pass). **drizzle-kit stays pinned 0.31.9; react-router-dom not bumped.**

## Verification
biome clean · type:check:all clean · backend 740/740 · frontend 302/302 · status:check in sync · `npm audit --audit-level=high` exits 0.

## Records (same PR, document-lifecycle rule)
- Tracker: **DEP-03** entry (done).
- `security-backlog.md` → **v1.4** with the DEP-03 section.
- STATUS.md regenerated.

Tracker: DEP-03. No standalone GitHub issue (fixed within the session that found it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)