### PR TITLE
fix(BUG-76/BUG-74): geocoder accept-rule keyed on addresstype + empty-vs-failed contract

### DIFF
--- a/jobs/COO/inbox/20260807_1536-QA-bug76-atdd-red-tests-complete.md
+++ b/jobs/COO/inbox/20260807_1536-QA-bug76-atdd-red-tests-complete.md
@@ -1,0 +1,67 @@
+# QA completion report — BUG-76 (P1) / BUG-74 (P2) ATDD RED acceptance suite
+
+**Tracker:** BUG-76 (P1), BUG-74 (P2, ride-along) · **GitHub:** #382 (BUG-76 reopen) ·
+**BRD:** n/a (bug fix, no new requirement) · **Branch:** `feat/bug76-accept-rule-fix`
+(pushed, **no PR** — per brief, a red PR would show red CI by design)
+
+## What was tested (scope, build ref)
+
+Turned the Architect's design (`jobs/architect/tech/20260807-BUG76-accept-rule-design.md`
+§7/§9.9, AC-0..AC-13) into a RED, pre-implementation acceptance suite against `main`
+(OP-35 ATDD-first — this brief is Architect-spawned). 3 new files, 18 assertions, **zero
+production code touched**.
+
+## Pass/Fail verdict per AC
+
+| AC | Red on main? |
+|---|---|
+| AC-1, AC-2, AC-3, AC-6, AC-9, AC-10 | **RED** — clean AssertionErrors, the load-bearing admission-side spec |
+| AC-11, AC-12, AC-13 | **RED** — the `status` field doesn't exist on the response at all today |
+| AC-0, AC-4, AC-5, AC-7, AC-8 (x2), AC-8b | **Already green on main** — flagged, not a defect in the suite (see below) |
+
+**10/18 assertions RED for the right reason** (verified: `npx vitest run --config
+vitest.config.backend.ts` on the 3 new files → 10 failed/8 passed, every failure a clean
+`AssertionError`, zero import errors/exceptions/broken mocks). Full backend suite
+(`npm run test:backend`): 748/758 passing — no collateral damage, the 10 failures are
+exactly the new file's intentional reds. `type:check:backend` and `npm run check` (Biome)
+clean.
+
+**Why 8/18 already pass — QA finding, not a suite defect:** the current bug over-rejects
+rather than under-rejects. It keys on Nominatim's `type` field and drops every
+`type=administrative` row wholesale — this catches the false positives (county/state/
+suburb/census/statistical) AND the true positives (Denver, Springfield IL/MO/MA) alike.
+So AC-4/5/7/8/8b (the "don't admit a county/suburb/census" cases) already hold today, for
+the wrong reason — they're regression guards for the *corrected* rule, not red specs of
+this fix. AC-0 (URL format) was never broken — production already sends
+`format=json&addressdetails=1` unconditionally; it's a QUAL-22 mock-fidelity gate, not
+fix behaviour. Full reasoning + per-row evidence: `jobs/qa/tech/20260807-bug76-atdd-red-tests.md`.
+
+## Mock-fidelity measure (OP-35/QUAL-22)
+
+Accept-rule + e2e files mock `global.fetch` (the real `fetchNominatim` boundary) with the
+exact committed `format=json` fixtures loaded off disk — never pre-parsed candidates.
+Every test asserts `fetch` was called exactly once (sanity check the double is actually
+exercised, not silently bypassed). AC-0 proves the mock is wired to the real constructed
+URL. The BUG-74 contract file mocks `nominatimSearch` at the service boundary instead —
+deliberate: it tests route serialization of an already-typed union, not raw-JSON parsing
+(that's the other two files' job); matches the existing accepted `geocode.test.ts`/BUG-79
+pattern. Full detail in the tech doc.
+
+## Bugs found
+
+None new — this is a pre-implementation ATDD suite for an already-tracked defect
+(BUG-76/BUG-74), not a live-testing pass.
+
+## CI
+
+No PR opened (per brief). Branch pushed and confirmed: `git status` clean, 3 new files
+committed, `feat/bug76-accept-rule-fix` on `origin`.
+
+## Open issues / blockers
+
+None. Handoff: Backend implements against this branch (design §3 `addressType`-keyed
+predicate, §6 `status` contract) until all 18 assertions are green, `type:check:all`
+clean, and no other backend suite regresses.
+
+Full detail: `jobs/qa/tech/20260807-bug76-atdd-red-tests.md` · Park doc:
+`jobs/qa/park-docs/20260807-QA-park.txt`

--- a/jobs/COO/inbox/20260807_2245-BACKEND-bug76-bug74-complete.md
+++ b/jobs/COO/inbox/20260807_2245-BACKEND-bug76-bug74-complete.md
@@ -1,7 +1,7 @@
 # BACKEND — BUG-76 (P1) / BUG-74 (P2) complete
 
 Tracker: BUG-76, BUG-74 · BRD GE-11/GE-16 · Branch: `feat/bug76-accept-rule-fix-impl`
-PR: (see below — opening after this report is written)
+PR: #421 — https://github.com/ryanv11/travel-tracker/pull/421
 
 ## What was built
 Re-keyed the geocoder's settlement accept-rule from Nominatim's `type`/`class` fields to
@@ -22,9 +22,9 @@ All 18 assertions across the 3 ATDD files: **PASS**. Verified: 10 previously-red
 3. FK notNull: n/a — no schema change.
 
 ## CI
-Not yet run — PR opening next; will confirm `gh pr checks <PR#>` green before considering
-this thread closed. (Report sent now per brief structure; PR # and CI status follow
-immediately after in the same session unless something breaks.)
+All 18 checks green (`scripts/ci-wait.sh pr 421` → PASS) at commit `5ea9a6b`: Backend
+Tests, Frontend Tests, Type Check, Biome, Contract Tests, E2E Tests, Dependency
+Vulnerability Scan, Secret Scanning, Static Analysis — no failures, no suppressions added.
 
 ## Also touched (declared, OP-28)
 `src/backend/services/__tests__/nominatim-client.test.ts` (pre-existing BUG-79 suite, not

--- a/jobs/COO/inbox/20260807_2245-BACKEND-bug76-bug74-complete.md
+++ b/jobs/COO/inbox/20260807_2245-BACKEND-bug76-bug74-complete.md
@@ -1,0 +1,54 @@
+# BACKEND — BUG-76 (P1) / BUG-74 (P2) complete
+
+Tracker: BUG-76, BUG-74 · BRD GE-11/GE-16 · Branch: `feat/bug76-accept-rule-fix-impl`
+PR: (see below — opening after this report is written)
+
+## What was built
+Re-keyed the geocoder's settlement accept-rule from Nominatim's `type`/`class` fields to
+`addresstype` (BUG-76), via a single shared predicate `isAcceptedSettlement` applied at
+both `nominatimSearch` and `nominatimLookup`. Added `status: 'ok'|'error'|'disabled'` to
+`GET /api/geocode`'s response body, always HTTP 200 (BUG-74). Implemented to QA's
+pre-written ATDD suite per design doc ADL-51 — no redesign.
+
+## Acceptance criteria (AC-0…AC-13, QA's suite)
+All 18 assertions across the 3 ATDD files: **PASS**. Verified: 10 previously-red now green,
+8 regression-guards still green (matches QA's mapping doc exactly, both before and after).
+
+## Security checklist (GET /api/geocode modified)
+1. Auth middleware: `requireAuth` applied globally (`app.use('/api/', requireAuth)` in
+   `server.ts`) — confirmed unchanged, pre-existing `nosemgrep` annotation on the route
+   documents this.
+2. userId scoping: n/a — proxy reads no user-owned table, no query added.
+3. FK notNull: n/a — no schema change.
+
+## CI
+Not yet run — PR opening next; will confirm `gh pr checks <PR#>` green before considering
+this thread closed. (Report sent now per brief structure; PR # and CI status follow
+immediately after in the same session unless something breaks.)
+
+## Also touched (declared, OP-28)
+`src/backend/services/__tests__/nominatim-client.test.ts` (pre-existing BUG-79 suite, not
+one of QA's 3 ATDD files) — its truncation test simulated filtered-out rows via the OLD
+discriminator (`type: 'administrative'`); re-keyed to `addresstype: 'county'` to preserve
+the test's actual intent under the corrected discriminator. Small targeted edit (1 helper
+signature + 3 fixture rows), not a wholesale rewrite.
+
+## Open issues / blockers
+None. One thing flagged, not absorbed: no GitHub issue exists yet for BUG-76/BUG-74
+specifically (searched by title and by the #382/#367/#393/#91 numbers referenced in tracker
+notes — none match). PR body references tracker IDs directly rather than a fabricated
+`Closes #N`. Frontend's half of BUG-74 (banner mapping `error`/`disabled` -> `failed:true`
+in `useCities.ts`, plus typing `status` onto `GeocodeResult` in
+`src/frontend/types/api.ts`) is explicitly out of scope here per the brief — noted as the
+next unblocked step below.
+
+## What is now unblocked
+- Frontend: BUG-74's banner-mapping half (needs `status` typed + `lookupCityCountry`
+  updated), and re-verifying BUG-75's picker against the now-wider candidate set (more
+  admin-boundary cities surface, e.g. Springfield IL/MO/MA).
+- QA: can UAT the PO's original Denver symptom directly once merged/deployed.
+- COO: tracker BUG-76/BUG-74 status updates at merge (tracker.json is COO-maintained, not
+  touched here).
+
+Park doc: `jobs/backend/park-docs/20260807-BACKEND-park.txt`
+API doc: `jobs/backend/tech/20260307-api-reference.md` (new "Geocode Proxy" section)

--- a/jobs/backend/context/current.txt
+++ b/jobs/backend/context/current.txt
@@ -1,4 +1,44 @@
-BACKEND CONTEXT — 2026-08-04 (QUAL-26 thread, latest)
+BACKEND CONTEXT — 2026-08-07 (BUG-76/BUG-74 thread, latest)
+PROJECT: Travel Tracker
+CURRENT STATUS: implemented BUG-76 (P1, geocoder accept-rule) + BUG-74 (P2,
+  empty-vs-failed response contract) on branch feat/bug76-accept-rule-fix-impl,
+  branched off QA's pre-pushed feat/bug76-accept-rule-fix (holding the red ATDD
+  suite, OP-35). Turned all 18 assertions (AC-0..AC-13) green. Classification
+  (design doc, ADL-51): latent gap, not a regression — Denver has no OSM
+  settlement place-node, only an admin-boundary relation the old filter dropped.
+  1. src/backend/services/nominatim-client.ts: parseCandidate now captures
+     addressType: raw.addresstype (present under format=json&addressdetails=1 —
+     production request shape UNCHANGED, per design doc §9.1's correction that
+     switching to jsonv2 would BREAK parseCandidate's raw.class read). New
+     shared predicate isAcceptedSettlement(candidate) keys admission on
+     addressType (city/town/village/hamlet/municipality), with the
+     "discriminator absent -> admit" passthrough retained for legacy
+     fixtures/the /lookup canonicalize-by-id path. Replaces the old
+     SETTLEMENT_TYPES.has(c.type) gate — type/class carried as metadata only,
+     no longer the admission decision — at BOTH nominatimSearch and
+     nominatimLookup (two independent probes — grep across src/backend +
+     reading geocoding.service.ts — confirmed nothing else reads
+     candidate.type/.class, so re-keying has no other blast radius).
+  2. src/backend/routes/geocode.ts: GET /api/geocode now serializes
+     status: 'ok'|'error'|'disabled' onto the response body (mirrors
+     NominatimSearchResult), always HTTP 200, additive/back-compat. This is
+     what made BUG-76 invisible — Denver's empty-candidates-at-200 was
+     indistinguishable from an upstream Nominatim failure. Frontend banner
+     mapping (error/disabled -> failed:true) is a SEPARATE follow-up, not
+     built here.
+  3. src/backend/services/__tests__/nominatim-client.test.ts: the pre-existing
+     BUG-79 truncation test's rawResult() helper simulated "filtered out" rows
+     via type:'administrative' (the OLD discriminator) — re-keyed to
+     addresstype:'county' to preserve the test's actual intent (truncated
+     computed pre-filter) under the corrected discriminator. Declared here per
+     OP-28: a targeted edit to a pre-existing test, not a QA ATDD file, not a
+     wholesale rewrite.
+  All of npm run check / type:check:all / test:backend (758/758) /
+  test:frontend (302/302) / status:check green. PR not yet opened as of this
+  entry — see park doc for status. Full detail:
+  jobs/backend/park-docs/20260807-BACKEND-park.txt
+
+BACKEND CONTEXT — 2026-08-04 (QUAL-26 thread)
 PROJECT: Travel Tracker
 CURRENT STATUS: implemented QUAL-26 (GitHub #396) on branch
   feat/qual26-build-marker off main. /health now identifies the running

--- a/jobs/backend/park-docs/20260807-BACKEND-park.txt
+++ b/jobs/backend/park-docs/20260807-BACKEND-park.txt
@@ -1,0 +1,118 @@
+BACKEND PARK DOC — 2026-08-07
+THREAD: BUG-76 (P1, geocoder accept-rule) + BUG-74 (P2, empty-vs-failed contract)
+BRANCH: feat/bug76-accept-rule-fix-impl (branched off origin/feat/bug76-accept-rule-fix, QA's)
+
+SCOPE
+Implement to QA's already-written RED ATDD suite (OP-35 ATDD-first), per the Architect
+design doc jobs/architect/tech/20260807-BUG76-accept-rule-design.md (ADL-51, §9 corrected
+design-of-record). Two defects bundled per the brief:
+  - BUG-76 (P1): the geocoder's settlement filter keyed on Nominatim's `type`/`class`
+    fields, which cannot distinguish a city modelled as an OSM admin-boundary relation
+    (type=administrative) from a county or state (also type=administrative). Denver has
+    no settlement place-node in OSM — only the admin-boundary relation — so it was NEVER
+    geocodable through the old filter. Classification: latent gap, not a regression.
+  - BUG-74 (P2, ride-along): GET /api/geocode collapsed every non-'ok' NominatimSearchResult
+    to candidates:[] at HTTP 200, making "upstream failed" indistinguishable from "genuine
+    no-match" — this is the exact mechanism that made BUG-76 invisible to the frontend/PO.
+
+WHAT WAS BUILT
+
+1. src/backend/services/nominatim-client.ts
+   - RawNominatimResult gains `addresstype?: string` (the raw Nominatim field).
+   - NominatimCandidate gains `addressType?: string` (parsed/carried).
+   - parseCandidate captures `addressType: raw.addresstype`. `class`/`type` are still
+     captured (cost nothing, other code doesn't read them per two independent probes —
+     see below) but are no longer read by the admission gate.
+   - New: SETTLEMENT_ADDRESSTYPES = {city, town, village, hamlet, municipality} (replaces
+     SETTLEMENT_TYPES, same five values, different field it's checked against).
+   - New: isAcceptedSettlement(candidate) — THE single shared admission predicate.
+     `candidate.addressType == null || SETTLEMENT_ADDRESSTYPES.has(candidate.addressType)`.
+     The null-passthrough is retained for two reasons (design doc §3.1): legacy
+     fixtures/callers that never set addressType, and the /lookup canonicalize-by-id path
+     where a discriminator-absent row is a deliberately-picked place, not noise.
+   - Both nominatimSearch's filter (was :230) and nominatimLookup's filter (was :267) now
+     call `isAcceptedSettlement(c)` — the old `c.type == null || SETTLEMENT_TYPES.has(c.type)`
+     literal is gone from both sites. One predicate, both call sites — DoD requirement met.
+   - Production request shape UNCHANGED: still format=json&addressdetails=1 (AC-0 pins
+     this; design doc §9.1 — jsonv2 would BREAK parseCandidate's raw.class read, was
+     considered and explicitly rejected).
+
+2. src/backend/routes/geocode.ts
+   - `const status = result.status;` captured right after `nominatimSearch()` returns,
+     alongside the existing `candidates`/`truncated` derivation (which are UNCHANGED —
+     still `[]`/`false` when status !== 'ok', same values, now just labelled).
+   - `res.json({ status, candidates: [...], country_code, region_iso, truncated })` —
+     `status` is a new first field, additive. HTTP 200 in all three cases (unchanged).
+   - No change to the D12 region_iso narrowing logic, no change to DISCOVERY_LIMIT/
+     CONSTRAINED_LIMIT, no change to the candidate serialization shape per row.
+
+3. src/backend/services/__tests__/nominatim-client.test.ts (pre-existing BUG-79 suite,
+   NOT one of QA's 3 ATDD files)
+   - This file's `rawResult()` helper simulated "rows the settlement filter drops" via
+     `type: 'administrative'` — the OLD discriminator. Under the new addressType-keyed
+     rule, those synthetic rows (which never set addresstype) would hit the null-
+     passthrough and be admitted, breaking the one test
+     ("computes truncation from the PRE-FILTER raw count...") that relies on 3/5 rows
+     being dropped to prove `truncated` reads the pre-filter count.
+   - Fix: `rawResult()` gained an `addresstype` override (default 'city', so every other
+     row in the file keeps passing unless a test overrides it), and the 3 "Admin" rows in
+     the truncation test now also set `addresstype: 'county'` — a real non-settlement
+     value — restoring the test's actual intent under the corrected discriminator. This
+     is a small, targeted, declared edit (OP-28) — not a QA ATDD file, not a wholesale
+     rewrite of the test file (single function signature + 2 call sites touched).
+
+WHY NOT TOUCHED
+- src/frontend/types/api.ts's GeocodeResult interface — does not yet type `status`. The
+  brief scoped the frontend banner mapping (error/disabled -> failed:true) as a SEPARATE
+  follow-up; adding the type without the consumer logic felt like scope creep into
+  Frontend's file for no behavioural gain (the field is present on the wire either way —
+  TS typing it is the follow-up's first step, paired with the actual mapping).
+- geocode.ts's `truncated`/D12 narrowing/DISCOVERY_LIMIT — untouched per design doc §5
+  (D7): country-constraining the discovery query is explicitly out of scope and must not
+  be bundled with the accept-rule fix.
+
+NEGATIVE-FINDINGS PROBES RUN
+"Nothing outside the filter reads candidate.type/.class" (design doc's D1 justification
+for re-keying with no other blast radius) — re-verified with two independent probes before
+touching the filter:
+  (a) `grep -rn '\.type\b|\.class\b' src/backend --include='*.ts'` excluding __tests__ —
+      only hits at the filter lines themselves and the parseCandidate assignment lines.
+  (b) Read geocoding.service.ts's NominatimCandidate consumption directly — only reads
+      latitude/longitude/osmType/osmId/displayName/name/regionIso, never .type/.class.
+Two probes, different methods, same result — re-keying the gate is confirmed safe.
+
+VERIFICATION
+- `npx vitest run --config vitest.config.backend.ts` on the 3 ATDD files: 18/18 pass
+  (was 8 passed/10 failed pre-fix, matching QA's mapping doc exactly).
+- `npm run test:backend`: 758/758 pass (45 files), including the corrected
+  nominatim-client.test.ts.
+- `npm run test:frontend`: 302/302 pass (no frontend files touched; confirms no
+  collateral breakage).
+- `npm run type:check:all`: clean.
+- `npm run check` (Biome): clean (0 errors; 5 pre-existing infos in
+  geocoding.resolveByOsmId.test.ts, a file this thread never touched — unrelated).
+- `npm run status:check`: STATUS.md up to date, no regen needed.
+- Accept-rule spot-check against the fixtures (design doc §9.3 table), confirmed by the
+  AC-1/AC-3/AC-4/AC-5/AC-8/AC-8b assertions passing: Denver 4/4 admitted, Springfield US
+  19/20 (census dropped, city twin kept), Cook County 0, Colorado 0, Paradise NV census
+  relation dropped + town node twin admitted.
+
+SECURITY CHECKLIST (route modified: GET /api/geocode)
+1. Auth middleware — requireAuth applied GLOBALLY via `app.use('/api/', requireAuth)` in
+   server.ts; geocode.ts's existing `// nosemgrep` comment at the route documents this
+   (pre-existing annotation, not touched). Confirmed still true — no route-level bypass
+   introduced.
+2. userId scoping — n/a. The geocode proxy reads no user-owned table; it's a stateless
+   Nominatim proxy (tier-1 reference lookup, per the route's own header comment). No new
+   query was added.
+3. FK notNull — n/a. No schema change in this thread.
+
+NOTHING FLAGGED TO COO beyond what's in the completion report — no AC looked wrong, no
+premise needed re-litigating, no scanner suppression needed.
+
+NEXT STEPS FOR OTHER JOBS
+- Frontend: BUG-74's other half — map `status: 'error'|'disabled'` to `failed:true` in
+  lookupCityCountry (useCities.ts), then BUG-71 owns the three-state copy on top of that
+  signal. GeocodeResult in src/frontend/types/api.ts needs the `status` field added first.
+- COO: open PR is feat/bug76-accept-rule-fix-impl -> main; tracker BUG-76/BUG-74 status
+  update happens at merge per standard flow (tracker.json is COO-maintained).

--- a/jobs/backend/tech/20260307-api-reference.md
+++ b/jobs/backend/tech/20260307-api-reference.md
@@ -1706,6 +1706,72 @@ Rename a region.
 
 ---
 
+## Geocode Proxy
+
+First-party backend proxy for Nominatim lookups (ADL-46 D7 §5.1). Added to this document
+2026-08-07 (BUG-76/BUG-74, ADL-51).
+
+### GET /api/geocode?q=...&country_code=...&region_iso=...
+
+Auth: `requireAuth` (applied globally, `app.use('/api/', requireAuth)` in `server.ts`). No
+`userId` scoping — reads no user-owned table, it's a stateless Nominatim proxy.
+
+Query params: `q` (required, search text), `country_code` (optional, ISO 3166-1 alpha-2 —
+when supplied, constrains the Nominatim query and narrows candidates to that country),
+`region_iso` (optional, ISO 3166-2 — narrows `candidates` to matches after the fact, never
+fabricates a result when none match).
+
+Response body:
+
+```json
+{
+  "status": "ok",
+  "candidates": [
+    {
+      "name": "Denver",
+      "display_name": "Denver, Colorado, United States",
+      "country_code": "US",
+      "region_iso": "US-CO",
+      "latitude": 39.7392364,
+      "longitude": -104.984862,
+      "osm_type": "relation",
+      "osm_id": 1411339
+    }
+  ],
+  "country_code": "US",
+  "region_iso": "US-CO",
+  "truncated": false
+}
+```
+
+- **`status`** (`'ok' | 'error' | 'disabled'`, BUG-74, ADL-51 §6): mirrors the internal
+  `NominatimSearchResult` union. **Always HTTP 200 regardless of `status`** — a non-2xx was
+  considered and rejected (it would collapse "our backend is unreachable" and "our backend
+  answered, but upstream Nominatim is the problem" into one signal, which is strictly less
+  information than the body carries). `'error'` = upstream Nominatim failure (network,
+  timeout, non-2xx, 429). `'disabled'` = `GEOCODING_ENABLED=false` (CI/non-prod only, never
+  prod). `candidates`/`country_code`/`region_iso` are `[]`/`null`/`null` whenever
+  `status !== 'ok'` — the same shape as a genuine no-match, now *labelled* so the two are
+  distinguishable. Consumers written before this field existed continue to work unmodified
+  (additive; the field is simply absent from their parsed response if they don't read it).
+- `candidates[]` — meaningful ONLY when `status === 'ok'`. Each entry: `osm_type`/`osm_id`
+  are the carried OSM identity (BUG-75 v3) a picked candidate's create request sends back —
+  optional on older fixtures, always present on a real Nominatim response.
+- `country_code`/`region_iso` (top-level) — the TOP candidate's values, for GE-15
+  auto-populate convenience. `null` under any non-`'ok'` status or a genuine empty result.
+- `truncated` (BUG-79) — `true` when Nominatim's raw response (pre settlement-filter) was
+  at least as large as the `limit` requested — there may be more matches upstream than
+  `candidates` shows. Always `false` under `status !== 'ok'`.
+
+**Settlement filter (BUG-76, ADL-51 §3):** candidates are admitted when Nominatim's
+`addresstype` is one of `city`/`town`/`village`/`hamlet`/`municipality`, or is absent
+(passthrough — legacy rows / a deliberately-picked `/lookup` id). Rejects `county`/`state`/
+`region`/`river`/`suburb`/`census`/`statistical`. This is why a Denver-style query now
+resolves: OSM models it as an admin-boundary relation, and the accept-rule is keyed on
+`addresstype`, not the class-`type` field a county/state also carries.
+
+---
+
 ## Static Assets
 
 GeoJSON boundary files for map rendering. Served directly as static files.

--- a/jobs/qa/context/current.txt
+++ b/jobs/qa/context/current.txt
@@ -214,3 +214,43 @@ NEXT STEPS (for incoming QA)
   Full design + per-check proves/does-not-prove table + trigger reasoning +
   cost: jobs/qa/tech/20260804-post-deploy-shakedown.md
   Completion report: jobs/COO/inbox/
+
+================================================================================
+2026-08-07 — BUG-76 (P1) / BUG-74 (P2) ATDD RED ACCEPTANCE SUITE (OP-35)
+================================================================================
+
+  Branch: feat/bug76-accept-rule-fix (off main, pushed, NO PR — brief
+  explicitly withheld a PR since a red PR would show red CI by design;
+  Backend branches from this pushed lineage and turns it green).
+
+  Turned the Architect's BUG-76 accept-rule design
+  (jobs/architect/tech/20260807-BUG76-accept-rule-design.md §7/§9.9,
+  AC-0..AC-13) into 18 assertions across 3 new files BEFORE Backend
+  implements anything:
+    - src/backend/services/__tests__/bug76-accept-rule.test.ts (AC-0,1,3-10)
+    - src/backend/routes/__tests__/bug76-geocode-e2e.test.ts (AC-2)
+    - src/backend/routes/__tests__/bug76-geocode-contract.test.ts (AC-11-13)
+
+  Result: 10/18 RED for the right reason (clean AssertionErrors, zero
+  exceptions/import errors) against main. 8/18 already pass on main — flagged
+  explicitly in-file and in the tech doc as regression guards, NOT red specs:
+  the current bug over-rejects (keys on `type`, drops every
+  type=administrative row wholesale, including the county/state/suburb/
+  census/statistical rows those 8 assertions guard against), so the negative
+  cases already hold, for the wrong reason. No production code touched.
+  Full breakdown: jobs/qa/tech/20260807-bug76-atdd-red-tests.md
+
+  Mock-fidelity (OP-35/QUAL-22): accept-rule + e2e files mock at the
+  `global.fetch` boundary with the real committed format=json fixtures
+  (never pre-parsed candidates), matching the existing nominatim-client.test.ts
+  pattern; the BUG-74 contract file mocks nominatimSearch at the service
+  boundary (matches the existing, accepted geocode.test.ts/BUG-79 pattern —
+  justified in the tech doc, not a shortcut). Every test asserts
+  fetch-called-exactly-once as a sanity check the double is actually
+  exercised.
+
+  NEXT: Backend implements against this branch (§3 addressType-keyed rule,
+  §6 status contract) until all 18 assertions are green + type:check:all
+  clean + no other backend suite regresses. Full detail + AC mapping:
+  jobs/qa/tech/20260807-bug76-atdd-red-tests.md
+  Completion report: jobs/COO/inbox/

--- a/jobs/qa/park-docs/20260807-QA-park.txt
+++ b/jobs/qa/park-docs/20260807-QA-park.txt
@@ -1,0 +1,90 @@
+QA PARK DOCUMENT — 2026-08-07
+================================================================================
+THREAD: BUG-76 (P1) / BUG-74 (P2) — ATDD-first RED acceptance suite (OP-35)
+STATUS: COMPLETE — handed off to Backend
+
+WHAT WAS DONE
+--------------------------------------------------------------------------------
+Turned the Architect's success criteria
+(jobs/architect/tech/20260807-BUG76-accept-rule-design.md §7, amended §9.9,
+AC-0..AC-13) into a RED, pre-implementation acceptance suite — ATDD-first per
+OP-35, since this brief was Architect-spawned (BUG-76 root cause was a
+design-level accept-rule change; BUG-74 rides along as the response-contract
+half).
+
+Branch: feat/bug76-accept-rule-fix, off main, pushed to origin. NO PR opened
+— the brief was explicit that a red PR would show red CI by design, and
+Backend is expected to branch from this pushed lineage rather than merge it
+as-is.
+
+3 new test files, 18 assertions total:
+  - src/backend/services/__tests__/bug76-accept-rule.test.ts
+  - src/backend/routes/__tests__/bug76-geocode-e2e.test.ts
+  - src/backend/routes/__tests__/bug76-geocode-contract.test.ts
+
+Zero production code touched (git diff confirms only new test files added).
+
+RESULT
+--------------------------------------------------------------------------------
+10/18 RED against main for the right reason — clean AssertionErrors
+(expected value vs. undefined/0/[]), zero import errors, zero thrown
+exceptions, zero broken mocks. Verified via:
+  npx vitest run --config vitest.config.backend.ts <3 new files>
+  → 10 failed, 8 passed (18 total)
+
+Full backend suite (npm run test:backend): 748/758 passing — the 10 new
+failures are exactly the 3 new files; the other 42 pre-existing test files
+are unaffected (no collateral damage). type:check:backend and npm run check
+(Biome) both clean.
+
+8/18 assertions already PASS on main — flagged explicitly, not hidden as a
+false green. Root cause: the CURRENT bug over-rejects (keys on Nominatim's
+`type` field, drops every type=administrative row wholesale — both the false
+positives AND the true positives). The 8 negative-case ACs (AC-0 x2, AC-4,
+AC-5, AC-7, AC-8 x2, AC-8b) test rows that were already being dropped today,
+for the wrong reason. They are legitimate regression guards for the
+corrected addressType-keyed rule (pin against a future over-widening that
+admits a county/state/suburb/census row) — not red specs of this fix. Full
+reasoning + per-AC breakdown: jobs/qa/tech/20260807-bug76-atdd-red-tests.md
+
+The genuinely red, load-bearing spec: AC-1, AC-2, AC-3, AC-6, AC-9, AC-10
+(admission side) + AC-11/AC-12/AC-13 (BUG-74 status field, absent entirely
+today).
+
+MOCK-FIDELITY (OP-35/QUAL-22)
+--------------------------------------------------------------------------------
+accept-rule + e2e files mock at the global `fetch` boundary (the exact
+surface fetchNominatim calls), loading the real committed
+format=json&addressdetails=1 fixtures off disk verbatim — never
+hand-authored or pre-parsed. Every test asserts fetch-called-exactly-once as
+a direct sanity check the double is actually exercised (the QUAL-22
+antidote: a silently-never-hit mock can still produce a result that looks
+plausible). AC-0 additionally proves the mock is wired to the REAL
+constructed URL, not bypassed. The contract file (AC-11-13) mocks at the
+nominatimSearch service boundary instead — deliberate, matches the existing
+accepted geocode.test.ts/BUG-79 pattern, justified in the tech doc (testing
+route serialization of an already-typed union, not raw-JSON parsing).
+
+OPEN ISSUES / BLOCKERS
+--------------------------------------------------------------------------------
+None. Suite is complete, pushed, and ready for Backend to implement against.
+
+ARTIFACTS
+--------------------------------------------------------------------------------
+- Branch: feat/bug76-accept-rule-fix (pushed, no PR)
+- Tech doc (full AC mapping + red-run evidence): jobs/qa/tech/20260807-bug76-atdd-red-tests.md
+- Context updated: jobs/qa/context/current.txt (appended, not rewritten)
+- Completion report: jobs/COO/inbox/
+
+NEXT (for incoming QA / whoever verifies Backend's fix)
+--------------------------------------------------------------------------------
+1. Once Backend's implementation branch is up, re-run the exact same 3 files
+   and confirm all 18 assertions are green (not just the 10 that were red —
+   the 8 already-green ones must STAY green post-fix, that's the regression
+   guard doing its job).
+2. Confirm type:check:all clean and no other backend suite regressed.
+3. The design doc's Definition of Done (§9.9) also requires: parseCandidate
+   reads addressType: raw.addresstype; the shared isAcceptedSettlement
+   predicate is the ONLY admission gate at both nominatimSearch and
+   nominatimLookup; no production request-format change (still format=json).
+   Spot-check these structurally, not just via the test suite passing.

--- a/jobs/qa/tech/20260807-bug76-atdd-red-tests.md
+++ b/jobs/qa/tech/20260807-bug76-atdd-red-tests.md
@@ -1,0 +1,124 @@
+# BUG-76 (P1) / BUG-74 (P2) — ATDD RED acceptance suite (OP-35)
+
+**Branch:** `feat/bug76-accept-rule-fix` (pushed, no PR — Backend branches from this lineage)
+**Design doc:** `jobs/architect/tech/20260807-BUG76-accept-rule-design.md` §7 (as amended §9.9)
+**Spec:** AC-0 … AC-13
+
+## Files
+
+| File | Covers | Mock boundary |
+|---|---|---|
+| `src/backend/services/__tests__/bug76-accept-rule.test.ts` | AC-0, AC-1, AC-3, AC-4, AC-5, AC-6, AC-7, AC-8 (+statistical variant), AC-8b, AC-9, AC-10 | `global.fetch` — real captured `format=json` fixtures loaded off disk, never pre-parsed candidates |
+| `src/backend/routes/__tests__/bug76-geocode-e2e.test.ts` | AC-2 | `global.fetch` only — real `nominatimSearch` + real accept-rule run through the real route |
+| `src/backend/routes/__tests__/bug76-geocode-contract.test.ts` | AC-11, AC-12, AC-13 | `nominatimSearch` service boundary (matches the existing, accepted `geocode.test.ts`/BUG-79 pattern — see rationale below) |
+
+## AC → test mapping
+
+| AC | Test | Red on main? |
+|---|---|---|
+| AC-0 | `bug76-accept-rule.test.ts` › `AC-0 — outgoing request…` (2 cases: search, lookup) | **No — see "Not red" below** |
+| AC-1 | `bug76-accept-rule.test.ts` › `AC-1 — denver_us.json…` | **Yes** |
+| AC-2 | `bug76-geocode-e2e.test.ts` › `AC-2 — auto-populates…` | **Yes** |
+| AC-3 | `bug76-accept-rule.test.ts` › `AC-3 — springfield_us.json…` | **Yes** |
+| AC-4 | `bug76-accept-rule.test.ts` › `AC-4 — neg_cook_county.json…` | No — see below |
+| AC-5 | `bug76-accept-rule.test.ts` › `AC-5 — neg_colorado_state.json…` | No — see below |
+| AC-6 | `bug76-accept-rule.test.ts` › `AC-6 — Denver CO … WHILE Cook County…` | **Yes** |
+| AC-7 | `bug76-accept-rule.test.ts` › `AC-7 — springfield_global.json…suburb…` | No — see below |
+| AC-8 | `bug76-accept-rule.test.ts` › `AC-8 — springfield_us.json…` + `AC-8 (statistical variant)…` | No — see below |
+| AC-8b | `bug76-accept-rule.test.ts` › `AC-8b — cdp_paradise_nv.json…` | No — see below |
+| AC-9 | `bug76-accept-rule.test.ts` › `AC-9 — springfield_global.json…municipality…` | **Yes** |
+| AC-10 | `bug76-accept-rule.test.ts` › `AC-10 — nominatimLookup…` | **Yes** |
+| AC-11 | `bug76-geocode-contract.test.ts` › `AC-11a`, `AC-11b` | **Yes** |
+| AC-12 | `bug76-geocode-contract.test.ts` › `AC-12…` | **Yes** |
+| AC-13 | `bug76-geocode-contract.test.ts` › `AC-13 (smoke)…` | **Yes** (on the one assertion the AC is actually about — `res.body.status`; flagged as not fully independently expressible, see below) |
+
+**Verified run (2026-08-07, against main via this branch before any production code touched):**
+`npx vitest run --config vitest.config.backend.ts <the 3 new files>` → **10 failed, 8 passed**
+(18 total). Every failure is a clean `AssertionError` (e.g. `expected 0 to be greater than 0`,
+`expected undefined to be 'error'`) — zero import errors, zero thrown exceptions, zero broken
+mocks. `npm run test:backend` (full suite) confirms **no collateral damage**: 748/758 passing,
+all 10 failures are the new ATDD file; the other 42 pre-existing test files are unaffected.
+`npm run type:check:backend` and `npm run check` (Biome) are clean on the new files.
+
+## Why 8/18 assertions already pass on main — flagged, not hidden
+
+The current bug (`nominatim-client.ts` `SETTLEMENT_TYPES.has(candidate.type)`, keyed on
+Nominatim's **class-type** `type` field) is an **over-broad reject**, not an under-broad one:
+every fixture row shaped `type=administrative` (or `type=census`/`type=waterway`) is dropped
+today regardless of what its `addresstype` says — including the county/state/river/suburb/
+census/statistical rows the negative ACs (AC-4, AC-5, AC-7, AC-8, AC-8b) exist to guard
+against. Those rows were never going to be admitted by today's code, for the wrong reason (the
+bug also drops the true positives — Denver, Springfield IL/MO/MA — that's the actual defect).
+So the negative-ACs pass on main already, and will continue to pass after the fix — they are
+**regression guards for the corrected `addresstype`-keyed rule** (pinning against a future
+over-widening, per D4/D5's explicit "reversible/tunable" framing), not red specifications of
+this fix. This is stated in the file header and inline above each such test, verified by
+running the suite (not asserted from reading the code alone — the two-probe standard: reading
+the filter logic AND running it against the real fixtures, which is exactly what this suite
+is).
+
+**AC-0** is a genuine precondition, also already true: `nominatim-client.ts:214`/`:256`
+unconditionally force `format=json&addressdetails=1` regardless of the accept-rule bug — this
+was never broken, and the fix doesn't touch it (design doc §9.1: production stays on
+`format=json`). AC-0 exists as the QUAL-22 mock-fidelity gate (proving the test double is wired
+to the real outgoing URL, not bypassed) and as a regression guard against a future accidental
+switch to `jsonv2` (which would silently break `parseCandidate`'s `raw.class` read) — not as a
+red spec of the accept-rule fix.
+
+**AC-13** is architecturally impossible to express as fully red pre-fix: there is no `status`
+field on the response yet, so nothing can be backward-INcompatible with it. Operationalized two
+ways instead: (a) the ONE assertion the AC is actually about (`res.body.status`) is red today;
+(b) the pre-existing `geocode.test.ts` (BUG-79) suite is left completely unmodified by this
+brief and continues passing unchanged — proving existing consumers/fixtures that never read
+`status` are unaffected by its future addition.
+
+**The genuinely red, load-bearing spec of this fix:** AC-1, AC-2, AC-3, AC-6, AC-9, AC-10 (the
+admission side — real cities currently dropped) plus AC-11/AC-12/AC-13 (the BUG-74 status field,
+which doesn't exist at all today).
+
+## Mock-fidelity measure (OP-35 / QUAL-22)
+
+1. **Fixture provenance.** Every fixture consumed by `bug76-accept-rule.test.ts` and
+   `bug76-geocode-e2e.test.ts` is `readFileSync`'d verbatim from
+   `src/backend/services/__tests__/fixtures/nominatim/bug76/*.json` — never hand-authored
+   inline. These are the Architect-committed, live-captured `format=json&addressdetails=1`
+   bodies (design doc §9.1, README.md in the fixtures dir).
+2. **Mock boundary.** The double replaces `global.fetch` — the exact function
+   `fetchNominatim` calls (`nominatim-client.ts:188`) — returning `{ok:true, status:200,
+   json: async () => <raw fixture array>}`. `parseCandidate` therefore runs against the real
+   raw shape (`class`, `type`, `addresstype`, `address{}`), not a pre-parsed
+   `NominatimCandidate`. This is the same technique the pre-existing, QUAL-22-citing
+   `nominatim-client.test.ts` already uses for the BUG-79 truncation suite.
+3. **Sanity check the double is actually exercised.** Every test asserts
+   `expect(fetch).toHaveBeenCalledTimes(1)` before inspecting the result — this is the direct
+   antidote to the QUAL-22 failure mode (a mock silently never hit, or an exception swallowed
+   by a try/catch, still produces "0 candidates" that could be misread as a correct empty
+   result rather than a broken double). AC-0 additionally asserts on the *literal constructed
+   URL* (`format=json`, `addressdetails=1`), which is only possible if the real
+   `nominatimSearch`/`nominatimLookup` code actually ran and built it — a stubbed-out
+   short-circuit could not produce this string.
+4. **Sanity check the double affects the outcome differently per fixture.** AC-1 (0 admitted
+   pre-fix) vs. AC-4 (0 admitted, but for the correct reason both before and after) vs. AC-9
+   (municipality row present in the 40-row fixture but currently absent from `candidates`)
+   all draw from *different* fixture files through the *identical* mock helper — proving the
+   fixture content, not the mock plumbing, drives the result.
+5. **`bug76-geocode-contract.test.ts` mocks at the `nominatimSearch` service boundary
+   instead**, matching the existing accepted `geocode.test.ts` (BUG-79) pattern. This is
+   deliberate, not a shortcut: AC-11/12/13 test the ROUTE's handling of an already-typed
+   `NominatimSearchResult` discriminated union, not whether raw Nominatim JSON parses
+   correctly (that's AC-0–AC-10's job, covered with real fixtures at the `fetch` boundary in
+   the other two files). Stubbing the service return value here cannot pass vacuously: the
+   values asserted on (`status`, `candidates`) are exactly what the mock returns, and the
+   route's `res.json()` serialization is what's under test.
+
+## No production code touched
+
+Confirmed via `git status`/`git diff` — only the 3 new test files were added. `SETTLEMENT_TYPES`,
+`parseCandidate`, and `geocode.ts`'s response serialization are untouched on this branch.
+
+## Handoff to Backend
+
+Backend branches from `feat/bug76-accept-rule-fix` (already pushed) and implements per the
+design doc (§3 accept-rule keyed on `addressType: raw.addresstype`, §6 the `status` contract)
+until all 18 assertions are green, `type:check:all` is clean, and no other backend suite
+regresses.

--- a/src/backend/routes/__tests__/bug76-geocode-contract.test.ts
+++ b/src/backend/routes/__tests__/bug76-geocode-contract.test.ts
@@ -1,0 +1,141 @@
+/**
+ * BUG-74 (P2, ride-along) — /api/geocode response `status` contract ATDD
+ * suite (OP-35). Design doc: jobs/architect/tech/20260807-BUG76-accept-rule-design.md
+ * §6, §7.5 (AC-11/AC-12/AC-13).
+ *
+ * RED-FIRST, PRE-IMPLEMENTATION: `geocode.ts:86` today collapses the
+ * discriminated `NominatimSearchResult` union to a bare array
+ * (`result.status === 'ok' ? result.candidates : []`) and never serializes
+ * `status` onto the response body — `res.body.status` is `undefined` for
+ * every case today. Every assertion below fails on main for that reason.
+ *
+ * MOCK BOUNDARY: this file mocks `nominatimSearch` at the SERVICE boundary
+ * (not `fetch`), matching the existing, already-accepted pattern in
+ * geocode.test.ts (BUG-79). That is deliberate, not a mock-fidelity
+ * shortcut: this suite tests the ROUTE's handling of an already-typed
+ * `NominatimSearchResult` discriminated union (ok/error/disabled) — it is
+ * not re-testing whether raw Nominatim JSON parses into candidates (that is
+ * bug76-accept-rule.test.ts's job, which DOES mock at the `fetch` boundary
+ * with real captured fixtures). Stubbing the service return value here
+ * cannot pass vacuously the way a hand-authored Nominatim JSON stub could:
+ * the values asserted on (`status`, `candidates`) are exactly the values the
+ * mock returns, and the route's serialization logic is what's under test.
+ *
+ * The end-to-end AC-2 (route -> real nominatimSearch -> real accept-rule ->
+ * Denver auto-populate) lives in bug76-geocode-e2e.test.ts, which does NOT
+ * mock nominatim-client.js, specifically so the real fetch-boundary fixture
+ * flows through unmodified.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockUserId = 'geocode-bug74-user-0000-0000-000000000000';
+let nextResult: unknown = { status: 'ok', candidates: [], truncated: false };
+
+vi.mock('../../middleware/auth.js', () => ({
+  requireAuth: (
+    req: import('express').Request,
+    _res: import('express').Response,
+    next: import('express').NextFunction,
+  ) => {
+    (req as import('express').Request & { user?: unknown }).user = {
+      id: mockUserId,
+      clerkId: 'clerk_geocode_bug74',
+      email: 'geocode-bug74@example.com',
+      isOwner: 0,
+    };
+    next();
+  },
+}));
+
+vi.mock('../../services/nominatim-client.js', () => ({
+  nominatimSearch: vi.fn(async () => nextResult),
+}));
+
+const { default: app } = await import('../../server-test-app.js');
+const supertest = (await import('supertest')).default;
+
+describe('GET /api/geocode — BUG-74 status contract (AC-11/AC-12/AC-13)', () => {
+  beforeEach(() => {
+    nextResult = { status: 'ok', candidates: [], truncated: false };
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // --------------------------------------------------------------
+  // AC-11 — error distinct from genuine empty. Both are HTTP 200 with
+  // candidates:[] today (indistinguishable) — this is the exact mechanism
+  // that made BUG-76 invisible (design doc §6.1).
+  // --------------------------------------------------------------
+  it('AC-11a — upstream status:error is HTTP 200 with body status:"error", candidates:[]', async () => {
+    nextResult = { status: 'error' };
+
+    const res = await supertest(app).get('/api/geocode?q=denver').expect(200);
+
+    expect(res.body.status).toBe('error');
+    expect(res.body.candidates).toEqual([]);
+  });
+
+  it('AC-11b — genuine no-match is HTTP 200 with body status:"ok", candidates:[] — distinguishable from AC-11a by status ONLY', async () => {
+    nextResult = { status: 'ok', candidates: [], truncated: false };
+
+    const res = await supertest(app).get('/api/geocode?q=zzzznomatch').expect(200);
+
+    expect(res.body.status).toBe('ok');
+    expect(res.body.candidates).toEqual([]);
+  });
+
+  // --------------------------------------------------------------
+  // AC-12 — disabled distinct from both ok-empty and error.
+  // --------------------------------------------------------------
+  it('AC-12 — GEOCODING_ENABLED=false path (status:disabled from the chokepoint) surfaces status:"disabled", not "ok"', async () => {
+    nextResult = { status: 'disabled' };
+
+    const res = await supertest(app).get('/api/geocode?q=denver').expect(200);
+
+    expect(res.body.status).toBe('disabled');
+    expect(res.body.status).not.toBe('ok');
+    expect(res.body.candidates).toEqual([]);
+  });
+
+  // --------------------------------------------------------------
+  // AC-13 — additive / back-compat. Not independently expressible as its
+  // own red assertion pre-fix (there is no `status` field yet to be
+  // backward-INcompatible with) — flagged per the brief. Operationalized two
+  // ways instead: (a) the pre-existing geocode.test.ts (BUG-79) suite is
+  // left completely unmodified by this brief and must keep passing, proving
+  // existing consumers/fixtures that never read `status` are unaffected;
+  // (b) this smoke assertion pins that the pre-existing fields survive
+  // unchanged alongside the new field once it exists.
+  // --------------------------------------------------------------
+  it('AC-13 (smoke) — existing candidates/country_code/region_iso/truncated fields are untouched by the status addition', async () => {
+    nextResult = {
+      status: 'ok',
+      candidates: [
+        {
+          displayName: 'Denver, Colorado, United States',
+          name: 'Denver',
+          latitude: 39.7392364,
+          longitude: -104.984862,
+          countryCode: 'US',
+          regionIso: 'US-CO',
+          osmType: 'relation',
+          osmId: 1411339,
+        },
+      ],
+      truncated: false,
+    };
+
+    const res = await supertest(app).get('/api/geocode?q=denver').expect(200);
+
+    expect(res.body.country_code).toBe('US');
+    expect(res.body.region_iso).toBe('US-CO');
+    expect(res.body.truncated).toBe(false);
+    expect(res.body.candidates).toHaveLength(1);
+    expect(res.body.candidates[0].name).toBe('Denver');
+    // The field this AC is actually about — currently absent on main.
+    expect(res.body.status).toBe('ok');
+  });
+});

--- a/src/backend/routes/__tests__/bug76-geocode-e2e.test.ts
+++ b/src/backend/routes/__tests__/bug76-geocode-e2e.test.ts
@@ -1,0 +1,91 @@
+/**
+ * BUG-76 (P1) — AC-2: end-to-end route test for the exact PO symptom.
+ * Design doc: jobs/architect/tech/20260807-BUG76-accept-rule-design.md §7.1.
+ *
+ * "Through GET /api/geocode?q=denver, the response country_code==='US' and
+ * region_iso==='US-CO' — country+state auto-populate."
+ *
+ * Deliberately does NOT `vi.mock('../../services/nominatim-client.js')` —
+ * unlike bug76-geocode-contract.test.ts (BUG-74 contract) and the
+ * pre-existing geocode.test.ts (BUG-79), which both stub the service
+ * boundary. Here the REAL nominatimSearch, REAL accept-rule filter, and REAL
+ * parseCandidate run; only `global.fetch` is stubbed, returning the exact
+ * captured `denver_us.json` fixture body. This is what makes the test
+ * genuinely end-to-end rather than re-mocking the exact seam the fix lives
+ * behind — a route-level test that mocked nominatimSearch's return value
+ * could not tell a correctly-wired route from one wired to a broken
+ * accept-rule, since the candidates would already be pre-filtered by the
+ * mock.
+ *
+ * No fake timers needed: `__resetChokepointForTests()` in `beforeEach` zeros
+ * `lastRequestAt`, so the chokepoint's first request in each test never hits
+ * the 1100ms inter-request delay (`Date.now() - 0` always exceeds
+ * REQUEST_DELAY_MS) — real timers, no risk of interaction between fake
+ * timers and supertest's real socket I/O (untested combination in this
+ * codebase; avoided rather than risked).
+ */
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { __resetChokepointForTests } from '../../services/nominatim-client.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const DENVER_FIXTURE = path.join(
+  __dirname,
+  '../../services/__tests__/fixtures/nominatim/bug76/denver_us.json',
+);
+
+const mockUserId = 'geocode-e2e-user-0000-0000-0000-000000000000';
+
+vi.mock('../../middleware/auth.js', () => ({
+  requireAuth: (
+    req: import('express').Request,
+    _res: import('express').Response,
+    next: import('express').NextFunction,
+  ) => {
+    (req as import('express').Request & { user?: unknown }).user = {
+      id: mockUserId,
+      clerkId: 'clerk_geocode_e2e',
+      email: 'geocode-e2e@example.com',
+      isOwner: 0,
+    };
+    next();
+  },
+}));
+
+const { default: app } = await import('../../server-test-app.js');
+const supertest = (await import('supertest')).default;
+
+describe('GET /api/geocode?q=denver — AC-2 end-to-end (route + real accept-rule)', () => {
+  beforeEach(() => {
+    __resetChokepointForTests();
+    vi.stubEnv('GEOCODING_ENABLED', 'true');
+
+    const denverBody = JSON.parse(readFileSync(DENVER_FIXTURE, 'utf-8'));
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => denverBody,
+      }),
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
+    vi.clearAllMocks();
+  });
+
+  it('AC-2 — auto-populates country_code=US, region_iso=US-CO (today: both null, real Nominatim query returns 0 admitted candidates)', async () => {
+    const res = await supertest(app).get('/api/geocode?q=denver').expect(200);
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(res.body.country_code).toBe('US');
+    expect(res.body.region_iso).toBe('US-CO');
+    expect(res.body.candidates.length).toBeGreaterThan(0);
+  });
+});

--- a/src/backend/routes/geocode.ts
+++ b/src/backend/routes/geocode.ts
@@ -85,6 +85,17 @@ geocodeRouter.get(
     const result = await nominatimSearch(params);
     let candidates = result.status === 'ok' ? result.candidates : [];
     const truncated = result.status === 'ok' ? (result.truncated ?? false) : false;
+    // BUG-74 (design doc §6/§9.9 AC-11/12/13): propagate the status the
+    // client already computed instead of discarding it. Before this, 'error'
+    // (Nominatim down), 'disabled' (GEOCODING_ENABLED=false), and 'ok' with a
+    // genuine no-match all collapsed to an indistinguishable candidates:[] at
+    // HTTP 200 — this is exactly why BUG-76 was invisible (Denver returned
+    // candidates:[] at 200, identical to a real miss). Always HTTP 200; the
+    // frontend distinguishes "our backend unreachable" (apiGet throws) from
+    // "our backend answered, upstream geocoder is the problem" (status field)
+    // — collapsing those into a non-2xx would lose that distinction. Additive
+    // field — existing consumers that don't read `status` are unaffected.
+    const status = result.status;
 
     // D12 step 2: if a region ISO was supplied and any candidate matches it,
     // narrow to those — but never fabricate a result when none match.
@@ -96,6 +107,11 @@ geocodeRouter.get(
     }
 
     res.json({
+      // BUG-74 (NEW): 'ok' | 'error' | 'disabled', mirroring the client's
+      // NominatimSearchResult union. Meaningful only when status==='ok' is
+      // `candidates` a genuine (possibly empty) result — see the comment
+      // above where `status` is captured.
+      status,
       // Full candidate list (D14) — labelled by region for the selector.
       // BUG-75 v3 §1/§B1: osm_type/osm_id are the carried identity a picked
       // candidate's create request sends back (§2.3/§B1); display_name was

--- a/src/backend/services/__tests__/bug76-accept-rule.test.ts
+++ b/src/backend/services/__tests__/bug76-accept-rule.test.ts
@@ -1,0 +1,325 @@
+/**
+ * BUG-76 (P1) — Geocoder accept-rule ATDD suite (OP-35, ATDD-first).
+ *
+ * RED-FIRST, PRE-IMPLEMENTATION. QA authored this suite against `main` before
+ * Backend's fix lands. It encodes AC-0..AC-10 from the design doc:
+ * jobs/architect/tech/20260807-BUG76-accept-rule-design.md §7 (as amended by
+ * §9.9). Do NOT loosen an assertion to make it pass — a red run here is the
+ * point; Backend turns these green.
+ *
+ * MOCK-FIDELITY (OP-35 / QUAL-22, non-negotiable — design doc §7 preamble,
+ * §9.2): every fixture below is the EXACT captured `format=json&addressdetails=1`
+ * JSON body committed at
+ * src/backend/services/__tests__/fixtures/nominatim/bug76/*.json, loaded
+ * verbatim off disk (never hand-authored). The test double is `global.fetch`
+ * itself — the same boundary `fetchNominatim` (nominatim-client.ts) calls —
+ * NOT a stub that hands `parseCandidate` already-shaped candidates. This is
+ * the same technique nominatim-client.test.ts already uses for the BUG-79
+ * truncation suite; the design doc README explicitly blesses it as the
+ * QUAL-22 antidote. Every test also asserts `fetch` was called exactly once,
+ * as a sanity check that the double is actually exercised and not bypassed by
+ * a swallowed exception (the QUAL-22 failure mode: a mock that's silently
+ * never hit still lets the test go green for the wrong reason).
+ *
+ * WHY SOME "REJECT" ACs (AC-4/5/7/8/8b) ALREADY PASS ON MAIN — flagged, not
+ * hidden: the CURRENT bug keys on Nominatim's `type` field, and every row in
+ * these negative fixtures happens to carry `type=administrative` (or
+ * `type=census`/`type=waterway`), none of which is in the current
+ * SETTLEMENT_TYPES set — so the current (over-broad) filter already drops
+ * them, for the wrong reason (it drops the true positives too, which is the
+ * actual bug). These tests are legitimate regression guards for the
+ * CORRECTED addresstype-keyed rule (they pin against a future over-widening
+ * that admits a county/state/suburb/census row) — they are not, by
+ * themselves, red specifications of this fix. AC-0/1/3/6/9/10 (and AC-2 in
+ * the companion e2e route file) are the genuinely red, load-bearing spec.
+ */
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  __resetChokepointForTests,
+  nominatimLookup,
+  nominatimSearch,
+} from '../nominatim-client.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const FIXTURE_DIR = path.join(__dirname, 'fixtures', 'nominatim', 'bug76');
+
+function loadFixture(name: string): unknown[] {
+  const raw = readFileSync(path.join(FIXTURE_DIR, name), 'utf-8');
+  return JSON.parse(raw) as unknown[];
+}
+
+function mockFetch(data: unknown[]) {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => data,
+    }),
+  );
+}
+
+function calledUrl(): string {
+  const mock = fetch as unknown as { mock: { calls: unknown[][] } };
+  expect(mock.mock.calls.length).toBeGreaterThan(0);
+  return mock.mock.calls[0][0] as string;
+}
+
+describe('BUG-76 — geocoder accept-rule (ATDD, RED against main)', () => {
+  beforeEach(() => {
+    __resetChokepointForTests();
+    vi.stubEnv('GEOCODING_ENABLED', 'true');
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
+  });
+
+  // ------------------------------------------------------------------
+  // AC-0 — mock-fidelity gate (already true on main; a precondition, not a
+  // fix-behaviour spec — see file header).
+  // ------------------------------------------------------------------
+  describe('AC-0 — outgoing request carries format=json & addressdetails=1', () => {
+    it('nominatimSearch', async () => {
+      mockFetch(loadFixture('denver_us.json'));
+      await nominatimSearch({ q: 'denver', countrycodes: 'us', limit: '10' });
+
+      expect(fetch).toHaveBeenCalledTimes(1);
+      const url = calledUrl();
+      expect(url).toContain('format=json');
+      expect(url).toContain('addressdetails=1');
+    });
+
+    it('nominatimLookup', async () => {
+      mockFetch(loadFixture('denver_us.json'));
+      await nominatimLookup(['R1411339']);
+
+      expect(fetch).toHaveBeenCalledTimes(1);
+      const url = calledUrl();
+      expect(url).toContain('format=json');
+      expect(url).toContain('addressdetails=1');
+    });
+  });
+
+  // ------------------------------------------------------------------
+  // AC-1 — Denver. RED today: current filter admits 0/4 rows (all
+  // type=administrative). Must admit Denver CO.
+  // ------------------------------------------------------------------
+  it('AC-1 — denver_us.json: Denver CO admitted (today: 0 candidates survive)', async () => {
+    mockFetch(loadFixture('denver_us.json'));
+    const result = await nominatimSearch({ q: 'denver', countrycodes: 'us', limit: '10' });
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(result.status).toBe('ok');
+    if (result.status !== 'ok') return;
+
+    expect(result.candidates.length).toBeGreaterThan(0);
+    const denverCO = result.candidates.find((c) => c.regionIso === 'US-CO');
+    expect(denverCO).toBeDefined();
+    expect(denverCO?.countryCode).toBe('US');
+    expect(Number.isFinite(denverCO?.latitude)).toBe(true);
+    expect(Number.isFinite(denverCO?.longitude)).toBe(true);
+  });
+
+  // ------------------------------------------------------------------
+  // AC-3 — Springfield US capitals. RED today: only the pre-existing VA
+  // `city` node survives (1 candidate); IL/MO/MA (type=administrative) are
+  // dropped. Must admit >=12, including IL/MO/MA by regionIso.
+  // ------------------------------------------------------------------
+  it('AC-3 — springfield_us.json: IL/MO/MA admitted alongside the VA twin, >=12 total', async () => {
+    mockFetch(loadFixture('springfield_us.json'));
+    const result = await nominatimSearch({ q: 'springfield', countrycodes: 'us', limit: '20' });
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(result.status).toBe('ok');
+    if (result.status !== 'ok') return;
+
+    expect(result.candidates.length).toBeGreaterThanOrEqual(12);
+    const regions = result.candidates.map((c) => c.regionIso);
+    expect(regions).toContain('US-IL');
+    expect(regions).toContain('US-MO');
+    expect(regions).toContain('US-MA');
+    // The pre-existing survivor (VA city node) must still be present.
+    expect(regions).toContain('US-VA');
+  });
+
+  // ------------------------------------------------------------------
+  // AC-4 — county rejected. NOT independently red on main (see file header):
+  // all 3 rows are type=administrative, already dropped by the current
+  // over-broad filter. Regression guard for the corrected rule.
+  // ------------------------------------------------------------------
+  it('AC-4 — neg_cook_county.json: no county admitted as a city', async () => {
+    mockFetch(loadFixture('neg_cook_county.json'));
+    const result = await nominatimSearch({ q: 'cook county', countrycodes: 'us', limit: '10' });
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(result.status).toBe('ok');
+    if (result.status !== 'ok') return;
+    expect(result.candidates).toEqual([]);
+  });
+
+  // ------------------------------------------------------------------
+  // AC-5 — state/county/river rejected. NOT independently red on main (same
+  // reason as AC-4). Regression guard.
+  // ------------------------------------------------------------------
+  it('AC-5 — neg_colorado_state.json: no state/county/river admitted', async () => {
+    mockFetch(loadFixture('neg_colorado_state.json'));
+    const result = await nominatimSearch({ q: 'colorado', countrycodes: 'us', limit: '10' });
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(result.status).toBe('ok');
+    if (result.status !== 'ok') return;
+    expect(result.candidates).toEqual([]);
+  });
+
+  // ------------------------------------------------------------------
+  // AC-6 — place_rank cannot discriminate (guards against a lazy fix). RED
+  // today via the Denver-admitted half (Cook-County-rejected half already
+  // holds, same as AC-4).
+  // ------------------------------------------------------------------
+  it('AC-6 — Denver CO (place_rank=12) admitted WHILE Cook County (place_rank=12) rejected', async () => {
+    const denverRaw = loadFixture('denver_us.json') as Array<{
+      addresstype: string;
+      place_rank: number;
+    }>;
+    const cookRaw = loadFixture('neg_cook_county.json') as Array<{ place_rank: number }>;
+
+    // Sanity on the fixtures themselves — the rank collision this AC exists
+    // to guard against.
+    const denverCityRow = denverRaw.find((r) => r.addresstype === 'city');
+    expect(denverCityRow?.place_rank).toBe(12);
+    expect(cookRaw.every((r) => r.place_rank === 12)).toBe(true);
+
+    mockFetch(denverRaw);
+    const denverResult = await nominatimSearch({ q: 'denver', countrycodes: 'us', limit: '10' });
+    expect(denverResult.status).toBe('ok');
+    if (denverResult.status === 'ok') {
+      expect(denverResult.candidates.some((c) => c.regionIso === 'US-CO')).toBe(true);
+    }
+
+    __resetChokepointForTests();
+    mockFetch(cookRaw);
+    const cookResult = await nominatimSearch({ q: 'cook county', countrycodes: 'us', limit: '10' });
+    expect(cookResult.status).toBe('ok');
+    if (cookResult.status === 'ok') {
+      expect(cookResult.candidates).toEqual([]);
+    }
+  });
+
+  // ------------------------------------------------------------------
+  // AC-7 — suburb rejected. NOT independently red on main (same reason as
+  // AC-4/5: type=administrative already dropped today). Regression guard —
+  // D4 is explicitly reversible/tunable, so this pins the current ruling.
+  // ------------------------------------------------------------------
+  it('AC-7 — springfield_global.json: no addresstype=suburb row admitted', async () => {
+    mockFetch(loadFixture('springfield_global.json'));
+    const result = await nominatimSearch({ q: 'springfield', limit: '40' });
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(result.status).toBe('ok');
+    if (result.status !== 'ok') return;
+
+    // The 3 suburb rows (Chelmsford GB rel 3180630, Queensland AU rel
+    // 11675581, NSW AU rel 6039399) must never appear.
+    const suburbOsmIds = new Set([3180630, 11675581, 6039399]);
+    const admittedOsmIds = result.candidates.map((c) => c.osmId).filter((id) => id != null);
+    for (const id of suburbOsmIds) {
+      expect(admittedOsmIds).not.toContain(id);
+    }
+  });
+
+  // ------------------------------------------------------------------
+  // AC-8 — census/statistical rejected, settlement twin kept, no dupe. NOT
+  // independently red on main for the springfield_us case (VA city node
+  // already survives type-keyed filtering today; the census row is already
+  // dropped). Regression guard. Also covers the `statistical` variant via
+  // the Bethesda MD CDP fixture (design doc §9.9 amendment).
+  // ------------------------------------------------------------------
+  it('AC-8 — springfield_us.json: Springfield VA appears exactly once (city node, not census)', async () => {
+    mockFetch(loadFixture('springfield_us.json'));
+    const result = await nominatimSearch({ q: 'springfield', countrycodes: 'us', limit: '20' });
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(result.status).toBe('ok');
+    if (result.status !== 'ok') return;
+
+    const vaRows = result.candidates.filter((c) => c.regionIso === 'US-VA');
+    expect(vaRows).toHaveLength(1);
+    expect(vaRows[0]?.osmId).toBe(158396042); // the `city` node, not the census relation (206834)
+    expect(Number.isFinite(vaRows[0]?.latitude)).toBe(true);
+  });
+
+  it('AC-8 (statistical variant) — cdp_bethesda_md.json: statistical relation rejected, city node twin admitted', async () => {
+    mockFetch(loadFixture('cdp_bethesda_md.json'));
+    const result = await nominatimSearch({ q: 'Bethesda, Maryland' });
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(result.status).toBe('ok');
+    if (result.status !== 'ok') return;
+
+    expect(result.candidates).toHaveLength(1);
+    expect(result.candidates[0]?.osmId).toBe(158248181); // the `city` node twin
+    expect(result.candidates.map((c) => c.osmId)).not.toContain(133482); // the `statistical` relation
+  });
+
+  // ------------------------------------------------------------------
+  // AC-8b — Paradise NV CDP twin. NOT independently red on main: the census
+  // relation is already dropped (type=census) and the town NODE twin is
+  // already admitted (type=town is in today's SETTLEMENT_TYPES). Both
+  // halves already hold pre-fix — a regression guard, not a red spec.
+  // ------------------------------------------------------------------
+  it('AC-8b — cdp_paradise_nv.json: census relation rejected, town node twin admitted', async () => {
+    mockFetch(loadFixture('cdp_paradise_nv.json'));
+    const result = await nominatimSearch({ q: 'Paradise, Nevada' });
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(result.status).toBe('ok');
+    if (result.status !== 'ok') return;
+
+    expect(result.candidates).toHaveLength(1);
+    expect(result.candidates[0]?.osmId).toBe(3139480510); // the `town` node twin
+    expect(result.candidates.map((c) => c.osmId)).not.toContain(170053); // the `census` relation
+  });
+
+  // ------------------------------------------------------------------
+  // AC-9 — municipality admitted. RED today: "Town of Springfield, Dane
+  // County, Wisconsin" is type=administrative (dropped today).
+  // ------------------------------------------------------------------
+  it('AC-9 — springfield_global.json: addresstype=municipality row admitted (Town of Springfield, WI)', async () => {
+    mockFetch(loadFixture('springfield_global.json'));
+    const result = await nominatimSearch({ q: 'springfield', limit: '40' });
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(result.status).toBe('ok');
+    if (result.status !== 'ok') return;
+
+    const admittedOsmIds = result.candidates.map((c) => c.osmId);
+    expect(admittedOsmIds).toContain(4014903); // "Town of Springfield, Dane County, Wisconsin" — addresstype=municipality
+  });
+
+  // ------------------------------------------------------------------
+  // AC-10 — /lookup applies the same accept-rule. RED today: a Denver
+  // admin-boundary `city` row (type=administrative) fed through
+  // nominatimLookup is dropped by the same current filter as nominatimSearch.
+  // ------------------------------------------------------------------
+  it('AC-10 — nominatimLookup: admin-boundary city row admitted (reused Denver row)', async () => {
+    const denverRaw = loadFixture('denver_us.json') as Array<{ addresstype: string }>;
+    const denverCityRow = denverRaw.filter((r) => r.addresstype === 'city');
+    expect(denverCityRow).toHaveLength(1); // sanity: exactly one `city` row in the fixture
+
+    mockFetch(denverCityRow);
+    const result = await nominatimLookup(['R1411339']);
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(result.status).toBe('ok');
+    if (result.status !== 'ok') return;
+
+    expect(result.candidates.length).toBeGreaterThan(0);
+    expect(result.candidates.some((c) => c.regionIso === 'US-CO')).toBe(true);
+  });
+});

--- a/src/backend/services/__tests__/nominatim-client.test.ts
+++ b/src/backend/services/__tests__/nominatim-client.test.ts
@@ -20,7 +20,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { __resetChokepointForTests, nominatimSearch } from '../nominatim-client.js';
 
-function rawResult(overrides: { name?: string; type?: string } = {}) {
+function rawResult(overrides: { name?: string; type?: string; addresstype?: string } = {}) {
   return {
     lat: '1.0',
     lon: '1.0',
@@ -28,6 +28,10 @@ function rawResult(overrides: { name?: string; type?: string } = {}) {
     name: overrides.name ?? 'Testville',
     class: 'place',
     type: overrides.type ?? 'city',
+    // BUG-76: addresstype is the admission-gate discriminator (nominatim-client.ts
+    // isAcceptedSettlement), not type/class — default 'city' so existing rows
+    // in this file keep passing the filter unless a test overrides it.
+    addresstype: overrides.addresstype ?? 'city',
     address: { country_code: 'us', 'ISO3166-2-lvl4': 'US-XX' },
   };
 }
@@ -80,17 +84,18 @@ describe('nominatimSearch — BUG-79 truncation signal', () => {
 
   it('computes truncation from the PRE-FILTER raw count, not the post-settlement-filter survivor count', async () => {
     // 5 raw rows at limit=5 (truncated should read true from the raw count),
-    // but 3 of them are 'administrative' areas the SETTLEMENT_TYPES filter
-    // drops — only 2 survive into `candidates`. Proves the signal survives
-    // the exact discard point the brief named (nominatim-client.ts's
-    // .filter() call), rather than being derived after the fact from a
-    // post-filter count that could never legitimately exceed the limit.
+    // but 3 of them are 'county' addresstype rows the isAcceptedSettlement
+    // filter drops (BUG-76: keyed on addresstype, not type/class) — only 2
+    // survive into `candidates`. Proves the signal survives the exact
+    // discard point the brief named (nominatim-client.ts's .filter() call),
+    // rather than being derived after the fact from a post-filter count that
+    // could never legitimately exceed the limit.
     mockFetchOnce([
       rawResult({ name: 'City1' }),
       rawResult({ name: 'City2' }),
-      rawResult({ name: 'Admin1', type: 'administrative' }),
-      rawResult({ name: 'Admin2', type: 'administrative' }),
-      rawResult({ name: 'Admin3', type: 'administrative' }),
+      rawResult({ name: 'Admin1', type: 'administrative', addresstype: 'county' }),
+      rawResult({ name: 'Admin2', type: 'administrative', addresstype: 'county' }),
+      rawResult({ name: 'Admin3', type: 'administrative', addresstype: 'county' }),
     ]);
 
     const promise = nominatimSearch({ q: 'springfield', limit: '5' });

--- a/src/backend/services/nominatim-client.ts
+++ b/src/backend/services/nominatim-client.ts
@@ -73,9 +73,19 @@ export interface NominatimCandidate {
   countryCode: string | null;
   /** ISO 3166-2 subdivision code (e.g. 'US-CO'), if present. */
   regionIso: string | null;
-  /** Nominatim class/type — used to filter to settlements. */
+  /** Nominatim class/type — carried metadata only; NOT the admission gate (BUG-76). */
   class?: string;
   type?: string;
+  /**
+   * BUG-76 — Nominatim's `addresstype` field (present under `format=json&
+   * addressdetails=1`, the request shape this module always sends). THE
+   * admission-gate discriminator (see `isAcceptedSettlement` below):
+   * `type`/`class` cannot distinguish a city modelled as an OSM admin-boundary
+   * relation (`type=administrative`) from a county or state (also
+   * `type=administrative`), but `addresstype` can (`city` vs `county` vs
+   * `state`). `undefined` when the caller's fixture predates this field.
+   */
+  addressType?: string;
   /**
    * BUG-75 v3 (§0/§2.3) — the carried identity pair. Optional (not `null`
    * defaulted to a required field) because some existing fixtures/callers in
@@ -100,6 +110,8 @@ interface RawNominatimResult {
   name?: string;
   class?: string;
   type?: string;
+  /** BUG-76 — the admission-gate discriminator; see NominatimCandidate.addressType. */
+  addresstype?: string;
   /** BUG-75 v3 §B1/§2.1 — the carried identity pair, straight off Nominatim. */
   osm_type?: string;
   osm_id?: number;
@@ -113,7 +125,31 @@ interface RawNominatimResult {
   };
 }
 
-const SETTLEMENT_TYPES = new Set(['city', 'town', 'village', 'hamlet', 'municipality']);
+/**
+ * BUG-76 (ADL-51 §3.1/§9.3) — the settlement discriminator, keyed on
+ * Nominatim's `addresstype` field, NOT `type`/`class`. `type=administrative`
+ * is shared by cities, counties, and states alike (both Denver CO and Cook
+ * County are `type=administrative`, `place_rank=12` — AC-6 pins this),  so it
+ * cannot discriminate; `addresstype` can (`city` vs `county` vs `state`).
+ *
+ * `census`/`statistical` (US Census/statistical artifacts) and `suburb`
+ * (sub-municipal) are deliberately excluded — reversible/tunable per design
+ * doc §9.4/§9.5, not a deep invariant. Do not blanket-add them back without
+ * re-reading §9.5 (a naive add reintroduces an un-dedupable duplicate for
+ * every place with both a statistical row and a settlement twin).
+ */
+const SETTLEMENT_ADDRESSTYPES = new Set(['city', 'town', 'village', 'hamlet', 'municipality']);
+
+/**
+ * BUG-76 (ADL-51 §3.4/§9.8) — THE single admission-gate predicate, shared by
+ * both nominatimSearch (:230-ish) and nominatimLookup (:267-ish) so the two
+ * call sites cannot drift apart again. Admits when the discriminator is
+ * absent (legacy fixtures; a deliberately-picked /lookup id — §3.1) or is a
+ * recognized settlement addresstype.
+ */
+function isAcceptedSettlement(candidate: NominatimCandidate): boolean {
+  return candidate.addressType == null || SETTLEMENT_ADDRESSTYPES.has(candidate.addressType);
+}
 
 /**
  * Discriminated result of one search (ADL-46 D10 §4.4.1): the caller must
@@ -225,10 +261,7 @@ export async function nominatimSearch(
     const truncated = Number.isFinite(requestedLimit) && data.length >= requestedLimit;
     const candidates = data
       .map(parseCandidate)
-      .filter(
-        (c): c is NominatimCandidate =>
-          c !== null && (c.type == null || SETTLEMENT_TYPES.has(c.type)),
-      );
+      .filter((c): c is NominatimCandidate => c !== null && isAcceptedSettlement(c));
     return { status: 'ok', candidates, truncated };
   } catch (err) {
     console.warn('[GEO] Nominatim request failed:', (err as Error).message);
@@ -262,10 +295,7 @@ export async function nominatimLookup(osmIds: string[]): Promise<NominatimSearch
     const data = await enqueue(() => fetchNominatim(url));
     const candidates = data
       .map(parseCandidate)
-      .filter(
-        (c): c is NominatimCandidate =>
-          c !== null && (c.type == null || SETTLEMENT_TYPES.has(c.type)),
-      );
+      .filter((c): c is NominatimCandidate => c !== null && isAcceptedSettlement(c));
     return { status: 'ok', candidates };
   } catch (err) {
     console.warn('[GEO] Nominatim lookup failed:', (err as Error).message);
@@ -293,6 +323,7 @@ function parseCandidate(raw: RawNominatimResult): NominatimCandidate | null {
     regionIso: raw.address?.['ISO3166-2-lvl4'] ?? null,
     class: raw.class,
     type: raw.type,
+    addressType: raw.addresstype,
     osmType,
     osmId,
     county: raw.address?.county ?? raw.address?.state_district ?? null,


### PR DESCRIPTION
## Summary

- **BUG-76 (P1):** re-keys the geocoder's settlement accept-rule from Nominatim's `type`/`class` fields to `addresstype`. The old filter admitted/rejected on `type`, which is `administrative` for cities, counties, AND states alike — Denver CO has no OSM settlement place-node, only an admin-boundary relation, so it was never geocodable through the old filter (latent gap, not a regression). A single shared predicate `isAcceptedSettlement` now gates both `nominatimSearch` and `nominatimLookup`.
- **BUG-74 (P2, ride-along):** `GET /api/geocode` now serializes `status: 'ok'|'error'|'disabled'` onto the response body instead of collapsing every non-`'ok'` result to `candidates:[]` at HTTP 200 — this collapse is the exact mechanism that made BUG-76 invisible to the frontend/PO (Denver's empty result was indistinguishable from an upstream failure). Always HTTP 200; additive/back-compat.

Implements to QA's pre-written RED ATDD suite (OP-35 ATDD-first) — no redesign. Design doc: `jobs/architect/tech/20260807-BUG76-accept-rule-design.md` (ADL-51, see §9 for the corrected design-of-record).

BRD: GE-11, GE-16. Tracker: BUG-76, BUG-74 (no existing GitHub issue found for either — searched by title and by adjacent issue numbers referenced in tracker notes; none matched).

## Changes

- `src/backend/services/nominatim-client.ts` — `parseCandidate` captures `addressType: raw.addresstype`; new `SETTLEMENT_ADDRESSTYPES` set + `isAcceptedSettlement` predicate replaces the old `SETTLEMENT_TYPES.has(c.type)` gate at both call sites. Production request shape unchanged (still `format=json&addressdetails=1` — switching to `jsonv2` was considered and rejected, it would break `parseCandidate`'s `raw.class` read).
- `src/backend/routes/geocode.ts` — response body gains `status`, mirroring `NominatimSearchResult`.
- `src/backend/services/__tests__/nominatim-client.test.ts` — pre-existing BUG-79 truncation test's fixture helper simulated filtered-out rows via the OLD discriminator (`type`); re-keyed to `addresstype` to preserve the test's actual intent (declared per OP-28, not a QA ATDD file).
- `jobs/backend/tech/20260307-api-reference.md` — new "Geocode Proxy" section documenting `GET /api/geocode`'s full response shape including the new `status` field.

## Test plan

- [x] QA's 3 ATDD files (`bug76-accept-rule.test.ts`, `bug76-geocode-e2e.test.ts`, `bug76-geocode-contract.test.ts`): 18/18 assertions (AC-0…AC-13) pass
- [x] `npm run test:backend`: 758/758 pass, 45 files, no regressions
- [x] `npm run test:frontend`: 302/302 pass (no frontend files touched)
- [x] `npm run type:check:all`: clean
- [x] `npm run check` (Biome): clean
- [x] `npm run status:check`: STATUS.md up to date
- [x] Two independent probes confirm nothing outside the filter reads `candidate.type`/`.class` (grep across `src/backend` + reading `geocoding.service.ts`) — re-keying has no other blast radius

## Security checklist (GET /api/geocode modified)

1. Auth middleware: `requireAuth` applied globally (`app.use('/api/', requireAuth)` in `server.ts`) — unchanged, pre-existing `nosemgrep` annotation documents this.
2. userId scoping: n/a — proxy reads no user-owned table.
3. FK notNull: n/a — no schema change.

## Out of scope (flagged, not absorbed)

Frontend's half of BUG-74 (banner mapping `error`/`disabled` → `failed:true` in `useCities.ts`'s `lookupCityCountry`, plus typing `status` onto `GeocodeResult` in `src/frontend/types/api.ts`) is a separate follow-up per the brief.

🤖 Generated with [Claude Code](https://claude.com/claude-code)