### PR TITLE
fix(BUG-81/BUG-74): clean collision-aware picker rows + geocoder-failure banner

### DIFF
--- a/jobs/COO/inbox/20260807_1810-FRONTEND-bug81-bug74-complete.txt
+++ b/jobs/COO/inbox/20260807_1810-FRONTEND-bug81-bug74-complete.txt
@@ -1,0 +1,38 @@
+FRONTEND completion report
+Tracker: BUG-81, BUG-74 · PR #427 · BRD GE-16, GE-15 · Branch: feat/bug81-picker-readability
+
+WHAT WAS BUILT
+CityPicker rows now compose "City, State, Country" from structured GeocodeCandidate
+fields (county added only to colliding rows, coordinate discriminator as rare last
+resort, cleaned display_name as fallback when structured fields are entirely absent) via
+new src/frontend/utils/composeCandidateLabel.ts, plus a max-h-72/overflow-y-auto scroll
+cap on the list. lookupCityCountry (useCities.ts) now maps status:'error'|'disabled' to
+failed:true, surfacing the existing BUG-73 banner for upstream geocoder failures.
+
+ACCEPTANCE CRITERIA
+- Default "City, State, Country", no county, no postcode, non-colliding candidate: PASS
+- Collision rule adds county only to colliding (name+state+country) rows: PASS
+- Missing state renders "City, Country", no empty comma: PASS
+- Rare fallback (still-identical after county) gets a discriminator, never identical: PASS
+- Legacy fixtures (no structured fields) fall back to cleaned display_name: PASS
+- List container has max-h/scroll class, long list scrolls in-picker: PASS
+- Existing truncated/onSelect/disabled contract unchanged: PASS
+- status:'error'/'disabled' -> failed:true -> existing banner shows: PASS
+- status:'ok' + empty candidates -> failed:false, no error banner: PASS
+- No new banner copy invented (BUG-71/73 text reused verbatim): PASS
+
+CI: gh pr checks 427 — 18/18 green (scripts/ci-wait.sh pr 427 confirmed PASS).
+
+OPEN ISSUES / BLOCKERS
+None. Two decisions made without a brief callout, flagged here:
+1. "Structured fields entirely absent" (fallback trigger) = state/country/county ALL
+   null/undefined — any one present routes through the structured composer.
+2. Rare-fallback discriminator chosen as rounded lat/long (not display_name) to keep
+   label style consistent within a list — brief offered either.
+Full rationale in the park doc.
+
+WHAT IS NOW UNBLOCKED
+PR ready for COO review/merge. Per the tracker note, UX reviews CityPicker (both call
+sites — AddPlaceFlow and the now-existing ChangeCityModal) for theme adherence next.
+
+Full detail: jobs/frontend/park-docs/20260807-FRONTEND-bug81-bug74-park.txt

--- a/jobs/frontend/context/current.txt
+++ b/jobs/frontend/context/current.txt
@@ -861,3 +861,37 @@ CityPicker's contract is ready for it but building the modal/button/hook
 itself is separate, un-briefed work (UX-12, P1, own UX spec). Full detail:
 jobs/frontend/park-docs/20260806-FRONTEND-bug75-citypicker-park.txt and
 jobs/frontend/tech/20260806-bug75-citypicker.md.
+
+UPDATE 2026-08-07 — BUG-81/BUG-74 picker readability + geocoder-failure
+banner (branch feat/bug81-picker-readability, PR #427, off main — the
+BUG-81 backend fields (state/country/county) and the BUG-74 status field
+were already merged to main as separate backend work before this brief).
+New src/frontend/utils/composeCandidateLabel.ts: pure label-composition
+function CityPicker now maps candidates through by index — default
+"City, State, Country" from structured fields (never postcode, which was
+never in those fields anyway), county added only to rows colliding on
+(name, state, country) case-insensitively, a rounded-coordinate
+discriminator as the rare last-resort if still identical, and a cleaned
+display_name (postcode-looking segments stripped) fallback for candidates
+with no structured fields at all — this last path is what keeps the
+existing BUG-75/UX-12 ATDD suites (AddPlaceFlow.city-picker.test.tsx,
+ChangeCityModal.test.tsx) green unmodified, since their fixtures predate
+BUG-81 and carry no state/country/county. CityPicker.tsx's list container
+also gained a max-h-72/overflow-y-auto inner scroll wrapper (outer rounded
+border/overflow-hidden kept) so a long list (Springfield ~20) scrolls
+within the picker instead of the page. BUG-74: lookupCityCountry
+(useCities.ts) now maps the backend's status:'error'|'disabled' to
+failed:true — reusing the existing BUG-73 amber banner text verbatim, no
+new copy invented, since AddPlaceFlow.tsx and ChangeCityModal.tsx both
+already render that banner off the same `failed` flag with no further
+changes needed. status:'ok' with empty candidates stays failed:false (a
+genuine no-match). GeocodeResult gained optional `status` in types/api.ts
+(same optional/additive pattern as `truncated`). New tests:
+composeCandidateLabel.test.ts (9), CityPicker.test.tsx (7, new file — no
+prior CityPicker unit test existed), 4 new cases in
+useCities.geocode.test.tsx. Full suite 321/321 green, backend 762/762
+untouched, type:check:all clean, biome clean (same 5 pre-existing infos
+noted in the BUG-75 park doc). Not built: the copy-decision question in
+the brief was pre-answered (reuse BUG-71/73 text verbatim) so nothing was
+invented there. Full detail:
+jobs/frontend/park-docs/20260807-FRONTEND-bug81-bug74-park.txt.

--- a/jobs/frontend/park-docs/20260807-FRONTEND-bug81-bug74-park.txt
+++ b/jobs/frontend/park-docs/20260807-FRONTEND-bug81-bug74-park.txt
@@ -1,0 +1,143 @@
+PARK DOCUMENT — Frontend — BUG-81 (picker readability) / BUG-74 (geocoder-failure banner)
+Date: 2026-08-07
+Branch: feat/bug81-picker-readability (off main)
+PR: #427 — CI 18/18 green, not merged (COO merges)
+
+TASK
+Two bundled UI fixes on the geocode/place-picker surface. BUG-81: CityPicker's raw
+display_name rows are noisy (postcode/county cruft) and uncapped-height. BUG-74: an
+upstream geocoder failure was indistinguishable from a genuine no-match. Both backend
+halves (structured state/country/county fields; the status field) were already merged
+to main before this brief — this thread is FRONTEND-only.
+
+READ FIRST (for the next agent touching this area)
+- src/frontend/utils/composeCandidateLabel.ts — the label-composition rule, doc comment
+  states the full algorithm.
+- src/frontend/components/shared/CityPicker.tsx — consumer; doc comment updated to point
+  at composeCandidateLabel.ts rather than re-describing the rule.
+- Tracker BUG-81 note — the PO-agreed rule this implements verbatim (Springfield PA
+  Delaware-County-vs-Bucks-County is the worked collision example, taken directly from
+  the PO's own framing).
+- src/frontend/components/TripDetail/__tests__/AddPlaceFlow.city-picker.test.tsx and
+  .../ChangeCityModal.test.tsx + fixtures/newportGeocode.ts — the two existing ATDD
+  consumers of CityPicker. Their fixtures predate BUG-81 and carry NO state/country/
+  county fields, so they exercise the "structured fields entirely absent" fallback path
+  (cleaned display_name) — this is WHY they stayed green unmodified. If you ever add
+  state/country/county to those fixtures, the picker output for those rows will change
+  from full display_name to the composed "City, ..." form — re-check those assertions
+  if you do.
+
+WHAT SHIPPED
+
+1. src/frontend/utils/composeCandidateLabel.ts (NEW) — pure function
+   composeCandidateLabels(candidates: GeocodeCandidate[]): string[], aligned by index.
+   Algorithm (see its own doc comment for the full rationale):
+     a. hasStructuredFields(c) = state != null || country != null || county != null.
+     b. Structured candidates: base label = [name, state, country] joined, skipping
+        empty parts. Never includes postcode (postcode was never in these fields).
+     c. Non-structured candidates: base label = cleanDisplayName(display_name) — strips
+        postcode-looking segments via two regexes (numeric \d{3,10}; UK-style
+        alphanumeric like "PO30 1JU") — falling back to the raw display_name if
+        stripping would leave nothing.
+     d. Collision pass: structured candidates sharing (name, state, country)
+        case-insensitively get county inserted: [name, county, state, country].
+     e. Rare-fallback pass: anything STILL identical (case-insensitive) after (d) gets
+        a rounded-coordinate suffix " (lat, long)".
+     f. Absolute-last-resort pass: anything still colliding (should not happen in
+        practice) gets a positional suffix " (2)", " (3)", ... — guarantees the "no two
+        rows are ever identical" requirement outright rather than leaving a
+        theoretical gap.
+   Deliberately pure/stateless (no React) so it's unit-testable on its own; CityPicker
+   just maps candidates through it by index.
+
+2. src/frontend/components/shared/CityPicker.tsx — row label now `labels[index]` from
+   composeCandidateLabels instead of `candidate.display_name`. List container
+   restructured: outer `border border-gray-200 rounded-md overflow-hidden` div kept (for
+   the rounded-corner clip), NEW inner `max-h-72 overflow-y-auto` div wraps the row map
+   — chose max-h-72 (18rem, ~6-8 rows at the existing px-3 py-2.5 row height) per the
+   brief's suggested range. onSelect/disabled/truncated contract unchanged. Doc comment
+   updated (not rewritten) to point at composeCandidateLabel.ts.
+
+3. src/frontend/types/api.ts — GeocodeResult gained optional `status?: 'ok' | 'error' |
+   'disabled'`, same optional/additive pattern as `truncated` (existing fixtures that
+   predate the field keep type-checking; the real backend always sends it per
+   jobs/backend/tech/20260307-api-reference.md's Geocode Proxy section, confirmed by
+   reading both the doc and src/backend/routes/geocode.ts directly — the doc matches the
+   code exactly, no drift to flag).
+
+4. src/frontend/hooks/useCities.ts — lookupCityCountry now computes
+   `upstreamFailed = result.status === 'error' || result.status === 'disabled'` and
+   returns that as `failed` (previously always `false` on any non-throwing response).
+   `status === 'ok'` (or omitted, for pre-BUG-74 mocks/fixtures) leaves `failed: false`
+   unchanged. NO changes to AddPlaceFlow.tsx or ChangeCityModal.tsx — both already read
+   `failed` off this same function (AddPlaceFlow.tsx:374/431, ChangeCityModal.tsx via
+   useCityDisambiguation.ts:61) and already render the exact BUG-73 banner text
+   ("Automatic lookup failed — you can select country and region manually.") for
+   `failed:true`, so the status-mapping fix flows through to both consumers with zero
+   further code changes. This is also why the brief's copy-decision question
+   ("if unclear, keep the existing BUG-73 banner text") didn't actually need a judgment
+   call — reusing it wasn't a choice against inventing new copy, it was the only
+   consistent outcome of not touching two working, tested UI blocks.
+
+5. Tests — composeCandidateLabel.test.ts (9 cases: default label, collision+county,
+   non-colliding-neighbor-unaffected, missing-state no-empty-comma, no-postcode,
+   legacy-fallback matching the real Newport IOW/Telford ATDD fixture text, rare-fallback
+   coordinate discriminator, label-count-matches-candidate-count). CityPicker.test.tsx
+   (NEW file — no prior CityPicker unit test existed; 7 cases covering the same ground at
+   the render layer plus the max-h-72/overflow-y-auto class assertion and the
+   onSelect/disabled/truncated contract). useCities.geocode.test.tsx — 4 new cases under
+   a new "BUG-74: status -> failed mapping" describe block (error, disabled, ok-empty,
+   status-omitted).
+
+VERIFICATION DONE
+- npx vitest run (targeted): 3 files, 28/28 green.
+- npm run test:frontend: 321/321 green, 45 files — includes the existing BUG-75/UX-12
+  ATDD suites (AddPlaceFlow.city-picker.test.tsx, ChangeCityModal.test.tsx), unmodified
+  and passing via the legacy-fallback path (see READ FIRST above).
+- npm run test:backend: 762/762 green (untouched, backend already shipped separately).
+- npm run type:check:all: clean.
+- npm run check (biome): clean after `biome check --write` fixed 3 formatting-only
+  findings (import order in CityPicker.tsx, two multi-line-array formattings in the new
+  test files) — no lint errors. 5 pre-existing infos remain in backend test files not
+  touched by this brief (same ones noted in the BUG-75 park doc — literal-key lint
+  suggestions in cities.identity-carry.test.ts / geocoding.resolveByOsmId.test.ts).
+- npm run status:check: up to date, no doc changes required (no status/verdict doc
+  asserted a fact this PR changes).
+- PR #427: 18/18 CI checks green (scripts/ci-wait.sh pr 427).
+- git diff --stat: 7 files, all src/frontend (types/api.ts, hooks/useCities.ts,
+  hooks/__tests__/useCities.geocode.test.tsx, components/shared/CityPicker.tsx modified;
+  components/shared/__tests__/CityPicker.test.tsx, utils/composeCandidateLabel.ts,
+  utils/__tests__/composeCandidateLabel.test.ts new). No backend/schema files touched.
+
+DECISIONS FLAGGED TO COO (see completion report for the short version)
+1. "Structured fields entirely absent" trigger for the display_name fallback is
+   `state == null && country == null && county == null` — i.e. ANY one of the three
+   present routes a candidate through the structured composer instead. This wasn't
+   explicit in the brief; picked because it's the natural reading of "entirely absent"
+   and it's exactly what keeps the existing ATDD fixtures (which have none of the three)
+   on the fallback path while a real backend response (which per the API doc always
+   sends at least `country`) always uses the structured path.
+2. Postcode-stripping in the display_name fallback is a heuristic (two regexes: numeric,
+   UK-style alphanumeric) — not a full postcode validator. Good enough for the observed
+   cases (US ZIP, UK postcodes in the tracker note's own examples) but could
+   false-negative on a postcode format that looks like ordinary text elsewhere in a
+   display_name. Low risk: worst case is a postcode slipping through on the FALLBACK
+   path only, which is itself a legacy/rare path once real API responses (which always
+   carry structured fields) dominate.
+3. Rare-fallback discriminator chosen as rounded lat/long over "fall back to
+   display_name" (the brief offered both) — kept the label style consistent
+   (structured labels stay structured-looking) rather than mixing formats mid-list.
+
+NOT BUILT / OUT OF SCOPE
+- No copy was invented for BUG-74 — confirmed this needed no judgment call (see WHAT
+  SHIPPED item 4).
+- UX review of the picker's overall theme adherence — explicitly deferred to UX per the
+  tracker note ("AFTER build: UX reviews the picker as a whole for adherence with the
+  app's overall theme").
+
+NEXT STEPS (when resumed)
+- COO: merge PR #427 once reviewed.
+- UX: review CityPicker (and the picker-precedence composition generally) for theme
+  adherence, per the PO's 2026-08-07 direction recorded in the BUG-81 tracker note.
+- Nothing else blocks on this thread — BUG-76/BUG-75/BUG-74/BUG-81's frontend layer is
+  now fully shipped pending merge + UAT.

--- a/jobs/frontend/tech/20260806-bug75-citypicker.md
+++ b/jobs/frontend/tech/20260806-bug75-citypicker.md
@@ -32,9 +32,22 @@ that file ~:422-444) — a deliberate visual-consistency reuse, not a code extra
 underlying data shape: post-creation `City` rows with an `id` vs. pre-creation
 `GeocodeCandidate`s that don't have one yet).
 
+> **UPDATED 2026-08-07 (BUG-81, PR #427)** — the row label described above as "renders
+> `candidate.display_name`" is superseded. Rows now render a label composed from the
+> candidate's structured `name`/`state`/`country` fields (with `county` added only for
+> colliding rows, `display_name` kept as the fallback when structured fields are entirely
+> absent) via `composeCandidateLabels` (`src/frontend/utils/composeCandidateLabel.ts`) —
+> raw `display_name` crammed in postcode/county cruft that made a long list (Springfield
+> ~20 US rows) hard to skim. The outer bordered container also gained an inner
+> `max-h-72 overflow-y-auto` scroll wrapper (outer `rounded-md overflow-hidden` unchanged)
+> so a long list scrolls within the picker instead of the page. Full detail:
+> `jobs/frontend/park-docs/20260807-FRONTEND-bug81-bug74-park.txt`. The rest of this
+> section (key strategy, visual-consistency reuse rationale) is unaffected and still
+> accurate.
+
 When `truncated` is true, renders "There may be more matches not shown." below the list —
 the BUG-79 caveat, same phrasing family as the region-select/Suggested-caption caveats
-elsewhere in `AddPlaceFlow.tsx`.
+elsewhere in `AddPlaceFlow.tsx`. (Unaffected by the 2026-08-07 update above.)
 
 ## AddPlaceFlow's ambiguity-detection trigger (where the caller decides to render it)
 
@@ -46,6 +59,12 @@ trigger would be (a currently-green regression-parity test — Denver/Denver Cou
 region with no `osm_id` — requires it).
 
 ## Extending to a second call site (UX-12)
+
+> **SUPERSEDED (2026-08-07)** — UX-12's "Change city" call site now exists:
+> `src/frontend/components/TripDetail/ChangeCityModal.tsx`, consuming `CityPicker`
+> unchanged per the plan below. Retained for history/rationale; not itself out of date
+> (the BUG-81 label-composition update above applies automatically to this consumer too,
+> with no changes required to `ChangeCityModal.tsx`).
 
 When UX-12 is briefed:
 1. Build the "Change city" control + modal shell (UX spec

--- a/src/frontend/components/shared/CityPicker.tsx
+++ b/src/frontend/components/shared/CityPicker.tsx
@@ -1,12 +1,24 @@
 /**
  * CityPicker — shared place-level candidate picker (BUG-75 / UX-12, v3 §1.3/§B5).
  *
- * Renders a set of geocode candidates by `display_name` and reports the
- * chosen candidate back to the caller. Exists because region-only
- * disambiguation is structurally insufficient: two distinct real places can
- * share a region (the two GB-ENG Newports — Isle of Wight and Telford and
- * Wrekin), so a region `<select>` collapses them into one indistinguishable
- * option. `display_name` is the discriminator a region selector throws away.
+ * Renders a set of geocode candidates and reports the chosen candidate back
+ * to the caller. Exists because region-only disambiguation is structurally
+ * insufficient: two distinct real places can share a region (the two GB-ENG
+ * Newports — Isle of Wight and Telford and Wrekin), so a region `<select>`
+ * collapses them into one indistinguishable option.
+ *
+ * BUG-81 (UAT finding on the BUG-76 build, 2026-08-07): row labels used to be
+ * the raw Nominatim `display_name`, which crams in county AND postcode plus
+ * occasional cruft, making a long list (Springfield ~20 US rows) hard to
+ * skim. Labels are now composed from the candidate's structured `name`/
+ * `state`/`country` fields via `composeCandidateLabels`
+ * (`../../utils/composeCandidateLabel.ts`) — "City, State, Country" by
+ * default, county added only to rows that collide on (name, state, country),
+ * a coordinate discriminator as the rare last resort, and `display_name`
+ * (cleaned of postcode-looking segments) as the fallback for candidates that
+ * carry no structured fields at all (legacy/fixture shapes). See that
+ * module's doc comment for the full rule — this component just maps
+ * candidates through it by index.
  *
  * ONE component, TWO call sites (v3 §A "Shared CityPicker reuse plan",
  * carried unchanged from v2 §8):
@@ -39,7 +51,9 @@
  * geocode.ts), so "there may be more matches not shown" still applies here,
  * same as the region-select and Suggested-caption caveats it sits alongside.
  */
+
 import type { GeocodeCandidate } from '../../types/api';
+import { composeCandidateLabels } from '../../utils/composeCandidateLabel';
 
 export interface CityPickerProps {
   /** Distinct-identity candidates to present, in the order given. */
@@ -64,20 +78,28 @@ function candidateKey(candidate: GeocodeCandidate, index: number): string {
 }
 
 export function CityPicker({ candidates, onSelect, truncated, disabled }: CityPickerProps) {
+  const labels = composeCandidateLabels(candidates);
   return (
     <div>
+      {/* BUG-81: outer border/rounding stays on this wrapper so the rounded
+          corners still clip visually; the scroll itself lives on the INNER
+          div so a long list (Springfield ~20) scrolls within the picker
+          instead of pushing the page. max-h-72 (~18rem) shows roughly 6-8
+          rows at this row height before scrolling kicks in. */}
       <div className="border border-gray-200 rounded-md overflow-hidden">
-        {candidates.map((candidate, index) => (
-          <div
-            key={candidateKey(candidate, index)}
-            className="px-3 py-2.5 cursor-pointer border-b border-gray-100 text-sm hover:bg-gray-50 last:border-b-0"
-            onClick={() => {
-              if (!disabled) onSelect(candidate);
-            }}
-          >
-            {candidate.display_name}
-          </div>
-        ))}
+        <div className="max-h-72 overflow-y-auto">
+          {candidates.map((candidate, index) => (
+            <div
+              key={candidateKey(candidate, index)}
+              className="px-3 py-2.5 cursor-pointer border-b border-gray-100 text-sm hover:bg-gray-50 last:border-b-0"
+              onClick={() => {
+                if (!disabled) onSelect(candidate);
+              }}
+            >
+              {labels[index]}
+            </div>
+          ))}
+        </div>
       </div>
       {/* BUG-79 (v3 §B5 m1): carried into the picker — matches the phrasing
           already used for the region-select/Suggested-caption caveats. */}

--- a/src/frontend/components/shared/__tests__/CityPicker.test.tsx
+++ b/src/frontend/components/shared/__tests__/CityPicker.test.tsx
@@ -1,0 +1,150 @@
+/**
+ * BUG-81 (BRD GE-16) — `CityPicker` component tests.
+ *
+ * Source: src/frontend/components/shared/CityPicker.tsx
+ *
+ * The label-composition rule itself is unit-tested directly in
+ * composeCandidateLabel.test.ts; these tests confirm CityPicker actually
+ * renders the composed labels (not raw display_name) and carries the
+ * BUG-81 scroll cap plus the existing truncated/onSelect/disabled contract.
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import type { GeocodeCandidate } from '../../../types/api';
+import { CityPicker } from '../CityPicker';
+
+function candidate(overrides: Partial<GeocodeCandidate> = {}): GeocodeCandidate {
+  return {
+    name: 'Springfield',
+    display_name: 'Springfield, Sangamon County, Illinois, 62701, United States',
+    country_code: 'US',
+    region_iso: 'US-IL',
+    latitude: 39.78,
+    longitude: -89.65,
+    osm_type: 'node',
+    osm_id: 1,
+    ...overrides,
+  };
+}
+
+describe('CityPicker — BUG-81 collision-aware labels', () => {
+  it('renders a non-colliding candidate as "City, State, Country" — no county, no postcode, not the raw display_name', () => {
+    render(
+      <CityPicker
+        candidates={[
+          candidate({
+            osm_id: 1,
+            state: 'Illinois',
+            country: 'United States',
+            county: 'Sangamon County',
+          }),
+        ]}
+        onSelect={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText('Springfield, Illinois, United States')).toBeInTheDocument();
+    expect(screen.queryByText(/Sangamon/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/62701/)).not.toBeInTheDocument();
+  });
+
+  it('adds county to two candidates that collide on (name, state, country)', () => {
+    render(
+      <CityPicker
+        candidates={[
+          candidate({
+            osm_id: 1,
+            name: 'Springfield',
+            state: 'Pennsylvania',
+            country: 'United States',
+            county: 'Delaware County',
+          }),
+          candidate({
+            osm_id: 2,
+            name: 'Springfield',
+            state: 'Pennsylvania',
+            country: 'United States',
+            county: 'Bucks County',
+          }),
+        ]}
+        onSelect={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByText('Springfield, Delaware County, Pennsylvania, United States'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('Springfield, Bucks County, Pennsylvania, United States'),
+    ).toBeInTheDocument();
+  });
+
+  it('renders "City, Country" with no empty comma for a candidate missing state', () => {
+    render(
+      <CityPicker
+        candidates={[
+          candidate({ osm_id: 1, name: 'Zurich', state: undefined, country: 'Switzerland' }),
+        ]}
+        onSelect={vi.fn()}
+      />,
+    );
+
+    const row = screen.getByText('Zurich, Switzerland');
+    expect(row).toBeInTheDocument();
+    expect(row.textContent).not.toContain(', ,');
+  });
+
+  it('falls back to a cleaned display_name for a candidate with no structured fields at all (legacy fixture shape)', () => {
+    render(
+      <CityPicker
+        candidates={[
+          candidate({
+            osm_id: 1,
+            name: 'Newport',
+            display_name: 'Newport, Isle of Wight, England, PO30 1JU, UK',
+            state: undefined,
+            country: undefined,
+            county: undefined,
+          }),
+        ]}
+        onSelect={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText(/Newport, Isle of Wight, England, UK/i)).toBeInTheDocument();
+  });
+
+  it('the list container carries a height cap and vertical scroll (BUG-81: a long list scrolls within the picker, not the page)', () => {
+    const many = Array.from({ length: 20 }, (_, i) =>
+      candidate({ osm_id: i, latitude: 39 + i * 0.01, longitude: -89 + i * 0.01 }),
+    );
+    const { container } = render(<CityPicker candidates={many} onSelect={vi.fn()} />);
+
+    const scrollContainer = container.querySelector('.max-h-72.overflow-y-auto');
+    expect(scrollContainer).not.toBeNull();
+    expect(scrollContainer?.children).toHaveLength(20);
+  });
+
+  it('still calls onSelect with the full candidate on click, and respects disabled', async () => {
+    const onSelect = vi.fn();
+    const user = userEvent.setup();
+    const c = candidate({ osm_id: 1, state: 'Illinois', country: 'United States' });
+    render(<CityPicker candidates={[c]} onSelect={onSelect} disabled />);
+
+    await user.click(screen.getByText('Springfield, Illinois, United States'));
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it('still renders the truncated caveat unchanged', () => {
+    render(
+      <CityPicker
+        candidates={[candidate({ osm_id: 1, state: 'Illinois', country: 'United States' })]}
+        onSelect={vi.fn()}
+        truncated
+      />,
+    );
+
+    expect(screen.getByText(/there may be more matches not shown/i)).toBeInTheDocument();
+  });
+});

--- a/src/frontend/hooks/__tests__/useCities.geocode.test.tsx
+++ b/src/frontend/hooks/__tests__/useCities.geocode.test.tsx
@@ -218,4 +218,65 @@ describe('lookupCityCountry', () => {
       vi.useRealTimers();
     }
   });
+
+  // BUG-74 (ADL-51 §6): the backend now labels an upstream geocoder failure or
+  // a disabled geocoder distinctly from a genuine no-match, both previously
+  // an indistinguishable candidates:[] at HTTP 200 — this is why BUG-76 was
+  // invisible to the user. lookupCityCountry must map both non-'ok' statuses
+  // to failed:true so the existing BUG-73 banner surfaces.
+  describe('BUG-74: status -> failed mapping', () => {
+    it('status:"error" (upstream Nominatim failure) maps to failed:true even though our backend answered 200', async () => {
+      const result: GeocodeResult = {
+        status: 'error',
+        candidates: [],
+        country_code: null,
+        region_iso: null,
+      };
+      vi.mocked(apiGet).mockResolvedValue(result);
+
+      const { failed, candidates, countryCode, regionIso } = await lookupCityCountry('Denver');
+
+      expect(failed).toBe(true);
+      expect(candidates).toEqual([]);
+      expect(countryCode).toBeNull();
+      expect(regionIso).toBeNull();
+    });
+
+    it('status:"disabled" (GEOCODING_ENABLED=false) maps to failed:true', async () => {
+      const result: GeocodeResult = {
+        status: 'disabled',
+        candidates: [],
+        country_code: null,
+        region_iso: null,
+      };
+      vi.mocked(apiGet).mockResolvedValue(result);
+
+      const { failed } = await lookupCityCountry('Denver');
+
+      expect(failed).toBe(true);
+    });
+
+    it('status:"ok" with empty candidates stays a genuine no-match — failed:false, no error banner', async () => {
+      const result: GeocodeResult = {
+        status: 'ok',
+        candidates: [],
+        country_code: null,
+        region_iso: null,
+      };
+      vi.mocked(apiGet).mockResolvedValue(result);
+
+      const { failed } = await lookupCityCountry('Zzznotacity');
+
+      expect(failed).toBe(false);
+    });
+
+    it('an omitted status (pre-BUG-74 response shape) defaults to failed:false — additive field, no regression', async () => {
+      const result: GeocodeResult = { candidates: [], country_code: null, region_iso: null };
+      vi.mocked(apiGet).mockResolvedValue(result);
+
+      const { failed } = await lookupCityCountry('Springfield');
+
+      expect(failed).toBe(false);
+    });
+  });
 });

--- a/src/frontend/hooks/useCities.ts
+++ b/src/frontend/hooks/useCities.ts
@@ -78,9 +78,12 @@ async function fetchGeocodeResultWithRetry(cityName: string): Promise<GeocodeRes
  * @param cityName - The city name to look up.
  * @returns Upper-cased country code (e.g. "FR"), region ISO (e.g. "US-CA"),
  *   both nullable, the full candidate list (empty on any failure), `failed` —
- *   true only when retries were exhausted without a successful response
- *   (never true for a successful "no match" response) — and `truncated`
- *   (BUG-79) — true when the backend's raw Nominatim response may have had
+ *   true when retries were exhausted without a successful response, OR
+ *   (BUG-74) when the backend answered but reported `status: 'error'` or
+ *   `'disabled'` — the upstream geocoder itself failed rather than our
+ *   backend being unreachable. Never true for a genuine `status: 'ok'`
+ *   no-match — that stays a real "found nothing", not an error. `truncated`
+ *   (BUG-79) is true when the backend's raw Nominatim response may have had
  *   more matches than `candidates` shows, false on any failure (nothing was
  *   truncated; nothing was returned at all).
  */
@@ -93,11 +96,17 @@ export async function lookupCityCountry(cityName: string): Promise<{
 }> {
   try {
     const result = await fetchGeocodeResultWithRetry(cityName);
+    // BUG-74: an upstream geocoder failure ('error') or a disabled geocoder
+    // ('disabled') is a failed lookup for the caller's purposes — same
+    // user-visible banner as a retries-exhausted network failure — even
+    // though our own backend answered with HTTP 200. `status` undefined
+    // (pre-BUG-74 fixtures/mocks) or 'ok' both leave `failed` false here.
+    const upstreamFailed = result.status === 'error' || result.status === 'disabled';
     return {
       countryCode: result.country_code?.toUpperCase() ?? null,
       regionIso: result.region_iso ?? null,
       candidates: result.candidates,
-      failed: false,
+      failed: upstreamFailed,
       truncated: result.truncated ?? false,
     };
   } catch {

--- a/src/frontend/types/api.ts
+++ b/src/frontend/types/api.ts
@@ -143,6 +143,19 @@ export interface GeocodeResult {
    * it where the truncation behaviour isn't what they're testing.
    */
   truncated?: boolean;
+  /**
+   * BUG-74 (ADL-51 §6) — mirrors the backend's internal `NominatimSearchResult`
+   * union (`src/backend/routes/geocode.ts`). Distinguishes "our backend
+   * answered, but the upstream geocoder failed or is disabled" (`'error'` /
+   * `'disabled'`) from a genuine no-match (`'ok'` with empty `candidates`) —
+   * previously both collapsed to an indistinguishable `candidates: []` at
+   * HTTP 200, which is exactly why BUG-76 was invisible to the user. Always
+   * HTTP 200 regardless of `status` (see the backend route doc comment for
+   * why a non-2xx was rejected). Typed optional for the same reason
+   * `truncated` is: existing hand-written fixtures that predate this field
+   * must keep type-checking; the real backend always sends it.
+   */
+  status?: 'ok' | 'error' | 'disabled';
 }
 
 // Minimal association shapes used inside trip responses

--- a/src/frontend/utils/__tests__/composeCandidateLabel.test.ts
+++ b/src/frontend/utils/__tests__/composeCandidateLabel.test.ts
@@ -1,0 +1,166 @@
+/**
+ * BUG-81 (BRD GE-16) — `composeCandidateLabels` unit tests.
+ *
+ * Source: src/frontend/utils/composeCandidateLabel.ts
+ *
+ * Covers the PO-agreed rule (tracker BUG-81): default "City, State, Country"
+ * from structured fields, county added only to rows colliding on
+ * (name, state, country), a coordinate discriminator as the rare last
+ * resort, and a cleaned `display_name` fallback for candidates with no
+ * structured fields at all.
+ */
+import { describe, expect, it } from 'vitest';
+import type { GeocodeCandidate } from '../../types/api';
+import { composeCandidateLabels } from '../composeCandidateLabel';
+
+function candidate(overrides: Partial<GeocodeCandidate> = {}): GeocodeCandidate {
+  return {
+    name: 'Springfield',
+    display_name: 'Springfield, Sangamon County, Illinois, 62701, United States',
+    country_code: 'US',
+    region_iso: 'US-IL',
+    latitude: 39.78,
+    longitude: -89.65,
+    ...overrides,
+  };
+}
+
+describe('composeCandidateLabels', () => {
+  it('composes "City, State, Country" from structured fields for a non-colliding candidate — no county, no postcode', () => {
+    const [label] = composeCandidateLabels([
+      candidate({ state: 'Illinois', country: 'United States', county: 'Sangamon County' }),
+    ]);
+
+    expect(label).toBe('Springfield, Illinois, United States');
+  });
+
+  it('adds county to two candidates sharing (name, state, country) — the real Springfield/Delaware-vs-Bucks-County case', () => {
+    const [pa1, pa2] = composeCandidateLabels([
+      candidate({
+        name: 'Springfield',
+        state: 'Pennsylvania',
+        country: 'United States',
+        county: 'Delaware County',
+      }),
+      candidate({
+        name: 'Springfield',
+        state: 'Pennsylvania',
+        country: 'United States',
+        county: 'Bucks County',
+      }),
+    ]);
+
+    expect(pa1).toBe('Springfield, Delaware County, Pennsylvania, United States');
+    expect(pa2).toBe('Springfield, Bucks County, Pennsylvania, United States');
+  });
+
+  it('leaves candidates outside the colliding (name, state, country) group unaffected — clean, no county', () => {
+    const [pa1, pa2, il] = composeCandidateLabels([
+      candidate({
+        name: 'Springfield',
+        state: 'Pennsylvania',
+        country: 'United States',
+        county: 'Delaware County',
+      }),
+      candidate({
+        name: 'Springfield',
+        state: 'Pennsylvania',
+        country: 'United States',
+        county: 'Bucks County',
+      }),
+      candidate({
+        name: 'Springfield',
+        state: 'Illinois',
+        country: 'United States',
+        county: 'Sangamon County',
+      }),
+    ]);
+
+    expect(pa1).toContain('Delaware County');
+    expect(pa2).toContain('Bucks County');
+    expect(il).toBe('Springfield, Illinois, United States');
+  });
+
+  it('renders "City, Country" without an empty comma when state is absent', () => {
+    const [label] = composeCandidateLabels([
+      candidate({ name: 'Zurich', country: 'Switzerland', state: undefined }),
+    ]);
+
+    expect(label).toBe('Zurich, Switzerland');
+    expect(label).not.toContain(', ,');
+  });
+
+  it('never includes a postcode when structured fields are present', () => {
+    const [label] = composeCandidateLabels([
+      candidate({
+        state: 'Virginia',
+        country: 'United States',
+        county: 'Fairfax County',
+        display_name: 'Springfield, Fairfax County, Virginia, 22150, United States',
+      }),
+    ]);
+
+    expect(label).not.toMatch(/22150/);
+  });
+
+  it('falls back to a cleaned display_name (postcode stripped) when structured fields are entirely absent — legacy/fixture shape', () => {
+    const [iow, telford] = composeCandidateLabels([
+      candidate({
+        name: 'Newport',
+        display_name: 'Newport, Isle of Wight, England, PO30 1JU, UK',
+        state: undefined,
+        country: undefined,
+        county: undefined,
+      }),
+      candidate({
+        name: 'Newport',
+        display_name: 'Newport, Telford and Wrekin, England, TF10 7AG, UK',
+        state: undefined,
+        country: undefined,
+        county: undefined,
+      }),
+    ]);
+
+    expect(iow).toBe('Newport, Isle of Wight, England, UK');
+    expect(telford).toBe('Newport, Telford and Wrekin, England, UK');
+  });
+
+  it('applies a coordinate discriminator as the rare fallback when rows are still identical after adding county', () => {
+    const [a, b] = composeCandidateLabels([
+      candidate({
+        name: 'Springfield',
+        state: 'Pennsylvania',
+        country: 'United States',
+        county: 'Delaware County',
+        latitude: 39.93,
+        longitude: -75.33,
+      }),
+      candidate({
+        name: 'Springfield',
+        state: 'Pennsylvania',
+        country: 'United States',
+        county: 'Delaware County',
+        latitude: 40.1,
+        longitude: -75.5,
+      }),
+    ]);
+
+    expect(a).not.toBe(b);
+    expect(a).toContain('39.93');
+    expect(b).toContain('40.10');
+  });
+
+  it('produces exactly as many labels as candidates given, aligned by index', () => {
+    const labels = composeCandidateLabels([
+      candidate({ state: 'Illinois', country: 'United States' }),
+      candidate({
+        name: 'Newport',
+        display_name: 'Newport, UK',
+        state: undefined,
+        country: undefined,
+      }),
+    ]);
+
+    expect(labels).toHaveLength(2);
+  });
+});

--- a/src/frontend/utils/composeCandidateLabel.ts
+++ b/src/frontend/utils/composeCandidateLabel.ts
@@ -1,0 +1,144 @@
+/**
+ * BUG-81 (BRD GE-16) — collision-aware label composition for the shared
+ * `CityPicker` (`src/frontend/components/shared/CityPicker.tsx`).
+ *
+ * UAT finding 2026-08-07: the picker rendered Nominatim's raw `display_name`,
+ * which crams in county AND postcode plus occasional cruft (e.g. "Springfield,
+ * Fairfax County, Virginia, 22150, United States"), making a long list
+ * (Springfield ~20 US rows) hard to skim. PO-agreed rule (tracker BUG-81):
+ *
+ *   - Default: "City, State, Country" from the STRUCTURED name fields
+ *     (`GeocodeCandidate.name/state/country`) — never postcode.
+ *   - Collision rule: 2+ candidates sharing (name + state + country),
+ *     case-insensitively, get COUNTY added to those rows only — the real
+ *     disambiguation case the PO flagged (multiple Springfields in ONE
+ *     state, e.g. PA Delaware County vs Bucks County).
+ *   - Rare fallback: if rows are STILL identical after adding county
+ *     (same name + state + county too), append a rounded-coordinate
+ *     discriminator so no two rows are ever identical.
+ *   - Legacy fallback: candidates entirely lacking structured fields
+ *     (state/country/county all absent — pre-BUG-81 fixtures, or a response
+ *     shape from before the backend sent these fields) fall back to a
+ *     cleaned `display_name` (postcode-looking segments stripped).
+ *
+ * Pure and stateless — no React, so it is unit-testable on its own and the
+ * component just maps candidates through it by index.
+ */
+import type { GeocodeCandidate } from '../types/api';
+
+/** True when a candidate carries ANY of the BUG-81 structured name fields. */
+function hasStructuredFields(candidate: GeocodeCandidate): boolean {
+  return candidate.state != null || candidate.country != null || candidate.county != null;
+}
+
+/** Joins non-empty parts with ", ", skipping null/undefined/blank entries —
+ *  never producing an empty-part comma (e.g. "City, , Country"). */
+function composeParts(parts: Array<string | null | undefined>): string {
+  return parts
+    .map((p) => p?.trim())
+    .filter((p): p is string => !!p)
+    .join(', ');
+}
+
+/** Case-insensitive collision key over a set of parts (missing parts treated
+ *  as the empty string, so "no state" is itself a distinguishing value). */
+function collisionKey(parts: Array<string | null | undefined>): string {
+  return parts.map((p) => (p ?? '').trim().toLowerCase()).join('|');
+}
+
+/** Groups indices by key, dropping any null keys (candidates that don't
+ *  participate in this grouping pass). */
+function groupIndicesByKey(keys: Array<string | null>): Map<string, number[]> {
+  const groups = new Map<string, number[]>();
+  keys.forEach((key, index) => {
+    if (key == null) return;
+    const list = groups.get(key);
+    if (list) {
+      list.push(index);
+    } else {
+      groups.set(key, [index]);
+    }
+  });
+  return groups;
+}
+
+/** Segments that look like a postcode — numeric (US ZIP, many EU codes) or
+ *  UK-style alphanumeric (e.g. "PO30 1JU", "SW1A 1AA"). Heuristic, not a
+ *  full postcode validator — good enough to strip the cruft `display_name`
+ *  carries without a false-positive risk on real place-name segments (which
+ *  don't look like this). */
+const NUMERIC_POSTCODE_RE = /^\d{3,10}$/;
+const ALPHANUMERIC_POSTCODE_RE = /^[A-Z0-9]{2,4}\s?\d[A-Z0-9]{0,3}$/i;
+
+function looksLikePostcodeSegment(segment: string): boolean {
+  return NUMERIC_POSTCODE_RE.test(segment) || ALPHANUMERIC_POSTCODE_RE.test(segment);
+}
+
+/** Strips postcode-looking segments out of a raw `display_name`, e.g.
+ *  "Newport, Isle of Wight, England, PO30 1JU, UK" ->
+ *  "Newport, Isle of Wight, England, UK". Falls back to the original string
+ *  if stripping would leave nothing (defensive — should not happen for a
+ *  real Nominatim `display_name`). */
+function cleanDisplayName(displayName: string): string {
+  const cleaned = displayName
+    .split(',')
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0 && !looksLikePostcodeSegment(s))
+    .join(', ');
+  return cleaned || displayName;
+}
+
+/**
+ * Composes one display label per candidate, aligned by index with the input
+ * array. See the module doc comment for the full rule.
+ */
+export function composeCandidateLabels(candidates: GeocodeCandidate[]): string[] {
+  const structuredFlags = candidates.map(hasStructuredFields);
+  const labels: string[] = candidates.map((candidate, index) =>
+    structuredFlags[index]
+      ? composeParts([candidate.name, candidate.state, candidate.country])
+      : cleanDisplayName(candidate.display_name) || candidate.name,
+  );
+
+  // Collision pass 1: structured candidates sharing (name, state, country)
+  // get county added to those rows only.
+  const nameStateCountryGroups = groupIndicesByKey(
+    candidates.map((c, i) =>
+      structuredFlags[i] ? collisionKey([c.name, c.state, c.country]) : null,
+    ),
+  );
+  for (const indices of nameStateCountryGroups.values()) {
+    if (indices.length < 2) continue;
+    for (const i of indices) {
+      const c = candidates[i];
+      labels[i] = composeParts([c.name, c.county, c.state, c.country]);
+    }
+  }
+
+  // Rare fallback: anything still identical (case-insensitive) after the
+  // above — including a legacy-fallback row that happens to collide with
+  // another — gets a rounded-coordinate discriminator so no two rows are
+  // ever identical.
+  const finalGroups = groupIndicesByKey(labels.map((label) => label.toLowerCase()));
+  for (const indices of finalGroups.values()) {
+    if (indices.length < 2) continue;
+    for (const i of indices) {
+      const c = candidates[i];
+      labels[i] = `${labels[i]} (${c.latitude.toFixed(2)}, ${c.longitude.toFixed(2)})`;
+    }
+  }
+
+  // Absolute last resort — coordinates rounded the same way is vanishingly
+  // unlikely but not impossible; guarantee uniqueness outright rather than
+  // leave two rows the user cannot tell apart.
+  const lastResortGroups = groupIndicesByKey(labels.map((label) => label.toLowerCase()));
+  for (const indices of lastResortGroups.values()) {
+    if (indices.length < 2) continue;
+    indices.forEach((i, order) => {
+      if (order === 0) return;
+      labels[i] = `${labels[i]} (${order + 1})`;
+    });
+  }
+
+  return labels;
+}


### PR DESCRIPTION
Closes tracker BUG-81, BUG-74. BRD GE-16 (city find-or-create UX), GE-15 (geocode auto-populate).

## BUG-81 — collision-aware picker labels

`CityPicker` rows compose `"City, State, Country"` from the structured
`GeocodeCandidate.state`/`country` fields instead of the raw Nominatim
`display_name`, which previously crammed in county AND postcode plus
occasional cruft (e.g. `"Springfield, Fairfax County, Virginia, 22150,
United States"`), per the PO-agreed rule recorded in the BUG-81 tracker note.

- Default: `[name, state, country]` joined, skipping empty parts. Postcode
  is never shown (it was never in these fields to begin with).
- Collision rule: 2+ candidates sharing `(name, state, country)`
  case-insensitively get `county` added to those rows only — e.g. two PA
  Springfields become `"Springfield, Delaware County, Pennsylvania, United
  States"` / `"Springfield, Bucks County, Pennsylvania, United States"`.
- Rare fallback: still-identical rows after adding county get a
  rounded-coordinate discriminator appended.
- Legacy fallback: a candidate with no structured fields at all (state/
  country/county all absent — the pre-BUG-81 fixture shape, still used by
  the existing BUG-75/UX-12 ATDD suites) falls back to a cleaned
  `display_name` (postcode-looking segments stripped).

Logic lives in `src/frontend/utils/composeCandidateLabel.ts` so it's
unit-testable independent of the component.

The picker's list container also gets a `max-h-72 overflow-y-auto` inner
scroll wrapper (outer rounded border/`overflow-hidden` unchanged) so a long
list (Springfield ~20 US rows) scrolls within the picker instead of pushing
the page.

## BUG-74 — surface the geocoder-failure banner

`lookupCityCountry` (`useCities.ts`) now maps the backend's new
`status: 'error' | 'disabled'` to `failed: true`, so the existing BUG-73
amber banner (`"Automatic lookup failed — you can select country and region
manually."`) surfaces for an upstream geocoder failure that previously
looked HTTP-200-identical to a genuine no-match. `status: 'ok'` with empty
candidates stays `failed: false` — a real no-match, no error banner. No new
copy — reuses the existing BUG-71/BUG-73 banner text per the brief; both
`AddPlaceFlow.tsx` and `ChangeCityModal.tsx` already read `failed` off this
same function, so both consumers pick this up with no further changes.

`GeocodeResult.status` added to `types/api.ts` (optional/additive, same
pattern as `truncated`).

## Tests

- `src/frontend/utils/__tests__/composeCandidateLabel.test.ts` — label
  composition + collision + fallback rules (9 tests).
- `src/frontend/components/shared/__tests__/CityPicker.test.tsx` — component
  renders composed labels, collision county, missing-state no-empty-comma,
  legacy display_name fallback, scroll-cap class, onSelect/disabled/truncated
  contract unchanged (7 tests).
- `src/frontend/hooks/__tests__/useCities.geocode.test.tsx` — 4 new cases for
  the status→failed mapping (error/disabled/ok-empty/status-omitted).

## Verification

- `npm run check` — clean (5 pre-existing infos in backend files not touched
  here, same ones noted in the BUG-75 park doc).
- `npm run type:check:all` — clean.
- `npm run test:backend` — 762/762 green (untouched).
- `npm run test:frontend` — 321/321 green, including the existing BUG-75/
  UX-12 ATDD suites (`AddPlaceFlow.city-picker.test.tsx`,
  `ChangeCityModal.test.tsx`) with no regressions — their fixtures have no
  structured fields, so they exercise the legacy display_name fallback path.
- `npm run status:check` — up to date, no doc changes required.
