### PR TITLE
docs(BUG-81): UX theme review of the city picker

### DIFF
--- a/jobs/COO/inbox/20260807_2330-UX-citypicker-theme-review-complete.txt
+++ b/jobs/COO/inbox/20260807_2330-UX-citypicker-theme-review-complete.txt
@@ -1,0 +1,41 @@
+BUG-81/BUG-74 · GE-16 · Branch: docs/ux-citypicker-theme-review · PR: TBD (see below)
+
+Reviewed the shipped city-disambiguation picker (CityPicker.tsx) and both call sites
+(AddPlaceFlow.tsx, ChangeCityModal.tsx) for adherence with the app's established design
+theme, per PO direction 2026-08-07. Review only — no code changed.
+
+VERDICT: theme-consistent. Spacing, typography, container styling, and colour vocabulary
+all match real sibling precedents (TripForm.tsx, PlaceDateForm.tsx, CountryTab.tsx) — not
+an invented bar. The two call sites render near byte-identically. Judged the picker against
+its own (legacy, non-Waypoint) component family, since AddPlaceFlow/ChangeCityModal are not
+migrated to wp-* tokens — confirmed already-known, already-tracked debt, not a new issue.
+
+FINDINGS (full detail + file:line + direction in jobs/ux/tech/20260807-UX-citypicker-theme-review.md):
+- BLOCKER: picker rows are bare <div onClick>, unreachable by keyboard (no tabIndex/role/
+  onKeyDown). Diverges from TripForm.tsx's own <button>-based pattern for the same "pick one
+  from a filtered list" interaction. Inherited from AddPlaceFlow's pre-existing rows, not
+  introduced by BUG-81 — but it fully blocks keyboard-only users from completing the flow.
+- SHOULD-FIX: `disabled` prop only gates the click handler, not the row's visual state —
+  no opacity/cursor change, unlike Button.tsx's disabled vocabulary used everywhere else.
+- SHOULD-FIX: text-amber-600 (pre-existing "please choose"/"more matches" captions, reused
+  by the picker) computes to ~3.2:1 contrast on white, below WCAG AA 4.5:1. Shared-pattern
+  fix (5 usages, 2 files), not picker-only.
+- Nice-to-have (3): scroll-cutoff lands near a row boundary (weak affordance, reasoned not
+  screenshotted); long fallback labels can wrap unevenly (recommend NOT truncating —
+  trade-off, not a defect); ChangeCityModal has no post-repoint status banner (behavioural,
+  secondary to the theme ask, flagged not sized per OP-34).
+- Not applicable (confirmed by 2 probes each): no light/dark theming anywhere in the app;
+  no `:active` states anywhere in the app's vocabulary — picker matches both, no gap.
+
+All three should-fix-or-higher items are accessibility/feedback gaps in inherited or
+shared code, not new colour/spacing divergences BUG-81 introduced.
+
+CI: PR not yet opened — opening now, will confirm green before this report is considered
+closed (see follow-up push below).
+
+Open issues: none blocking. COO decision needed on whether findings 1-3 become their own
+tracker item(s) before/alongside PO UAT of BUG-81's readability fix — flagged in the tech
+doc's "Open items for COO", not pre-decided by me.
+
+Unblocked: COO has the full findings set for tracker disposition. Nothing routed to
+Frontend directly per role boundary.

--- a/jobs/COO/inbox/20260807_2330-UX-citypicker-theme-review-complete.txt
+++ b/jobs/COO/inbox/20260807_2330-UX-citypicker-theme-review-complete.txt
@@ -1,4 +1,4 @@
-BUG-81/BUG-74 · GE-16 · Branch: docs/ux-citypicker-theme-review · PR: TBD (see below)
+BUG-81/BUG-74 · GE-16 · PR #429 · Branch: docs/ux-citypicker-theme-review
 
 Reviewed the shipped city-disambiguation picker (CityPicker.tsx) and both call sites
 (AddPlaceFlow.tsx, ChangeCityModal.tsx) for adherence with the app's established design
@@ -30,8 +30,7 @@ FINDINGS (full detail + file:line + direction in jobs/ux/tech/20260807-UX-citypi
 All three should-fix-or-higher items are accessibility/feedback gaps in inherited or
 shared code, not new colour/spacing divergences BUG-81 introduced.
 
-CI: PR not yet opened — opening now, will confirm green before this report is considered
-closed (see follow-up push below).
+CI: all 18 checks green (scripts/ci-wait.sh pr 429 — PASS @ 7e3c8f1).
 
 Open issues: none blocking. COO decision needed on whether findings 1-3 become their own
 tracker item(s) before/alongside PO UAT of BUG-81's readability fix — flagged in the tech

--- a/jobs/ux/context/current.txt
+++ b/jobs/ux/context/current.txt
@@ -1,3 +1,46 @@
+UX CONTEXT — 2026-08-07 — CityPicker theme review (BUG-81/BUG-74), review-only thread
+================================================================================
+PROJECT: Travel Tracker
+CURRENT STATUS: Complete. PO direction 2026-08-07 (tracker BUG-81 note): after the BUG-81
+readability fix + BUG-74 frontend banner shipped (PR #427), review the picker "as a whole"
+for adherence with the app's overall design theme. Deliverable:
+jobs/ux/tech/20260807-UX-citypicker-theme-review.md. Branch
+docs/ux-citypicker-theme-review, PR TBD (see completion report in jobs/COO/inbox/ for the
+number and CI status).
+
+Reviewed CityPicker.tsx, its two call sites (AddPlaceFlow.tsx, ChangeCityModal.tsx), and
+composeCandidateLabel.ts against sibling patterns in the same non-Waypoint component family
+(TripForm.tsx, Admin/CountryTab.tsx, PlaceDateForm.tsx) plus the Waypoint primitives
+(design/Button.tsx, design/Input.tsx, design/badges.ts) to establish what "the app's theme"
+actually is rather than inventing a new bar.
+
+VERDICT: theme-consistent on spacing/typography/container/colour-vocabulary axes (all
+confirmed against a real sibling precedent, not assumed) and the two call sites render
+near byte-identically. Three real gaps, all accessibility/feedback rather than new
+colour/spacing divergences: (1) BLOCKER — picker rows are bare `<div onClick>`, unreachable
+by keyboard, diverging from TripForm.tsx's own `<button>`-based pattern for the identical
+"pick one row from a filtered list" interaction; inherited from AddPlaceFlow's pre-existing
+city-search rows, not newly introduced by BUG-81. (2) SHOULD-FIX — the `disabled` prop only
+gates the click handler, not the row's visual state, diverging from Button.tsx's
+opacity-60/cursor-not-allowed disabled vocabulary used everywhere else in this file family.
+(3) SHOULD-FIX — text-amber-600 (used for "please choose"/"more matches" captions,
+pre-existing across AddPlaceFlow+ChangeCityModal, not new) computes to ~3.2:1 contrast on
+white, below WCAG AA's 4.5:1 for normal text. Remainder are nice-to-have polish or
+"not applicable" (confirmed: the app has no light/dark theming system at all, and no
+`:active` mousedown states anywhere — both by two independent probes, so the picker
+following the same omissions is consistent, not a gap). Full findings + severities +
+file:line in the tech doc; distinguishes theme-adherence (PO's actual ask) from general
+polish throughout.
+
+BUGS DISCOVERED: none new — all findings are pre-existing patterns the picker inherits
+consistently (see tech doc's per-finding "diverges from established pattern" vs.
+"pre-existing, app-wide" framing).
+
+WHAT'S NOW UNBLOCKED: COO has the findings to decide whether findings 1-3 become their own
+tracker items (keyboard reachability especially — it fully blocks a keyboard-only user from
+completing the disambiguation flow) before or alongside PO UAT of BUG-81's readability fix.
+
+================================================================================
 UX CONTEXT — 2026-08-01 (updated twice same day — city entry/disambiguation spec delivered,
 then extended with a resolution design + MVP scope after PO follow-up)
 PROJECT: Travel Tracker

--- a/jobs/ux/park-docs/20260807-UX-park.txt
+++ b/jobs/ux/park-docs/20260807-UX-park.txt
@@ -1,0 +1,116 @@
+UX PARK DOCUMENT — 2026-08-07
+================================================================================
+
+THREAD: City-disambiguation picker theme review (BUG-81/BUG-74), PO direction 2026-08-07,
+review-only — no code changed, no implementation dispatched.
+
+DELIVERABLE
+  jobs/ux/tech/20260807-UX-citypicker-theme-review.md
+
+SCOPE COVERED
+  Reviewed the shipped picker (CityPicker.tsx) and both call sites (AddPlaceFlow.tsx,
+  ChangeCityModal.tsx) plus composeCandidateLabel.ts (BUG-81's label-composition util) for
+  adherence with the app's established design theme: visual consistency (spacing,
+  typography, borders, row height, hover/active/selected/cursor states), colour usage (the
+  amber caveat/banner vocabulary, light/dark handling), the new max-h-72 scroll container
+  and its interaction with the "more matches not shown" caveat, readability of composed
+  labels including collision/coordinate-fallback variants, consistency across the two call
+  sites, and accessibility basics (focus, keyboard, contrast).
+
+METHOD
+  Compared against real sibling components rather than an invented bar, per the brief's
+  explicit instruction: TripForm.tsx (a `<button>`-based selectable-list precedent),
+  Admin/CountryTab.tsx (a bordered scrollable list precedent), PlaceDateForm.tsx and
+  ErrorMessage.tsx (amber/red banner vocabulary precedents), plus the Waypoint
+  design-system primitives (design/Button.tsx, design/Input.tsx, design/badges.ts,
+  theme-waypoint.css) to establish which of the app's TWO live component families (legacy
+  raw-Tailwind vs. wp-* tokens) this picker actually belongs to before judging it against
+  either.
+
+KEY FINDING — the app has two live design families, not one, and that's expected
+  design/Button.tsx and design/Input.tsx both self-document as "PHASE 1 ONLY... not yet
+  swapped into any existing call site" — confirmed by grepping wp- usage across
+  src/frontend/components (17 files use it: App.tsx, TripDetail furniture, TripCard,
+  ItemCard, CityItemsPage, etc.; AddPlaceFlow/ChangeCityModal/CityPicker are not among
+  them). This was already flagged as known debt in the 2026-08-01 UX park doc. Judged the
+  picker against its OWN family (the un-migrated legacy Tailwind modals), which is what the
+  brief's "don't invent a new system" instruction actually requires — judging it against
+  the wp-* tokens instead would have manufactured a false divergence out of a known,
+  already-tracked, deliberately-phased rollout.
+
+FINDINGS SUMMARY (full detail + file:line + direction in the tech doc)
+  [BLOCKER] Picker rows are bare <div onClick>, unreachable by keyboard — no tabIndex,
+    role, or onKeyDown. Diverges from TripForm.tsx:253-262's own <button>-based pattern for
+    the identical "pick one row from a filtered list" interaction. Inherited from
+    AddPlaceFlow's pre-existing city-search rows (which CityPicker's own doc comment says
+    it deliberately copied), not newly introduced by BUG-81 — named as inherited, not
+    blamed on this build.
+  [SHOULD-FIX] `disabled` prop only gates the click handler (CityPicker.tsx:96), not the
+    row's visual state — no opacity/cursor change, diverging from Button.tsx's
+    disabled:opacity-60/cursor-not-allowed pair used by every other actionable control in
+    this file family.
+  [SHOULD-FIX] text-amber-600 (used for "please choose"/"more matches" captions, all
+    pre-existing across AddPlaceFlow+ChangeCityModal except the picker's own reuse of the
+    same vocabulary) computes to ~3.2:1 contrast on white — below WCAG AA's 4.5:1 for
+    normal-size text. Flagged as a shared-pattern fix (5 usages across 2 files), not a
+    picker-only patch.
+  [Consistent, confirmed — no action] Row spacing/typography/container styling matches the
+    AddPlaceFlow rows CityPicker was modeled on almost byte-for-byte; amber colour
+    vocabulary matches PlaceDateForm/AddPlaceFlow/ChangeCityModal exactly; the two call
+    sites render the picker + heading + failure banner near identically (compared JSX
+    line-by-line, not just "looks similar").
+  [Nice-to-have] max-h-72 (288px) / row height (~41px) ≈ 7.02 rows — cutoff lands close to
+    a row boundary, weak partial-row "scroll hint"; the truncated-caveat and
+    "list has more rows than fit" are separate signals that can both be silent at once.
+    Flagged as reasoned pixel math, not a rendered screenshot — noted as such.
+  [Nice-to-have] No truncate/line-clamp on rows — long collision/coordinate-fallback labels
+    wrap to 2 lines, uneven row height. Recommended AGAINST truncating (would hide the
+    exact disambiguating info the collision rule exists to surface) rather than prescribing
+    a fix — a real trade-off, not a clean defect.
+  [Nice-to-have, secondary to the theme ask] ChangeCityModal has no post-repoint status
+    banner (AddPlaceFlow's creationStatusMessage has no ChangeCityModal equivalent) — a
+    behavioural cross-call-site inconsistency, not a colour/spacing one; flagged as
+    discretionary scope per OP-34, not sized unprompted.
+  [Not applicable, confirmed by two probes each] No light/dark theming system anywhere in
+    the app (grep dark:/darkMode — zero hits; grep prefers-color-scheme — zero hits;
+    index.css hardcodes one light palette). No :active mousedown states anywhere in the
+    app's button/row vocabulary (grepped app-wide; Button.tsx/Input.tsx read in full show
+    only hover/focus/disabled). Both axes the brief asked about don't apply — not a gap.
+
+BUGS DISCOVERED (per _shared/frameworks.txt rule 30)
+  None new. Every finding is either a pre-existing pattern the picker inherits consistently,
+  or an already-tracked known-debt item (the non-Waypoint token family) restated only to
+  confirm it isn't new. No TRIVIAL/MINOR/MAJOR/CRITICAL classification applies since none of
+  these are functional defects in the picker's own new code — they're either accessibility
+  gaps in inherited markup or contrast values in a pre-existing shared colour token.
+
+NEGATIVE-FINDINGS COMPLIANCE
+  Two claims of absence made in the tech doc, both cleared on two independent probes each:
+  (1) "no light/dark theming system" — grep for `dark:`/`darkMode` (zero hits) AND grep for
+  `prefers-color-scheme` (zero hits) AND direct read of index.css (one hardcoded palette).
+  (2) "no `:active` states anywhere" — grep for `active:` Tailwind variants across
+  components/ and design/ (zero hits outside unrelated `is_active` data fields) AND direct
+  read of Button.tsx/Input.tsx in full (only hover/focus/disabled variants defined).
+
+OPEN ITEMS FOR COO
+  1. Decide whether findings 1-3 (keyboard reachability, disabled-state affordance, amber
+     contrast) become their own tracker item(s) before or alongside PO UAT of BUG-81's
+     readability fix — finding 1 in particular fully blocks a keyboard-only user from
+     completing the "choose the one you mean" disambiguation flow, with no alternative path
+     once the picker is showing.
+  2. Finding 10 (ChangeCityModal's missing post-repoint status feedback) is flagged as
+     discretionary/secondary to the theme-adherence ask per OP-34's value-axis note — my
+     call was to surface it, not size or recommend it unprompted.
+  3. No new dependency, no scanner suppression, no schema change — nothing else needs COO
+     sign-off beyond the above.
+
+WHAT'S NOW UNBLOCKED
+  COO has the full findings set to decide tracker disposition. Frontend: nothing dispatched
+  from this review — per the brief, findings route through COO, not directly to Frontend.
+
+GIT
+  Branch: docs/ux-citypicker-theme-review (docs-only commit: jobs/ux/tech/ review doc +
+  jobs/ housekeeping — context, this park doc, completion report).
+  PR number and CI status: see completion report in jobs/COO/inbox/.
+
+================================================================================

--- a/jobs/ux/tech/20260807-UX-citypicker-theme-review.md
+++ b/jobs/ux/tech/20260807-UX-citypicker-theme-review.md
@@ -1,0 +1,217 @@
+# UX Theme Review — City Disambiguation Picker (BUG-81/BUG-74)
+
+**Date:** 2026-08-07
+**Reviewer:** UX
+**Scope:** PO direction 2026-08-07 (tracker BUG-81 note) — review the shipped picker "as a
+whole" for adherence with the app's overall design theme. Review only; no code changed.
+
+**Files reviewed:**
+- `src/frontend/components/shared/CityPicker.tsx`
+- `src/frontend/components/TripDetail/AddPlaceFlow.tsx` (call site 1)
+- `src/frontend/components/TripDetail/ChangeCityModal.tsx` (call site 2)
+- `src/frontend/utils/composeCandidateLabel.ts`
+
+**Method:** compared against sibling components in the same (non-Waypoint) family —
+`TripForm.tsx`, `Admin/CountryTab.tsx`, `PlaceDateForm.tsx`, `ErrorMessage.tsx` — plus the
+Waypoint design-system primitives (`design/Button.tsx`, `design/Input.tsx`, `design/badges.ts`,
+`theme-waypoint.css`) to establish what "the app's theme" actually is, per the brief's
+instruction not to invent a new system.
+
+## Overall verdict
+
+**Theme-consistent on every axis I could compare against an established in-app precedent** —
+spacing, row structure, container styling, and colour vocabulary all match sibling patterns
+closely, and the two call sites are near byte-identical. Two **should-fix** gaps and one
+**blocker** exist, but all three are **accessibility/feedback gaps that predate or sit
+alongside this component**, not new colour/spacing divergences BUG-81 introduced. Rest of the
+findings are nice-to-have polish.
+
+---
+
+## Findings
+
+### 1. [BLOCKER — accessibility] Picker rows are unreachable by keyboard
+
+`CityPicker.tsx:91-101` renders each candidate as a bare `<div onClick=...>` — no `tabIndex`,
+no `role`, no `onKeyDown`. A keyboard-only user cannot select a candidate at all; there is no
+alternative path once the picker is showing (the region `<select>` fallback doesn't apply once
+`disambiguation.mode === 'picker'`). Same is true of the pre-existing city-search-result rows
+in `AddPlaceFlow.tsx:544-556` and `ChangeCityModal.tsx:196-208` that `CityPicker`'s own doc
+comment (lines 42-47) says it deliberately copied.
+
+**This is not a new divergence BUG-81 introduced** — it inherits AddPlaceFlow's pre-existing
+pattern. But the app already has an established **accessible** pattern for exactly this
+interaction ("pick one row from a filtered/searchable list"): `TripForm.tsx:253-262` renders
+its country-autocomplete options as real `<button type="button">` elements — natively
+focusable, Enter/Space-activatable, no extra markup. `CityPicker` diverges from that sibling
+precedent, not from an invented external bar.
+
+**Direction:** render each row as `<button type="button" className="w-full text-left ...">`
+(same visual classes, swap the element) in `CityPicker.tsx`, and ideally in the two upstream
+city-search-result lists it was copied from, matching `TripForm.tsx`'s own button pattern. No
+new dependency.
+
+### 2. [SHOULD-FIX] Disabled state has no visual signal
+
+`CityPicker.tsx:92-98`: the row's `className` is static regardless of the `disabled` prop —
+only the `onClick` handler is gated (`if (!disabled) onSelect(candidate)`, line 96). During a
+pending submission (`createCity.isPending || addPlace.isPending`, passed at
+`AddPlaceFlow.tsx:714` / `ChangeCityModal.tsx:292`) the rows still show `hover:bg-gray-50` and
+`cursor-pointer` as if fully live — a click silently does nothing.
+
+Every other actionable control in this same file family pairs a disabled state with a visible
+change: the submit buttons at `AddPlaceFlow.tsx:833` / `ChangeCityModal.tsx:352` both use
+`disabled:opacity-60 ... disabled:cursor-not-allowed`, and the `Button` primitive
+(`design/Button.tsx:30`) bakes the identical pair into its base classes. This is the
+established app-wide vocabulary for "this control cannot be used right now," and the picker's
+rows don't use it — a genuine "every action must have a visible result" gap.
+
+**Direction:** branch the row className on `disabled`, e.g.
+`disabled ? 'opacity-60 cursor-not-allowed' : 'hover:bg-gray-50 cursor-pointer'`, matching
+`Button.tsx`'s own pair exactly rather than inventing a new disabled treatment.
+
+### 3. [SHOULD-FIX] `text-amber-600` caption contrast is below WCAG AA
+
+Used for "— please choose the one you mean" (`AddPlaceFlow.tsx:703`, `ChangeCityModal.tsx:281`),
+"— multiple matches found, please choose" (`AddPlaceFlow.tsx:724`, `ChangeCityModal.tsx:301`),
+and the picker's own "There may be more matches not shown" (`CityPicker.tsx:107`). Computed
+contrast of Tailwind `amber-600` (#D97706) on white is **~3.2:1**, below the 4.5:1 AA minimum
+for normal-size text — these all render at `text-xs`/inline with `text-sm`, not large text.
+
+This is a **pre-existing, app-wide pattern** (all three usages above predate BUG-81 except the
+picker's own caveat, which just reuses the existing vocabulary exactly as its own doc comment
+states it should, `CityPicker.tsx:104-105`) — not something BUG-81 introduced, and not
+something a picker-scoped fix can close on its own since the same colour is used identically
+in AddPlaceFlow's pre-existing captions.
+
+**Direction:** darken to `amber-700` (#B45309, ~4.6:1, clears AA) for this caption class
+app-wide, or pair the caution captions with a non-colour cue. I'd size this as a small,
+one-line-per-callsite change rather than a redesign, but flag to COO as a shared-pattern fix
+(touches 5 existing usages across 2 files), not a CityPicker-only patch.
+
+### 4. [Consistent — confirmed, no action] Row spacing, typography, and container styling
+
+`CityPicker.tsx:92-94` (`px-3 py-2.5 ... text-sm ... border-b border-gray-100`) is close to
+character-identical to the pre-existing city-search-result rows it was modeled on
+(`AddPlaceFlow.tsx:548`, `ChangeCityModal.tsx:200`) — same padding, same type scale, same hover
+tone, with only an added `last:border-b-0` (a correctness improvement, not a divergence — see
+finding 4a). The outer wrapper (`border border-gray-200 rounded-md overflow-hidden`,
+`CityPicker.tsx:89`) matches the same bordered-list-container convention used throughout this
+component family: `AddPlaceFlow.tsx:543`, `TripForm.tsx:241`, `Admin/CountryTab.tsx`. This
+axis is genuinely consistent — no gap to report.
+
+### 4a. [Consistent, informational] `last:border-b-0`
+
+`CityPicker.tsx:94` adds `last:border-b-0`, which AddPlaceFlow's own search-result row list
+doesn't have on its per-city rows (`AddPlaceFlow.tsx:548`) — but that list's last visible
+border sits correctly between the last city row and the separate "+ Add new" row underneath it
+(itself carrying `last:border-b-0`, `AddPlaceFlow.tsx:558`), so there's no double-border defect
+there either. Noting only so this isn't misread as an inconsistency — both lists render
+correctly, just via slightly different means given their different row sets.
+
+### 5. [Consistent — confirmed, no action] Amber as the app's caution/caveat accent
+
+Confirmed by two probes: a grep for `amber` across `src/frontend/components` and `design/`
+(7 hits outside tests), and direct reads of `AddPlaceFlow.tsx`, `ChangeCityModal.tsx`, and
+`PlaceDateForm.tsx`. All non-decorative amber usage (i.e. excluding `RatingStars.tsx`'s
+unrelated star-rating fill) uses the same `amber-50`/`amber-200`/`amber-300` background+border
+with `amber-600`/`amber-800` text for warnings and tentative-value captions. The picker's
+"There may be more matches not shown" (`amber-600`) and the "please choose" accents fit this
+vocabulary exactly — this is the right colour, just at the contrast finding 3 flags.
+
+### 6. [Consistent — confirmed, no action] The two call sites render identically
+
+Compared `AddPlaceFlow.tsx:699-716` against `ChangeCityModal.tsx:277-294` line by line: the
+"Multiple places match…" heading, the amber "please choose the one you mean" accent, the
+`CityPicker` props (`candidates`, `onSelect`, `truncated`, `disabled`), and the geocoder-failure
+banner (`AddPlaceFlow.tsx:678-689` vs. `ChangeCityModal.tsx:263-274`) are near byte-identical.
+This is a genuinely strong result — not just "looks similar," the JSX and classes match.
+
+### 7. [NICE-TO-HAVE] Scroll-affordance boundary math
+
+`max-h-72` (288px) divided by the row's rendered height (~41px: 10px+10px padding, ~20px
+line-height, 1px border) works out to **~7.02 rows** — the cutoff lands close to a clean row
+boundary, so there's little/no partial-row "sliver" to visually hint more content lies below.
+The only signal that the list itself continues past the visible rows would then be the native
+scrollbar; the "There may be more matches not shown" caveat is a **separate** signal (upstream
+API truncation, `truncated` prop) that stays absent whenever the API returned everything but
+the picker still has more rows than fit on screen — so a scrollable-but-not-`truncated` list
+gets no caveat text at all, only a scrollbar. *(This is arithmetic from the Tailwind utility
+values, not a rendered screenshot — flagging as reasoned, not visually confirmed.)*
+
+**Direction (optional polish):** pick a max-height that intentionally clips mid-row (e.g.
+`max-h-[270px]`) so a visibly cut-off row signals "scroll for more" independent of whether the
+browser's scrollbar is easy to notice. Low priority — the scrollbar remains a functional
+signal even without this.
+
+### 8. [NICE-TO-HAVE] Long/collision-fallback labels can wrap unevenly
+
+`CityPicker.tsx`'s row `div` has no `truncate`/`line-clamp`/fixed height. The county-appended
+or coordinate-appended fallback labels from `composeCandidateLabel.ts` (e.g. "Springfield,
+Fairfax County, Virginia, United States (38.79, -77.19)") will wrap to two lines in the 480px
+modal, making that row taller than its neighbours. I'd recommend **against** truncating —
+truncation would hide exactly the disambiguating information the collision rule
+(`composeCandidateLabel.ts`'s whole reason for existing) is there to surface — so this is a
+genuine trade-off, not a clean fix, and I'm flagging the uneven row rhythm rather than
+prescribing a specific resolution. Low priority; skimmability of the common case (short,
+single-line labels) is unaffected.
+
+### 9. [Informational, already tracked — no new action] Non-Waypoint token family
+
+`CityPicker`/`AddPlaceFlow`/`ChangeCityModal` all use the legacy raw-Tailwind vocabulary
+(`teal-600`, `gray-*`, `amber-*`) rather than the `wp-*` tokens now live elsewhere
+(`TripDetail.tsx`, `PlaceSection.tsx`, `ItemCard.tsx`, `CityItemsPage.tsx`, `TripCard.tsx`,
+etc. — confirmed by grepping `wp-` usage across `src/frontend/components`). This was already
+flagged as known debt in the 2026-08-01 UX spec park doc
+(`jobs/ux/park-docs/20260801-UX-park.txt`: *"AddPlaceFlow.tsx is not migrated to Waypoint
+tokens... flagged, not fixed"*) and both `design/Button.tsx` and `design/Input.tsx` document
+themselves as *"PHASE 1 ONLY... not yet swapped into any existing call site."* **This is not a
+new divergence BUG-81 introduced** — the picker is fully consistent with the family it lives
+in. Repeating it here only so it isn't mistaken for something this build caused; no new action
+beyond the already-tracked Phase 2 migration.
+
+### 10. [NICE-TO-HAVE, secondary to the theme ask] ChangeCityModal has no post-repoint status feedback
+
+`ChangeCityModal.tsx`'s `repointTo` (lines 102-109) calls `onClose()` unconditionally on
+success — there is no equivalent of `AddPlaceFlow`'s `creationStatusMessage` banner ("We're
+still confirming this location…" / "We couldn't automatically confirm this location…",
+`AddPlaceFlow.tsx:286-290`) for a re-point that resolves to a pending/unresolvable city. This
+is a **behavioural** inconsistency between the two call sites (the brief's "consistency across
+call sites" question), not a colour/spacing theme issue, so I'm rating it below the PO's
+specific ask — but naming it since a silent close after re-pointing to an unconfirmed city
+gives the user no signal at all, which is a sharper version of the same gap BUG-74/BUG-73
+exist to close for the create path. Worth a tracker item if the PO wants full parity; not
+mine to size unprompted (OP-34 value-axis note — this reads like discretionary scope, not a
+clear defect).
+
+### 11. [Not applicable — confirmed] Light/dark theming
+
+Two probes: grep for `dark:`/`darkMode` across `src/frontend` (zero hits) and grep for
+`prefers-color-scheme` (zero hits), plus a direct read of `index.css` showing one hardcoded
+light palette (`background: #f9fafb; color: #111827`) with no variant. The app has no
+light/dark theming system anywhere — this axis of the brief doesn't apply; not a picker-specific
+gap.
+
+### 12. [Not applicable — confirmed] `:active` (mousedown) states
+
+Grepped for `active:` Tailwind variants across `components/` and `design/` — zero hits outside
+unrelated `is_active` data fields. `design/Button.tsx` and `design/Input.tsx` (read in full)
+define only hover/focus/disabled variants, no active state. The picker's rows following the
+same omission is consistent with the app's own primitives, not a gap.
+
+---
+
+## Summary table
+
+| # | Finding | Severity | Theme-adherence (PO's ask) or general polish |
+|---|---|---|---|
+| 1 | Picker rows unreachable by keyboard | **Blocker** | Diverges from `TripForm.tsx`'s own accessible pattern — theme-adherence |
+| 2 | No visual signal for disabled rows | **Should-fix** | Diverges from `Button.tsx`/sibling disabled vocabulary — theme-adherence |
+| 3 | `amber-600` caption contrast ~3.2:1 (<4.5:1 AA) | **Should-fix** | Pre-existing app-wide pattern, inherited — theme-adherence (contrast) |
+| 4/4a/5/6 | Spacing, container, colour vocabulary, cross-call-site parity | **Consistent — no action** | Confirms theme-adherence, no issue |
+| 7 | Scroll-cutoff lands near a row boundary | Nice-to-have | Polish |
+| 8 | Uneven row height on wrapped fallback labels | Nice-to-have | Polish (deliberate trade-off, not a clean fix) |
+| 9 | Non-Waypoint token family | Informational, already tracked | Known Phase 2 debt, not new |
+| 10 | No post-repoint status banner in ChangeCityModal | Nice-to-have | Behavioural, secondary to colour/spacing ask |
+| 11 | No dark/light theming anywhere | Not applicable | N/A — app has no theming system |
+| 12 | No `:active` states anywhere | Not applicable — consistent | Confirms theme-adherence |


### PR DESCRIPTION
Tracker BUG-81 (GE-16) — PO direction 2026-08-07: after the BUG-81 readability fix
(#424, #427) shipped, review the picker "as a whole" for adherence with the app's
overall design theme. Review only, no code changed.

Deliverable: `jobs/ux/tech/20260807-UX-citypicker-theme-review.md`

## Verdict
Theme-consistent — spacing, typography, container styling, and colour vocabulary all
match real sibling components (TripForm.tsx, PlaceDateForm.tsx, Admin/CountryTab.tsx),
and the two call sites (AddPlaceFlow.tsx, ChangeCityModal.tsx) render near
byte-identically.

## Findings
- **Blocker (accessibility):** picker rows are bare `<div onClick>`, unreachable by
  keyboard — diverges from `TripForm.tsx`'s own `<button>`-based pattern for the same
  interaction. Inherited from AddPlaceFlow's pre-existing rows, not introduced by BUG-81.
- **Should-fix:** `disabled` prop only gates the click handler, not the row's visual
  state — diverges from `Button.tsx`'s disabled vocabulary used elsewhere in this file
  family.
- **Should-fix:** `text-amber-600` caption contrast (~3.2:1 on white) is below WCAG AA
  4.5:1 — a pre-existing, app-wide pattern the picker reuses consistently, not new.
- A few nice-to-have polish items and two "not applicable, confirmed" axes (no dark/light
  theming anywhere in the app; no `:active` states anywhere) — full detail in the doc.

BRD: GE-16. No code changed — docs only.