### PR TITLE
chore(QUAL-33): backend code-hygiene sweep (audit U2-U6,U11,U12)

### DIFF
--- a/.semgrep/security.yml
+++ b/.semgrep/security.yml
@@ -43,9 +43,12 @@ rules:
   # resulting in every chained query being flagged regardless of whether userId
   # scoping is present somewhere in the chain.
   #
-  # The shading.service.ts queries (trips, tripPlaces) are intentionally unscoped —
-  # they aggregate across all users to compute map shading states, applied via JOIN
-  # condition rather than WHERE clause. A reliable rule would need to either:
+  # The live shading.service.ts queries (trips, tripPlaces) ARE user-scoped — the
+  # userId condition is applied via a JOIN (`.leftJoin(trips, and(eq(trips.id, ...),
+  # eq(trips.userId, userId)))`) rather than a WHERE clause, which is exactly what
+  # defeats simple WHERE-based pattern matching below. (The one genuinely unscoped
+  # shading query, getRegionCoverageMap, was dead code — its result was never read
+  # — and has been removed under QUAL-33.) A reliable rule would need to either:
   #   (a) Use taint tracking (semgrep Pro), or
   #   (b) Be narrowed to only flag direct .where()-less terminations with no chain at all
   #

--- a/jobs/COO/inbox/20260808_0913-BACKEND-qual33-hygiene-sweep-complete.md
+++ b/jobs/COO/inbox/20260808_0913-BACKEND-qual33-hygiene-sweep-complete.md
@@ -1,0 +1,115 @@
+# BACKEND — QUAL-33 code-hygiene sweep — COMPLETE
+
+PR: https://github.com/ryanv11/travel-tracker/pull/432 (`chore/qual33-backend-hygiene` → `main`)
+CI: all 18 checks green (`scripts/ci-wait.sh pr 432` → PASS)
+Not merged (per brief — COO merges).
+
+## Per-item disposition
+
+**U2 — false comment (server.ts header).** Done. "5. auth stub (SEC-09)" → "5. auth —
+requireAuth verifies Clerk JWTs via JWKS, applied globally (SEC-09)". Verified
+`app.use('/api/', requireAuth)` at server.ts:198 gates every `/api/` route.
+
+**U3 — false semgrep comment.** Done. Rewrote the rule-2 TODO comment: live shading
+queries in `shading.service.ts` ARE user-scoped via JOIN (`eq(trips.userId, userId)`
+inside `.leftJoin(...)`), not unscoped — confirmed by reading every query in the file.
+Comment-only change; the `rules:` block (patterns/message/severity/paths) is
+byte-for-byte unchanged; no suppression added or widened (OP-30 compliant).
+
+**U4 — dead code, shading.service.ts.** Done, two probes per deletion:
+- `getCityShading` — 0 callers. Probe 1: grepped `getCityShading` across `src/`, only
+  the definition matched. Probe 2: read `routes/map.ts` (the only route file that
+  imports from this service) — it imports `getAllCountryShading`, `getCountryShading`,
+  `getRegionShading`, not `getCityShading`. **Correction to the audit doc**: the audit
+  (`audits/session-b-code-safety.md`) claims this function is *unscoped* — that's now
+  stale. Reading the current function body shows it takes `userId` and joins on
+  `eq(trips.userId, userId)` (ADL-28 R1 already fixed this before the audit's finding
+  was acted on). It was dead, but correctly scoped. Removed as dead code only; did not
+  cite it as a scoping fix.
+- `_coverage` param on `computeCountryState` — function body never referenced it.
+  Probe 1: read the function body. Probe 2: the pre-existing test file already had a
+  test literally titled "coverage parameter is ignored — same result with or without
+  coverage", independently confirming the same fact before I touched anything.
+- `getRegionCoverageMap` — its only consumer was the now-dead `_coverage` param;
+  removing it drops one full extra query from every `getAllCountryShading` /
+  `getCountryShading` call (was previously computed and discarded).
+- `*Unregioned` SQL aggregates in `countrySelectShape` — 3 extra `CASE WHEN`
+  expressions per query, confirmed never read by `computeCountryState`'s body.
+
+Rewrote `shading.service.test.ts`'s `computeCountryState()` suite in full (**Write, not
+Edit** — declaring per CLAUDE.md's source-rewrite rule) to drop the now-invalid second
+argument from every call and the Unregioned fixture fields. Small, fully-owned test
+file, not a shared-record file; the rewrite was a mechanical consequence of the U4
+signature change (every test case needed one line changed). All prior test *cases*
+(state combinations covered) preserved; only the dead-parameter plumbing removed.
+
+**U5 — unused CORS credentials.** Done. Removed `credentials: true` + "Reserved for
+Phase 2 session cookies" comment from `server.ts`, and the identical flag from its
+test-harness mirror `server-test-app.ts` (that file's own docstring states its purpose
+is to exercise the identical pipeline as `server.ts`, so left it out of sync would have
+been wrong). Confirmed no cookie reliance via grep: no `cookie-parser`, `req.cookies`,
+`res.cookie(` anywhere in `src/`, and no frontend fetch uses
+`credentials: 'include'`/`withCredentials`. **One item beyond the brief's literal
+scope, flagging for visibility**: also removed an adjacent stale comment on the same
+CORS block, `// Authorization reserved for Phase 2`, on the `allowedHeaders` line —
+Authorization is actively used today (Clerk header-based auth, confirmed via grep
+showing `Authorization` header usage in `apiClient.ts`/`main.tsx`), not reserved. Same
+false-comment class as U2/U3, directly adjacent to the line I was already touching;
+flagging so this can be double-checked as a deliberate small addition, not scope creep
+that hid something.
+
+**U6 — vestigial dynamic imports.** Done for `items.ts` (4 call sites: lines ~47, 66,
+147, 184 per brief, now static `and`/`eq`). **Brief drift noted**: `trips.ts` has no
+dynamic imports — grepped `import(` in the file (no match) and read its import block
+(already fully static `and, desc, eq` from drizzle-orm at the top). Left untouched,
+nothing to fix there.
+
+**U11 — dead eslint-disable directives.** Done. Removed from `auth.ts:28` and
+`error-handler.ts:25`. Verified two ways: no `.eslintrc*`/`eslint.config.*` file
+anywhere in the repo, and no `eslint` package in `package.json` dependencies (`lint`
+script is `biome lint src/`).
+
+**U12 — dead branch, cities.ts.** Done. `useRatingSort` ternary's false-branch and the
+true-branch's `sort_order !== 'asc'` case both evaluated to `desc(effectiveRatingSql)`.
+Collapsed to `useRatingSort && sort_order === 'asc' ? asc(...) : desc(...)`. Verified
+behaviourally identical across all 4 input combinations before changing.
+
+## Security checklist (server.ts/auth-adjacent + semgrep)
+
+1. U5 removal does not affect auth — Clerk is Authorization-header based, not
+   cookie-based; confirmed no cookie reliance anywhere in the app (backend or
+   frontend).
+2. U3 is comment-only — semgrep rule logic (patterns, message, severity, paths)
+   unchanged; no suppression added or widened.
+3. No route auth changed by this sweep — `requireAuth`/`requireOwner` placement
+   untouched everywhere.
+
+## Verification
+
+- `npm run check` (Biome) — 0 errors, exit 0 (5 pre-existing info-level suggestions in
+  an unrelated geocoding test file — out of scope, not touched, flagged to whichever
+  agent owns that file)
+- `npm run type:check:all` — clean
+- `npm run test:backend` — 759/759 passed
+- `npm run test:frontend` — 321/321 passed
+- `npm run status:check` — up to date
+- CI on PR #432 — 18/18 checks green
+
+## Not touched (per brief)
+
+`requireAuth` catch-all swallow, `DB_TYPE=postgres` scaffolding, transaction-convention
+question, `asyncHandler`, routes→repo layering, `buildApp()` factory. Did not edit
+`_project/tracker.json` (left for COO per brief, avoiding collision with the 3 other
+parallel sweeps).
+
+## Files touched
+
+- `.semgrep/security.yml`
+- `src/backend/server.ts`
+- `src/backend/server-test-app.ts`
+- `src/backend/middleware/auth.ts`
+- `src/backend/middleware/error-handler.ts`
+- `src/backend/repositories/items.ts`
+- `src/backend/routes/cities.ts`
+- `src/backend/services/shading.service.ts`
+- `src/backend/services/__tests__/shading.service.test.ts` (full rewrite, declared above)

--- a/src/backend/middleware/auth.ts
+++ b/src/backend/middleware/auth.ts
@@ -25,7 +25,6 @@ import { userRepository } from '../repositories/users.js';
 // ----------------------------------------------------------------
 
 declare global {
-  // eslint-disable-next-line @typescript-eslint/no-namespace
   namespace Express {
     interface Request {
       user?: {

--- a/src/backend/middleware/error-handler.ts
+++ b/src/backend/middleware/error-handler.ts
@@ -22,7 +22,6 @@ export function errorHandler(
   err: AppError,
   req: Request,
   res: Response,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   _next: NextFunction,
 ): void {
   const statusCode = err.statusCode ?? 500;

--- a/src/backend/repositories/items.ts
+++ b/src/backend/repositories/items.ts
@@ -44,14 +44,12 @@ export const itemRepository = {
       minRating?: number;
     },
   ): Promise<Record<string, unknown>[]> {
-    const { and: drizzleAnd, eq: drizzleEq } = await import('drizzle-orm');
+    const conditions: SQL[] = [eq(items.tripId, tripId), eq(items.userId, userId)];
+    if (filters?.placeId) conditions.push(eq(items.tripPlaceId, Number(filters.placeId)));
+    if (filters?.type) conditions.push(eq(items.itemType, filters.type));
+    if (filters?.status) conditions.push(eq(items.status, filters.status));
 
-    const conditions: SQL[] = [drizzleEq(items.tripId, tripId), drizzleEq(items.userId, userId)];
-    if (filters?.placeId) conditions.push(drizzleEq(items.tripPlaceId, Number(filters.placeId)));
-    if (filters?.type) conditions.push(drizzleEq(items.itemType, filters.type));
-    if (filters?.status) conditions.push(drizzleEq(items.status, filters.status));
-
-    return fetchItemsWithExtensions(drizzleAnd(...conditions), {
+    return fetchItemsWithExtensions(and(...conditions), {
       sortBy: filters?.sortBy,
       sortOrder: filters?.sortOrder,
       minRating: filters?.minRating,
@@ -63,9 +61,8 @@ export const itemRepository = {
    * Returns null if not found or not owned.
    */
   async findById(userId: string, itemId: number): Promise<Record<string, unknown> | null> {
-    const { and: drizzleAnd, eq: drizzleEq } = await import('drizzle-orm');
     const results = await fetchItemsWithExtensions(
-      drizzleAnd(drizzleEq(items.id, itemId), drizzleEq(items.userId, userId)),
+      and(eq(items.id, itemId), eq(items.userId, userId)),
     );
     return results[0] ?? null;
   },
@@ -144,8 +141,7 @@ export const itemRepository = {
     const item = inserted[0];
     await insertExtension(item.id, data.itemType, extensionBody);
 
-    const { eq: drizzleEq } = await import('drizzle-orm');
-    const result = await fetchItemsWithExtensions(drizzleEq(items.id, item.id));
+    const result = await fetchItemsWithExtensions(eq(items.id, item.id));
     return result[0];
   },
 
@@ -181,8 +177,7 @@ export const itemRepository = {
 
     await updateExtension(itemType, itemId, extensionBody);
 
-    const { eq: drizzleEq } = await import('drizzle-orm');
-    const result = await fetchItemsWithExtensions(drizzleEq(items.id, itemId));
+    const result = await fetchItemsWithExtensions(eq(items.id, itemId));
     return result[0] ?? null;
   },
 

--- a/src/backend/routes/cities.ts
+++ b/src/backend/routes/cities.ts
@@ -810,11 +810,7 @@ citiesRouter.get(
     // sort_order=asc flips the direction.
     const useRatingSort = !sort_by || sort_by === 'rating';
     const rows = await query.orderBy(
-      useRatingSort
-        ? sort_order === 'asc'
-          ? asc(effectiveRatingSql)
-          : desc(effectiveRatingSql)
-        : desc(effectiveRatingSql),
+      useRatingSort && sort_order === 'asc' ? asc(effectiveRatingSql) : desc(effectiveRatingSql),
     );
 
     // Apply min_rating filter in JS (simpler than raw SQL for this case)

--- a/src/backend/server-test-app.ts
+++ b/src/backend/server-test-app.ts
@@ -83,7 +83,6 @@ app.use(
     },
     methods: ['GET', 'POST', 'PATCH', 'DELETE', 'OPTIONS'],
     allowedHeaders: ['Content-Type', 'Authorization'],
-    credentials: true,
   }),
 );
 

--- a/src/backend/server.ts
+++ b/src/backend/server.ts
@@ -6,7 +6,7 @@
  *   2. cors        — CORS allowlist (SEC-02)
  *   3. json/urlencoded with 100kb limit (SEC-05)
  *   4. rate limiter (SEC-07)
- *   5. auth stub (SEC-09)
+ *   5. auth — requireAuth verifies Clerk JWTs via JWKS, applied globally (SEC-09)
  *   6. route handlers
  *   7. global error handler — LAST (SEC-06)
  *
@@ -152,8 +152,7 @@ app.use(
       }
     },
     methods: ['GET', 'POST', 'PATCH', 'DELETE', 'OPTIONS'],
-    allowedHeaders: ['Content-Type', 'Authorization'], // Authorization reserved for Phase 2
-    credentials: true, // Reserved for Phase 2 session cookies
+    allowedHeaders: ['Content-Type', 'Authorization'],
   }),
 );
 

--- a/src/backend/services/__tests__/shading.service.test.ts
+++ b/src/backend/services/__tests__/shading.service.test.ts
@@ -114,6 +114,10 @@ describe('computeState()', () => {
 // computeCountryState() — simplified any-visit rule (MAP-01)
 // Country is highlighted whenever any city in the country has a trip,
 // regardless of region tier. Region detail shown via RegionLayer at zoom >= 4.
+//
+// QUAL-33: the region-coverage second parameter was dead (computed by a query
+// whose result was never read) and has been dropped from the signature along
+// with the unused *Unregioned row fields — see audits/session-b-code-safety.md.
 // ----------------------------------------------------------------
 
 const baseRow = {
@@ -121,9 +125,6 @@ const baseRow = {
   hasActive: 0,
   completedCount: 0,
   planningCount: 0,
-  hasActiveUnregioned: 0,
-  completedUnregioned: 0,
-  planningUnregioned: 0,
 };
 
 describe('computeCountryState()', () => {
@@ -131,87 +132,54 @@ describe('computeCountryState()', () => {
   describe('region_tier_enabled = 0 (non-region-tier country)', () => {
     it('returns "visited_once" when one completed trip', () => {
       const row = { ...baseRow, regionTierEnabled: 0, completedCount: 1 };
-      expect(computeCountryState(row, undefined)).toBe('visited_once');
+      expect(computeCountryState(row)).toBe('visited_once');
     });
 
     it('returns "planned" when only planning trips', () => {
       const row = { ...baseRow, regionTierEnabled: 0, planningCount: 2 };
-      expect(computeCountryState(row, undefined)).toBe('planned');
+      expect(computeCountryState(row)).toBe('planned');
     });
 
     it('returns "active" when active trip', () => {
       const row = { ...baseRow, regionTierEnabled: 0, hasActive: 1 };
-      expect(computeCountryState(row, undefined)).toBe('active');
+      expect(computeCountryState(row)).toBe('active');
     });
 
     it('returns "never_visited" when no trips', () => {
-      expect(computeCountryState(baseRow, undefined)).toBe('never_visited');
+      expect(computeCountryState(baseRow)).toBe('never_visited');
     });
   });
 
   // Region-tier countries (US, AU, CA): shade on any visit — same as non-region-tier
   describe('region_tier_enabled = 1 (region-tier country, e.g. US/AU/CA)', () => {
-    it('returns "visited_once" when one completed trip, even with partial region coverage', () => {
+    it('returns "visited_once" when one completed trip', () => {
       const row = { ...baseRow, regionTierEnabled: 1, completedCount: 1 };
-      const partialCoverage = { totalRegions: 50, visitedRegions: 1 };
-      expect(computeCountryState(row, partialCoverage)).toBe('visited_once');
+      expect(computeCountryState(row)).toBe('visited_once');
     });
 
-    it('returns "visited_once" when one completed trip and coverage is undefined', () => {
-      const row = { ...baseRow, regionTierEnabled: 1, completedCount: 1 };
-      expect(computeCountryState(row, undefined)).toBe('visited_once');
-    });
-
-    it('returns "visited_multiple" when multiple completed trips, partial coverage', () => {
+    it('returns "visited_multiple" when multiple completed trips', () => {
       const row = { ...baseRow, regionTierEnabled: 1, completedCount: 3 };
-      const partialCoverage = { totalRegions: 50, visitedRegions: 2 };
-      expect(computeCountryState(row, partialCoverage)).toBe('visited_multiple');
+      expect(computeCountryState(row)).toBe('visited_multiple');
     });
 
-    it('returns "planned" when only planning trips, partial coverage', () => {
+    it('returns "planned" when only planning trips', () => {
       const row = { ...baseRow, regionTierEnabled: 1, planningCount: 2 };
-      const partialCoverage = { totalRegions: 50, visitedRegions: 0 };
-      expect(computeCountryState(row, partialCoverage)).toBe('planned');
+      expect(computeCountryState(row)).toBe('planned');
     });
 
-    it('returns "active" when active trip, partial coverage', () => {
+    it('returns "active" when active trip', () => {
       const row = { ...baseRow, regionTierEnabled: 1, hasActive: 1 };
-      const partialCoverage = { totalRegions: 50, visitedRegions: 1 };
-      expect(computeCountryState(row, partialCoverage)).toBe('active');
+      expect(computeCountryState(row)).toBe('active');
     });
 
-    it('returns "never_visited" when no trips, even with full region coverage', () => {
+    it('returns "never_visited" when no trips', () => {
       const row = { ...baseRow, regionTierEnabled: 1 };
-      const fullCoverage = { totalRegions: 3, visitedRegions: 3 };
-      expect(computeCountryState(row, fullCoverage)).toBe('never_visited');
+      expect(computeCountryState(row)).toBe('never_visited');
     });
 
-    it('returns "visited_multiple" when all regions visited and multiple completed trips', () => {
+    it('returns "visited_multiple" when multiple completed trips', () => {
       const row = { ...baseRow, regionTierEnabled: 1, completedCount: 3 };
-      const fullCoverage = { totalRegions: 3, visitedRegions: 3 };
-      expect(computeCountryState(row, fullCoverage)).toBe('visited_multiple');
-    });
-
-    it('uses all-city stats regardless of unregioned stats', () => {
-      // Visiting Colorado (region_id set) shows up in completedCount, not completedUnregioned.
-      // The country should still be highlighted.
-      const row = {
-        ...baseRow,
-        regionTierEnabled: 1,
-        completedCount: 1,
-        completedUnregioned: 0, // city has a region_id — would fail old case (b) check
-      };
-      const partialCoverage = { totalRegions: 50, visitedRegions: 1 };
-      expect(computeCountryState(row, partialCoverage)).toBe('visited_once');
-    });
-
-    it('coverage parameter is ignored — same result with or without coverage', () => {
-      const row = { ...baseRow, regionTierEnabled: 1, completedCount: 2 };
-      const partialCoverage = { totalRegions: 50, visitedRegions: 1 };
-      const fullCoverage = { totalRegions: 50, visitedRegions: 50 };
-      expect(computeCountryState(row, partialCoverage)).toBe('visited_multiple');
-      expect(computeCountryState(row, fullCoverage)).toBe('visited_multiple');
-      expect(computeCountryState(row, undefined)).toBe('visited_multiple');
+      expect(computeCountryState(row)).toBe('visited_multiple');
     });
   });
 });

--- a/src/backend/services/shading.service.ts
+++ b/src/backend/services/shading.service.ts
@@ -22,42 +22,6 @@ import {
 import { shadingConfigRepository } from '../repositories/shadingConfig.js';
 
 // ----------------------------------------------------------------
-// Country shading — region coverage helper
-// ----------------------------------------------------------------
-
-interface RegionCoverage {
-  totalRegions: number;
-  visitedRegions: number;
-}
-
-/**
- * Returns a map of country_code → { totalRegions, visitedRegions }.
- * A region is "visited" when any trip_place exists for a city in that region,
- * regardless of trip status. Used for case (c) of the country shading rule
- * (shading-spec.md §4.0).
- */
-async function getRegionCoverageMap(): Promise<Map<string, RegionCoverage>> {
-  const db = getDb();
-  const rows = await db
-    .select({
-      countryCode: regions.countryCode,
-      totalRegions: sql<number>`COUNT(DISTINCT ${regions.id})`,
-      visitedRegions: sql<number>`COUNT(DISTINCT CASE WHEN ${tripPlaces.id} IS NOT NULL THEN ${regions.id} END)`,
-    })
-    .from(regions)
-    .leftJoin(cities, eq(cities.regionId, regions.id))
-    .leftJoin(tripPlaces, eq(tripPlaces.cityId, cities.id))
-    .groupBy(regions.countryCode);
-
-  return new Map(
-    rows.map((r) => [
-      r.countryCode,
-      { totalRegions: Number(r.totalRegions), visitedRegions: Number(r.visitedRegions) },
-    ]),
-  );
-}
-
-// ----------------------------------------------------------------
 // Types
 // ----------------------------------------------------------------
 
@@ -167,23 +131,14 @@ function buildResult(stateKey: string, config: ShadingConfigMap): ShadingResult 
  * level, regardless of whether the country has a region tier enabled.
  * Region-level detail is shown via the RegionLayer at zoom >= 4 (MAP-01).
  *
- * The `_coverage` parameter is kept in the signature for call-site compatibility
- * but is no longer used.
- *
  * Exported for unit testing.
  */
-export function computeCountryState(
-  row: {
-    regionTierEnabled: number;
-    hasActive: number;
-    completedCount: number;
-    planningCount: number;
-    hasActiveUnregioned: number;
-    completedUnregioned: number;
-    planningUnregioned: number;
-  },
-  _coverage: RegionCoverage | undefined,
-): string {
+export function computeCountryState(row: {
+  regionTierEnabled: number;
+  hasActive: number;
+  completedCount: number;
+  planningCount: number;
+}): string {
   // Country is highlighted based on any visit to any city, regardless of region tier.
   // Region-level detail is shown via the RegionLayer at higher zoom (MAP-01).
   return computeState(
@@ -226,17 +181,12 @@ async function getTripCountriesStats(
 }
 
 /** Drizzle select shape for country shading query (§4.1 Query A). */
-const countrySelectShape = (co: typeof countries, c: typeof cities, t: typeof trips) => ({
+const countrySelectShape = (co: typeof countries, t: typeof trips) => ({
   countryCode: co.countryCode,
   regionTierEnabled: co.regionTierEnabled,
-  // All-city stats
   hasActive: sql<number>`MAX(CASE WHEN ${t.status} = 'active' THEN 1 ELSE 0 END)`,
   completedCount: sql<number>`COUNT(DISTINCT CASE WHEN ${t.status} IN ('review_pending', 'locked') THEN ${t.id} END)`,
   planningCount: sql<number>`COUNT(DISTINCT CASE WHEN ${t.status} = 'planning' THEN ${t.id} END)`,
-  // Unregioned-city stats (c.region_id IS NULL)
-  hasActiveUnregioned: sql<number>`MAX(CASE WHEN ${c.regionId} IS NULL AND ${t.status} = 'active' THEN 1 ELSE 0 END)`,
-  completedUnregioned: sql<number>`COUNT(DISTINCT CASE WHEN ${c.regionId} IS NULL AND ${t.status} IN ('review_pending', 'locked') THEN ${t.id} END)`,
-  planningUnregioned: sql<number>`COUNT(DISTINCT CASE WHEN ${c.regionId} IS NULL AND ${t.status} = 'planning' THEN ${t.id} END)`,
 });
 
 /**
@@ -246,14 +196,13 @@ const countrySelectShape = (co: typeof countries, c: typeof cities, t: typeof tr
  */
 export async function getAllCountryShading(userId: string): Promise<CountryShadingResult[]> {
   const db = getDb();
-  const [config, coverage, tcStats] = await Promise.all([
+  const [config, tcStats] = await Promise.all([
     getConfigMap(userId),
-    getRegionCoverageMap(),
     getTripCountriesStats(userId),
   ]);
 
   const rows = await db
-    .select(countrySelectShape(countries, cities, trips))
+    .select(countrySelectShape(countries, trips))
     .from(countries)
     .leftJoin(cities, eq(cities.countryCode, countries.countryCode))
     .leftJoin(tripPlaces, eq(tripPlaces.cityId, cities.id))
@@ -270,7 +219,7 @@ export async function getAllCountryShading(userId: string): Promise<CountryShadi
           planningCount: Math.max(Number(r.planningCount), tc.planningCount),
         }
       : r;
-    const stateKey = computeCountryState(merged, coverage.get(r.countryCode));
+    const stateKey = computeCountryState(merged);
     return { countryCode: r.countryCode, ...buildResult(stateKey, config) };
   });
 }
@@ -285,14 +234,13 @@ export async function getCountryShading(
   userId: string,
 ): Promise<CountryShadingResult | null> {
   const db = getDb();
-  const [config, coverage, tcStats] = await Promise.all([
+  const [config, tcStats] = await Promise.all([
     getConfigMap(userId),
-    getRegionCoverageMap(),
     getTripCountriesStats(userId),
   ]);
 
   const rows = await db
-    .select(countrySelectShape(countries, cities, trips))
+    .select(countrySelectShape(countries, trips))
     .from(countries)
     .leftJoin(cities, eq(cities.countryCode, countries.countryCode))
     .leftJoin(tripPlaces, eq(tripPlaces.cityId, cities.id))
@@ -311,7 +259,7 @@ export async function getCountryShading(
         planningCount: Math.max(Number(r.planningCount), tc.planningCount),
       }
     : r;
-  const stateKey = computeCountryState(merged, coverage.get(r.countryCode));
+  const stateKey = computeCountryState(merged);
   return { countryCode: r.countryCode, ...buildResult(stateKey, config) };
 }
 
@@ -357,34 +305,4 @@ export async function getRegionShading(
       ...buildResult(stateKey, config),
     };
   });
-}
-
-/**
- * Returns shading state for a single city.
- * Uses the single-city query from shading spec §3.1.
- * Scoped to the given userId so each user sees only their own trip data
- * (ADL-28 R1 — previously unscoped, aggregating every user's trips).
- */
-export async function getCityShading(cityId: number, userId: string): Promise<ShadingResult> {
-  const db = getDb();
-  const config = await getConfigMap(userId);
-
-  // Shading spec §3.1
-  const rows = await db
-    .select({
-      hasActive: sql<number>`MAX(CASE WHEN ${trips.status} = 'active' THEN 1 ELSE 0 END)`,
-      completedCount: sql<number>`COUNT(DISTINCT CASE WHEN ${trips.status} IN ('review_pending', 'locked') THEN ${trips.id} END)`,
-      planningCount: sql<number>`COUNT(DISTINCT CASE WHEN ${trips.status} = 'planning' THEN ${trips.id} END)`,
-    })
-    .from(tripPlaces)
-    .leftJoin(trips, and(eq(trips.id, tripPlaces.tripId), eq(trips.userId, userId)))
-    .where(eq(tripPlaces.cityId, cityId));
-
-  const r = rows[0] ?? { hasActive: 0, completedCount: 0, planningCount: 0 };
-  const stateKey = computeState(
-    Number(r.completedCount),
-    Number(r.planningCount),
-    Number(r.hasActive) === 1,
-  );
-  return buildResult(stateKey, config);
 }


### PR DESCRIPTION
## Summary

Mechanical, low-risk code-hygiene cleanups from the 2026-07 code-safety audit
(`audits/session-b-code-safety.md`), tracker **QUAL-33**. No behaviour change
except the confirmed-dead-code removals (U4) and the unused CORS credentials
flag (U5), both verified inert before removal.

## Items and resolution

- **U2 — false comment.** `src/backend/server.ts` header comment described
  auth as a "stub" (SEC-09). Auth is real: `requireAuth` (Clerk JWT/JWKS
  verification) is applied globally at `app.use('/api/', requireAuth)`.
  Comment now describes the real mechanism.
- **U3 — false + dangerous comment.** `.semgrep/security.yml` rule-2 comment
  claimed shading queries are "intentionally unscoped … aggregate across all
  users." False for the live code — every live shading query in
  `shading.service.ts` scopes via a JOIN condition
  (`eq(trips.userId, userId)`), which is exactly what defeats the simple
  WHERE-based Semgrep pattern the TODO discusses. Comment-only fix; rule
  logic (`rules:` block) is byte-for-byte unchanged; **no suppression added
  or widened** (OP-30).
- **U4 — dead code** in `src/backend/services/shading.service.ts`:
  - `getCityShading` — exported, 0 callers. Verified by two independent
    probes: (1) grep for `getCityShading` across `src/`, only the definition
    matched; (2) read `routes/map.ts`, the only route file that imports from
    this service, and confirmed it imports `getAllCountryShading`,
    `getCountryShading`, `getRegionShading` but not `getCityShading`. Note:
    the audit doc's claim that this function is *unscoped* is stale —
    ADL-28 R1 already added `userId` scoping to it before this brief; it was
    dead but correctly scoped. Removed as dead code only.
  - The `_coverage` param on `computeCountryState` — the function body never
    referenced it (confirmed by reading the function and by a pre-existing
    test literally named "coverage parameter is ignored").
  - `getRegionCoverageMap` — its only consumer was the now-removed
    `_coverage` param, so it's dead too; removing it drops one full extra
    aggregate query from every `getAllCountryShading`/`getCountryShading`
    call.
  - The `*Unregioned` SQL aggregates in `countrySelectShape` — computed via
    3 extra `CASE WHEN` expressions per query, never read by
    `computeCountryState`.
- **U5 — unused CORS credentials.** Removed `credentials: true` +
  "Reserved for Phase 2 session cookies" comment from `server.ts`, and the
  identical flag from its test-harness mirror `server-test-app.ts` (that
  file's own docstring states it exists to mirror `server.ts`'s pipeline
  exactly). Confirmed via grep: no `cookie-parser`, `req.cookies`,
  `res.cookie(...)` anywhere in the app, and no frontend fetch call uses
  `credentials: 'include'`/`withCredentials` — Clerk auth is
  Authorization-header based (confirmed by grep for `Authorization` usage in
  `apiClient.ts`/`main.tsx`). Also removed an adjacent stale "Authorization
  reserved for Phase 2" comment on the same CORS block — Authorization is
  actively used today, not reserved.
- **U6 — vestigial dynamic imports.** Replaced `await import('drizzle-orm')`
  (4 call sites in `src/backend/repositories/items.ts`) with the file's
  existing static `and`/`eq` imports. `trips.ts` had no dynamic imports to
  fix — the brief's line numbers had drifted; verified by grepping
  `import(` in that file (no match) and reading its import block (already
  fully static).
- **U11 — dead directives.** Removed dead `eslint-disable` comments in
  `middleware/auth.ts` and `middleware/error-handler.ts`. Verified two ways:
  no `.eslintrc*`/`eslint.config.*` file in the repo, and no `eslint`
  dependency in `package.json` (`lint` script runs `biome lint src/`).
- **U12 — dead branch.** `routes/cities.ts` `useRatingSort` ternary: the
  `useRatingSort === false` branch and the `sort_order !== 'asc'` inner
  branch both evaluated to `desc(effectiveRatingSql)`. Collapsed to
  `useRatingSort && sort_order === 'asc' ? asc(...) : desc(...)` — verified
  behaviourally identical across all four (useRatingSort × sort_order)
  input combinations before making the change.

## Security checklist (brief-mandated, since this touches server.ts/auth-adjacent + semgrep)

1. U5 removal does not affect auth — Clerk is header-based (`Authorization`),
   not cookie-based; confirmed no cookie reliance anywhere in the app.
2. U3 is a comment-only change — the semgrep rule logic (patterns, message,
   severity, paths) is unchanged; no suppression added.
3. No route auth changed by this sweep — `requireAuth`/`requireOwner`
   placement is untouched everywhere.

## Notes for reviewer

- `src/backend/services/__tests__/shading.service.test.ts` was rewritten in
  full (`Write`, not `Edit`) to match `computeCountryState`'s new signature
  and drop the now-invalid coverage/Unregioned fixtures. Declaring this per
  the CLAUDE.md source-rewrite rule — it's a small, fully-owned test file,
  not a shared-record file, and the rewrite is a mechanical consequence of
  the U4 signature change (every test case needed its second argument
  dropped).
- Did **not** touch: `requireAuth` catch-all swallow, `DB_TYPE=postgres`
  scaffolding, transaction-convention question, `asyncHandler`, routes→repo
  layering, `buildApp()` factory — all explicitly out of scope per brief.
- Did not edit `_project/tracker.json` — left for the COO per brief (avoids
  collision with 3 other parallel sweeps).

## Test plan

- [x] `npm run check` (Biome lint + format) — 0 errors (5 pre-existing infos
      in an unrelated geocoding test file, out of scope)
- [x] `npm run type:check:all` — clean
- [x] `npm run test:backend` — 759/759 passed
- [x] `npm run test:frontend` — 321/321 passed
- [x] `npm run status:check` — up to date

🤖 Generated with [Claude Code](https://claude.com/claude-code)