### PR TITLE
chore(QUAL-02/21/22): test-coverage sweep

### DIFF
--- a/jobs/COO/inbox/20260808_0930-QA-qual-coverage-sweep-complete.md
+++ b/jobs/COO/inbox/20260808_0930-QA-qual-coverage-sweep-complete.md
@@ -1,0 +1,19 @@
+**QUAL-02 / QUAL-21 / QUAL-22** · PR [#433](https://github.com/ryanv11/travel-tracker/pull/433) · BRD: GE-16 (QUAL-21/22) · Branch: `chore/qa-coverage-sweep`
+
+**Scope tested:** test-coverage sweep, three independent tracker items. Build ref: `chore/qa-coverage-sweep` merged with `origin/main` (includes PR #432/QUAL-33, picked up mid-thread, zero conflicts).
+
+**Verdict per item:**
+
+- **QUAL-22 (mock drift, PASS/fixed).** `adl46-access-model.test.ts`'s geocoding mock exported only `resolveCity`; `cities.ts` also calls `resolveCityName`/`resolveByOsmId`, so the undefined export threw and the route's own catch silently degraded every call to `'disabled'` — Group B tests exercised an accidental fallback, not what they claimed to test. Fixed: mock now exports real spies for all three. B4 (the ambiguous-verdict test) now sets a genuine `'ambiguous'` `CityResolution` and asserts (a) `resolveCityName` was actually called with the right args, (b) `resolveCity`'s fire-and-forget re-check is correctly skipped for `'ambiguous'` per ADL-46 §2.6 — the one real behavioural difference the old fallback could never distinguish. **How I confirmed non-vacuous:** ran the full file (32/32 pass) with both new assertions actually executing; B1/B2/B3/B5/B6 unchanged in outcome since default resolution stays `'disabled'`.
+
+- **QUAL-21 (route coverage, PASS/added).** New file `cities.resolve-then-create.test.ts` — every existing suite mocked `resolveCityName` to `'disabled'`, so the resolve-then-create success path had zero route-level coverage (named root cause of 2 shipped defects). Mocks only `global.fetch` with a real committed Nominatim fixture (`springfield_il.json`); real `resolveCityName`/`classifyCandidates`/accept-rule run — matches the existing `bug76-geocode-e2e.test.ts` pattern. Two branches: resolves to existing record (200, no insert), creates new record (201, `geocode_status=resolved`, OSM ref stamped). **How I confirmed non-vacuous:** mutation-tested by temporarily forcing `GEOCODING_ENABLED=false` — both tests failed immediately on `fetch` call-count, confirming the assertions are load-bearing.
+
+- **QUAL-02 (assertion strength, PASS/partial).** Re-probed the tracker's "findings 1/2 already fixed" note rather than trusting it — confirmed true (filter-inversion, GET /api/trips sort already strong from PR #320, untouched). Strengthened two remaining weak spots: `trips.crud.test.ts`'s response-shape test (was `toHaveProperty`-only, now seeds real category/companion/activity/place/country data and asserts type+value); added a sort-order test for `GET /api/cities/:id/carry-forward`'s `desc(trips.endDate)` (zero prior coverage). Finding 4 (cross-trip item isolation) remains untouched, still open — out of this brief's named scope.
+
+**Files touched (for merge ordering):** `adl46-access-model.test.ts`, `cities.carry-forward.test.ts`, `trips.crud.test.ts` (modified), `cities.resolve-then-create.test.ts` (new). None overlap the guardrail list (`shading.service.ts` tests, cities.ts rating-sort test — lives in `items.rating-sort-filter.test.ts`, not touched).
+
+**CI:** `scripts/ci-wait.sh pr 433` — 18/18 checks green (Backend/Frontend/E2E/Contract Tests, Type Check, Biome, Semgrep, Gitleaks, Dependency Scan). Local: `npm run check`/`type:check:all`/`test:backend` (762/762)/`test:frontend` (321/321)/`status:check` all clean.
+
+**Open issues/blockers:** None. Did not touch `_project/tracker.json` per brief instruction (parallel sweeps this round) — tracker updates for QUAL-02/21/22 are on COO post-merge.
+
+Full detail: `jobs/qa/tech/20260808-qual-coverage-sweep.md`. Park doc: `jobs/qa/park-docs/20260808-QA-park.txt`.

--- a/jobs/qa/context/current.txt
+++ b/jobs/qa/context/current.txt
@@ -254,3 +254,68 @@ NEXT STEPS (for incoming QA)
   clean + no other backend suite regresses. Full detail + AC mapping:
   jobs/qa/tech/20260807-bug76-atdd-red-tests.md
   Completion report: jobs/COO/inbox/
+
+================================================================================
+2026-08-08 — QUAL-02 / QUAL-21 / QUAL-22 TEST-COVERAGE SWEEP
+================================================================================
+
+  Branch: chore/qa-coverage-sweep (off main, merged origin/main mid-thread to
+  pick up concurrent PR #432/QUAL-33 with no conflicts). PR #433, 18/18 CI
+  checks green.
+
+  QUAL-22 (mock-fidelity, review finding F8) — FIXED. adl46-access-model.
+  test.ts's geocoding.service mock exported only resolveCity; cities.ts's
+  POST handler also calls resolveCityName/resolveByOsmId, so calling the
+  undefined export threw a TypeError the route's own try/catch silently
+  swallowed to 'disabled'. Every Group B test exercised the accidental
+  disabled/pending fallback regardless of what it claimed to test. Mock now
+  exports resolveCityName/resolveByOsmId for real (as vi.fn spies),
+  defaulting to the same 'disabled' outcome so B1/B2/B3/B5/B6 (status-
+  independent) are behaviourally unchanged. B4 (the test that specifically
+  claims to prove the 'ambiguous' verdict) now sets a genuine 'ambiguous'
+  CityResolution and asserts (a) resolveCityName was actually called with
+  the right args, (b) the fire-and-forget resolveCity re-resolution is
+  correctly SKIPPED for 'ambiguous' per ADL-46 F1/F2 ruling §2.6 — the one
+  real behavioural difference the old accidental fallback could never
+  distinguish, since 'ambiguous' and 'disabled' both landed in the same
+  pending-insert branch pre-fix.
+
+  QUAL-21 (route coverage, review finding F4) — new file cities.
+  resolve-then-create.test.ts. Every existing POST /api/cities suite mocks
+  resolveCityName to 'disabled', so resolution.status === 'ok' — the whole
+  point of resolve-then-create — had never been reached by a green
+  route-level test (root-caused two shipped defects per the tracker note).
+  Mocks ONLY global.fetch with a real committed Nominatim fixture
+  (springfield_il.json, single unambiguous candidate so no region_id is
+  needed to disambiguate); the real resolveCityName/classifyCandidates/
+  accept-rule all run — same fetch-boundary pattern as the existing
+  bug76-geocode-e2e.test.ts. Branch A: pass-1 misses on a typo, pass-2
+  canonical lookup finds a pre-existing row (200, no insert). Branch B: both
+  passes miss, row inserted from the canonical response (201, geocode_
+  status=resolved, OSM ref stamped). resolveCity's fire-and-forget is
+  mocked to a no-op (irrelevant to this file, and left real would race the
+  fetch-call-count assertions). Mutation-tested (forced GEOCODING_
+  ENABLED=false) to confirm both tests fail for the right reason, not
+  vacuously.
+
+  QUAL-02 (assertion strength) — tracker note: findings 1/2 (filter-
+  inversion, sort-order) were already fixed in PR #320; this closes two
+  further weak spots under the same finding. trips.crud.test.ts's
+  response-shape test seeded only 1 trip and asserted toHaveProperty(key)
+  with no value/type check on categories/companions/activities/places/
+  countries — rewritten to seed real association data and assert type
+  (array) + value. cities.carry-forward.test.ts had zero coverage of its
+  desc(trips.endDate) sort (every existing test seeds ≤1 item) — added a
+  3-trip, seeded-out-of-order test asserting exact descending order.
+
+  Files touched: adl46-access-model.test.ts, cities.carry-forward.test.ts,
+  trips.crud.test.ts (all modified), cities.resolve-then-create.test.ts
+  (new). None overlap the brief's avoid-list (shading.service.ts tests,
+  cities.ts rating-sort test).
+
+  765→762 backend tests locally before/after the origin/main merge (QUAL-33
+  removed some now-redundant shading tests, unrelated to this thread) — all
+  passing. type:check:all clean, biome clean (5 pre-existing INFO-level
+  lint notices in untouched files, confirmed pre-existing via diff against
+  main). Full detail: jobs/qa/tech/20260808-qual-coverage-sweep.md
+  Completion report: jobs/COO/inbox/

--- a/jobs/qa/park-docs/20260808-QA-park.txt
+++ b/jobs/qa/park-docs/20260808-QA-park.txt
@@ -1,0 +1,100 @@
+QA PARK DOCUMENT — 2026-08-08
+================================================================================
+THREAD: QUAL-02 / QUAL-21 / QUAL-22 — test-coverage sweep
+STATUS: COMPLETE — PR #433 open, 18/18 CI green, not yet merged (COO merges)
+
+WHAT WAS DONE
+--------------------------------------------------------------------------------
+Independent test-coverage lane, three items:
+
+QUAL-22 (do first per brief — real correctness gap in the suite): fixed a
+drifted mock in adl46-access-model.test.ts. The geocoding.service mock
+exported only resolveCity; cities.ts's POST handler also calls
+resolveCityName/resolveByOsmId, so the undefined export threw and the
+route's own try/catch silently swallowed it to 'disabled'. Every Group B
+test exercised the accidental disabled/pending fallback regardless of what
+it claimed to test. Mock now exports resolveCityName/resolveByOsmId for
+real as vi.fn spies; B4 (the test that specifically claims to prove the
+'ambiguous' verdict is handled) now configures a genuine 'ambiguous'
+CityResolution and asserts two non-vacuous things: resolveCityName was
+called with the right args, and resolveCity's fire-and-forget re-resolution
+is correctly SKIPPED for 'ambiguous' (ADL-46 F1/F2 ruling §2.6) — the one
+real behavioural difference the old accidental fallback could never
+distinguish.
+
+QUAL-21: new file cities.resolve-then-create.test.ts. Every existing
+POST /api/cities suite mocks resolveCityName to 'disabled', so the
+resolve-then-create SUCCESS path (resolution.status === 'ok') had zero
+route-level coverage — named as the root cause of two shipped defects.
+Mocks only global.fetch with a real committed Nominatim fixture
+(springfield_il.json), letting the real resolveCityName/classifyCandidates/
+accept-rule run — same fetch-boundary pattern as bug76-geocode-e2e.test.ts.
+Two tests: resolves to an existing record (pass-2 canonical match), and
+creates a new record (both passes miss, insert from canonical response).
+Mutation-tested (forced GEOCODING_ENABLED=false) to confirm both fail for
+the right reason.
+
+QUAL-02: re-probed the tracker's "findings 1/2 already fixed" note rather
+than inheriting it — confirmed true (filter-inversion and GET /api/trips
+sort-order are both already strong). Strengthened two genuinely-remaining
+weak spots: trips.crud.test.ts's response-shape test (was toHaveProperty-
+only, now seeds real data and asserts type+value) and a new sort-order test
+for GET /api/cities/:id/carry-forward (desc(trips.endDate) — zero prior
+coverage, every existing test seeds ≤1 item).
+
+RESULT
+--------------------------------------------------------------------------------
+4 files touched: adl46-access-model.test.ts, cities.carry-forward.test.ts,
+trips.crud.test.ts (modified), cities.resolve-then-create.test.ts (new).
+None overlap the brief's avoid-list (shading.service.ts tests, cities.ts
+rating-sort test — that lives in items.rating-sort-filter.test.ts, not
+touched).
+
+Full local verification (post-merge with origin/main's PR #432/QUAL-33,
+which this branch picked up mid-thread with zero conflicts):
+  npm run check           — clean (5 pre-existing INFO lint notices,
+                             confirmed pre-existing, in files not touched)
+  npm run type:check:all  — clean
+  npm run test:backend    — 762/762 passing
+  npm run test:frontend   — 321/321 passing
+  npm run status:check    — STATUS.md up to date
+
+PR #433, 18/18 CI checks green (Backend Tests, Frontend Tests, E2E Tests,
+Contract Tests, Type Check, Biome, Semgrep, Gitleaks, Dependency Scan — all
+pass). Did NOT merge (QA doesn't merge its own PR — COO's job).
+
+MOCK-FIDELITY NOTE (the throughline across all three items)
+--------------------------------------------------------------------------------
+QUAL-22 is the textbook OP-35/QUAL-22 failure mode itself: a mock that
+silently omits an export a route depends on can still produce a plausible-
+looking green suite, because the route's own defensive error handling
+absorbs the gap. QUAL-21 was written to deliberately NOT repeat this —
+rather than mock resolveCityName's return value (which would just relocate
+the same "pre-decided result" problem one level up), it mocks only the
+actual network boundary (global.fetch) with a real, previously-captured
+Nominatim response, so the real resolver logic is what's under test. Both
+new/fixed test groups were mutation-tested (temporarily broken on purpose)
+to confirm they fail for the right reason before being trusted as green.
+
+OPEN ISSUES / BLOCKERS
+--------------------------------------------------------------------------------
+None. PR ready for COO review/merge. Did not touch _project/tracker.json
+per the brief (COO updates tracker post-merge — parallel sweeps running
+this round, per the brief's explicit instruction).
+
+ARTIFACTS
+--------------------------------------------------------------------------------
+- Branch: chore/qa-coverage-sweep (pushed, PR #433 open)
+- Tech doc (full per-item detail + verification evidence):
+  jobs/qa/tech/20260808-qual-coverage-sweep.md
+- Context updated: jobs/qa/context/current.txt (appended, not rewritten)
+- Completion report: jobs/COO/inbox/
+
+NEXT (for COO)
+--------------------------------------------------------------------------------
+1. Review + merge PR #433 (squash, per standard workflow).
+2. Update _project/tracker.json for QUAL-02 (partial -> further-partial or
+   done depending on whether findings 3/4 are considered fully closed —
+   finding 4 (cross-trip item isolation) was NOT touched by this thread,
+   still open), QUAL-21 (pending -> done), QUAL-22 (pending -> done).
+3. Post-merge: scripts/ci-wait.sh branch main to confirm main stays green.

--- a/jobs/qa/tech/20260808-qual-coverage-sweep.md
+++ b/jobs/qa/tech/20260808-qual-coverage-sweep.md
@@ -1,0 +1,194 @@
+# QUAL-02 / QUAL-21 / QUAL-22 — test-coverage sweep
+
+Branch: `chore/qa-coverage-sweep`. PR: [#433](https://github.com/ryanv11/travel-tracker/pull/433) — 18/18 CI checks green.
+
+## QUAL-22 — mock drift (`adl46-access-model.test.ts`)
+
+**Finding (review F8):** the `vi.mock('../../services/geocoding.service.js', ...)` factory
+exported only `resolveCity`:
+
+```ts
+vi.mock('../../services/geocoding.service.js', () => ({
+  resolveCity: async () => undefined,
+}));
+```
+
+`src/backend/routes/cities.ts:27` imports `resolveByOsmId, resolveCity, resolveCityName` and
+calls `resolveCityName` at line 478 inside a try/catch:
+
+```ts
+let resolution: Awaited<ReturnType<typeof resolveCityName>>;
+try {
+  resolution = await resolveCityName(name, country_code, { regionIso });
+} catch {
+  resolution = { status: 'disabled', candidates: [] };
+}
+```
+
+Since the mock didn't export `resolveCityName`, calling it (`undefined(...)`) threw a
+`TypeError`, caught by the route's own catch, silently degrading every call to
+`{ status: 'disabled', candidates: [] }`. Every Group B test (D13 find-or-create invariants)
+therefore exercised the disabled/pending fallback path regardless of what it claimed to test.
+
+**Verified against the real module** (two probes, per the negative-findings rule — this is a
+positive "the export exists and is called" claim, established by both reading the source and
+confirming via a live test run):
+- `grep -n "export " src/backend/services/geocoding.service.ts` — confirms
+  `resolveCityName`, `resolveByOsmId`, `resolveCity` are all real exports.
+- `grep -n "resolveByOsmId\|resolveCity\|resolveCityName" src/backend/routes/cities.ts` —
+  confirms all three are imported and `resolveCityName`/`resolveCity` are called; `resolveByOsmId`
+  is called only inside `createOrReuseCarriedCity` (the `osm_type`/`osm_id` carried-ref branch),
+  which Group B's tests never exercise (none send `osm_type`/`osm_id` — file header comment
+  already states this).
+
+**Fix.** The mock now exports real, controllable doubles:
+
+```ts
+let mockCityResolution: CityResolution = { status: 'disabled', candidates: [] };
+const resolveCityNameSpy = vi.fn(async (): Promise<CityResolution> => mockCityResolution);
+const resolveCitySpy = vi.fn(async () => undefined);
+
+vi.mock('../../services/geocoding.service.js', () => ({
+  resolveCity: resolveCitySpy,
+  resolveCityName: resolveCityNameSpy,
+  resolveByOsmId: async () => null,
+}));
+```
+
+Default resolution stays `'disabled'` — identical terminal outcome to the pre-fix throw/catch —
+so B1/B2/B3/B5/B6 (whose pass/fail never depended on `resolution.status`, only on pass-1
+find-or-create matches or the pending-insert fallback) are **behaviourally unchanged**. Verified:
+all 32 tests in the file still pass after the fix, unmodified for those five.
+
+**B4 — the one test where this mattered.** B4's own name and comment claim to prove "ambiguous
+no-region request does not silently pick one of two existing regioned rows." Pre-fix, it never
+reached an `'ambiguous'` verdict at all — it silently ran the `'disabled'` fallback, which
+happens to satisfy the same two loose invariants the test asserted (no silent pick, no
+duplicate) for an unrelated reason. Fixed to set a genuine `'ambiguous'` `CityResolution`
+(two candidates, distinct `region_iso`, matching what `classifyCandidates` would really produce
+for two real Springfields with no region requested) and added two non-vacuous checks:
+
+1. `expect(resolveCityNameSpy).toHaveBeenCalledWith('Springfield', 'US', { regionIso: null })`
+   — proves the mock was actually reached with the arguments D12 §4.3.1 requires, not
+   short-circuited by an earlier pass-1 match.
+2. `expect(resolveCitySpy).not.toHaveBeenCalled()` — proves the route's ADL-46 F1/F2 ruling §2.6
+   behaviour (skip the fire-and-forget re-resolution for an `'ambiguous'` verdict, since the
+   route already holds the answer and re-firing burns a second Nominatim request for a
+   provably identical result) is genuinely exercised. This is the **one real behavioural
+   difference** between `'ambiguous'` and `'disabled'` in `cities.ts` (`if (created &&
+   resolution.status !== 'ambiguous') { resolveCity(...) }`) — before the fix, both statuses
+   landed in the identical pending-insert branch, so nothing could ever have told them apart.
+
+Confirmed non-vacuous by running the full file: 32/32 pass, including B4 with both new
+assertions actually executing (not skipped, not throwing).
+
+## QUAL-21 — resolve-then-create route coverage (new file)
+
+**Finding (review F4):** every backend route suite that posts to `/api/cities` mocks
+`resolveCityName` to `{ status: 'disabled', candidates: [] }` —
+`adl46-access-model.test.ts` (see above) and `cities-find-or-create.test.ts` both do this
+deliberately (their own concern is find-or-create logic, not the geocoder). That means
+`resolution.status === 'ok'` — the canonical-name convergence branch that is the entire point
+of "resolve-THEN-create" (§4.3 steps 3-4a/4b) — had never been reached by a green CI run at the
+route level. The tracker note names this as the root cause of two shipped defects (F1, and the
+ambiguous-status regression).
+
+**Design choice — mock only `global.fetch`, not `resolveCityName`.** Mocking
+`resolveCityName`'s return value would repeat the exact problem this item exists to fix: a
+pre-decided result cannot tell a correctly wired route from one wired to a broken resolver.
+Instead this file follows the pattern `bug76-geocode-e2e.test.ts` already established —
+`vi.stubGlobal('fetch', ...)` returning a real, committed Nominatim fixture body verbatim, and
+`__resetChokepointForTests()` + `GEOCODING_ENABLED=true` so the real `nominatimSearch` →
+`classifyCandidates` → `isAcceptedSettlement` chain runs end to end. Only `resolveCity` (the
+fire-and-forget background re-check, irrelevant to this file's concern and non-deterministic if
+left real — it would race the `fetch`-call-count assertions) is mocked to a no-op, via
+`importOriginal` partial-mock so `resolveCityName`/`resolveByOsmId` stay real:
+
+```ts
+vi.mock('../../services/geocoding.service.js', async (importOriginal) => {
+  const real = await importOriginal<typeof import('../../services/geocoding.service.js')>();
+  return { ...real, resolveCity: async () => undefined };
+});
+```
+
+**Fixture choice.** `services/__tests__/fixtures/nominatim/bug76/springfield_il.json` — a
+single, unambiguous settlement candidate (Springfield, Illinois, `addresstype=city`). Chosen
+over `denver_us.json` (used elsewhere) specifically because Denver's fixture contains TWO
+distinct settlement candidates in different states (Denver, CO and Denver, IA — both pass the
+`addresstype` accept-rule), which resolves to `'ambiguous'` unless a `region_id` narrows it.
+Springfield IL's single-candidate fixture reaches `'ok'` with no region needed, keeping the two
+new tests focused on the resolve-then-create branch logic rather than region disambiguation
+(already covered by `adl46-access-model.test.ts` Group B).
+
+**Two tests, the two branches QUAL-21 names:**
+
+- **Branch A (resolves to an EXISTING record).** Pre-seed a `Springfield`/`US` row (the
+  CANONICAL name the geocoder will return) — never under the typo the request submits, so a
+  match can only come from the resolve step's pass-2 canonical-name lookup (`findOrUpgradeCity`
+  called a second time with `canonicalName`), not pass-1. Request submits `Springfeild` (typo).
+  Asserts: `fetch` called exactly once, `200`, `res.body.id === existing.id`, no new row
+  inserted under either the typo or the canonical name (`cityRows` count checks both).
+- **Branch B (CREATES a new record).** No pre-existing row at all. Same typo'd request. Pass-1
+  and pass-2 both miss, so the route inserts from the canonical geocoder response. Asserts:
+  `201`, `geocode_status: 'resolved'`, name/lat/lon from the fixture (not the typo), and the
+  OSM ref (`osmType: 'relation'`, `osmId: 126326`) is stamped on the row — the M-A rule
+  (`cities.ts` comment ~line 505) that makes the row discoverable by the resolved-by-OSM merge
+  mechanism.
+
+**Non-vacuousness — mutation-tested, not just asserted.** Copied the file to a scratch path,
+flipped `GEOCODING_ENABLED` to `'false'` in `beforeEach`, and re-ran:
+
+```
+FAIL branch A — AssertionError: expected "vi.fn()" to be called 1 times, but got 0 times
+FAIL branch B — AssertionError: expected "vi.fn()" to be called 1 times, but got 0 times
+```
+
+Both fail immediately on `expect(fetch).toHaveBeenCalledTimes(1)` — the geocoder never runs
+when disabled, exactly as expected — confirming the assertions are load-bearing rather than
+coincidentally satisfied.
+
+## QUAL-02 — assertion strength
+
+Tracker note on this entry: findings 1 (filter-inversion) and 2 (sort-order) were already fixed
+in PR #320 (category_id/country trip filters seeded to 3 with an exactly-1 assertion; GET
+/api/trips sort-order test). Findings 3 (response-shape) and 4 (cross-trip item isolation) were
+explicitly deferred out of that PR's scope on purpose. This brief scoped me to filter-inversion,
+sort-order, and response-shape — re-probed the current suite (not inherited the tracker's
+"already fixed" claim wholesale) and found:
+
+- **Repository-level and route-level filter-inversion tests** (category_id, activity_id,
+  country — `repositories/__tests__/trips.test.ts`, `routes/__tests__/trip-countries.test.ts`)
+  already use the 3-trip inversion-proof pattern from PR #320. Route-level `GET /api/trips`
+  sort-order test (`trips.crud.test.ts`) already asserts exact order via `toEqual([...])` with
+  out-of-order seeding. **No further action** — confirmed already strong, not re-touched.
+- **`trips.crud.test.ts`'s "each trip in list has expected response shape" test** — genuinely
+  weak: `expect(trip).toHaveProperty('categories')` etc. with no value/type check, so a route
+  returning `{ categories: null }` would still pass. Rewritten to seed real
+  category/companion/activity/place/country rows and assert both `Array.isArray(...)` and
+  `.toEqual(...)` against the exact expected content, including the nested `place.city` object
+  shape (region_name/region_iso survive serialization).
+- **`GET /api/cities/:id/carry-forward`'s `desc(trips.endDate)` sort** (`cities.ts:731`) — a
+  genuine, previously-undetected sort-order gap distinct from PR #320's scope (that PR touched
+  trip filters/sort, not this endpoint). Every existing test in
+  `cities.carry-forward.test.ts` seeds at most one `next_time` item, so an unsorted or
+  ascending-sorted query would have passed identically. Added a 3-trip test, seeded
+  deliberately out of order (Middle, Earliest, Latest insertion order), asserting the response
+  comes back Latest → Middle → Earliest by both `source_trip_name` and
+  `source_trip_end_date`.
+
+Scope was deliberately held to these two files per the brief's "don't rewrite the whole suite"
+instruction — did not touch `items.rating-sort-filter.test.ts` (guardrail: avoid, another agent
+touching cities.ts's rating-sort area this round) or attempt an exhaustive sweep for every
+`toHaveProperty`-only assertion in the codebase.
+
+## Full verification run (post origin/main merge, PR #432/QUAL-33 included)
+
+- `npm run check` — clean (Biome). 5 remaining INFO-level `useLiteralKeys` lint notices are
+  pre-existing, in `geocoding.resolveByOsmId.test.ts` and `cities.identity-carry.test.ts`,
+  neither touched by this thread — confirmed via `git diff main` showing no changes to those
+  files, and via checking the same finding appears against a clean `main` checkout.
+- `npm run type:check:all` — clean.
+- `npm run test:backend` — 762/762 passing (765 before the origin/main merge; QUAL-33 removed
+  some now-redundant shading tests, accounting for the delta — unrelated to this thread).
+- `npm run test:frontend` — 321/321 passing (untouched by this thread).
+- `npm run status:check` — `_project/STATUS.md` up to date.

--- a/src/backend/routes/__tests__/adl46-access-model.test.ts
+++ b/src/backend/routes/__tests__/adl46-access-model.test.ts
@@ -35,6 +35,7 @@ import { and, eq } from 'drizzle-orm';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import * as schema from '../../db/schema.js';
 import { createTestDb, type TestDb } from '../../repositories/__tests__/test-db.js';
+import type { CityResolution } from '../../services/geocoding.service.js';
 
 // ----------------------------------------------------------------
 // Test user constants
@@ -51,6 +52,23 @@ let testDb: TestDb | null = null;
 let mockIsOwner = 1;
 let mockUserId = USER_A_ID;
 let mockAuthEnabled = true;
+
+// QUAL-22 (review finding F8): the resolveCityName result the mocked
+// geocoding service returns from POST /api/cities's resolve-then-create step.
+// Defaults to 'disabled' — the same terminal outcome the route's own
+// try/catch produced when this mock omitted resolveCityName entirely (a
+// TypeError swallowed by cities.ts's catch), so every test that does not
+// explicitly set this keeps its original, already-verified behaviour. Group
+// B tests that exist specifically to prove the 'ambiguous' verdict is
+// handled (B4) now set this to a real 'ambiguous' CityResolution instead of
+// relying on that accidental fallback — see B4 below.
+let mockCityResolution: CityResolution = { status: 'disabled', candidates: [] };
+// Spies so a test can assert resolveCityName/resolveCity were actually
+// INVOKED (and with what), not just infer it from downstream DB state —
+// QUAL-22's own point is that an un-exercised mock can still produce a
+// result that "looks plausible", so the fix asserts the call itself.
+const resolveCityNameSpy = vi.fn(async (): Promise<CityResolution> => mockCityResolution);
+const resolveCitySpy = vi.fn(async () => undefined);
 
 // ----------------------------------------------------------------
 // Module mocks — must be declared before any imports that use them
@@ -87,11 +105,23 @@ vi.mock('../../middleware/auth.js', () => ({
   },
 }));
 
-// resolveCity is a no-op in this suite — none of these tests depend on the
-// geocoder actually resolving anything (that is S2's proxy work), only on the
-// find-or-create / containment logic around it.
+// QUAL-22 (review finding F8) — the drifted mock. This factory used to export
+// ONLY resolveCity, but cities.ts's POST handler also imports resolveCityName
+// and resolveByOsmId (routes/cities.ts:27). Calling an undefined export threw
+// a TypeError that the route's own try/catch around resolveCityName silently
+// swallowed into `{ status: 'disabled', candidates: [] }` — so every Group B
+// test exercised the disabled/pending fallback path regardless of what it
+// claimed to test, and resolveByOsmId would have thrown uncaught if any test
+// had exercised the carried-ref branch. Both are now exported for real,
+// matching the module's actual surface (verified against
+// services/geocoding.service.ts's `export` lines, not assumed).
 vi.mock('../../services/geocoding.service.js', () => ({
-  resolveCity: async () => undefined,
+  resolveCity: resolveCitySpy,
+  resolveCityName: resolveCityNameSpy,
+  // Group B never sends osm_type/osm_id (see file header), so the carried-ref
+  // branch that calls this is never reached here — exported anyway so a
+  // future test cannot silently repeat the same drift by adding one.
+  resolveByOsmId: async () => null,
 }));
 
 vi.mock('../../services/shading.service.js', () => ({
@@ -215,6 +245,9 @@ beforeEach(async () => {
   mockAuthEnabled = true;
   mockIsOwner = 1;
   mockUserId = USER_A_ID;
+  mockCityResolution = { status: 'disabled', candidates: [] };
+  resolveCitySpy.mockClear();
+  resolveCityNameSpy.mockClear();
 });
 
 afterEach(() => {
@@ -222,6 +255,7 @@ afterEach(() => {
   mockAuthEnabled = true;
   mockIsOwner = 1;
   mockUserId = USER_A_ID;
+  mockCityResolution = { status: 'disabled', candidates: [] };
 });
 
 // ================================================================
@@ -528,9 +562,48 @@ describe('ADL-46 Group B — D13 find-or-create invariants (POST /api/cities)', 
     const il = await seedCity(testDb!, { countryCode: 'US', name: 'Springfield', regionId: ilId });
     const mo = await seedCity(testDb!, { countryCode: 'US', name: 'Springfield', regionId: moId });
 
+    // QUAL-22 fix: before the mock exported resolveCityName at all, calling it
+    // threw and the route's catch degraded to 'disabled' — this test then
+    // "passed" via the pending-fallback branch (step 4c) without ever
+    // exercising resolveCityName's 'ambiguous' verdict, which is the thing its
+    // own name and comment claim to prove. Now the geocoder double is told to
+    // actually return 'ambiguous' (two distinct region_iso candidates,
+    // multi-region — the real shape classifyCandidates would produce for two
+    // real Springfields with no region requested).
+    mockCityResolution = {
+      status: 'ambiguous',
+      reason: 'multi-region',
+      candidates: [
+        {
+          displayName: 'Springfield, Illinois, United States',
+          name: 'Springfield',
+          latitude: 39.8,
+          longitude: -89.64,
+          countryCode: 'US',
+          regionIso: 'US-IL',
+          addressType: 'city',
+        },
+        {
+          displayName: 'Springfield, Missouri, United States',
+          name: 'Springfield',
+          latitude: 37.21,
+          longitude: -93.29,
+          countryCode: 'US',
+          regionIso: 'US-MO',
+          addressType: 'city',
+        },
+      ],
+    };
+
     const res = await supertest(app)
       .post('/api/cities')
       .send({ name: 'Springfield', country_code: 'US' }); // no region_id
+
+    // Non-vacuous check: resolveCityName was actually called (not skipped via
+    // an early pass-1 match) and with the arguments D12 §4.3.1 requires —
+    // the user's submitted name/country, no region. Without this the test
+    // could still pass by short-circuiting before ever reaching the mock.
+    expect(resolveCityNameSpy).toHaveBeenCalledWith('Springfield', 'US', { regionIso: null });
 
     // Judgement call (flagged in QA report): ADL-46 states this case explicitly
     // has "no safe automatic answer" and must not guess, but does not prescribe
@@ -554,6 +627,16 @@ describe('ADL-46 Group B — D13 find-or-create invariants (POST /api/cities)', 
       .where(eq(schema.cities.regionId, moId));
     expect(ilRows).toHaveLength(1);
     expect(moRows).toHaveLength(1);
+
+    // ADL-46 F1/F2 ruling §2.6 (route comment, cities.ts:570-577): an
+    // 'ambiguous' verdict must SKIP the fire-and-forget resolveCity
+    // re-resolution — the route already holds the verdict; re-firing it burns
+    // a second Nominatim request for a provably identical answer. This is the
+    // one behavioural difference between the 'ambiguous' and 'disabled'
+    // outcomes that the pre-fix accidental fallback could never distinguish
+    // (both landed in the same step-4c pending-insert branch), so it is the
+    // most direct proof this test now exercises 'ambiguous' for real.
+    expect(resolveCitySpy).not.toHaveBeenCalled();
   });
 
   it('B5 — exactly one row matches name+country with no region requested → returns it (no regression)', async () => {

--- a/src/backend/routes/__tests__/cities.carry-forward.test.ts
+++ b/src/backend/routes/__tests__/cities.carry-forward.test.ts
@@ -280,6 +280,67 @@ describe('GET /api/cities/:id/carry-forward — BUG-17 status filter removed', (
     expect(res.body).toHaveLength(0);
   });
 
+  // QUAL-02 (sort-order gap): the route orders by desc(trips.endDate)
+  // (cities.ts:731) but this file had no test asserting that order — every
+  // existing test seeds at most one item, so an unsorted or ASC-sorted query
+  // would pass identically. Three trips against the SAME city, seeded
+  // out of order so a passing assertion can't be explained by insertion-order
+  // coincidence (same pattern as trips.crud.test.ts's QUAL-02 finding 2 fix).
+  it('orders results by source trip end_date DESCENDING, not insertion order (QUAL-02 sort-order gap)', async () => {
+    const db = testDb!;
+    await db
+      .insert(schema.countries)
+      .values({ countryCode: 'IE', name: 'Ireland' })
+      .onConflictDoNothing();
+    const [city] = await db
+      .insert(schema.cities)
+      .values({ name: 'Dublin', countryCode: 'IE', geocodeStatus: 'resolved' })
+      .returning();
+
+    async function seedTripWithNextTimeItem(endDate: string, tripName: string) {
+      const [trip] = await db
+        .insert(schema.trips)
+        .values({
+          name: tripName,
+          startDate: '2025-01-01',
+          endDate,
+          status: 'locked',
+          userId: TEST_USER_ID,
+        })
+        .returning();
+      const [place] = await db
+        .insert(schema.tripPlaces)
+        .values({ tripId: trip.id, cityId: city.id, userId: TEST_USER_ID })
+        .returning();
+      await db.insert(schema.items).values({
+        tripId: trip.id,
+        tripPlaceId: place.id,
+        itemType: 'restaurant',
+        status: 'next_time',
+        userId: TEST_USER_ID,
+      });
+    }
+
+    // Seeded MIDDLE, EARLIEST, LATEST — deliberately not already in date order.
+    await seedTripWithNextTimeItem('2025-06-01', 'Middle Trip');
+    await seedTripWithNextTimeItem('2025-01-01', 'Earliest Trip');
+    await seedTripWithNextTimeItem('2025-12-01', 'Latest Trip');
+
+    const res = await supertest(app).get(`/api/cities/${city.id}/carry-forward`).expect(200);
+
+    expect(res.body).toHaveLength(3);
+    expect(res.body.map((r: { source_trip_name: string }) => r.source_trip_name)).toEqual([
+      'Latest Trip',
+      'Middle Trip',
+      'Earliest Trip',
+    ]);
+    expect(res.body.map((r: { source_trip_end_date: string }) => r.source_trip_end_date)).toEqual([
+      '2025-12-01',
+      '2025-06-01',
+      '2025-01-01',
+    ]);
+  });
+
   it('returns 200 empty array for a city with no next_time items', async () => {
     const db = testDb!;
     await db

--- a/src/backend/routes/__tests__/cities.resolve-then-create.test.ts
+++ b/src/backend/routes/__tests__/cities.resolve-then-create.test.ts
@@ -1,0 +1,222 @@
+/**
+ * QUAL-21 — route-level coverage for the resolve-then-create SUCCESS path
+ * (POST /api/cities, ADL-46 §4.3 steps 3-4a/4b).
+ *
+ * Review finding F4 (jobs/architect/tech/20260731-ADL46-release-fresh-eyes-review.md):
+ * every existing route-level suite that exercises POST /api/cities mocks
+ * `resolveCityName` to `{ status: 'disabled', candidates: [] }` (see
+ * adl46-access-model.test.ts and cities-find-or-create.test.ts — both
+ * deliberately, so as not to depend on live geocoding for THEIR concerns).
+ * That means `resolution.status === 'ok'` — the canonical-name convergence
+ * branch that is the entire point of "resolve-THEN-create" — has never been
+ * reached by a green CI run at the route level. This is the root cause named
+ * in the tracker entry as already having shipped two real defects (F1, and
+ * the ambiguous-status regression) invisibly.
+ *
+ * Mock-fidelity (avoids repeating QUAL-22's mistake one level up): this file
+ * does NOT mock `resolveCityName` — it mocks only `global.fetch`, the exact
+ * boundary Nominatim egress crosses, with a real captured Nominatim response
+ * fixture loaded verbatim off disk. The REAL nominatimSearch, REAL
+ * classifyCandidates/isAcceptedSettlement accept-rule, and REAL
+ * resolveCityName all run — the same pattern
+ * routes/__tests__/bug76-geocode-e2e.test.ts already established for exactly
+ * this reason (a mocked resolveCityName return value cannot tell a correctly
+ * wired route from one wired to a broken resolver, since the result is
+ * already pre-decided by the mock). `resolveCity` (the fire-and-forget
+ * background re-resolution at cities.ts:579) IS mocked to a no-op — it is
+ * irrelevant to what this file tests and, left real, would race the test's
+ * fetch-call-count assertions with a second, non-deterministic egress call.
+ *
+ * Fixture: services/__tests__/fixtures/nominatim/bug76/springfield_il.json —
+ * a single, unambiguous settlement candidate (Springfield, Illinois,
+ * addresstype=city), chosen specifically so classifyCandidates reaches 'ok'
+ * without needing a region_id in the request (regionIsos.length === 1) and
+ * without colliding with the multi-candidate denver_us.json fixture used
+ * elsewhere (which resolves to TWO distinct region_isos and would go
+ * 'ambiguous' unless a region_id narrows it).
+ */
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { and, eq } from 'drizzle-orm';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as schema from '../../db/schema.js';
+import { createTestDb, type TestDb } from '../../repositories/__tests__/test-db.js';
+import { __resetChokepointForTests } from '../../services/nominatim-client.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SPRINGFIELD_IL_FIXTURE = path.join(
+  __dirname,
+  '../../services/__tests__/fixtures/nominatim/bug76/springfield_il.json',
+);
+
+const USER_ID = 'user-qual21-0000-0000-0000-000000000000';
+
+let testDb: TestDb | null = null;
+
+vi.mock('../../db/index.js', async (importOriginal) => {
+  const real = await importOriginal<typeof import('../../db/index.js')>();
+  return {
+    ...real,
+    getDb: () => {
+      if (!testDb) throw new Error('[TEST] testDb not initialised');
+      return testDb;
+    },
+  };
+});
+
+vi.mock('../../middleware/auth.js', () => ({
+  requireAuth: (
+    req: import('express').Request,
+    _res: import('express').Response,
+    next: import('express').NextFunction,
+  ) => {
+    (req as import('express').Request & { user?: unknown }).user = {
+      id: USER_ID,
+      clerkId: 'clerk_qual21',
+      email: 'qual21@example.com',
+      isOwner: 0, // ADL-46 D4: city creation is open to any authenticated user
+    };
+    next();
+  },
+}));
+
+// resolveCityName / resolveByOsmId are deliberately REAL (see file header) —
+// only resolveCity's fire-and-forget background re-check is neutralised.
+vi.mock('../../services/geocoding.service.js', async (importOriginal) => {
+  const real = await importOriginal<typeof import('../../services/geocoding.service.js')>();
+  return {
+    ...real,
+    resolveCity: async () => undefined,
+  };
+});
+
+vi.mock('../../services/shading.service.js', () => ({
+  getAllCountryShading: async () => [],
+  getCountryShading: async () => null,
+  getRegionShading: async () => [],
+  invalidateConfigCache: () => undefined,
+}));
+
+const { default: app } = await import('../../server-test-app.js');
+const supertest = (await import('supertest')).default;
+
+async function seedUser(db: TestDb) {
+  const now = Date.now();
+  await db
+    .insert(schema.users)
+    .values({
+      id: USER_ID,
+      clerkId: 'clerk_qual21',
+      email: 'qual21@example.com',
+      isOwner: 0,
+      createdAt: new Date(now),
+      updatedAt: new Date(now),
+    })
+    .onConflictDoNothing();
+}
+
+async function seedCountry(db: TestDb, countryCode: string, name: string) {
+  await db
+    .insert(schema.countries)
+    .values({ countryCode, name, regionTierEnabled: 0 })
+    .onConflictDoNothing();
+}
+
+async function cityRows(db: TestDb, name: string, countryCode: string) {
+  return db
+    .select()
+    .from(schema.cities)
+    .where(and(eq(schema.cities.countryCode, countryCode), eq(schema.cities.name, name)));
+}
+
+describe('POST /api/cities — resolve-then-create SUCCESS path (QUAL-21, real fetch-boundary mock)', () => {
+  beforeEach(async () => {
+    testDb = await createTestDb();
+    await seedUser(testDb);
+    await seedCountry(testDb, 'US', 'United States');
+
+    __resetChokepointForTests();
+    vi.stubEnv('GEOCODING_ENABLED', 'true');
+
+    const springfieldBody = JSON.parse(readFileSync(SPRINGFIELD_IL_FIXTURE, 'utf-8'));
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => springfieldBody,
+      }),
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
+    vi.clearAllMocks();
+    testDb = null;
+  });
+
+  it('branch A — resolves to an EXISTING record: pass-1 misses on the submitted spelling, the geocoder canonicalizes it, pass-2 finds the pre-existing canonical row (200, no insert)', async () => {
+    const db = testDb!;
+    // Pre-existing row under the CANONICAL name the geocoder will return —
+    // never under the typo the request submits, so a match here can only
+    // come from the resolve step's pass-2 canonical-name lookup, not pass-1.
+    const [existing] = await db
+      .insert(schema.cities)
+      .values({
+        name: 'Springfield',
+        countryCode: 'US',
+        geocodeStatus: 'resolved',
+        latitude: 39.799,
+        longitude: -89.644,
+      })
+      .returning();
+
+    const res = await supertest(app)
+      .post('/api/cities')
+      .send({ name: 'Springfeild', country_code: 'US' }); // deliberate typo
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(res.status).toBe(200);
+    expect(res.body.id).toBe(existing.id);
+    expect(res.body.name).toBe('Springfield');
+
+    // No new row inserted — the canonical lookup found and reused the
+    // existing row rather than creating a second one under the typo'd name
+    // or a duplicate under the canonical name.
+    expect(await cityRows(db, 'Springfield', 'US')).toHaveLength(1);
+    expect(await cityRows(db, 'Springfeild', 'US')).toHaveLength(0);
+  });
+
+  it('branch B — CREATES a new record: pass-1 AND pass-2 both miss, so the row is inserted from the canonical geocoder response (201, geocode_status=resolved)', async () => {
+    const db = testDb!;
+    // No pre-existing Springfield row at all in this test.
+
+    const res = await supertest(app)
+      .post('/api/cities')
+      .send({ name: 'Springfeild', country_code: 'US' }); // deliberate typo
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(res.status).toBe(201);
+    // Built from the CANONICAL candidate name, not the submitted typo (§4.3
+    // step 4b — this is the actual convergence work resolve-then-create
+    // exists to do).
+    expect(res.body.name).toBe('Springfield');
+    expect(res.body.country_code).toBe('US');
+    expect(res.body.geocode_status).toBe('resolved');
+    expect(res.body.latitude).toBeCloseTo(39.7990175, 5);
+    expect(res.body.longitude).toBeCloseTo(-89.6439575, 5);
+
+    // Exactly one row exists — under the canonical name, not the typo — and
+    // it carries the geocoder's OSM ref (D12/M-A: stamped on every resolve so
+    // the row is discoverable by the resolved-by-OSM merge mechanism).
+    expect(await cityRows(db, 'Springfeild', 'US')).toHaveLength(0);
+    const rows = await cityRows(db, 'Springfield', 'US');
+    expect(rows).toHaveLength(1);
+    expect(rows[0].osmType).toBe('relation');
+    expect(rows[0].osmId).toBe(126326);
+    expect(rows[0].createdByUserId).toBe(USER_ID);
+  });
+});

--- a/src/backend/routes/__tests__/trips.crud.test.ts
+++ b/src/backend/routes/__tests__/trips.crud.test.ts
@@ -159,23 +159,86 @@ describe('GET /api/trips', () => {
     expect(names).toContain('Trip B');
   });
 
-  it('each trip in list has expected response shape', async () => {
+  // QUAL-02 finding 3 (response-shape assertions too shallow): the original
+  // version of this test only asserted `toHaveProperty(key)` for
+  // categories/companions/activities/places/countries — a route that
+  // returned `{ categories: null }` or `{ categories: 'oops' }` would still
+  // pass, since toHaveProperty alone does not check type or value. Every
+  // association is now seeded with real data and asserted by TYPE (array)
+  // and by VALUE (the seeded id/name/shape survives serialization correctly,
+  // including the snake_case field mapping and the nested place.city object).
+  it('each trip in list has expected response shape, including value/type checks on every association (QUAL-02 finding 3)', async () => {
     const db = testDb!;
-    await seedTrip(db, { name: 'Shape Trip' });
+    const trip = await seedTrip(db, {
+      name: 'Shape Trip',
+      startDate: '2026-05-01',
+      endDate: '2026-05-08',
+      status: 'planning',
+    });
+
+    const [category] = await db
+      .insert(schema.tripCategories)
+      .values({ userId: TEST_USER_ID, name: 'Adventure' })
+      .returning();
+    await db.insert(schema.tripCategoriesMap).values({ tripId: trip.id, categoryId: category.id });
+
+    const [companion] = await db
+      .insert(schema.companions)
+      .values({ userId: TEST_USER_ID, name: 'Alex' })
+      .returning();
+    await db
+      .insert(schema.tripCompanionsMap)
+      .values({ tripId: trip.id, companionId: companion.id });
+
+    const [activity] = await db
+      .insert(schema.activities)
+      .values({ userId: TEST_USER_ID, name: 'Hiking' })
+      .returning();
+    await db.insert(schema.tripActivitiesMap).values({ tripId: trip.id, activityId: activity.id });
+
+    const city = await seedCityWithRegion(db, 'Newport', 'Wales', 'GB-WLS');
+    await db
+      .insert(schema.tripPlaces)
+      .values({ tripId: trip.id, cityId: city.id, userId: TEST_USER_ID });
+
+    await db.insert(schema.tripCountries).values({ tripId: trip.id, countryCode: 'GB' });
 
     const res = await supertest(app).get('/api/trips').expect(200);
+    const body = res.body[0];
 
-    const trip = res.body[0];
-    expect(trip).toHaveProperty('id');
-    expect(trip).toHaveProperty('name', 'Shape Trip');
-    expect(trip).toHaveProperty('start_date');
-    expect(trip).toHaveProperty('end_date');
-    expect(trip).toHaveProperty('status');
-    expect(trip).toHaveProperty('categories');
-    expect(trip).toHaveProperty('companions');
-    expect(trip).toHaveProperty('activities');
-    expect(trip).toHaveProperty('places');
-    expect(trip).toHaveProperty('countries');
+    // Scalars — VALUE-checked, not merely present.
+    expect(body.id).toBe(trip.id);
+    expect(body.name).toBe('Shape Trip');
+    expect(body.start_date).toBe('2026-05-01');
+    expect(body.end_date).toBe('2026-05-08');
+    expect(body.status).toBe('planning');
+
+    // Associations — TYPE (array, not null/object/string) AND VALUE (the
+    // seeded row survives serialization with the right shape and content).
+    expect(Array.isArray(body.categories)).toBe(true);
+    expect(body.categories).toEqual([{ id: category.id, name: 'Adventure' }]);
+
+    expect(Array.isArray(body.companions)).toBe(true);
+    expect(body.companions).toEqual([{ id: companion.id, name: 'Alex' }]);
+
+    expect(Array.isArray(body.activities)).toBe(true);
+    expect(body.activities).toEqual([{ id: activity.id, name: 'Hiking' }]);
+
+    expect(Array.isArray(body.countries)).toBe(true);
+    expect(body.countries).toEqual([{ country_code: 'GB', name: 'United Kingdom' }]);
+
+    expect(Array.isArray(body.places)).toBe(true);
+    expect(body.places).toHaveLength(1);
+    expect(body.places[0]).toMatchObject({
+      city_id: city.id,
+      city: {
+        id: city.id,
+        name: 'Newport',
+        country_code: 'GB',
+        region_name: 'Wales',
+        region_iso: 'GB-WLS',
+      },
+    });
   });
 
   it('does not return trips belonging to another user', async () => {


### PR DESCRIPTION
Test-coverage sweep across three tracker items, dispatched as an independent lane alongside other concurrent QUAL/hygiene work.

## QUAL-02 — assertion strength
Tracker note: findings 1 (filter-inversion) and 2 (sort-order) were already fixed in PR #320 (category_id/country filters, GET /api/trips sort). This PR closes two further weak spots still open under the same finding:

- `src/backend/routes/__tests__/trips.crud.test.ts` — "each trip in list has expected response shape" only asserted `toHaveProperty(key)` for categories/companions/activities/places/countries (would pass even if the route returned `null` or a string for any of them). Rewritten to seed real category/companion/activity/place/country data and assert both TYPE (array) and VALUE.
- `src/backend/routes/__tests__/cities.carry-forward.test.ts` — `GET /api/cities/:id/carry-forward` orders by `desc(trips.endDate)` (cities.ts:731) but had zero test coverage of that order (every existing test seeds ≤1 item). Added a 3-trip, seeded-out-of-order test asserting exact descending order.

## QUAL-21 — resolve-then-create route coverage
New file `src/backend/routes/__tests__/cities.resolve-then-create.test.ts`. Every existing POST /api/cities suite mocks `resolveCityName` to `'disabled'`, so `resolution.status === 'ok'` — the whole point of "resolve-THEN-create" — had never been reached by a green route-level test (review finding F4; root-caused two shipped defects per the tracker note). This file mocks only `global.fetch` with a real committed Nominatim fixture (`springfield_il.json`), letting the real `resolveCityName`/`classifyCandidates`/accept-rule run — same pattern as the existing `bug76-geocode-e2e.test.ts`.

- Branch A: pass-1 misses on a typo'd name, pass-2 canonical lookup finds a pre-existing row → 200, no insert.
- Branch B: pass-1 and pass-2 both miss → row inserted from the canonical geocoder response → 201, `geocode_status=resolved`, OSM ref stamped.

Mutation-tested (temporarily forcing `GEOCODING_ENABLED=false`) to confirm both tests fail for the right reason rather than passing vacuously.

## QUAL-22 — mock-fidelity fix (drifted geocoding mock)
`adl46-access-model.test.ts`'s `geocoding.service.js` mock exported only `resolveCity`. `cities.ts`'s POST handler also calls `resolveCityName`/`resolveByOsmId`; calling the undefined export threw a TypeError the route's own try/catch silently swallowed into `{status: 'disabled'}`. Every Group B test therefore exercised the accidental disabled/pending fallback regardless of what it claimed to test — review finding F8.

Fix: the mock now exports `resolveCityName`/`resolveByOsmId` for real (as spies), defaulting to the same `'disabled'` outcome so B1/B2/B3/B5/B6 (which don't depend on resolution status) are behaviourally unchanged. B4 — the test that specifically claims to prove the `'ambiguous'` verdict is handled — now configures a genuine `'ambiguous'` `CityResolution` and asserts:
- `resolveCityName` was actually called with the expected args (non-vacuous check)
- the fire-and-forget `resolveCity` re-resolution is correctly SKIPPED for `'ambiguous'` (ADL-46 F1/F2 ruling §2.6) — the one real behavioural difference the old accidental fallback could never distinguish, since both `'ambiguous'` and `'disabled'` landed in the same pending-insert branch before the fix.

## Merge ordering note
No files in the "avoid" list (`shading.service.ts` tests, cities.ts rating-sort test) were touched. `cities.resolve-then-create.test.ts` is a new file with no overlap. This branch already has origin/main (including PR #432, QUAL-33) merged in — merging this PR should be conflict-free.

## Test plan
- [x] `npm run check` — clean (5 pre-existing INFO-level lint notices in untouched files only)
- [x] `npm run type:check:all` — clean
- [x] `npm run test:backend` — 762/762 passing
- [x] `npm run test:frontend` — 321/321 passing
- [x] `npm run status:check` — up to date
- [x] Mutation-tested QUAL-21's new tests to confirm non-vacuous pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)