### PR TITLE
chore: hard-block guards — direct-to-main commits + tracker-ID dups

### DIFF
--- a/.claude/hooks/no-protected-commit.sh
+++ b/.claude/hooks/no-protected-commit.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+# PreToolUse guard — hard-block a direct `git commit` while HEAD is on a protected branch
+# (main or production).
+#
+# Why: CLAUDE.md branch-per-brief + "COO never commits to main, ever" (incl. own doc/tracker
+# edits). A real accidental direct-to-main commit happened during two concurrent COO sessions
+# (open-dialogues D-13, contained by luck). `production` is even more sensitive — it is the
+# prod deploy target and "agents never touch it" — so it is covered too.
+#
+# Scope is COMMITS, not pushes, on purpose: the prod promotion is
+# `git merge --ff-only origin/main` + `git push` on production — a fast-forward, no commit —
+# so it sails through untouched. Server-side GitHub branch protection stays the real gate;
+# this is the local backstop against the accidental bare `git commit` on the wrong branch.
+#
+# Escape hatch for a genuine emergency (should be near-never): prefix the command with
+# ALLOW_PROTECTED_COMMIT=1.
+
+cmd=$(jq -r '.tool_input.command // empty' 2>/dev/null)
+[ -n "$cmd" ] || exit 0
+
+# Strip quoted strings + heredoc bodies (same discipline as block-db-push) so a commit
+# MESSAGE that contains the text "git commit" cannot self-trip the guard.
+stripped=$(printf '%s\n' "$cmd" | awk '
+  inHd { if ($0 == hd) inHd = 0; next }
+  {
+    line = $0
+    if (match(line, /<<-?[[:space:]]*['"'"'"]?[A-Za-z_][A-Za-z0-9_]*/)) {
+      hd = substr(line, RSTART, RLENGTH); sub(/<<-?[[:space:]]*/, "", hd); gsub(/['"'"'"]/, "", hd); inHd = 1
+    }
+    gsub(/'"'"'[^'"'"']*'"'"'/, "", line); gsub(/"[^"]*"/, "", line); print line
+  }')
+
+# Only care about `git commit` invocations (git commit, git -C x commit, git commit -m ...).
+# `commit-tree` and friends are excluded by requiring commit to end at a space or line end.
+printf '%s' "$stripped" | grep -qE '(^|[;&|(]|&&|\|\||[[:space:]])git([[:space:]]+-[^[:space:]]+[[:space:]]+[^[:space:]]+)*[[:space:]]+commit([[:space:]]|$)' || exit 0
+
+# If the SAME command creates/switches to a branch first (checkout -b / switch -c), the commit
+# lands there, not on the protected branch — don't block. Keeps `git checkout -b x && git commit`
+# working. Errs permissive on this edge; the target case (a bare commit on main) is still caught.
+printf '%s' "$stripped" | grep -qE 'git[[:space:]]+(checkout[[:space:]]+-b|switch[[:space:]]+-c)' && exit 0
+
+# Explicit emergency override.
+printf '%s' "$cmd" | grep -q 'ALLOW_PROTECTED_COMMIT' && exit 0
+
+branch=$(git symbolic-ref --short HEAD 2>/dev/null)
+case "$branch" in
+  main|production)
+    cat <<JSON
+{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"Blocked: direct commit to '$branch' is forbidden (CLAUDE.md branch-per-brief; COO never commits to main/production, incl. doc/tracker edits). Create a feat/fix/chore branch, commit there, open a PR. The prod promotion uses git merge --ff-only (no commit) and is unaffected. Genuine emergency: prefix ALLOW_PROTECTED_COMMIT=1."}}
+JSON
+    exit 0
+    ;;
+esac
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -10,6 +10,10 @@
           {
             "type": "command",
             "command": "bash /workspace/.claude/hooks/block-db-push.sh"
+          },
+          {
+            "type": "command",
+            "command": "bash /workspace/.claude/hooks/no-protected-commit.sh"
           }
         ]
       }

--- a/.claude/skills/coo-startup/SKILL.md
+++ b/.claude/skills/coo-startup/SKILL.md
@@ -139,6 +139,24 @@ echo '{"tool_name":"Bash","tool_input":{"command":"gh issue create --body \"migr
   | bash /workspace/.claude/hooks/atdd-first-guard.sh | grep -q "atdd-first-guard" \
   && echo "FAIL: atdd-first guard fires when ATDD stated (should be silent)" \
   || echo "atdd-first guard (ATDD-stated path) OK"
+
+# no-protected-commit guard must DENY a git commit on a protected branch. Tested in a
+# throwaway repo on `main` so it never touches this checkout's branch/state.
+canary_tmp=$(mktemp -d); git -C "$canary_tmp" init -q -b main 2>/dev/null \
+  || (git -C "$canary_tmp" init -q && git -C "$canary_tmp" checkout -q -b main)
+( cd "$canary_tmp" && echo '{"tool_input":{"command":"git commit -m x"}}' \
+  | bash /workspace/.claude/hooks/no-protected-commit.sh | grep -q '"deny"' ) \
+  && echo "no-protected-commit guard OK" || echo "FAIL: no-protected-commit guard broken"
+( cd "$canary_tmp" && git checkout -q -b fix/canary 2>/dev/null; echo '{"tool_input":{"command":"git commit -m x"}}' \
+  | bash /workspace/.claude/hooks/no-protected-commit.sh | grep -q '"deny"' ) \
+  && echo "FAIL: no-protected-commit fires on a feature branch (should be silent)" \
+  || echo "no-protected-commit guard (feature-branch path) OK"
+rm -rf "$canary_tmp"
+
+# tracker-check must pass on the live tracker (fail-closed gate: a non-zero exit is a real
+# integrity problem — duplicate ID, missing field, or a brdRef not present in the BRD).
+npm run --silent tracker:check >/dev/null 2>&1 \
+  && echo "tracker-check OK" || echo "FAIL: tracker-check reports a tracker.json integrity problem"
 ```
 
 Any FAIL → fix the hook before doing anything else this session. Secondary tell for the

--- a/.claude/skills/pre-push/SKILL.md
+++ b/.claude/skills/pre-push/SKILL.md
@@ -11,6 +11,7 @@ npm run type:check:all     # TypeScript (frontend + backend)
 npm run test:backend       # Backend unit tests
 npm run test:frontend      # Frontend unit tests
 npm run status:check       # _project/STATUS.md in sync with tracker.json
+npm run tracker:check      # tracker.json integrity — no duplicate IDs, brdRefs valid
 ```
 
 If `status:check` fails, run `npm run status` and commit the regenerated

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,8 @@ jobs:
       - run: npm run check
       - name: STATUS.md freshness
         run: npm run status:check
+      - name: tracker.json integrity
+        run: npm run tracker:check
 
   typecheck:
     name: Type Check

--- a/.planning/drift-ledger.jsonl
+++ b/.planning/drift-ledger.jsonl
@@ -3463,3 +3463,16 @@
 {"ts":"2026-08-08T19:09:06Z","action":"edit","file":"/workspace/jobs/COO/open-dialogues.md"}
 {"ts":"2026-08-08T19:18:05Z","action":"write","file":"/tmp/claude-1000/-workspace/8c50785c-fbaf-4ba6-8a42-cf31b0769923/scratchpad/parked-restructure.mjs"}
 {"ts":"2026-08-08T19:18:52Z","action":"edit","file":"/workspace/_project/tracker.json"}
+{"ts":"2026-08-08T19:21:53Z","action":"edit","file":"/home/node/.claude/projects/-workspace/memory/feedback_grep_tracker_id_is_free_before_assigning.md"}
+{"ts":"2026-08-08T19:38:29Z","action":"write","file":"/workspace/.claude/hooks/no-protected-commit.sh"}
+{"ts":"2026-08-08T19:39:05Z","action":"edit","file":"/workspace/.claude/hooks/no-protected-commit.sh"}
+{"ts":"2026-08-08T19:39:51Z","action":"write","file":"/workspace/scripts/tracker-check.js"}
+{"ts":"2026-08-08T19:40:26Z","action":"write","file":"/workspace/scripts/tracker-check.js"}
+{"ts":"2026-08-08T19:41:26Z","action":"edit","file":"/workspace/_project/tracker.json"}
+{"ts":"2026-08-08T19:41:50Z","action":"edit","file":"/workspace/.claude/settings.json"}
+{"ts":"2026-08-08T19:41:58Z","action":"edit","file":"/workspace/package.json"}
+{"ts":"2026-08-08T19:42:07Z","action":"edit","file":"/workspace/.github/workflows/ci.yml"}
+{"ts":"2026-08-08T19:42:19Z","action":"edit","file":"/workspace/.claude/skills/pre-push/SKILL.md"}
+{"ts":"2026-08-08T19:42:46Z","action":"edit","file":"/workspace/CLAUDE.md"}
+{"ts":"2026-08-08T19:42:53Z","action":"edit","file":"/workspace/CLAUDE.md"}
+{"ts":"2026-08-08T19:43:30Z","action":"edit","file":"/workspace/.claude/skills/coo-startup/SKILL.md"}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,10 @@ Run `/pre-push` before every `git push` and iterate until all checks pass.
 ## Git workflow
 
 ### Branching (adopted 2026-03-21)
-- **Never commit directly to `main`**
+- **Never commit directly to `main`** (or `production`) — hard-blocked by
+  `.claude/hooks/no-protected-commit.sh` (PreToolUse). Emergency override:
+  prefix the command with `ALLOW_PROTECTED_COMMIT=1`. The prod promotion uses
+  `git merge --ff-only` (no commit) and is unaffected.
 - Each agent brief gets its own branch:
   - `feat/<slug>` — new features (e.g. `feat/nr14-backend-auth`)
   - `fix/<slug>` — bug fixes (e.g. `fix/d04-country-name`)
@@ -437,6 +440,13 @@ When raising a GitHub issue for something that has a tracker entry, include the 
 in the issue title — e.g. `fix(BUG-15): wrap executeCarryForward in a transaction`.
 The tracker entry's `notes` field must include the GitHub issue number in return.
 This applies to all new issues — bugs, features, chores — anything with a tracker entry.
+
+**Tracker integrity is machine-enforced.** Before assigning a new ID, take max+1 of the
+whole prefix across BOTH `tracker.json` and CLAUDE.md governance IDs (OP-NN rules also live
+in the tracker — it is the complete OP registry). `npm run tracker:check` (in `/pre-push`
+and CI) hard-fails on any duplicate ID, missing required field, or `brdRefs` value that
+isn't a real BRD requirement ID. A duplicate tracker ID has slipped three times and git
+never catches it — this gate does.
 
 ### Opening a PR
 ```bash

--- a/_project/STATUS.md
+++ b/_project/STATUS.md
@@ -129,7 +129,7 @@ _Tracker last updated: 2026-07-28 (B9 merged — QUAL-03 + QUAL-11 done, PR #292
 | requirement | `███████████████████░` 32/33 | 32 | 1 | 6 |
 | bug | `████████████░░░░░░░░` 48/80 | 48 | 32 | 3 |
 | task | `████████████████████` 11/11 | 11 | 0 | 0 |
-| chore | `████████████░░░░░░░░` 26/45 | 26 | 19 | 1 |
+| chore | `████████████░░░░░░░░` 29/48 | 29 | 19 | 1 |
 
 <details>
 <summary>Deferred (9)</summary>
@@ -163,4 +163,4 @@ _Tracker last updated: 2026-07-28 (B9 merged — QUAL-03 + QUAL-11 done, PR #292
 
 ---
 
-_155 done · 9 deferred · 5 closed · 82 open — 251 tracked items_
+_158 done · 9 deferred · 5 closed · 82 open — 254 tracked items_

--- a/_project/tracker.json
+++ b/_project/tracker.json
@@ -2909,6 +2909,43 @@
       "brdRefs": [],
       "phase": 6,
       "notes": "Promoted 2026-08-08 from open-dialogues D-12 (items 2-4). The QUAL-05 state-language sweep (PR #259) was scoped to FLAG, not resolve, anything whose fix would pre-empt a product/architecture decision; four BRD contradictions came back flagged. ITEM 1 (SE-01/SE-03 three-role drift) is RESOLVED — ADL-46 -> BRD v3.13 rewrote SE-01/SE-03/AD-09, and BUG-61/62/63 are its live symptoms. THESE THREE REMAIN — all wording-level, the shipped app is unaffected, none urgent: (2) §7 and §11 state import tooling is out of scope and manual entry is the answer, but import requirements IM-01-33 are DRAFTED-not-approved, so deleting those lines pre-empts the PO's import decision while leaving them is fine until IM is approved or dropped; (3) §5.15 MB-01's requirement text still scopes mobile to the read path only while WP-04 shipped a fully editable mobile layout (the §5.15 preamble was already stamped SUPERSEDED by WP-04 in v3.7, but MB-01 itself was not) — whether to widen MB-01's stated scope, and whether that implies anything about offline support, is a product call; (4) §5.7 PH-02 ('the app does not store or copy photos') vs IM-06 (client-side EXIF import) will read as contradicting once import exists — conditional, collapses into item 2, only needs resolving if import is approved. HANDLING: items 2+4 together whenever the import decision is made; item 3 whenever mobile scope next comes up. Each resolution is itself a BRD change to §10 / the relevant requirement and bumps the BRD version AT THAT POINT — this tracker item is deliberately NOT a BRD bump; it exists so the questions surface at /coo-startup instead of only living in the done QUAL-05 note. Relates QUAL-05."
+    },
+
+    // ─── GOVERNANCE-RULE BACKFILL (2026-08-08) — OP rules that were adopted into CLAUDE.md ──
+    // ─── without a tracker entry; backfilled so the tracker is the complete OP-id registry ──
+    // ─── and tracker-check's dup-id gate covers the CLAUDE.md-vs-tracker OP collision. ──────
+    {
+      "id": "OP-33",
+      "type": "chore",
+      "title": "Spike-gate the BRD — no requirement enters as approved on an unverified premise",
+      "status": "done",
+      "owner": "coo",
+      "priority": "P1",
+      "brdRefs": [],
+      "phase": 6,
+      "notes": "Governance rule, adopted 2026-08-05 (PR #402) from the Jul29-Aug4 retro (GE-17, BUG-76, the v3.15 'works offline' overclaim). BACKFILLED to the tracker 2026-08-08: it had no tracker entry, which is the exact reason OP-33/34 got re-used as duplicate ids this session (a tracker-only grep maxed at OP-32). Rule text lives in CLAUDE.md '### Spike-gate the BRD'. Substance: a requirement whose case rests on a premise not yet established enters the BRD as PROPOSED + spike-gated, not approved; its load-bearing premises are written down as a verify-checklist before the spike; BRD promotion waits for the checklist to clear; 'only way / sole option / there is no alternative' justifications are premises, not conclusions, and get the negative-findings two-probe treatment. Decision-layer counterpart to 'success criteria before dispatch'. Now enforced against recurrence by scripts/tracker-check.js (dup-id gate)."
+    },
+    {
+      "id": "OP-34",
+      "type": "chore",
+      "title": "PO input is authoritative but not infallible — probe it like any other source",
+      "status": "done",
+      "owner": "coo",
+      "priority": "P1",
+      "brdRefs": [],
+      "phase": 6,
+      "notes": "Governance rule, adopted 2026-08-05 (PR #402) on PO direction ('just because I'm the PO doesn't mean I always know best'). BACKFILLED to the tracker 2026-08-08 (see OP-33 — the missing entry caused this session's dup-id slip). Rule text in CLAUDE.md '### PO input is authoritative but not infallible'. Substance: PO input is tested on two axes before it becomes law/work — TRUTH (a factual claim like 'it works offline' / 'this used to work' is probed exactly as an agent's claim; the negative-findings two-probe rule binds; the PO being the source does not exempt it) and VALUE (a discretionary / 'wouldn't it be nice' request gets a proportionate impact-cost-benefit assessment with a recommendation before promotion). Both resolve to probe-before-promote; the PO is a source, not an exception."
+    },
+    {
+      "id": "OP-35",
+      "type": "chore",
+      "title": "ATDD-first for Architect-spawned briefs — QA writes red acceptance tests before the implementer runs",
+      "status": "done",
+      "owner": "coo",
+      "priority": "P1",
+      "brdRefs": [],
+      "phase": 6,
+      "notes": "Governance rule, adopted 2026-08-05 (ADL-50), promoting open-dialogue D-17 after its trial on the ADL-46 release. BACKFILLED to the tracker 2026-08-08 (see OP-33). Rule text in CLAUDE.md '### ATDD-first for Architect-spawned briefs'. Substance: for an implementation brief an Architect spec spawns, the COO dispatches QA FIRST to turn the success criteria into RED acceptance/integration tests, handed to the implementer as the executable definition of done — breaking the closed loop where the implementer writes both the code and the tests that certify it. Trigger is objective (keyed to Architect involvement, not a subjective complexity call). Mock-fidelity is part of the rule: a suite that can pass vacuously has specified nothing (QUAL-22). Backed by .claude/hooks/atdd-first-guard.sh + a startup canary. Full record + honest qualification: ADL-50."
     }
 
   ]

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "db:studio": "drizzle-kit studio",
     "status": "node scripts/status.js",
     "status:check": "node scripts/status.js --check",
+    "tracker:check": "node scripts/tracker-check.js",
     "test:backend": "vitest run --config vitest.config.backend.ts",
     "test:backend:watch": "vitest --config vitest.config.backend.ts",
     "test:frontend": "vitest run --config vitest.config.frontend.ts",

--- a/scripts/tracker-check.js
+++ b/scripts/tracker-check.js
@@ -1,0 +1,72 @@
+#!/usr/bin/env node
+/**
+ * tracker-check — hard gate on tracker.json integrity. Run in /pre-push and CI.
+ *
+ * Enforces what git cannot catch on its own (CLAUDE.md + the grep-tracker-id-is-free
+ * memory — a duplicate tracker ID has slipped THREE times: BUG-77, DEP-03, OP-33/34, none
+ * flagged by git):
+ *   1. tracker.json (JSONC) parses.
+ *   2. Every item carries the required fields.
+ *   3. No duplicate `id`, across all prefixes. Governance OP rules are backfilled into the
+ *      tracker, so it is the single OP registry and a within-file dup check also catches the
+ *      CLAUDE.md-vs-tracker OP collision that bit us this session.
+ *   4. brdRefs integrity: every brdRefs value names a real requirement ID in the BRD.
+ *
+ * Exit non-zero on any violation. Zero-network, zero-false-positive on clean data.
+ */
+
+import { readFileSync } from 'fs';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { stripJsonComments, TRACKER_PATH } from './lib/tracker-data.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const BRD_PATH = resolve(__dirname, '../_project/travel-tracker-BRD.md');
+
+const errors = [];
+
+let tracker;
+try {
+  tracker = JSON.parse(stripJsonComments(readFileSync(TRACKER_PATH, 'utf8')));
+} catch (e) {
+  console.error(`tracker-check: FAIL — tracker.json does not parse: ${e.message}`);
+  process.exit(1);
+}
+
+const items = Array.isArray(tracker.items) ? tracker.items : [];
+if (!items.length) {
+  console.error('tracker-check: FAIL — no items[] array found in tracker.json');
+  process.exit(1);
+}
+
+// 2. required fields
+const REQUIRED = ['id', 'type', 'title', 'status', 'priority'];
+for (const it of items) {
+  const missing = REQUIRED.filter((k) => it[k] === undefined || it[k] === '');
+  if (missing.length) errors.push(`item ${it.id || '(no id)'} missing required field(s): ${missing.join(', ')}`);
+}
+
+// 3. duplicate ids
+const counts = new Map();
+for (const it of items) if (it.id) counts.set(it.id, (counts.get(it.id) || 0) + 1);
+for (const [id, n] of counts) if (n > 1) errors.push(`duplicate id: ${id} appears ${n} times`);
+
+// 4. brdRefs integrity
+const brdText = readFileSync(BRD_PATH, 'utf8');
+const brdIds = new Set(brdText.match(/\b[A-Z][A-Z0-9]*-\d+\b/g) || []);
+for (const it of items) {
+  if (!Array.isArray(it.brdRefs)) continue;
+  for (const ref of it.brdRefs) {
+    const bare = String(ref).replace(/^BRD-/, '');
+    if (!brdIds.has(ref) && !brdIds.has(bare)) {
+      errors.push(`item ${it.id}: brdRef "${ref}" is not a requirement ID present in the BRD`);
+    }
+  }
+}
+
+if (errors.length) {
+  console.error(`tracker-check: FAIL — ${errors.length} problem(s):`);
+  for (const e of errors) console.error(`  - ${e}`);
+  process.exit(1);
+}
+console.log(`tracker-check: OK — ${items.length} items, no duplicate ids, brdRefs valid.`);


### PR DESCRIPTION
Three mechanical checks so we stop relying on "remember to do X" (PO direction — the dup-ID rule failed 3× despite being written down).

### 1. `no-protected-commit.sh` — PreToolUse hard block
Blocks `git commit` while HEAD is on **main or production**. Covers the D-13 accidental-direct-commit failure mode. Design choices:
- **Commits, not pushes** — the prod promotion (`git merge --ff-only origin/main` + push) is a fast-forward, no commit, so it's unaffected.
- **Production included** — it's the prod deploy target and more sensitive than main; the local backstop covers both, GitHub branch protection stays the server-side gate.
- Escape hatch: `ALLOW_PROTECTED_COMMIT=1`. Message-text and `checkout -b … && commit` don't false-trip. 9/9 scenarios tested.

### 2. `tracker-check.js` — `npm run tracker:check`, in /pre-push + CI
Hard-fails on any **duplicate ID**, missing required field, or **`brdRef` not present in the BRD**. A dup tracker ID has slipped 3× (BUG-77, DEP-03, OP-33/34) and git never catches it.

### 3. Root-cause fix for the OP dup
Backfilled **OP-33/34/35** as tracker entries — they were CLAUDE.md governance rules with *no tracker home*, which is precisely why a tracker-only grep missed them. The tracker is now the complete, contiguous **OP-01..37** registry, so a within-file dup check also covers the CLAUDE.md-vs-tracker collision.

### Plumbing
- Both guards get **/coo-startup canaries** (deny-path proven, not trusted silent).
- CLAUDE.md gets **one-line pointers** to each — a mechanically-enforced rule keeps the directive (hooks fail open, so intent must survive a dead hook) but sheds the rationale.

Doc/config/script only. Pre-push green: biome + types + status + tracker-check + 762 backend + 346 frontend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)