### PR TITLE
docs: retire backlog-clearance-plan via HISTORICAL banner

### DIFF
--- a/.planning/drift-ledger.jsonl
+++ b/.planning/drift-ledger.jsonl
@@ -3495,3 +3495,4 @@
 {"ts":"2026-08-08T20:20:07Z","action":"edit","file":"/workspace/_project/tracker.json"}
 {"ts":"2026-08-08T20:20:27Z","action":"edit","file":"/workspace/jobs/COO/open-dialogues.md"}
 {"ts":"2026-08-08T20:21:57Z","action":"edit","file":"/workspace/jobs/COO/backlog-clearance-plan.md"}
+{"ts":"2026-08-08T21:08:32Z","action":"edit","file":"/workspace/jobs/COO/backlog-clearance-plan.md"}

--- a/jobs/COO/backlog-clearance-plan.md
+++ b/jobs/COO/backlog-clearance-plan.md
@@ -1,10 +1,17 @@
 # Backlog Clearance Plan
 
+> **HISTORICAL — snapshot as of 2026-07-26, executed and retired 2026-08-08. Not maintained.**
+> Waves 0 and 1 were dispatched and merged; every item this plan sequenced lives in
+> `_project/tracker.json` (which is, and always was, the authority for status). The §8b Wave-2
+> BRD gate is superseded by each bug's own tracker note carrying its owed BRD ID (BUG-45→FL-06/CR-03,
+> BUG-53→DP-07, UX-11→DP-08, BUG-47→TR-16). Kept in place, rather than deleted, because it is cited
+> across the ADL log, ADL-41 and the BRD changelog as decision history. Do not treat anything below
+> as current — it is a record of how the backlog was cleared, not a live plan.
+
 **Version:** 1.0
 **Date:** 2026-07-26
 **Author:** COO
-**Status:** LIVE — approved by PO 2026-07-26. Update wave status here as briefs land; this
-document is presumed current until stamped otherwise (CLAUDE.md → Document lifecycle).
+**Status:** ~~LIVE~~ **HISTORICAL (retired 2026-08-08)** — see banner above.
 
 Sequencing plan for clearing the entire open bug backlog plus the feature items that share
 its code surface. Ordered for **throughput, not priority** — PO's explicit instruction was


### PR DESCRIPTION
Retires the backlog-clearance-plan. Unlike the execution-queue and cleanup-wave-plan (deleted — disposable parallel-session lists), this one **drove Waves 0/1 and is cited 13× across immutable decision history** (the ADL log, ADL-41, the BRD v3.8 changelog, 2 archived completion reports). Per the document-lifecycle rule, a woven-in executed doc gets a **HISTORICAL banner**, not deletion — one edit, all 13 citations stay valid, and it's out of the current-truth set.

All its content is already in the tracker:
- The §8b Wave-2 BRD gate is superseded by each bug's own note carrying its owed BRD ID (BUG-45→FL-06/CR-03, BUG-53→DP-07, UX-11→DP-08, BUG-47→TR-16).
- §6's BUG-48 "39MB payload, not a threshold bug" insight is in BUG-48's note.

Doc-only. Pre-push green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)