### PR TITLE
chore: reconcile UAT (owner+non-owner complete) + new findings + BUG-87 decision

### DIFF
--- a/_project/STATUS.md
+++ b/_project/STATUS.md
@@ -17,7 +17,7 @@ _Tracker last updated: 2026-07-28 (B9 merged — QUAL-03 + QUAL-11 done, PR #292
 | PHASE-5 | Integrations — Notification Engine | ⬜ Pending |
 | PHASE-6 | v3 Planning-First Delivery | ⬜ Pending |
 
-## Open work (96)
+## Open work (85)
 
 ### P0 — Blockers (1)
 
@@ -25,23 +25,19 @@ _Tracker last updated: 2026-07-28 (B9 merged — QUAL-03 + QUAL-11 done, PR #292
 |---|---|---|---|
 | FEAT-IT | Item Logging | frontend | ◐ Partial |
 
-### P1 — Critical (5)
+### P1 — Critical (2)
 
 | ID | Title | Owner | Status |
 |---|---|---|---|
-| BRD-GE16 | Any authenticated user can add a city via constrained find-or-create (GE-16) | backend | done_pending_uat |
-| BUG-50 | No way to delete an entire trip | frontend | done_pending_uat |
-| BUG-51 | Companion name edits in admin panel don't consistently propagate to trips | frontend | done_pending_uat |
 | BUG-63 | Non-owner cannot add a place to a trip — categories/activities /active reads and POST /api/cities are all owner-gated (REPRODUCED + ROOT-CAUSED) | architect | ⬜ Pending |
 | QUAL-18 | E2E serves the frontend from vite preview, not Express — so no CSP header is ever under test | qa | ⬜ Pending |
 
-### P2 — Important (54)
+### P2 — Important (47)
 
 | ID | Title | Owner | Status |
 |---|---|---|---|
 | ENV-01 | Geocoding retry queue stuck — Nominatim blocked by devcontainer firewall | coo | ⬜ Pending |
 | FUTURE-03 | Companion model — linked/unlinked users with invite flow | coo | ⬜ Pending |
-| BRD-IT0809 | Rating sort and filter in item list views, cross-trip by city (IT-08/09) | frontend | done_pending_uat |
 | BRD-AD09 | Categories/activities are global seeded defaults; deactivation is owner-only (AD-09) | backend | ◐ Partial |
 | BRD-GE18 | Reference-data provenance and in-product attribution credits surface (GE-18) | frontend | ⬜ Pending |
 | BRD-PH03 | Photo management accessible from trip detail header (PH-03) | frontend | ◐ Partial |
@@ -50,21 +46,17 @@ _Tracker last updated: 2026-07-28 (B9 merged — QUAL-03 + QUAL-11 done, PR #292
 | BRD-PL06 | Co-planning — companions contribute to idea pool on shared trips (PL-06, Phase 3) | architect | ⬜ Pending |
 | BRD-LB01 | Destination recommendations view — aggregated across trips (LB-01) | fullstack | ⬜ Pending |
 | BRD-MB0102 | Mobile reference mode — bookings readable + directions links on phone (MB-01–02) | frontend | ⬜ Pending |
-| BRD-DP06 | First place added to a trip inherits the trip's date range (DP-06) | fullstack | done_pending_uat |
 | OQ-03 | Approximate/partial dates for shell trips — year-only or month-only, and their effect on shading and ordering | architect | ⬜ Pending |
 | OP-25 | Scheduled cloud health-check routines (daily CI/drift, weekly doc-lifecycle) + cron-flag surfacing in /coo-startup | coo | ⛔ Blocked |
 | BUG-40 | Place deletion should prompt (delete all / move to trip-level / cancel) when the place has items | fullstack | ⬜ Pending |
 | BUG-41 | Multi-leg / connecting flights within a single booking | database | ⬜ Pending |
 | BUG-42 | Multiple companions/seats per booking item | database | ⬜ Pending |
-| BUG-44 | Car rental pickup location should show as subtext under provider | frontend | done_pending_uat |
 | BUG-46 | Activities selector missing from trip create flow (only present on edit) | frontend | ⬜ Pending |
 | BUG-48 | Country→state map shading zoom threshold too high / laggy | frontend | ⬜ Pending |
-| BUG-49 | City markers render behind state shading layer | frontend | done_pending_uat |
-| BUG-52 | Trip search doesn't match on country name | frontend | done_pending_uat |
+| BUG-49 | City markers render behind state shading layer | frontend | ⬜ Pending |
 | BUG-53 | Trip list place display: show state (not country) under city, surface country separately | ux | ⬜ Pending |
 | BUG-55 | City entry doesn't auto-populate country/state — CSP blocks the Nominatim call (deployment defect) | architect | ⬜ Pending |
-| BUG-57 | Intelligent date defaults across item entry, keyed off the trip's date range | fullstack | done_pending_uat |
-| BUG-58 | Moving a trip backward in the status workflow deselects it from the left panel | frontend | done_pending_uat |
+| BUG-58 | Moving a trip backward in the status workflow deselects it from the left panel | frontend | ⬜ Pending |
 | BUG-62 | Admin panel is still fully owner-gated at the page/nav level — non-owner users can't reach the Companions tab even after AD-08 made companions per-user | frontend | done_pending_uat |
 | BUG-65 | A review_pending trip has no delete affordance — TR-14 is unreachable in that state | frontend | ⬜ Pending |
 | BUG-66 | ReviewPanel's forward Lock path repeats BUG-58's onClose()-after-mutation pattern | frontend | ⬜ Pending |
@@ -77,14 +69,12 @@ _Tracker last updated: 2026-07-28 (B9 merged — QUAL-03 + QUAL-11 done, PR #292
 | BUG-72 | City search dropdown shows name + country only — user selects a specific city blind | backend | done_pending_uat |
 | BUG-73 | Geocode lookup failure is silent — user cannot distinguish 'picked Virginia' from 'lookup failed' | frontend | done_pending_uat |
 | BUG-74 | BUG-73's failure signal covers only the browser↔backend hop — an upstream geocoder failure still reports as 'found nothing' | backend | done_pending_uat |
-| BUG-80 | Saved places render as name + country only — two different Newports in one trip are indistinguishable | backend | done_pending_uat |
-| BUG-79 | Region selector not narrowed for an ambiguous US city, though it is for the UK | frontend | done_pending_uat |
-| BUG-77 | 22 region-tier countries ship with zero regions — 22 latent BUG-30s (ADL-48 S1) | database | done_pending_uat |
 | BUG-81 | Disambiguation picker rows hard to skim — raw display_name shows county + postcode noise | frontend | done_pending_uat |
 | BUG-84 | requireAuth catch{} swallows ALL errors into an unlogged 401 (config/JWKS/DB indistinguishable from a bad token) | backend | ⬜ Pending |
 | BUG-85 | Stuck geocode-pending cities are invisible and unactionable — no visibility into the retry queue or its cause, no user recovery (GE-19) | architect | ⬜ Pending |
 | BUG-87 | Add-place picker does not narrow/rank candidates by the trip's assigned country/countries | architect | ⬜ Pending |
 | BUG-90 | "Scotland" and other UK home nations not selectable in the add-trip country picker | architect | ⬜ Pending |
+| BUG-91 | Trip-create form saves and closes prematurely when selecting from the picker (can't set dates in the same flow) | frontend | ⬜ Pending |
 | QUAL-25 | Spike — build ADL-48's gazetteer for real and measure it before committing to S1/S2/S3 | architect | done_pending_uat |
 | QUAL-26 | You cannot tell which build staging is serving — put the commit SHA in /health, the UI and the shakedown | backend | done_pending_uat |
 | ENV-02 | Staging 502s — Railway proxy 'connection dial timeout' to a single-replica service; app-side causes ruled out | coo | ⬜ Pending |
@@ -94,7 +84,7 @@ _Tracker last updated: 2026-07-28 (B9 merged — QUAL-03 + QUAL-11 done, PR #292
 | QUAL-39 | PO-journey Playwright pack — encode the PO's UAT checklist flows as E2E specs | qa | ⬜ Pending |
 | QUAL-40 | react-hook-form + shared zod schemas in ItemForm — real client validation + retires several folded cleanups (Architect ADL first) | frontend | ⬜ Pending |
 
-### P3 — Minor (36)
+### P3 — Minor (35)
 
 | ID | Title | Owner | Status |
 |---|---|---|---|
@@ -104,7 +94,6 @@ _Tracker last updated: 2026-07-28 (B9 merged — QUAL-03 + QUAL-11 done, PR #292
 | FUTURE-02 | Companion endorsements — tag who added place/item, allow endorsements | coo | ⬜ Pending |
 | BRD-LB02 | Stats and patterns view (LB-02, Phase 2) | frontend | ⬜ Pending |
 | BRD-LB03 | Shareable recommendations link (LB-03, Phase 3) | architect | ⬜ Pending |
-| BRD-IT10 | Optional Google Maps URL per item — one-click directions (IT-10) | architect | done_pending_uat |
 | UX-11 | Trip-list status pill colours should match map shading colours (admin-driven) | ux | ⬜ Pending |
 | OP-31 | Set up a GitHub App for scheduled-routine GitHub write access — blocks OP-25's cron-flag issue creation | architect | ⬜ Pending |
 | WP-05 | Waypoint reskin must not be reported as closing unrelated data/behavior gaps it only reskins the display of | coo | ⬜ Pending |
@@ -112,7 +101,6 @@ _Tracker last updated: 2026-07-28 (B9 merged — QUAL-03 + QUAL-11 done, PR #292
 | BUG-45 | Convert free-text airline/car-rental-provider fields to a sourced dropdown with Other fallback | coo | ⬜ Pending |
 | BUG-47 | Auto-populate activities from trip/place content instead of manual pre-selection | architect | ⬜ Pending |
 | BUG-54 | Category/activity color customization | ux | ⬜ Pending |
-| BUG-56 | City name not auto-capitalized on entry | frontend | done_pending_uat |
 | BUG-67 | Locked-trip delete refusal is decided from client-held status, not re-checked at confirm time | frontend | ⬜ Pending |
 | BUG-68 | Clerk's telemetry endpoint is CSP-blocked in deployed environments — console noise, no functional impact | unassigned | ⬜ Pending |
 | DEP-03 | GitHub Actions pinned to v4 target Node.js 20 — deprecated, force-run on Node 24 | unassigned | ⬜ Pending |
@@ -120,12 +108,13 @@ _Tracker last updated: 2026-07-28 (B9 merged — QUAL-03 + QUAL-11 done, PR #292
 | QUAL-23 | Migration 0014 preconditions are manual-only; zero-owner DB commits dangling FKs silently (review F3) | database | ⬜ Pending |
 | BUG-69 | geocodeRetryQueue polls 'unresolvable' cities forever — no terminal branch | frontend | ⬜ Pending |
 | BUG-70 | Companion.is_active typed number but serialized boolean (third instance of the class) | frontend | ⬜ Pending |
-| BUG-78 | 'Suggested:' region caption not bold enough to read as a value needing checking | frontend | done_pending_uat |
 | BUG-82 | CityPicker rows keyboard-inaccessible (bare div onClick) + disabled has no visual state — a11y | frontend | ⬜ Pending |
 | BUG-86 | "Back to trip" button in review status deselects the trip instead of returning to the active view | frontend | ⬜ Pending |
 | BUG-88 | Post-trip review has no trip-level or place-level rating (only item-level) | architect | ⬜ Pending |
 | BUG-89 | Country/city geocode lookup is intolerant of misspellings and informal spellings | backend | ⬜ Pending |
 | UX-13 | Grey out / lock the city name on the disambiguation picker screen (editing it there doesn't re-run the lookup) | frontend | ⬜ Pending |
+| UX-14 | First place's dates render in blue while later places' dates don't (inconsistent styling) | frontend | ⬜ Pending |
+| BUG-92 | Companions are not seeded from a global starting list | architect | ⬜ Pending |
 | QUAL-28 | The devcontainer allowlist matches IPs, not hostnames — any Cloudflare-proxied origin is reachable by pinning it to an allowlisted CF edge | architect | ⬜ Pending |
 | QUAL-34 | Shared-record append collisions — union-merge driver for the ledger + per-agent context files (never adopted, 3rd recording) | coo | ⬜ Pending |
 | QUAL-35 | Lean the /coo-startup audit — gate heavy checks on a change-probe; de-inline UAT + open-dialogues | coo | ⬜ Pending |
@@ -139,9 +128,9 @@ _Tracker last updated: 2026-07-28 (B9 merged — QUAL-03 + QUAL-11 done, PR #292
 
 | Type | Progress | Done | Open | Deferred/Closed |
 |---|---|---|---|---|
-| feature | `███████████▓░░░░░░░░` 30/57 | 30 | 27 | 4 |
+| feature | `████████████▓░░░░░░░` 35/57 | 35 | 22 | 4 |
 | requirement | `███████████████████░` 32/33 | 32 | 1 | 6 |
-| bug | `████████████░░░░░░░░` 48/83 | 48 | 35 | 3 |
+| bug | `██████████████░░░░░░` 57/84 | 57 | 27 | 3 |
 | task | `██████████████████░░` 11/12 | 11 | 1 | 0 |
 | chore | `███████████░░░░░░░░░` 30/55 | 30 | 25 | 1 |
 
@@ -177,4 +166,4 @@ _Tracker last updated: 2026-07-28 (B9 merged — QUAL-03 + QUAL-11 done, PR #292
 
 ---
 
-_159 done · 9 deferred · 5 closed · 96 open — 269 tracked items_
+_173 done · 9 deferred · 5 closed · 85 open — 272 tracked items_

--- a/_project/tracker.json
+++ b/_project/tracker.json
@@ -1445,7 +1445,7 @@
       "id": "BRD-IT0809",
       "type": "feature",
       "title": "Rating sort and filter in item list views, cross-trip by city (IT-08/09)",
-      "status": "done_pending_uat",
+      "status": "done",
       "owner": "frontend",
       "priority": "P2",
       "brdRefs": ["IT-08","IT-09"],
@@ -1489,7 +1489,7 @@
       "id": "BRD-GE16",
       "type": "feature",
       "title": "Any authenticated user can add a city via constrained find-or-create (GE-16)",
-      "status": "done_pending_uat",
+      "status": "done",
       "owner": "backend",
       "priority": "P1",
       "brdRefs": ["GE-16"],
@@ -1733,7 +1733,7 @@
       "id": "BRD-DP06",
       "type": "feature",
       "title": "First place added to a trip inherits the trip's date range (DP-06)",
-      "status": "done_pending_uat",
+      "status": "done",
       "owner": "fullstack",
       "priority": "P2",
       "brdRefs": ["DP-06"],
@@ -1744,7 +1744,7 @@
       "id": "BRD-IT10",
       "type": "feature",
       "title": "Optional Google Maps URL per item — one-click directions (IT-10)",
-      "status": "done_pending_uat",
+      "status": "done",
       "owner": "architect",
       "priority": "P3",
       "brdRefs": ["IT-10"],
@@ -1999,7 +1999,7 @@
       "id": "BUG-44",
       "type": "bug",
       "title": "Car rental pickup location should show as subtext under provider",
-      "status": "done_pending_uat",
+      "status": "done",
       "owner": "frontend",
       "priority": "P2",
       "brdRefs": [],
@@ -2065,18 +2065,18 @@
       "id": "BUG-49",
       "type": "bug",
       "title": "City markers render behind state shading layer",
-      "status": "done_pending_uat",
+      "status": "pending",
       "owner": "frontend",
       "priority": "P2",
       "brdRefs": ["MP-02"],
       "phase": 6,
-      "notes": "Found 2026-07-21 UAT, logged only — not yet briefed. When state shading activates it visually covers city tag markers — layer/z-order issue, city markers should stay on top. FIXED 2026-07-28 (GitHub #296, PR #301, Wave 1 sub-wave A brief B1). Root cause was not CSS or JSX order: RegionLayer, CountryLayer and CityMarkers are all native MapLibre GL layers, so paint order is the order layers were ADDED to the style. CountryLayer and CityMarkers mount unconditionally on MapView's first render; RegionLayer mounts lazily once zoom crosses REGION_ZOOM_THRESHOLD and region data loads, and MapLibre's addLayer with no beforeId always inserts at the top of the stack — so region shading landed above city-markers the moment it activated, despite CityMarkers appearing later in MapView's JSX. Fix: beforeId: 'city-markers' on regionFillLayer, which the Layer component honours on both initial addLayer and later moveLayer, so it holds across remounts as the user zooms. COO verified the failure mode this fix could have had — a beforeId naming a layer that does not exist throws — and it cannot occur: MapView.tsx:160 mounts CityMarkers unconditionally and CityMarkers always renders its Source+Layer (empty FeatureCollection when there are no trips). Region outline is a fill-outline-color paint property, not a second layer, so one beforeId covers it. Regression test at src/frontend/components/Map/__tests__/RegionLayer.test.ts. Stale doc comment at MapView.tsx:6 ('zoom >= 4' vs the constant's 3) fixed in the same PR per the document lifecycle rule. brdRefs backfilled to MP-02, the governing requirement ('zooming in on the map reveals region-level shading and city-level pins') — flagged by the B1 agent, verified against the BRD by the COO before adding. REGION_ZOOM_THRESHOLD and the 39 MB region payload deliberately untouched (BUG-48 / ADL-44)."
+      "notes": "Found 2026-07-21 UAT, logged only — not yet briefed. When state shading activates it visually covers city tag markers — layer/z-order issue, city markers should stay on top. FIXED 2026-07-28 (GitHub #296, PR #301, Wave 1 sub-wave A brief B1). Root cause was not CSS or JSX order: RegionLayer, CountryLayer and CityMarkers are all native MapLibre GL layers, so paint order is the order layers were ADDED to the style. CountryLayer and CityMarkers mount unconditionally on MapView's first render; RegionLayer mounts lazily once zoom crosses REGION_ZOOM_THRESHOLD and region data loads, and MapLibre's addLayer with no beforeId always inserts at the top of the stack — so region shading landed above city-markers the moment it activated, despite CityMarkers appearing later in MapView's JSX. Fix: beforeId: 'city-markers' on regionFillLayer, which the Layer component honours on both initial addLayer and later moveLayer, so it holds across remounts as the user zooms. COO verified the failure mode this fix could have had — a beforeId naming a layer that does not exist throws — and it cannot occur: MapView.tsx:160 mounts CityMarkers unconditionally and CityMarkers always renders its Source+Layer (empty FeatureCollection when there are no trips). Region outline is a fill-outline-color paint property, not a second layer, so one beforeId covers it. Regression test at src/frontend/components/Map/__tests__/RegionLayer.test.ts. Stale doc comment at MapView.tsx:6 ('zoom >= 4' vs the constant's 3) fixed in the same PR per the document lifecycle rule. brdRefs backfilled to MP-02, the governing requirement ('zooming in on the map reveals region-level shading and city-level pins') — flagged by the B1 agent, verified against the BRD by the COO before adding. REGION_ZOOM_THRESHOLD and the 39 MB region payload deliberately untouched (BUG-48 / ADL-44). || REOPENED 2026-08-08 — FAILED UAT (owner+non-owner). PO: a trip to Sydney shows NO city marker and state shading covers the map name labels underneath; the 'markers behind shading' fix did not hold in the deployed build. RE-PROBE BEFORE BRIEFING (two causes look identical): 'Sydney shows no tag' could be marker-behind-shading (this bug) OR the Sydney city being geocode-pending/unresolved (no coords -> GE-13 excludes it from the map) — check the DB row's geocode_status first. SEPARATE sub-observation (PO 'unsure if it needs fixing'): state shading covers the state-NAME labels for ALL states — a label-vs-shading z-order/legibility question distinct from the marker z-order."
     },
     {
       "id": "BUG-50",
       "type": "bug",
       "title": "No way to delete an entire trip",
-      "status": "done_pending_uat",
+      "status": "done",
       "owner": "frontend",
       "priority": "P1",
       "brdRefs": ["TR-14"],
@@ -2087,7 +2087,7 @@
       "id": "BUG-51",
       "type": "bug",
       "title": "Companion name edits in admin panel don't consistently propagate to trips",
-      "status": "done_pending_uat",
+      "status": "done",
       "owner": "frontend",
       "priority": "P1",
       "brdRefs": [],
@@ -2098,7 +2098,7 @@
       "id": "BUG-52",
       "type": "bug",
       "title": "Trip search doesn't match on country name",
-      "status": "done_pending_uat",
+      "status": "done",
       "owner": "frontend",
       "priority": "P2",
       "brdRefs": ["TR-13"],
@@ -2142,7 +2142,7 @@
       "id": "BUG-56",
       "type": "bug",
       "title": "City name not auto-capitalized on entry",
-      "status": "done_pending_uat",
+      "status": "done",
       "owner": "frontend",
       "priority": "P3",
       "brdRefs": [],
@@ -2153,7 +2153,7 @@
       "id": "BUG-57",
       "type": "feature",
       "title": "Intelligent date defaults across item entry, keyed off the trip's date range",
-      "status": "done_pending_uat",
+      "status": "done",
       "owner": "fullstack",
       "priority": "P2",
       "brdRefs": ["IT-11"],
@@ -2164,12 +2164,12 @@
       "id": "BUG-58",
       "type": "bug",
       "title": "Moving a trip backward in the status workflow deselects it from the left panel",
-      "status": "done_pending_uat",
+      "status": "pending",
       "owner": "frontend",
       "priority": "P2",
       "brdRefs": ["TR-11"],
       "phase": 6,
-      "notes": "Found 2026-07-21 UAT, logged only — not yet briefed. Moving a trip to an earlier status (backward through the workflow) clears the trip selection entirely, forcing the user to re-find and re-select it in the left panel. Expected: trip stays selected, detail panel just updates to reflect the new status. Meaningful friction at high trip volume. CLASSIFIED + FIXED 2026-07-28 (brief B7, GitHub #316), classified as a GAP not a regression: two independent probes (git log --follow on TripDetailPage.tsx/ReviewPanel.tsx/useTripDetailController's unlock logic, showing no #208 changes; and a full diff of the pre-#208 TripsLayout.tsx/TripDetail.tsx against their current versions) confirm the actual mechanism was byte-identical before and after the WP-03/WP-04 reskin (PR #208) that shipped the same UAT day — coincidental timing, not a regression it introduced. Root cause: the only user-reachable backward transition is 'Return to Planning' (review_pending -> planning, BUG-04's fix) inside ReviewPanel.tsx, whose handler called onClose() immediately after the status mutation succeeded — onClose is wired to navigate('/trips'), which drops the trip's :id from the URL and clears selection in the same click that changes status. Fix: removed the onClose() call from handleReturnToPlanning; the status mutation alone is sufficient; once trip.status flips to 'planning', TripDetailPage/MobileTripsLayout naturally stop rendering ReviewPanel for this trip and render TripDetail/MobileTripDetailView instead, same :id still in the URL. The other backward path (Unlock, locked -> review_pending, in useTripDetailController) never called onClose() and was already correct — confirmed by a new regression test, not just inspection. NOT touched: the forward Lock path inside ReviewPanel.tsx also calls onClose() after locking (review_pending -> locked) — same pattern, but forward, not filed as BUG-58, and out of this brief's stated scope ('trip stays selected when its status moves backward'); flagged to COO as a related but separate possible issue, not fixed here to avoid scope creep. Tests: ReviewPanel.test.tsx +2 (Return to Planning does NOT call onClose; still shows its confirm dialog first), useTripDetailController.test.tsx +1 (Unlock does not navigate, guarding the already-correct path against future regression). PR #319, CI 18/18 green."
+      "notes": "Found 2026-07-21 UAT, logged only — not yet briefed. Moving a trip to an earlier status (backward through the workflow) clears the trip selection entirely, forcing the user to re-find and re-select it in the left panel. Expected: trip stays selected, detail panel just updates to reflect the new status. Meaningful friction at high trip volume. CLASSIFIED + FIXED 2026-07-28 (brief B7, GitHub #316), classified as a GAP not a regression: two independent probes (git log --follow on TripDetailPage.tsx/ReviewPanel.tsx/useTripDetailController's unlock logic, showing no #208 changes; and a full diff of the pre-#208 TripsLayout.tsx/TripDetail.tsx against their current versions) confirm the actual mechanism was byte-identical before and after the WP-03/WP-04 reskin (PR #208) that shipped the same UAT day — coincidental timing, not a regression it introduced. Root cause: the only user-reachable backward transition is 'Return to Planning' (review_pending -> planning, BUG-04's fix) inside ReviewPanel.tsx, whose handler called onClose() immediately after the status mutation succeeded — onClose is wired to navigate('/trips'), which drops the trip's :id from the URL and clears selection in the same click that changes status. Fix: removed the onClose() call from handleReturnToPlanning; the status mutation alone is sufficient; once trip.status flips to 'planning', TripDetailPage/MobileTripsLayout naturally stop rendering ReviewPanel for this trip and render TripDetail/MobileTripDetailView instead, same :id still in the URL. The other backward path (Unlock, locked -> review_pending, in useTripDetailController) never called onClose() and was already correct — confirmed by a new regression test, not just inspection. NOT touched: the forward Lock path inside ReviewPanel.tsx also calls onClose() after locking (review_pending -> locked) — same pattern, but forward, not filed as BUG-58, and out of this brief's stated scope ('trip stays selected when its status moves backward'); flagged to COO as a related but separate possible issue, not fixed here to avoid scope creep. Tests: ReviewPanel.test.tsx +2 (Return to Planning does NOT call onClose; still shows its confirm dialog first), useTripDetailController.test.tsx +1 (Unlock does not navigate, guarding the already-correct path against future regression). PR #319, CI 18/18 green. || REOPENED 2026-08-08 — FAILED UAT (owner+non-owner). PO: LOCKING a trip deselects it entirely from the left panel. BUG-58's original fix covered the BACKWARD status move; the LOCK (forward) transition still drops the selection. Widen to hold selection across ALL status transitions. Sibling: BUG-86 ('Back to trip' in review status also deselects) — same 'status transition drops the selection' family; fix together."
     },
     {
       "id": "BUG-59",
@@ -2213,7 +2213,7 @@
       "priority": "P2",
       "brdRefs": ["AD-08"],
       "phase": 6,
-      "notes": "Found 2026-07-23 by the Frontend agent closing out BRD-AD08's last piece (issue #244, PR #245, repointing useAdmin.ts's companion hooks at the new /api/companions route). companions.ts/CompanionTab.tsx themselves have no owner-only gating, but they're unreachable in practice: App.tsx wraps the entire /admin route in <RequireOwner> and the Admin nav link is rendered only when `me.isOwner` — both BUG-26's deliberate, tested fix (App.test.tsx, 6 tests) from before AD-08 existed. AD-08's access model says any authenticated user should manage their own companions, so this page-level gate is now stale for at least one tab. Deliberately NOT fixed as part of PR #245 — correct fix means moving from page-level RequireOwner to per-tab gating inside AdminPanel.tsx (keeping categories/activities/shading-config-colours*/countries-regions owner-only, opening companions), which touches shared nav/route infra and reverses part of BUG-26's tested contract, judged too architecturally significant for a same-brief hook-URL fix. *Note: map shading config (AD-07) has the identical page-gating problem — its API routes are requireAuth-only per PR #243, but there's no dedicated shading-config UI tab yet to gate per-tab in the first place, so this bug's UI-side fix should cover both companions and shading config if/when a shading-config UI exists. Full detail in ADL-28's addendum and jobs/frontend/park-docs/20260723-FRONTEND-companions-api-route-park.txt. Not a security hole (backend correctly enforces per-user scoping either way) — pure UI-reachability gap. Needs a scoped brief: per-tab gating in AdminPanel.tsx + updated App.test.tsx BUG-26 assertions.\n\nFIXED 2026-07-28 (GitHub #298, B2 backlog-clearance brief, branch fix/bug62-admin-per-tab-gating): App.tsx's page-level RequireOwner removed (the wrapper component and the useMe/isOwner check gating the Admin nav link are both gone — nav link and /admin route now behave exactly like Map/Trips, any authenticated user). Per-tab gating moved into AdminPanel.tsx: a TABS array now carries an `ownerOnly` flag per tab; Companions and Map Shading (a UI tab now exists — the * caveat above is resolved, ShadingTab.tsx was already live in AdminPanel.tsx) are open to any authenticated user, Categories, Activities, and Countries stay owner-only, hidden from the tab bar and double-guarded on render (defence-in-depth) for non-owners. Fail-closed while identity is loading (no flash), matching the old RequireOwner's no-flash behaviour. App.test.tsx's 6 BUG-26 assertions rewritten to 2 BUG-62 assertions (nav link always shown, /admin always reaches AdminPage — the 'Not authorised' page-level message is gone by design). New src/frontend/components/Admin/__tests__/AdminPanel.test.tsx (8 tests) covers the per-tab contract directly: loading state, owner sees all 5 tabs, non-owner sees only Companions+Shading and owner-only tab content never renders. Verified: npm run check (clean), type:check:all (clean), test:frontend 156/156, test:backend 583/1-skipped (unaffected, no backend changes), full Playwright e2e suite 52/52 (admin.spec.ts 5/5 unaffected — BYPASS_AUTH test user is the seeded owner). See BRD-AD09's note above for the bundled backend half of #298 — turned out to already be enforced, no backend change needed."
+      "notes": "Found 2026-07-23 by the Frontend agent closing out BRD-AD08's last piece (issue #244, PR #245, repointing useAdmin.ts's companion hooks at the new /api/companions route). companions.ts/CompanionTab.tsx themselves have no owner-only gating, but they're unreachable in practice: App.tsx wraps the entire /admin route in <RequireOwner> and the Admin nav link is rendered only when `me.isOwner` — both BUG-26's deliberate, tested fix (App.test.tsx, 6 tests) from before AD-08 existed. AD-08's access model says any authenticated user should manage their own companions, so this page-level gate is now stale for at least one tab. Deliberately NOT fixed as part of PR #245 — correct fix means moving from page-level RequireOwner to per-tab gating inside AdminPanel.tsx (keeping categories/activities/shading-config-colours*/countries-regions owner-only, opening companions), which touches shared nav/route infra and reverses part of BUG-26's tested contract, judged too architecturally significant for a same-brief hook-URL fix. *Note: map shading config (AD-07) has the identical page-gating problem — its API routes are requireAuth-only per PR #243, but there's no dedicated shading-config UI tab yet to gate per-tab in the first place, so this bug's UI-side fix should cover both companions and shading config if/when a shading-config UI exists. Full detail in ADL-28's addendum and jobs/frontend/park-docs/20260723-FRONTEND-companions-api-route-park.txt. Not a security hole (backend correctly enforces per-user scoping either way) — pure UI-reachability gap. Needs a scoped brief: per-tab gating in AdminPanel.tsx + updated App.test.tsx BUG-26 assertions.\n\nFIXED 2026-07-28 (GitHub #298, B2 backlog-clearance brief, branch fix/bug62-admin-per-tab-gating): App.tsx's page-level RequireOwner removed (the wrapper component and the useMe/isOwner check gating the Admin nav link are both gone — nav link and /admin route now behave exactly like Map/Trips, any authenticated user). Per-tab gating moved into AdminPanel.tsx: a TABS array now carries an `ownerOnly` flag per tab; Companions and Map Shading (a UI tab now exists — the * caveat above is resolved, ShadingTab.tsx was already live in AdminPanel.tsx) are open to any authenticated user, Categories, Activities, and Countries stay owner-only, hidden from the tab bar and double-guarded on render (defence-in-depth) for non-owners. Fail-closed while identity is loading (no flash), matching the old RequireOwner's no-flash behaviour. App.test.tsx's 6 BUG-26 assertions rewritten to 2 BUG-62 assertions (nav link always shown, /admin always reaches AdminPage — the 'Not authorised' page-level message is gone by design). New src/frontend/components/Admin/__tests__/AdminPanel.test.tsx (8 tests) covers the per-tab contract directly: loading state, owner sees all 5 tabs, non-owner sees only Companions+Shading and owner-only tab content never renders. Verified: npm run check (clean), type:check:all (clean), test:frontend 156/156, test:backend 583/1-skipped (unaffected, no backend changes), full Playwright e2e suite 52/52 (admin.spec.ts 5/5 unaffected — BYPASS_AUTH test user is the seeded owner). See BRD-AD09's note above for the bundled backend half of #298 — turned out to already be enforced, no backend change needed. || UAT 2026-08-08: BUG-62's OWN scope — a non-owner reaching/using the Companions tab — PASSED (PO as non-owner added companions, assigned them to trips, and renamed-with-propagation). The PO logged a FAIL, but for an OUT-OF-SCOPE reason: the companion list 'isn't seeded from a global starting list.' That seed expectation is split to BUG-92. Left at done_pending_uat pending PO confirm that the access-scope pass is accepted (then -> done). OPEN PRODUCT QUESTION on the split: companions are per-user (AD-08), so a GLOBAL seeded list may conflict with that model — see BUG-92."
     },
     {
       "id": "BUG-63",
@@ -2638,7 +2638,7 @@
       "id": "BUG-80",
       "type": "bug",
       "title": "Saved places render as name + country only — two different Newports in one trip are indistinguishable",
-      "status": "done_pending_uat",
+      "status": "done",
       "owner": "backend",
       "priority": "P2",
       "brdRefs": ["GE-16", "GE-17"],
@@ -2649,7 +2649,7 @@
       "id": "BUG-78",
       "type": "bug",
       "title": "'Suggested:' region caption not bold enough to read as a value needing checking",
-      "status": "done_pending_uat",
+      "status": "done",
       "owner": "frontend",
       "priority": "P3",
       "brdRefs": ["GE-15", "GE-16"],
@@ -2660,7 +2660,7 @@
       "id": "BUG-79",
       "type": "bug",
       "title": "Region selector not narrowed for an ambiguous US city, though it is for the UK",
-      "status": "done_pending_uat",
+      "status": "done",
       "owner": "frontend",
       "priority": "P2",
       "brdRefs": ["GE-15", "GE-16"],
@@ -2671,7 +2671,7 @@
       "id": "BUG-77",
       "type": "bug",
       "title": "22 region-tier countries ship with zero regions — 22 latent BUG-30s (ADL-48 S1)",
-      "status": "done_pending_uat",
+      "status": "done",
       "owner": "database",
       "priority": "P2",
       "brdRefs": ["GE-01", "GE-02", "GE-04", "GE-05"],
@@ -2768,7 +2768,7 @@
       "priority": "P2",
       "brdRefs": [],
       "phase": 6,
-      "notes": "Found 2026-08-08 owner UAT (findings 1.2 + 6.2), PO-directed. Searching 'Newport' on a UK trip returns only USA Newports because the picker's discovery lookup (geocode.ts DISCOVERY_LIMIT path) narrows by the country the GEOCODER auto-detects from its top candidate, NOT by the trip's declared countries. PO direction verbatim: 'you can select multiple countries when setting up or editing a trip so I think the places should narrow based on the country or countries assigned to the trip.' So the picker must receive the trip's country SET and narrow/rank by it. CLASSIFICATION (OP-32): GAP — trip-country narrowing was the ADL-48 spike's 'recommended, not day one' signal, never built. NOT BUG-76 (that was the settlement-types filter, done). OPEN DESIGN QUESTION for Architect + PO: hard FILTER vs soft RANK. The spike recommended RANK — a hard filter to trip countries loses valid off-country results, and the PO affirmed adding an off-trip-country place (a USA place on an Argentina trip) 'is fine' — so a soft rank that surfaces trip-country matches first without hard-excluding others is the likely answer. ARCHITECT-GATED (changes the lookup contract: pass the trip country set into /api/geocode + /api/cities) + BRD home needed (new GE requirement + success criteria) + ATDD-first per OP-35. Headline of the geocoder-picker bundle (with BUG-72 labels/dedup, UX-13 grey-out, coords-display)."
+      "notes": "Found 2026-08-08 owner UAT (findings 1.2 + 6.2), PO-directed. Searching 'Newport' on a UK trip returns only USA Newports because the picker's discovery lookup (geocode.ts DISCOVERY_LIMIT path) narrows by the country the GEOCODER auto-detects from its top candidate, NOT by the trip's declared countries. PO direction verbatim: 'you can select multiple countries when setting up or editing a trip so I think the places should narrow based on the country or countries assigned to the trip.' So the picker must receive the trip's country SET and narrow/rank by it. CLASSIFICATION (OP-32): GAP — trip-country narrowing was the ADL-48 spike's 'recommended, not day one' signal, never built. NOT BUG-76 (that was the settlement-types filter, done). PO DECISION 2026-08-08: use the trip's country set as a HARD FILTER, not a rank. The trip's countries are declared at trip creation and are editable (a trip can span multiple countries); to add a place outside them, the user edits the trip to add that country first. This resolves the spike's 'a hard filter loses valid results' concern — results aren't lost, the country set is editable. Absorbs finding 1.2 (constrain cross-country place adds to the trip's declared countries — the current 'USA place on an Argentina trip' is behaviour to CONSTRAIN, not keep). UX follow-through for Architect/UX: when a city search returns nothing because the city's country isn't on the trip, surface a discoverable 'add a country to this trip' path rather than a silent empty result. UI AFFORDANCE (PO 2026-08-08): the picker must carry a visible note that results are filtered by the trip's country/countries (e.g. 'Showing places in: United Kingdom' or similar) so the narrowing is explained, not surprising. Interacts with BUG-91 (the trip-create form is where the country set is declared) and BUG-90 (a GB trip country already admits all UK-nation cities; sub-country filtering is a separate question). ARCHITECT-GATED (changes the lookup contract: pass the trip country set into /api/geocode + /api/cities) + BRD home needed (new GE requirement + success criteria) + ATDD-first per OP-35. Headline of the geocoder-picker bundle (with BUG-72 labels/dedup, UX-13 grey-out, coords-display)."
     },
 
     {
@@ -2817,6 +2817,42 @@
       "brdRefs": [],
       "phase": 6,
       "notes": "Found 2026-08-08 owner UAT (finding 6.3, PO 'yes'). On the picker/disambiguation screen the city name entered on the previous screen is editable, but editing it does NOT re-run the geocode lookup, so a changed value silently mismatches the candidates. Grey out / make read-only with a hint to go back to change it. Small frontend fix; part of the geocoder-picker bundle."
+    },
+
+    {
+      "id": "BUG-91",
+      "type": "bug",
+      "title": "Trip-create form saves and closes prematurely when selecting from the picker (can't set dates in the same flow)",
+      "status": "pending",
+      "owner": "frontend",
+      "priority": "P2",
+      "brdRefs": [],
+      "phase": 6,
+      "notes": "Found 2026-08-08 non-owner UAT (finding N1). Adding a trip and selecting from the picker (country) saves and closes the whole create form, forcing the user to re-open the trip to edit dates — breaks the single add-trip flow. Observed as non-owner; owner-scope UNVERIFIED (re-check whether it also affects the owner path — the PO listed it only under non-owner). Rising importance: BUG-87 makes the trip's declared country set authoritative for place-picker filtering, so the trip-create country step (this form) is now doubly load-bearing. frontend."
+    },
+
+    {
+      "id": "UX-14",
+      "type": "ux",
+      "title": "First place's dates render in blue while later places' dates don't (inconsistent styling)",
+      "status": "pending",
+      "owner": "frontend",
+      "priority": "P3",
+      "brdRefs": [],
+      "phase": 6,
+      "notes": "Found 2026-08-08 UAT (finding N2, owner+non-owner). The first place's date fields render blue while subsequent places' dates render normally — visually inconsistent. Likely tied to BRD-DP06 (first place inherits the trip's dates) — confirm whether blue is a deliberate 'inherited/pre-filled' cue or a styling bug, and make consistent either way. Minor. frontend."
+    },
+
+    {
+      "id": "BUG-92",
+      "type": "enhancement",
+      "title": "Companions are not seeded from a global starting list",
+      "status": "pending",
+      "owner": "architect",
+      "priority": "P3",
+      "brdRefs": [],
+      "phase": 6,
+      "notes": "Found 2026-08-08 UAT (finding 18); split from BUG-62, whose own access-scope PASSED. PO expected a starting companion list; there is none (0 companions in seed-data). OPEN PRODUCT QUESTION (needs PO decision before spec): companions are per-user (AD-08), so a GLOBAL seeded list may conflict with that model — is a starting list actually desired, what would it contain, and is it global or a per-user default population? If desired it's a seed-data addition (+ possibly a per-user default-population step). Held for the product call; no build until the model question is answered."
     },
 
     {

--- a/jobs/PO/uat-log.md
+++ b/jobs/PO/uat-log.md
@@ -109,6 +109,35 @@ shouldn't drop real places, so a pass").
 5. **"Back to trip"** button in review status just deselects the trip; PO expects it to return to the
    **active** status view. [NEW UI bug]
 
+### ▶ NON-OWNER RESULTS — 2026-08-08 (PO, second Clerk account) — UAT COMPLETE
+
+_**No cross-account data bleed observed** — the flagged security-invariant risk (userId-scoping-by-convention across ~65 sites) did not surface as a defect in this pass._
+
+**Re-confirmed PASS (non-owner):** BUG-52, **BRD-IT08/09 (now tested → PASS)**, BUG-56, BUG-78, BUG-80,
+BRD-DP06, BUG-44, BRD-IT10, BUG-51. Owner-side passes (BUG-50/57/77/79, BRD-GE16) stand. → **all 14 clean
+passes flipped `done_pending_uat` → `done`.**
+
+**FAIL / reopened:**
+- **BUG-49 → reopened (pending).** Trip to Sydney shows **no city marker** and **state shading covers the
+  map name labels**. The 'markers behind shading' fix didn't hold. Re-probe: 'no Sydney marker' could be
+  behind-shading OR Sydney city geocode-pending (GE-13 map-exclusion) — check the DB row first. Shading-over-
+  labels is a separate z-order/legibility question (PO 'unsure if it needs fixing').
+- **BUG-58 → reopened (pending).** Locking a trip deselects it (owner + non-owner). Original fix covered
+  *backward* moves; the *lock* transition still deselects. Sibling of BUG-86.
+- **BUG-62 → held.** Its own scope (non-owner Companions access) **passed**; the PO's fail was the
+  out-of-scope 'not seeded from a global list' → split to **BUG-92** (open product question: per-user model
+  vs global seed). Awaiting PO confirm to flip → done.
+
+**Still PARTIAL (open):** BUG-71, BUG-72, BUG-81 (city-picker cluster — sub-findings now tracked as
+BUG-87/BUG-90/UX-13). BUG-73/74 not exercised (geocode-failure signal only fires on a real failure).
+
+**NEW non-owner findings:** N1 trip-create form saves/closes on picker select → **BUG-91**; N2 first-place
+dates blue, later places not (both roles) → **UX-14**; N3 lock deselects → **BUG-58** (reopened above).
+
+**PO decision captured (BUG-87):** narrow the place picker by the trip's country set as a **hard filter**
+(not a rank); the country set is declared at trip creation and editable; to add an off-country place, edit
+the trip's countries first; the picker carries a visible note that results are filtered by the trip's countries.
+
 #### Group 1 — Trips & list
 
 1. **[BUG-50] Delete an entire trip.**


### PR DESCRIPTION
UAT is complete for the Scotland dogfood batch (owner + non-owner). **No cross-account data bleed observed** in the non-owner pass — the flagged userId-scoping-by-convention risk did not surface as a defect.

## Reconciliation
- **14 clean passes → `done`:** BUG-44/50/51/52/56/57/77/78/79/80, BRD-DP06/GE16/IT0809/IT10.
- **BUG-49 → reopened (pending):** UAT fail — Sydney trip shows no marker + state shading covers labels; the "markers behind shading" fix didn't hold. Re-probe marker-behind-shading vs geocode-pending before briefing.
- **BUG-58 → reopened (pending):** lock transition still deselects (both roles); original fix only covered backward moves. Sibling of BUG-86.
- **BUG-62 → held:** its own scope (non-owner Companions access) **passed**; the "not seeded from a global list" fail is out-of-scope → split to **BUG-92**. Awaiting PO confirm to flip → done.
- `done_pending_uat`: **26 → 10** (remaining: BUG-71/72/81 partials, BUG-73/74 not-exercised, DEP-05/QUAL-20/25/26 infra).

## New findings
- **BUG-91** trip-create form saves/closes on picker select (can't set dates in the flow) — P2
- **UX-14** first-place dates render blue, later places don't (both roles) — P3
- **BUG-92** companions not seeded from a global list — **open product question** (per-user model vs global seed)

## BUG-87 (narrowing) — PO decisions folded in
- **Hard FILTER** by the trip's country set (not a rank); country set declared at trip creation and **editable**; to add an off-country place, edit the trip's countries first.
- Absorbs finding 1.2 (constrain cross-country adds).
- **UI affordance:** a visible "results filtered by your trip's countries" note in the picker + a discoverable "add a country to this trip" path on empty results.

`tracker:check` OK (279) · `status:check` OK · Biome OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)