### PR TITLE
feat(OP-39): dispatch gate — brief-header + agent-side rejection (R4)

### DIFF
--- a/.claude/skills/coo-dispatch/SKILL.md
+++ b/.claude/skills/coo-dispatch/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: coo-dispatch
+description: COO dispatch gate — run before dispatching any implementation/spec brief. Consolidates the pre-dispatch rules into one checklist and defines the required brief-header the receiving agent enforces. Completes the COO lifecycle after /coo-startup and before /coo-merge-and-close.
+---
+
+# COO Dispatch Gate (OP-39, design-reflection R4)
+
+Run this before dispatching any brief that **produces committed deliverables** — implementation,
+spec/ADL, schema/migration, docs. **Read-only research/review/investigation dispatches are exempt**
+(they commit nothing, so they need no header).
+
+Completes the COO lifecycle: **/coo-startup → /coo-dispatch → /coo-merge-and-close**.
+
+## Why this exists
+
+No PostToolUse hook can see an Agent-tool dispatch prompt, so the brief — the single
+highest-leverage artifact in the system — was mechanically ungoverned; the warn-only
+`atdd-first-guard.sh` / `negative-findings-guard.sh` only ever saw the gh-issue *echo* of a brief,
+not the brief itself. This gate moves the controls onto the artifact and makes enforcement
+**agent-side**: the brief carries a gate header, and the receiving agent refuses to start without it
+(`_shared/frameworks.txt` standard 31). A checklist the COO merely *remembers* to run has the exact
+weakness that sank the earlier brief-template (it only works if you remember it) — the header **plus**
+agent-side rejection is the teeth.
+
+## The gate — confirm each before dispatch
+
+**Readiness**
+1. **Classified (OP-32)** — regression / deployment / gap, stated. An unclassified item is not dispatchable.
+2. **BRD home (BRD gate)** — any new requirement IDs are in the BRD and the version is bumped.
+3. **Success criteria (mandatory)** — a measurable definition of done is stated.
+4. **Reuse audit** — checked for an existing home/component to extend rather than duplicate (PO standing pref).
+5. **Premise-verification (OP-26)** — load-bearing "X doesn't exist / isn't enforced / is unreachable"
+   claims have two independent probes that could fail differently, or are marked `UNVERIFIED`.
+
+**Verification**
+6. **ATDD-first (OP-35)** — if Architect-gated (schema / access-matrix / data-integrity invariant /
+   shared-contract), mark `ATDD-first: yes` and dispatch **QA before** the implementer.
+7. **Security checklist (OP-06)** — if routes are added/modified, the brief names: auth middleware
+   (`requireAuth`/`requireOwner`), `userId` scoping on every user-data query, `.notNull()` on user FKs.
+8. **Fresh-eyes (OP-27)** — if an Architect deliverable that will be cited elsewhere, plan the
+   second-Architect review; resolve the author's own flagged open questions *first*.
+
+**Mechanics**
+9. **Isolation** — any git-touching role agent gets `isolation: "worktree"`; the brief's first step
+   confirms `pwd`/toplevel matches the worktree, then `npm install` before anything needing node_modules.
+10. **Tracker cross-ref** — the brief names the tracker ID; the tracker entry names the issue #.
+11. **Model tiering** — right tier for the stakes; scaffolding scaled to the model, never the guardrails.
+
+## Required brief header
+
+Paste at the top of every deliverable-producing brief. Fill every field (`n/a` where a line doesn't apply):
+
+```
+=== COO DISPATCH GATE ===
+Tracker: <ID>              BRD: <req IDs | n/a>
+Class (OP-32): <regression | deployment | gap>
+Success criteria: <measurable done>
+ATDD-first (OP-35): <yes — QA dispatched first | no — why>
+Security checklist (OP-06): <applies — named in brief | n/a>
+Reuse audit: <what was checked / what is reused>
+Isolation: <worktree | read-only>
+Fresh-eyes (OP-27): <planned | n/a>
+=========================
+```
+
+The receiving agent **must refuse to start** a deliverable-producing brief that lacks this header and
+flag it to the COO outbox (frameworks.txt standard 31).
+
+## Consolidation note (R3 follow-up)
+
+This gate subsumes the brief-channel role of the two warn-only hooks (`atdd-first-guard.sh`,
+`negative-findings-guard.sh`) — they guard only the gh-issue echo, which this replaces at the source.
+Flagged as **R3 pruning candidates**; not removed in this pass (removal is a separate deliberate act).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -241,6 +241,19 @@ ambiguous "done" in the tracker. Adopted 2026-07-07 after finding the project ha
 definition-of-done doc anywhere (the `objective.txt` stub meant to hold this was never
 filled in and has been deleted).
 
+### Dispatch gate before briefing (mandatory, OP-39)
+
+Adopted 2026-08-08 (design-reflection R4, PO-directed). Before dispatching any brief that produces
+committed deliverables, run the `/coo-dispatch` skill: it consolidates the pre-dispatch rules
+(classify OP-32 · BRD gate · success criteria · reuse audit · premise-verification · ATDD-first
+OP-35 · security checklist OP-06 · fresh-eyes OP-27 · worktree isolation · tracker cross-ref · model
+tiering) into one gate and defines a required brief-header. **Enforcement is agent-side**
+(`_shared/frameworks.txt` standard 31): the receiving agent refuses to start a deliverable brief that
+lacks the `=== COO DISPATCH GATE ===` header and flags it — because a checklist the COO merely
+*remembers* to run has the weakness that sank the earlier brief-template (no PostToolUse hook can see
+an Agent-tool dispatch prompt). **Read-only research/review/investigation dispatches are exempt.**
+Completes the COO lifecycle: `/coo-startup → /coo-dispatch → /coo-merge-and-close`.
+
 ### Spike-gate the BRD: no requirement enters as "approved" on an unverified premise (mandatory, OP-33)
 
 Adopted 2026-08-05 after the GE-17 retro: a requirement was BRD-approved (v3.14) on four unverified

--- a/_project/STATUS.md
+++ b/_project/STATUS.md
@@ -131,7 +131,7 @@ _Tracker last updated: 2026-07-28 (B9 merged — QUAL-03 + QUAL-11 done, PR #292
 | requirement | `███████████████████░` 32/33 | 32 | 1 | 6 |
 | bug | `██████████████░░░░░░` 59/85 | 59 | 26 | 3 |
 | task | `██████████████████░░` 11/12 | 11 | 1 | 0 |
-| chore | `███████████░░░░░░░░░` 30/55 | 30 | 25 | 1 |
+| chore | `███████████░░░░░░░░░` 31/56 | 31 | 25 | 1 |
 
 <details>
 <summary>Deferred (9)</summary>
@@ -165,4 +165,4 @@ _Tracker last updated: 2026-07-28 (B9 merged — QUAL-03 + QUAL-11 done, PR #292
 
 ---
 
-_175 done · 9 deferred · 5 closed · 84 open — 273 tracked items_
+_176 done · 9 deferred · 5 closed · 84 open — 274 tracked items_

--- a/_project/tracker.json
+++ b/_project/tracker.json
@@ -3091,6 +3091,18 @@
       "notes": "Recorded 2026-08-08 (review-execution-queue item 8) — branch protection was configured on `main` 2026-07-31 (PO, COO-guided) but never written into a tracked home. Enforced, verified via gh api: require PR (0 approvals), 9 required status checks (6 CI + 3 Security), strict:true (require-branch-up-to-date — closes the D-15 base-skew class), enforce_admins, linear history, no force pushes. `production` deliberately NOT protected — direct fast-forward push is the promotion path (ADL-35). This closed open-dialogue D-15 (green PR on a stale base merged into a red main). Same-PR skill updates: /pre-push now states it is a fast pre-filter and CI is the authoritative gate; /coo-merge-and-close notes a PR behind main needs `gh pr update-branch` + ~85s CI re-run before the merge button works."
     },
 
+    {
+      "id": "OP-39",
+      "type": "chore",
+      "title": "Dispatch gate — brief-header + agent-side rejection (design-reflection R4)",
+      "status": "done",
+      "owner": "coo",
+      "priority": "P2",
+      "brdRefs": [],
+      "phase": 6,
+      "notes": "Adopted 2026-08-08 from design-reflection R4 (PO-directed; PO chose enforcement level B — skill + brief-header + agent-side rejection — over the checklist-only option, because a checklist the COO merely remembers to run has the exact weakness that sank the earlier brief-template). PROBLEM the reflection surfaced: no PostToolUse hook can see an Agent-tool dispatch prompt, so the brief — the highest-leverage artifact in the system — was mechanically ungoverned; the warn-only atdd-first-guard.sh / negative-findings-guard.sh only ever see the gh-issue ECHO of a brief. FIX (3 parts): (1) .claude/skills/coo-dispatch/SKILL.md — the COO dispatch gate, run before any deliverable-producing dispatch; consolidates the scattered pre-dispatch rules (OP-32 classify, BRD gate, success criteria, reuse audit, OP-26 premise-verification, OP-35 ATDD-first, OP-06 security checklist, OP-27 fresh-eyes, worktree isolation, tracker cross-ref, model tiering) into one checklist + the required brief-header spec. (2) _shared/frameworks.txt standard 31 — every role reads frameworks on init (verified), and now must REFUSE to start a deliverable-producing brief lacking the `=== COO DISPATCH GATE ===` header and flag it to COO. Agent-side enforcement = the OP-15c pattern (push enforcement to the artifact the agent actually receives). (3) CLAUDE.md directive under COO operating mode. SCOPE: read-only research/review/investigation dispatches are EXEMPT (they commit nothing). CONSOLIDATION / anti-sprawl (per the reflection's own R3 finding): this gate subsumes the brief-channel role of the two warn-only hooks — flagged as R3 pruning candidates, NOT removed in this pass (removal is a separate deliberate act). Completes the COO lifecycle: /coo-startup -> /coo-dispatch -> /coo-merge-and-close."
+    },
+
     // ─── STANDALONE-DOC MIGRATION (2026-08-08) — review-execution-queue + cleanup-wave-plan ──
     // ─── retired into the tracker (one canonical home). Both files deleted in the same PR. ──
     {

--- a/_shared/frameworks.txt
+++ b/_shared/frameworks.txt
@@ -119,3 +119,14 @@ BUG DISCOVERY AND CLASSIFICATION
     severity — must be listed in the Park Document under a "Bugs Discovered" section.
     Format: [SEVERITY] Short description — disposition (fixed | deferred | escalated to COO)
     Bugs that were reclassified must note both the initial and final classification.
+
+DISPATCH GATE
+
+31. DISPATCH-GATE HEADER CHECK (OP-39): Before starting any brief that produces committed
+    deliverables (code, spec/ADL, schema, migration, docs), verify it carries the COO
+    dispatch-gate header — a block opening `=== COO DISPATCH GATE ===` with, at minimum, Class
+    (OP-32), Success criteria, ATDD-first, Security checklist, Reuse audit and Isolation. If the
+    header is ABSENT, STOP and flag it to the COO in your outbox — do NOT proceed on an un-gated
+    brief. This is enforcement on the artifact you actually receive (no hook can see an Agent-tool
+    dispatch prompt). Read-only research/review/investigation dispatches are EXEMPT — they commit
+    nothing and need no header. See the /coo-dispatch skill for the full gate and header spec.

--- a/jobs/COO/context/current.txt
+++ b/jobs/COO/context/current.txt
@@ -1,3 +1,10 @@
+> HISTORICAL — snapshot as of 2026-03-21, not maintained. RETIRED 2026-08-08 (OP-39 hygiene pass).
+> This file was maintained by the deprecated COO-system-prompt.txt init/close ritual (read on init,
+> update on close). That ritual was superseded by the park-doc system (jobs/COO/park-docs/) and the
+> prompt itself was deleted 2026-07-26 (QUAL-06, migrated into the /coo-startup skill), but this file
+> was never retired — so it sat as a March-era orphan. The live COO handoff is the most recent park
+> doc + the tracker + open-dialogues; do NOT read this as current state. Kept (not deleted) for record.
+
 COO CONTEXT — 2026-03-21 (session 6, close)
 PROJECT: Travel Tracker
 


### PR DESCRIPTION
Design-reflection **R4**, PO-directed (enforcement level **B**: skill + brief-header + agent-side rejection).

## Problem
No PostToolUse hook can see an Agent-tool dispatch prompt, so the brief — the highest-leverage artifact in the system — was mechanically ungoverned; the warn-only `atdd-first-guard.sh`/`negative-findings-guard.sh` only ever saw the gh-issue *echo*.

## Fix (controls moved onto the artifact)
- **`.claude/skills/coo-dispatch/SKILL.md`** — the COO dispatch gate: consolidates the scattered pre-dispatch rules (classify OP-32 · BRD gate · success criteria · reuse · premise-verification · ATDD-first OP-35 · security checklist OP-06 · fresh-eyes OP-27 · isolation · tracker cross-ref · tiering) + the required `=== COO DISPATCH GATE ===` brief-header.
- **`_shared/frameworks.txt` standard 31** — agents (all read frameworks on init) **refuse to start** a deliverable-producing brief lacking the header and flag it. This is the OP-15c pattern — the teeth a "COO remembers to run it" checklist lacks (which is what sank the earlier brief-template).
- **CLAUDE.md** OP-39 directive · **tracker** OP-39 entry.
- Retired the stale `jobs/COO/context/current.txt` (5-month orphan) with a HISTORICAL banner.

## Scope / consolidation
- Read-only research/review/investigation dispatches are **exempt**.
- Subsumes the two warn-only hooks' brief-channel role → flagged as **R3 pruning candidates**, not removed here (anti-sprawl, per the reflection's own finding).
- Completes the COO lifecycle: `/coo-startup → /coo-dispatch → /coo-merge-and-close`.

`tracker:check` OK (281) · `status:check` OK · Biome OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)