### PR TITLE
chore: Bundle B fixes -> done_pending_uat (PR #458)

### DIFF
--- a/_project/STATUS.md
+++ b/_project/STATUS.md
@@ -56,7 +56,7 @@ _Tracker last updated: 2026-07-28 (B9 merged — QUAL-03 + QUAL-11 done, PR #292
 | BUG-48 | Country→state map shading zoom threshold too high / laggy | frontend | ⬜ Pending |
 | BUG-53 | Trip list place display: show state (not country) under city, surface country separately | ux | ⬜ Pending |
 | BUG-55 | City entry doesn't auto-populate country/state — CSP blocks the Nominatim call (deployment defect) | architect | ⬜ Pending |
-| BUG-58 | Moving a trip backward in the status workflow deselects it from the left panel | frontend | ⬜ Pending |
+| BUG-58 | Moving a trip backward in the status workflow deselects it from the left panel | frontend | done_pending_uat |
 | BUG-65 | A review_pending trip has no delete affordance — TR-14 is unreachable in that state | frontend | ⬜ Pending |
 | BUG-66 | ReviewPanel's forward Lock path repeats BUG-58's onClose()-after-mutation pattern | frontend | ⬜ Pending |
 | QUAL-08 | sanitiseUrl() has zero call sites and photo_album_ref has no server-side scheme validation | fullstack | ⬜ Pending |
@@ -73,7 +73,7 @@ _Tracker last updated: 2026-07-28 (B9 merged — QUAL-03 + QUAL-11 done, PR #292
 | BUG-85 | Stuck geocode-pending cities are invisible and unactionable — no visibility into the retry queue or its cause, no user recovery (GE-19) | architect | ⬜ Pending |
 | BUG-87 | Add-place picker does not narrow/rank candidates by the trip's assigned country/countries | architect | ⬜ Pending |
 | BUG-90 | "Scotland" and other UK home nations not selectable in the add-trip country picker | architect | ⬜ Pending |
-| BUG-91 | Trip-create form saves and closes prematurely when selecting from the picker (can't set dates in the same flow) | frontend | ⬜ Pending |
+| BUG-91 | Trip-create form saves and closes prematurely when selecting from the picker (can't set dates in the same flow) | frontend | done_pending_uat |
 | QUAL-25 | Spike — build ADL-48's gazetteer for real and measure it before committing to S1/S2/S3 | architect | done_pending_uat |
 | QUAL-26 | You cannot tell which build staging is serving — put the commit SHA in /health, the UI and the shakedown | backend | done_pending_uat |
 | ENV-02 | Staging 502s — Railway proxy 'connection dial timeout' to a single-replica service; app-side causes ruled out | coo | ⬜ Pending |
@@ -108,13 +108,13 @@ _Tracker last updated: 2026-07-28 (B9 merged — QUAL-03 + QUAL-11 done, PR #292
 | BUG-69 | geocodeRetryQueue polls 'unresolvable' cities forever — no terminal branch | frontend | ⬜ Pending |
 | BUG-70 | Companion.is_active typed number but serialized boolean (third instance of the class) | frontend | ⬜ Pending |
 | BUG-82 | CityPicker rows keyboard-inaccessible (bare div onClick) + disabled has no visual state — a11y | frontend | ⬜ Pending |
-| BUG-86 | "Back to trip" button in review status deselects the trip instead of returning to the active view | frontend | ⬜ Pending |
+| BUG-86 | "Back to trip" button in review status deselects the trip instead of returning to the active view | frontend | done_pending_uat |
 | BUG-88 | Post-trip review has no trip-level or place-level rating (only item-level) | architect | ⬜ Pending |
 | BUG-89 | Country/city geocode lookup is intolerant of misspellings and informal spellings | backend | ⬜ Pending |
 | UX-13 | Grey out / lock the city name on the disambiguation picker screen (editing it there doesn't re-run the lookup) | frontend | ⬜ Pending |
-| UX-14 | First place's dates render in blue while later places' dates don't (inconsistent styling) | frontend | ⬜ Pending |
+| UX-14 | First place's dates render in blue while later places' dates don't (inconsistent styling) | frontend | done_pending_uat |
 | BUG-92 | Companions are not seeded from a global starting list | architect | ⬜ Pending |
-| BUG-93 | Newly-added place's map marker doesn't appear until a refresh (render lag on add) | frontend | ⬜ Pending |
+| BUG-93 | Newly-added place's map marker doesn't appear until a refresh (render lag on add) | frontend | done_pending_uat |
 | QUAL-28 | The devcontainer allowlist matches IPs, not hostnames — any Cloudflare-proxied origin is reachable by pinning it to an allowlisted CF edge | architect | ⬜ Pending |
 | QUAL-34 | Shared-record append collisions — union-merge driver for the ledger + per-agent context files (never adopted, 3rd recording) | coo | ⬜ Pending |
 | QUAL-35 | Lean the /coo-startup audit — gate heavy checks on a change-probe; de-inline UAT + open-dialogues | coo | ⬜ Pending |

--- a/_project/tracker.json
+++ b/_project/tracker.json
@@ -2164,12 +2164,12 @@
       "id": "BUG-58",
       "type": "bug",
       "title": "Moving a trip backward in the status workflow deselects it from the left panel",
-      "status": "pending",
+      "status": "done_pending_uat",
       "owner": "frontend",
       "priority": "P2",
       "brdRefs": ["TR-11"],
       "phase": 6,
-      "notes": "Found 2026-07-21 UAT, logged only — not yet briefed. Moving a trip to an earlier status (backward through the workflow) clears the trip selection entirely, forcing the user to re-find and re-select it in the left panel. Expected: trip stays selected, detail panel just updates to reflect the new status. Meaningful friction at high trip volume. CLASSIFIED + FIXED 2026-07-28 (brief B7, GitHub #316), classified as a GAP not a regression: two independent probes (git log --follow on TripDetailPage.tsx/ReviewPanel.tsx/useTripDetailController's unlock logic, showing no #208 changes; and a full diff of the pre-#208 TripsLayout.tsx/TripDetail.tsx against their current versions) confirm the actual mechanism was byte-identical before and after the WP-03/WP-04 reskin (PR #208) that shipped the same UAT day — coincidental timing, not a regression it introduced. Root cause: the only user-reachable backward transition is 'Return to Planning' (review_pending -> planning, BUG-04's fix) inside ReviewPanel.tsx, whose handler called onClose() immediately after the status mutation succeeded — onClose is wired to navigate('/trips'), which drops the trip's :id from the URL and clears selection in the same click that changes status. Fix: removed the onClose() call from handleReturnToPlanning; the status mutation alone is sufficient; once trip.status flips to 'planning', TripDetailPage/MobileTripsLayout naturally stop rendering ReviewPanel for this trip and render TripDetail/MobileTripDetailView instead, same :id still in the URL. The other backward path (Unlock, locked -> review_pending, in useTripDetailController) never called onClose() and was already correct — confirmed by a new regression test, not just inspection. NOT touched: the forward Lock path inside ReviewPanel.tsx also calls onClose() after locking (review_pending -> locked) — same pattern, but forward, not filed as BUG-58, and out of this brief's stated scope ('trip stays selected when its status moves backward'); flagged to COO as a related but separate possible issue, not fixed here to avoid scope creep. Tests: ReviewPanel.test.tsx +2 (Return to Planning does NOT call onClose; still shows its confirm dialog first), useTripDetailController.test.tsx +1 (Unlock does not navigate, guarding the already-correct path against future regression). PR #319, CI 18/18 green. || REOPENED 2026-08-08 — FAILED UAT (owner+non-owner). PO: LOCKING a trip deselects it entirely from the left panel. BUG-58's original fix covered the BACKWARD status move; the LOCK (forward) transition still drops the selection. Widen to hold selection across ALL status transitions. Sibling: BUG-86 ('Back to trip' in review status also deselects) — same 'status transition drops the selection' family; fix together."
+      "notes": "Found 2026-07-21 UAT, logged only — not yet briefed. Moving a trip to an earlier status (backward through the workflow) clears the trip selection entirely, forcing the user to re-find and re-select it in the left panel. Expected: trip stays selected, detail panel just updates to reflect the new status. Meaningful friction at high trip volume. CLASSIFIED + FIXED 2026-07-28 (brief B7, GitHub #316), classified as a GAP not a regression: two independent probes (git log --follow on TripDetailPage.tsx/ReviewPanel.tsx/useTripDetailController's unlock logic, showing no #208 changes; and a full diff of the pre-#208 TripsLayout.tsx/TripDetail.tsx against their current versions) confirm the actual mechanism was byte-identical before and after the WP-03/WP-04 reskin (PR #208) that shipped the same UAT day — coincidental timing, not a regression it introduced. Root cause: the only user-reachable backward transition is 'Return to Planning' (review_pending -> planning, BUG-04's fix) inside ReviewPanel.tsx, whose handler called onClose() immediately after the status mutation succeeded — onClose is wired to navigate('/trips'), which drops the trip's :id from the URL and clears selection in the same click that changes status. Fix: removed the onClose() call from handleReturnToPlanning; the status mutation alone is sufficient; once trip.status flips to 'planning', TripDetailPage/MobileTripsLayout naturally stop rendering ReviewPanel for this trip and render TripDetail/MobileTripDetailView instead, same :id still in the URL. The other backward path (Unlock, locked -> review_pending, in useTripDetailController) never called onClose() and was already correct — confirmed by a new regression test, not just inspection. NOT touched: the forward Lock path inside ReviewPanel.tsx also calls onClose() after locking (review_pending -> locked) — same pattern, but forward, not filed as BUG-58, and out of this brief's stated scope ('trip stays selected when its status moves backward'); flagged to COO as a related but separate possible issue, not fixed here to avoid scope creep. Tests: ReviewPanel.test.tsx +2 (Return to Planning does NOT call onClose; still shows its confirm dialog first), useTripDetailController.test.tsx +1 (Unlock does not navigate, guarding the already-correct path against future regression). PR #319, CI 18/18 green. || REOPENED 2026-08-08 — FAILED UAT (owner+non-owner). PO: LOCKING a trip deselects it entirely from the left panel. BUG-58's original fix covered the BACKWARD status move; the LOCK (forward) transition still drops the selection. Widen to hold selection across ALL status transitions. Sibling: BUG-86 ('Back to trip' in review status also deselects) — same 'status transition drops the selection' family; fix together. || FIXED PR #458 (done_pending_uat): ReviewPanel onClose was navigate('/trips') dropping the trip id; new shared useReviewPanelVisibility hook decides panel-vs-detail via dismiss state, not navigation — fixes the forward LOCK path. Awaiting PO re-UAT."
     },
     {
       "id": "BUG-59",
@@ -2751,12 +2751,12 @@
       "id": "BUG-86",
       "type": "bug",
       "title": "\"Back to trip\" button in review status deselects the trip instead of returning to the active view",
-      "status": "pending",
+      "status": "done_pending_uat",
       "owner": "frontend",
       "priority": "P3",
       "brdRefs": [],
       "phase": 6,
-      "notes": "Found 2026-08-08 owner UAT (finding 1.5, PO 'yes'). In review/review_pending status the 'Back to trip' control deselects the trip entirely (blank panel) rather than returning to the active-status trip view the PO expects. Small frontend fix. Same 'status transition drops the selection' family as BUG-58 (locking a trip also deselects it) — consider fixing together."
+      "notes": "Found 2026-08-08 owner UAT (finding 1.5, PO 'yes'). In review/review_pending status the 'Back to trip' control deselects the trip entirely (blank panel) rather than returning to the active-status trip view the PO expects. Small frontend fix. Same 'status transition drops the selection' family as BUG-58 (locking a trip also deselects it) — consider fixing together. || FIXED PR #458 (done_pending_uat): same root as BUG-58 (ReviewPanel onClose navigation); 'Back to trip' now returns to the trip view via the shared visibility hook, not a deselecting navigate. Awaiting PO re-UAT."
     },
 
     {
@@ -2823,24 +2823,24 @@
       "id": "BUG-91",
       "type": "bug",
       "title": "Trip-create form saves and closes prematurely when selecting from the picker (can't set dates in the same flow)",
-      "status": "pending",
+      "status": "done_pending_uat",
       "owner": "frontend",
       "priority": "P2",
       "brdRefs": [],
       "phase": 6,
-      "notes": "Found 2026-08-08 non-owner UAT (finding N1). Adding a trip and selecting from the picker (country) saves and closes the whole create form, forcing the user to re-open the trip to edit dates — breaks the single add-trip flow. Observed as non-owner; owner-scope UNVERIFIED (re-check whether it also affects the owner path — the PO listed it only under non-owner). Rising importance: BUG-87 makes the trip's declared country set authoritative for place-picker filtering, so the trip-create country step (this form) is now doubly load-bearing. frontend."
+      "notes": "Found 2026-08-08 non-owner UAT (finding N1). Adding a trip and selecting from the picker (country) saves and closes the whole create form, forcing the user to re-open the trip to edit dates — breaks the single add-trip flow. Observed as non-owner; owner-scope UNVERIFIED (re-check whether it also affects the owner path — the PO listed it only under non-owner). Rising importance: BUG-87 makes the trip's declared country set authoritative for place-picker filtering, so the trip-create country step (this form) is now doubly load-bearing. frontend. || FIXED PR #458 (done_pending_uat): reproduced against TripForm — clicking a country was already safe; pressing ENTER in the country search fell through to native form submission, saving/closing the create modal. Fixed with a scoped onKeyDown preventDefault. Confirmed NOT owner-scoped. Awaiting PO re-UAT."
     },
 
     {
       "id": "UX-14",
       "type": "ux",
       "title": "First place's dates render in blue while later places' dates don't (inconsistent styling)",
-      "status": "pending",
+      "status": "done_pending_uat",
       "owner": "frontend",
       "priority": "P3",
       "brdRefs": [],
       "phase": 6,
-      "notes": "Found 2026-08-08 UAT (finding N2, owner+non-owner). The first place's date fields render blue while subsequent places' dates render normally — visually inconsistent. Likely tied to BRD-DP06 (first place inherits the trip's dates) — confirm whether blue is a deliberate 'inherited/pre-filled' cue or a styling bug, and make consistent either way. Minor. frontend."
+      "notes": "Found 2026-08-08 UAT (finding N2, owner+non-owner). The first place's date fields render blue while subsequent places' dates render normally — visually inconsistent. Likely tied to BRD-DP06 (first place inherits the trip's dates) — confirm whether blue is a deliberate 'inherited/pre-filled' cue or a styling bug, and make consistent either way. Minor. frontend. || RESOLVED PR #458 (done_pending_uat): NOT a bug — the blue date accent is a deliberate, uniform, data-driven signal (hasExplicitDates) that BRD-DP06 happens to trigger for the first place at creation. Added a title tooltip to make the signal self-explanatory. Awaiting PO glance."
     },
 
     {
@@ -2859,12 +2859,12 @@
       "id": "BUG-93",
       "type": "bug",
       "title": "Newly-added place's map marker doesn't appear until a refresh (render lag on add)",
-      "status": "pending",
+      "status": "done_pending_uat",
       "owner": "frontend",
       "priority": "P3",
       "brdRefs": [],
       "phase": 6,
-      "notes": "Found 2026-08-08 UAT, split from a BUG-49 mis-attribution. PO added a Sydney place; the map marker did not paint immediately and appeared only after a lag/refresh. VERIFIED it is NOT geocoding: Sydney (city 12) resolved with coords at creation (geocode_attempts=0, created_at==updated_at), so the marker DATA existed immediately — the map simply didn't re-render/refetch on add. Likely a query-invalidation / marker-refresh gap after a place-add (confirm: does the map-markers query invalidate on place mutation?). Minor UX. frontend."
+      "notes": "Found 2026-08-08 UAT, split from a BUG-49 mis-attribution. PO added a Sydney place; the map marker did not paint immediately and appeared only after a lag/refresh. VERIFIED it is NOT geocoding: Sydney (city 12) resolved with coords at creation (geocode_attempts=0, created_at==updated_at), so the marker DATA existed immediately — the map simply didn't re-render/refetch on add. Likely a query-invalidation / marker-refresh gap after a place-add (confirm: does the map-markers query invalidate on place mutation?). Minor UX. frontend. || FIXED PR #458 (done_pending_uat): useAddPlace invalidated ['trips', tripId] which does not prefix-match the bare ['trips'] the map CityMarkers query uses; fixed to invalidate ['trips'] (matching useRemovePlace/BUG-32). Marker now appears immediately. Awaiting PO re-UAT."
     },
 
     {


### PR DESCRIPTION
Flips BUG-58/86/91/93 and UX-14 to done_pending_uat after the Bundle B merge (#458), with root causes recorded. UX-14 resolved as not-a-bug (deliberate signal + tooltip). Awaiting PO re-UAT on staging. tracker:check OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)