### PR TITLE
chore(BUG-87): ADL-54 OP-27 fresh-eyes review — verdict SOUND

### DIFF
--- a/jobs/COO/inbox/20260808_2230-ARCHITECT-adl54-fresh-eyes-review-complete.txt
+++ b/jobs/COO/inbox/20260808_2230-ARCHITECT-adl54-fresh-eyes-review-complete.txt
@@ -1,0 +1,40 @@
+TO: COO
+FROM: Architect (fresh-eyes reviewer, OP-27)
+DATE: 2026-08-08
+RE: ADL-54 fresh-eyes review COMPLETE — BUG-87 / GE-20 / PR #463
+
+Header: BUG-87 · ADL-54 (reviewed) · reviews PR #463 · BRD GE-20 (v3.21) · branch chore/adl54-fresh-eyes-review · review PR #<PR> (see CI line)
+
+VERDICT: SOUND & READY FOR BUILD. Zero blocking findings. Six non-blocking refinements to fold into
+the briefs. Deliverable: jobs/architect/tech/20260808-ADL54-fresh-eyes-review.md.
+
+PREMISES (re-probed independently, 2 probes each — NOT inherited):
+- trip_countries user-declared/editable: VERIFIED. Write path = setCountries (trips.ts:174/329) +
+  addCountries/removeCountry (trip-countries.ts); places.ts writes no country row. Schema comment
+  schema.ts:464-466 "derived from trip_places" is STALE (impl PR corrects it, D-1.1).
+- Nominatim countrycodes comma list: UNVERIFIED by probe (firewall). Documented + failure is visible
+  in staging, not silent. ATDD test 4 asserts client args, not Nominatim — run a real multi-country
+  geocode on staging early.
+- D9 security: VERIFIED. Filter narrows GLOBAL reference data; GE-16 containment preserved;
+  trip.countries owner-scoped. No leak, no new scoping. No schema change (D8 confirmed).
+
+NON-BLOCKING (fold into dispatch):
+- F1 (act on this) Drizzle inArray(col,[]) => sql`false` (verified in node_modules). A naive
+  empty-set impl returns ZERO rows — inverts Q1's SHOW-ALL. Brief A: branch on set.length on BOTH
+  endpoints; ADD an explicit present-but-EMPTY-STRING ATDD case for both (the input a zero-country
+  trip actually sends; the only one that trips the footgun).
+- F2 "cannot be bypassed" is frontend-enforced but Brief B is ATDD-first:no. Require ONE Brief-B test
+  that the param is sent on both lookup paths.
+- F3 BUG-90 invariant: trip_countries codes must stay within cities.country_code code-space or a
+  pseudo-country silently empties the picker. Carry into BUG-90's brief.
+- F4 State cities-path precedence (both params present) in Brief A. Never hit today, but make it total.
+- F5 D2 single-country limit tier (10) is defensible/tunable, not a BUG-79 regression. No action needed.
+- F6 PR #463 title says "ADL-53" — should be ADL-54 (renumbered). Fix before merge.
+
+ATDD marks (backend yes / frontend no) and Q1/Q2/Q3 resolutions: all sound; my only additions are
+F1 (empty-string case) and F2 (one FE guard) — contents of the bar, not the yes/no marks.
+
+NOW UNBLOCKED: the two-brief dispatch (QA ATDD -> Brief A backend contract -> Brief B frontend) once
+F1/F2/F4 are folded in, F3 noted for BUG-90, F6 fixed. No blockers.
+
+CI: see the review PR checks line in my final report.

--- a/jobs/architect/context/current.txt
+++ b/jobs/architect/context/current.txt
@@ -1,4 +1,37 @@
 =============================================================================
+ADL-54 FRESH-EYES REVIEW BLOCK — PREPENDED 2026-08-08, DOES NOT REPLACE ANY BLOCK BELOW
+=============================================================================
+Deliverable: jobs/architect/tech/20260808-ADL54-fresh-eyes-review.md. Branch
+  chore/adl54-fresh-eyes-review. Role: SECOND fresh Architect (OP-27), reviewing ADL-54
+  (trip-country-scoped place picker hard-filter; BUG-87 / BRD GE-20, PR #463).
+
+VERDICT: SOUND & READY FOR BUILD — zero blocking findings, six non-blocking refinements.
+  All three load-bearing premises re-verified independently (2 probes each):
+  P1 trip_countries is user-declared/editable (write-callers = setCountries@trips.ts:174/329 +
+     addCountries/removeCountry@trip-countries.ts; places.ts writes NO country row — full-symbol
+     grep confirms). Schema doc-comment schema.ts:464-466 "derived from trip_places" is STALE.
+  P2 Nominatim countrycodes comma-list: UNVERIFIED by probe (firewall) — documented + non-silent
+     failure (visible in staging); ATDD test 4 asserts client args not Nominatim, so run a real
+     multi-country geocode on staging early.
+  P3 D9 security correct — filter narrows GLOBAL reference data; GE-16 containment ANDs & is
+     preserved (cities.ts:93); trip.countries owner-scoped via findByIdOrThrow. No leak, no new
+     scoping owed.
+
+NON-BLOCKING (fold into briefs): F1 Drizzle inArray(col,[]) => sql`false` (verified in
+  node_modules) — a naive empty-set impl returns ZERO rows, INVERTING Q1's SHOW-ALL ruling; Brief A
+  must branch on set.length AND the ATDD bar must add an explicit present-but-EMPTY-STRING case for
+  BOTH endpoints (the only input that trips the footgun). F2 "cannot be bypassed" is frontend-
+  enforced but Brief B is ATDD-first:no — require one FE test that the param is sent on both lookup
+  paths. F3 cross-bug invariant for BUG-90: trip_countries codes MUST stay within cities.country_code
+  code-space or a pseudo-country silently empties the picker. F4 state cities-path precedence (both
+  params) in Brief A. F5 D2 single-country limit tier (10) is defensible/tunable, not a BUG-79
+  regression. F6 PR #463 title says "ADL-53" — should be ADL-54 (renumbered); fix before merge.
+
+Seam vs GE-14/15/16 + D12 create-constraint: CLEAN. country_codes (filter, 2 GET reads) and
+  country_code (D12 create constraint) are separate params on separate paths; no frontend caller
+  sends country_code to the GET reads today, so "both present" is theoretical (ADL makes it total
+  anyway — good). No earlier verdict invalidated.
+=============================================================================
 BUG-76 ACCEPT-RULE DESIGN BLOCK — PREPENDED 2026-08-07, DOES NOT REPLACE ANY BLOCK BELOW
 =============================================================================
 Deliverable: jobs/architect/tech/20260807-BUG76-accept-rule-design.md (ADL-51 in the main log).

--- a/jobs/architect/park-docs/20260808-ARCHITECT-park-adl54-fresh-eyes-review.txt
+++ b/jobs/architect/park-docs/20260808-ARCHITECT-park-adl54-fresh-eyes-review.txt
@@ -1,0 +1,80 @@
+ARCHITECT PARK DOC — 2026-08-08
+Thread: OP-27 fresh-eyes review of ADL-54 (trip-country picker hard-filter)
+Branch: chore/adl54-fresh-eyes-review · PR: (this review) · Reviews: PR #463 (ADL-54)
+Tracker: BUG-87 · BRD: GE-20 (approved, v3.21)
+
+WHAT THIS THREAD DID
+  Second, fresh Architect performing the mandatory OP-27 fresh-eyes review of ADL-54 (authored by a
+  different agent). Deliverable: jobs/architect/tech/20260808-ADL54-fresh-eyes-review.md.
+  I critiqued and stress-tested rather than confirmed; scoped the whole ADL incl. the COO
+  Q1/Q2/Q3 adjudication (ADL-52 clause 2); re-probed the load-bearing premises independently
+  rather than inheriting them.
+
+VERDICT: SOUND & READY FOR BUILD — zero blocking findings, six non-blocking refinements for the
+  COO to fold into the two implementation briefs.
+
+PREMISE RE-PROBES (2 probes each — did not inherit)
+  P1 trip_countries user-declared/editable: VERIFIED. Write-callers = setCountries (trips.ts:174
+     create, :329 PATCH) + addCountries/removeCountry (trip-countries.ts:34/49); repo defs
+     repositories/trips.ts:378/389/402. Full-symbol grep of tripCountries across src/backend shows
+     places.ts / place repo write NO country row. Schema doc-comment schema.ts:464-466 ("derived
+     from trip_places") is STALE — impl PR should correct it (D-1.1).
+  P2 Nominatim countrycodes comma list: UNVERIFIED by probe — firewall blocks Nominatim (documented
+     geocode.ts:42-45). Existing single-code path already sends countrycodes (geocode.ts:83) via
+     URLSearchParams (nominatim-client.ts:268) => country_codes=gb,us goes out as gb%2Cus.
+     Documented Nominatim behaviour + comma-encoding standard, so very likely correct. Blind spot:
+     ATDD test 4 asserts CLIENT ARGS not Nominatim's response, so it can't catch a Nominatim-side
+     misparse. Failure is VISIBLE in staging, not silent. Rec: run a real multi-country geocode on
+     staging early.
+  P3 D9 security: VERIFIED correct. cities/countries are global catalogues; country_codes only
+     NARROWS globally-readable data, no privilege boundary. GE-16 containment ANDs with inArray and
+     is preserved (cities.ts:64-68 / :93). "filtered by" note + empty-state derive from
+     trip.countries, owner-scoped via findByIdOrThrow(userId,tripId). No leak; no new scoping; FK
+     .notNull item N/A (no schema change). D8 no-schema-change confirmed.
+
+NON-BLOCKING FINDINGS (full detail in the review doc §0 table + §2-§5)
+  F1 (most important) Drizzle inArray(col,[]) => sql`false` (verified in
+     node_modules/drizzle-orm/sql/expressions/conditions.js:73). A naive "always push inArray from
+     the param" impl returns ZERO rows for an empty set — the exact OPPOSITE of Q1's SHOW-ALL ruling.
+     Design D3 is correct; the HAZARD is in impl. Brief A must branch on set.length on BOTH endpoints;
+     the ATDD bar must add an explicit present-but-EMPTY-STRING case for both (distinct from the
+     "absent" tests 2/5 — the empty string is what a zero-country trip's FE sends and the only input
+     that trips the footgun).
+  F2 "cannot be bypassed from within the picker" (GE-20 criterion) is FRONTEND-enforced (param must
+     be sent on both lookup paths) but Brief B is ATDD-first:no => untested link. Require ONE Brief-B
+     test pinning "param sent on both paths." Refinement to D10, not an override.
+  F3 BUG-90 forward seam: BUG-87 assumes trip_countries.country_code ⊆ cities.country_code code-space.
+     Correct today (FK-RESTRICT forces real ISO codes; Scotland->GB->all UK cities, PO-accepted). But
+     if BUG-90 introduces a parallel "commonly-known-as-country" code-space and any such code lands in
+     trip_countries without existing in cities.country_code, inArray matches ZERO cities and the
+     picker silently empties. Carry as an INVARIANT into BUG-90's brief.
+  F4 cities.ts precedence when BOTH country_code + country_codes present is unspecified (geocode IS
+     specified). Never hit today (no FE caller sends country_code to the GET reads). State the cities
+     total contract in Brief A.
+  F5 D2 single-country discovery uses CONSTRAINED_LIMIT(10) with no region picked. Defensible &
+     consistent with geocode.ts:36-39; NOT a BUG-79 regression; residual small risk (>10 same-name in
+     one big country truncates) degrades gracefully (truncated surfaced). Tunable — I lean toward
+     DISCOVERY_LIMIT for the region-unpicked discovery path, but non-blocking.
+  F6 PR #463 title says "ADL-53"; deliverable is ADL-54 (renumbered — ADL-53 is the BUG-84
+     citiesRepository design, PR #456). Fix PR title before merge.
+
+SEAM (GE-14/15/16 + D12): CLEAN. country_codes (filter) vs country_code (D12 create constraint) are
+  separate params on separate paths. No FE caller sends country_code to the GET reads today
+  (useCities.ts:131 /api/cities?q=, :46 /api/geocode?q= — q only). GE-14 unchanged but inArray;
+  GE-15 candidate space constrained, BUG-71/75 machinery composes unchanged; GE-16 re-point reused for
+  D4a. No earlier verdict/method/reason invalidated.
+
+ATDD-first marks (D10): correct (backend yes / frontend no). My additions are F1 (empty-string case)
+  + F2 (one FE param-sent guard) — contents of the bar, not the yes/no marks.
+
+Q1/Q2/Q3: all sound. Q1 correct but see F1 impl guard. Q2 reuses GE-16/GE-19 re-point family. Q3
+  presentation, punted to FE/UX.
+
+WHAT IS NOW UNBLOCKED
+  ADL-54 is validated. COO can formalize the two-brief dispatch (QA ATDD -> Brief A backend contract
+  -> Brief B frontend) once F1/F2/F4 are folded into the briefs, F3 noted for BUG-90, F6 fixed.
+
+OPEN / HANDED TO COO
+  - Fold F1/F2/F4 into briefs; carry F3 invariant into BUG-90; fix PR #463 title (F6).
+  - Close P2's blind spot with an early real-staging multi-country geocode before any UAT verdict.
+  - No blockers.

--- a/jobs/architect/tech/20260808-ADL54-fresh-eyes-review.md
+++ b/jobs/architect/tech/20260808-ADL54-fresh-eyes-review.md
@@ -1,0 +1,218 @@
+# ADL-54 — OP-27 fresh-eyes review (second, fresh Architect)
+
+**Date:** 2026-08-08 · **Reviewer:** Architect (fresh context — did NOT author ADL-54)
+**Target:** `jobs/architect/tech/ADL-54-trip-country-picker-filter.md` (on
+`origin/feat/bug87-trip-country-picker-filter`, PR #463), INCLUDING its "COO Adjudication"
+(Q1/Q2/Q3) section · **Tracker:** BUG-87 · **BRD:** GE-20 (approved, v3.21)
+**Mandate:** critique and stress-test — scope the whole ADL (ADL-52 clause 2), check the seam vs
+GE-14/15/16 and the D12 single-`country_code` create-constraint, re-probe the load-bearing factual
+claims, stress-test the edge cases and the Q1/Q2/Q3 resolutions and the ATDD-first marks.
+
+---
+
+## VERDICT: SOUND & READY FOR BUILD — no blocking findings.
+
+The design is correct and its three load-bearing factual premises independently re-verify (two
+probes each, below). The seam against GE-14/15/16 and the D12 create-constraint is clean — the new
+`country_codes` read-path param genuinely does not contradict or double-apply against the existing
+single `country_code`. Security (D9) holds. I found **zero blocking issues** and **six non-blocking
+refinements** the COO should fold into the two implementation briefs before dispatch — the most
+important of which (F1) is an implementation footgun that, if hit, silently produces the *exact
+opposite* of the PO's Q1 ruling. None require a redesign; all are brief-level guardrails.
+
+---
+
+## 0. Summary table
+
+| # | Finding | Severity | Disposition |
+|---|---|---|---|
+| P1 | `trip_countries` is user-declared/editable, not derived on place-add | VERIFIED (2 probes) | Premise holds — design correct |
+| P2 | Nominatim `countrycodes` accepts a comma list | UNVERIFIED by probe (firewall) | Documented + non-silent failure; flag for early staging check |
+| P3 | Filter narrows global reference data; no new user-scoping | VERIFIED (2 probes) | D9 correct, no leak |
+| F1 | Drizzle `inArray(col, [])` → `sql\`false\`` — a naive impl of the empty set returns ZERO rows (contradicts Q1 SHOW-ALL) | Non-blocking (impl risk) | Brief A must branch on `set.length`; add an explicit **empty-string** ATDD case for BOTH endpoints |
+| F2 | "Cannot be bypassed from within the picker" is enforced by the *frontend* passing the param, but Brief B is ATDD-first: no → the headline guarantee has an untested link | Non-blocking | Require one Brief-B test pinning "param sent on both lookup paths" |
+| F3 | BUG-90 forward seam: BUG-87 assumes `trip_countries.country_code` ⊆ `cities.country_code` code-space | Non-blocking (cross-bug invariant) | Carry into BUG-90's brief; do not let BUG-90 introduce a parallel code-space |
+| F4 | `cities.ts` precedence when BOTH `country_code` and `country_codes` are present is unspecified (geocode precedence IS specified) | Non-blocking (never hit today) | State the cities-path total contract in Brief A |
+| F5 | D2 single-country discovery uses `CONSTRAINED_LIMIT` (10) with no region picked yet | Non-blocking (tunable, not a regression) | Consider `DISCOVERY_LIMIT` for the region-unpicked discovery path |
+| F6 | PR #463 title says "ADL-53"; the deliverable is ADL-54 (renumbered) | Cosmetic | Fix PR title before merge |
+
+---
+
+## 1. Independent re-probe of the load-bearing premises (I did NOT inherit them)
+
+### P1 — `trip_countries` is a user-declared, editable set (NOT derived on place-add). **VERIFIED.**
+This is the premise the whole design rests on; if it were derived, a hard filter would be circular.
+Two probes that fail differently:
+- **Probe A — write-caller grep.** The only writers of the country junction are
+  `tripRepository.setCountries` (called at `trips.ts:174` POST create, `trips.ts:329` PATCH) and
+  `addCountries`/`removeCountry` (the sub-router, `trip-countries.ts:34`/`:49`). Definitions at
+  `repositories/trips.ts:378/389/402`.
+- **Probe B — full-symbol grep for `tripCountries`/`trip_countries` across `src/backend`.**
+  `places.ts` and the place repository do **not** appear; the place-add path (`places.ts` →
+  `placeRepository.create`) writes no country row (I also read `places.ts:75-120` — it only
+  *reads* `cities.countryCode` for the response payload). The schema doc-comment at
+  `schema.ts:464-466` ("Derived from trip_places via city → country_code") is **stale**; the live
+  path is user-declared. The ADL's §1.1 conclusion and its "correct the comment in the impl PR"
+  (D-1.1) are both right.
+- Corroborated on the frontend: `TripForm.tsx:55/115` holds `selectedCountryCodes` and submits
+  `country_codes` on both create and edit — the editable declared set the PO described.
+
+### P2 — Nominatim `countrycodes` natively accepts a comma-separated list. **UNVERIFIED by probe.**
+The firewall blocks reaching Nominatim from this environment (a constraint the codebase already
+documents at `geocode.ts:42-45`). What I *can* verify: the existing single-code path already sets
+`params.countrycodes = country_code.toLowerCase()` (`geocode.ts:83`) and `nominatim-client.ts:268`
+passes it verbatim through `URLSearchParams`, so `country_codes=gb,us` would go out as
+`countrycodes=gb%2Cus`. Nominatim's documented behaviour is to accept a comma list here, and
+comma-URL-encoding is standard, so this is very likely correct — but **it is a documentation claim,
+not a probe result from this box.** Blind spot: if Nominatim rejects or mis-parses the encoded
+comma, the multi-country geocode union silently returns wrong/empty candidates. Crucially, **ATDD
+test 4 asserts on the client CALL ARGS, not on Nominatim's response** — so the red-test bar cannot
+catch a Nominatim-side misbehaviour either. Failure mode is **visible in staging UAT** (empty/odd
+geocode results), not silent-and-plausible in prod. **Recommendation:** have QA/impl exercise a real
+multi-country geocode against staging early, before this is trusted in a UAT verdict. Non-blocking.
+
+### P3 — The filter narrows global reference data; no new user-data scoping (D9). **VERIFIED.**
+- `cities` and `countries` are global catalogues; `GET /api/cities` and `GET /api/geocode` sit under
+  the app-level `requireAuth` and carry no per-user *authorization* gate on country. A client
+  passing arbitrary `country_codes` can only **narrow** which globally-readable cities it sees —
+  never widen access or reach another user's private rows. No privilege boundary is crossed.
+- The GE-16 creator-containment clause on `cities` search (`cities.ts:64-68`) ANDs with the new
+  `inArray` and is preserved — `where(and(...conditions, containment))` (`cities.ts:93`) keeps it
+  intact when `inArray` joins `conditions`.
+- The "filtered by" note and empty-state derive from `trip.countries`, which comes from
+  `GET /api/trips/:id` behind `findByIdOrThrow(userId, tripId)` (owner-scoped). Nothing new is
+  exposed. **D9 is correct — no leak, no new scoping owed, `.notNull()` FK item N/A (no schema
+  change).**
+
+**Schema-change gate:** D8 is right that this is read-path only — no migration, no new column, no
+expand/contract. I confirm no schema change is proposed; the only schema-adjacent action is the
+non-functional doc-comment correction (D-1.1).
+
+---
+
+## 2. Seam analysis (ADL-52 clause 2 — the whole document, and the joints)
+
+**Does `country_codes` (filter) contradict or double-apply against `country_code` (D12 create
+constraint)? No.** They are genuinely separate params on separate paths:
+- `country_code` (single) is the D12 create-time constraint, consumed by the POST create path
+  (`cities.ts:404+`, `resolveCityName`) and `geocode.schemas.ts`. `country_codes` (the trip set) is
+  consumed only by the two GET read lookups. **No frontend caller sends `country_code` to either GET
+  today** (probe: the only frontend hits are `useCities.ts:131` `/api/cities?q=` and
+  `:46` `/api/geocode?q=` — both send `q` only; `useCities.ts:106/193` merely *read* `country_code`
+  off responses / type a POST body). So the "both params present" case the ADL makes total (D1:
+  single wins) is purely theoretical — a genuine strength, not a gap, and the totality is good
+  hygiene. **F4:** the ADL states the precedence for `/api/geocode` but is silent on `/api/cities`,
+  where naive addition yields `eq(country_code) AND inArray(country_codes)` = intersection. Harmless
+  (and never hit), but Brief A should state the cities-path contract explicitly so the implementer
+  doesn't guess.
+- **GE-14 (DB-first search):** unchanged except the added `inArray` in the `conditions` array
+  (`cities.ts:52`). Find-first-in-catalogue behaviour preserved.
+- **GE-15 (auto-populate):** constraining the geocode candidate space is the whole fix;
+  `candidates[0].country_code` (`geocode.ts:140`) can now only be an in-set country. The BUG-71/75
+  tentative-suggestion + `CityPicker` machinery composes unchanged — each candidate carries its own
+  `country_code`. No earlier verdict invalidated.
+- **GE-16 (find-or-create / re-point):** unaffected; the re-point path is *reused* for the D4a
+  country-add affordance, consistent with GE-19's re-point reuse.
+
+**F5 (limit tier vs BUG-79).** D2 keeps `CONSTRAINED_LIMIT` (10) for a single-country set and
+`DISCOVERY_LIMIT` (40) for ≥2. This is *consistent* with `geocode.ts:36-39` ("a country-constrained
+call keeps the original narrow limit — countrycodes already restricts the search space"), so it is
+**not** a BUG-79 regression — the "slots spread across countries" failure mode cannot occur once
+`countrycodes` pins the country. Residual, smaller risk: the picker's discovery call runs *before a
+region is picked*, so a single-country trip in a large country searching a very common name (e.g.
+"Springfield" on a US trip) could exceed 10 in-country same-name matches and truncate the intended
+one (the D14 candidate the user needs). It degrades gracefully (`truncated` is surfaced,
+`geocode.ts:149`) and is still better than today's unconstrained-40. **Non-blocking, tunable** — I'd
+lean toward `DISCOVERY_LIMIT` whenever the discovery lookup is country-constrained-but-region-unpicked
+(i.e. always, in the picker path), but the ADL already flags the choice as low-risk and I agree.
+
+**F3 — BUG-90 forward seam (the one worth carrying forward).** D7 is correct *today*:
+`trip_countries.country_code` FK-RESTRICTs to `countries.countryCode` (`schema.ts:476-478`), so it
+can hold only real ISO codes, a Scotland trip stores `GB`, and BUG-87 filters `GB` → all UK cities
+(PO-accepted). No ordering dependency — confirmed. **But BUG-87's hard filter silently assumes
+`trip_countries.country_code` is drawn from the same code-space as `cities.country_code`.** If a
+future BUG-90 design introduces a parallel "commonly-known-as-country" code-space (its tracker note
+floats "expose home nations as selectable 'countries'" and "a curated list … that aren't strict ISO
+country entries"), and any such code lands in `trip_countries` that does **not** exist in
+`cities.country_code`, then `inArray(cities.countryCode, ['<pseudo>'])` matches **zero** cities and a
+Scotland trip's picker goes silently empty. This is not a BUG-87 defect — BUG-87 is correct as
+designed — but it is a **cross-bug invariant** the COO must carry into BUG-90's brief: *whatever
+BUG-90 stores in `trip_countries` must resolve to codes that exist in `cities.country_code`.*
+
+---
+
+## 3. Edge cases (the hard-filter behaviours the ADL designs)
+
+**F1 (most important — an implementation footgun that inverts Q1).** Q1's PO ruling is SHOW-ALL +
+nudge for a zero-country trip. I verified directly in the installed Drizzle source
+(`node_modules/drizzle-orm/sql/expressions/conditions.js:73`) that `inArray(column, [])` returns
+`` sql`false` ``. So an implementer who naively "always pushes `inArray(cities.countryCode, set)`
+from the param" produces `WHERE … false` for an empty set → **zero rows returned** — the literal
+hard-empty behaviour the PO *rejected*, and it would read as a mystifying "new trip shows nothing."
+The ADL's D3 specifies the correct behaviour (empty ⇒ run unconstrained), so this is not a design
+error; it is an implementation hazard the brief must nail down:
+- **Brief A must branch on `set.length`** — only push `inArray` / set `countrycodes` when the set is
+  non-empty — on *both* endpoints.
+- **The ATDD bar (D10) must add an explicit present-but-empty case** (`country_codes=` empty string)
+  for **both** `/api/cities` and `/api/geocode`, distinct from the "absent" cases (tests 2/5). The
+  empty-string input is exactly what a zero-country trip's frontend would send (`[].join(',') === ''`),
+  and it is the *only* input that trips the `inArray([])` → `false` footgun. Without this red test the
+  Q1 guarantee is unpinned.
+
+**F2 — "cannot be bypassed from within the picker" has an untested link.** This GE-20 success
+criterion is a genuine end-to-end guarantee, but its enforcement straddles both briefs: the backend
+only filters *when the param is present* (Brief A, ATDD-tested), and the frontend must *always send
+the param on both lookup paths* (Brief B, `useCitySearch` + the geocode lookup). Brief B is
+ATDD-first: no, so the load-bearing "param is always sent" link has **no red test**. A future
+frontend refactor could drop the param on one path and silently reopen BUG-87 with every backend
+test still green. **Recommendation (non-blocking):** keep Brief B ATDD-first: no for the affordances,
+but require at least one Brief-B component/integration test asserting the picker passes the trip's
+`country_codes` to both lookup calls — the executable guard for the "cannot be bypassed" criterion.
+This is a refinement to D10's rationale, not an override of it.
+
+**Off-country add (Q2 / D4a) and multi-country union:** sound. Union is a plain `inArray`; the empty
+*filtered* result (a real city whose only match is off-trip) correctly falls to the static empty-state
+linking the trip country editor (reusing TripForm / the sub-router — a legitimate reuse, consistent
+with the project's reuse-not-duplication preference).
+
+---
+
+## 4. Q1 / Q2 / Q3 resolutions and the ATDD-first marks
+
+- **Q1 (SHOW-ALL + nudge):** correct and lower-risk than hard-empty; matches GE-20. The *only* caveat
+  is the F1 implementation guard above — the ruling is right, the code must not betray it.
+- **Q2 (static empty-state + editor link, day one; inline "add [country]?" a fast-follow):** sound.
+  Zero extra geocode calls, guaranteed correct, reuses the GE-16/GE-19 re-point family. The deferred
+  D4b probe is a legitimate fast-follow, not a hidden dependency.
+- **Q3 (name-and-truncate the "filtered by" note):** fine; pure presentation, correctly punted to the
+  frontend/UX brief.
+- **ATDD-first marks (D10): correct.** Backend contract = yes (a wrong filter is silent-and-plausible
+  — too loose keeps the bug, too tight vanishes valid results — and precisely specifiable; it changes
+  a shared lookup contract). Frontend affordances = no (UAT-visible, complex frontend, the deliberate
+  OP-35 exclusion). The mock-fidelity call-out (the `nominatim-client` double must honour
+  `countrycodes` or test 4 passes vacuously, QUAL-22) is exactly right and must stay in the QA brief.
+  My only additions are F1 (empty-string case) and F2 (one frontend param-sent guard) — refinements to
+  the *contents* of the ATDD bar, not to the yes/no marks.
+
+---
+
+## 5. GE-20 success criteria — testability & brief split
+
+All eight GE-20 success criteria are measurable and testable (single-country narrowing, multi-country
+union, the note, off-country empty-state, zero-country unconstrained+prompt, no-bypass, addability
+reversibility, and GE-16/D12/BUG-75 unchanged). The **backend contract (Brief A) → frontend wiring
+(Brief B)** split is coherent, off `main`, no expand/contract needed (D8). Sequencing QA(ATDD) →
+Brief A → Brief B is correct; BUG-90 has no ordering dependency (D7, F3 caveat noted). The only
+criterion whose *test* currently lives in a brief with no red-test bar is "cannot be bypassed" — see
+F2.
+
+---
+
+## 6. Disposition
+
+**Ready to build.** The COO should fold F1 and F2 into the brief dispatch (F1 into Brief A's ATDD bar
++ implementation notes; F2 into Brief B), carry F3 into BUG-90's future brief, add the one-line F4
+cities-precedence statement to Brief A, treat F5 as a tunable default the impl can pick, fix the PR
+title (F6), and have QA/impl run an early real-staging multi-country geocode to close P2's blind spot.
+None of these gate the design; ADL-54 is architecturally sound and its premises are independently
+verified.


### PR DESCRIPTION
OP-27 fresh-eyes review (second, fresh Architect) of **ADL-54** — trip-country-scoped place picker hard-filter — on PR #463.

- Tracker: **BUG-87**
- BRD: **GE-20** (approved, v3.21)
- Reviews: **PR #463** / ADL-54

## Verdict: SOUND & READY FOR BUILD — zero blocking findings, six non-blocking refinements.

All three load-bearing premises re-probed independently (2 probes each):
- `trip_countries` is user-declared/editable (write path = `setCountries`/`addCountries`/`removeCountry`; `places.ts` writes no country row). Schema doc-comment "derived from trip_places" is stale.
- Nominatim `countrycodes` comma-list: UNVERIFIED by probe (firewall) — documented, non-silent failure; run a real multi-country geocode on staging early.
- D9 security: filter narrows global reference data; GE-16 containment preserved; `trip.countries` owner-scoped. No leak.

Seam vs GE-14/15/16 + the D12 `country_code` create-constraint is clean — `country_codes` (filter) and `country_code` (create) are separate params on separate paths.

Non-blocking refinements to fold into the briefs: **F1** Drizzle `inArray(col,[])`→`false` inverts Q1 (branch on `set.length`; add empty-string ATDD case); **F2** frontend param-sent guard for "cannot be bypassed"; **F3** BUG-90 code-space invariant; **F4** cities-path precedence; **F5** limit tier (tunable); **F6** PR #463 title says ADL-53, should be ADL-54.

Deliverable: `jobs/architect/tech/20260808-ADL54-fresh-eyes-review.md`.

This PR is docs-only (review + park doc + context + COO report). No source changes.