### PR TITLE
test(BUG-87/GE-20): ATDD bar — RED, Backend implements to green (do not merge alone)

### DIFF
--- a/jobs/COO/inbox/20260808_2330-QA-bug87-ge20-atdd-red-bar-complete.txt
+++ b/jobs/COO/inbox/20260808_2330-QA-bug87-ge20-atdd-red-bar-complete.txt
@@ -1,0 +1,66 @@
+QA COMPLETION REPORT
+================================================================================
+Tracker: BUG-87 / GE-20 · GitHub PR #466 · BRD §5.1 GE-20 (approved v3.21)
+Branch: feat/bug87-ge20
+
+WHAT WAS TESTED
+--------------------------------------------------------------------------------
+Authored the RED acceptance/integration ATDD bar for GE-20 (trip-country-
+scoped place picker) per OP-35 — BEFORE Backend implements Brief A, per
+ADL-54's ATDD-first: yes marking. Two new files against current main
+(@ 4c38d90):
+  - src/backend/routes/__tests__/ge20-cities-country-filter.test.ts
+  - src/backend/routes/__tests__/ge20-geocode-country-filter.test.ts
+11 assertions total, covering GE-20's success criteria + the ADL-54
+fresh-eyes review's F1 (empty-set footgun) and F4 (seam vs the D12
+create-path constraint) findings.
+
+PASS/FAIL VERDICT (RED bar — this IS the intended state)
+--------------------------------------------------------------------------------
+5/11 RED for the right reason (clean AssertionErrors, no import/exception
+noise): cities single-country narrow, cities multi-country union, cities
+off-country-empty, geocode client-args+union, geocode off-country-empty.
+6/11 pass — 4 genuine regression guards (absent-param backward-compat x2,
+F4 seam vs POST /api/cities D12 create constraint x2) + 2 F1 empty-string
+guards that pass VACUOUSLY today (no filtering exists yet) but are kept,
+labelled honestly, to catch the specific naive-implementation footgun
+fresh-eyes flagged as the top non-blocking risk. All 6 explicitly labelled
+in-file (GUARD/REGRESSION GUARD) — not miscounted as red, per the BUG-76
+ATDD precedent.
+
+Confirmed in CI (PR #466, run 31297060411): Backend Tests — 5 failed, 768
+passed, matching local exactly. Every other check green: Frontend Tests,
+Type Check, Biome, Contract Tests, E2E Tests, Semgrep, Gitleaks, Dependency
+Scan — all pass.
+
+BUGS FOUND
+--------------------------------------------------------------------------------
+None (this thread authors tests against unbuilt behaviour, not a bug hunt
+against shipped code).
+
+CI
+--------------------------------------------------------------------------------
+gh pr checks 466 — Backend Tests FAIL (expected, by design — the ATDD red
+bar). All 8 other checks PASS. This is the correct/intended CI state for
+an ATDD handoff PR; do not merge alone.
+
+OPEN ISSUES / BLOCKERS
+--------------------------------------------------------------------------------
+None blocking. Two noted gaps carried forward for Backend's brief (not
+blockers to starting):
+1. ADL-54's recommended invalid-country_codes-value rejection and ~10-code
+   cap are Brief A implementation details, not in my enumerated 7-item
+   test list — not red-tested, Backend should still implement per the ADL.
+2. Fresh-eyes P2 (non-blocking): Nominatim's real multi-country
+   `countrycodes` behaviour is UNVERIFIED from this environment (firewall).
+   My geocode double models documented behaviour, not a live probe —
+   recommend an early real multi-country geocode check against staging
+   before this feature is trusted in a UAT verdict.
+
+NEXT
+--------------------------------------------------------------------------------
+Dispatch Backend to implement Brief A against feat/bug87-ge20, targeting
+all 11 assertions green (5 currently red; the 2 F1 guards must stay green
+for the RIGHT reason — an explicit set.length branch, not luck). Full
+detail: jobs/qa/tech/20260808-ge20-atdd-red-tests.md. Park doc (thread 2):
+jobs/qa/park-docs/20260808-QA-park.txt.

--- a/jobs/COO/inbox/20260808_2400-BACKEND-bug87-ge20-brief-a-complete.txt
+++ b/jobs/COO/inbox/20260808_2400-BACKEND-bug87-ge20-brief-a-complete.txt
@@ -1,0 +1,58 @@
+BUG-87 / GE-20 · PR #466 · BRD GE-20 (v3.21) · Branch feat/bug87-ge20
+
+WHAT WAS BUILT: country_codes read-path hard filter on GET /api/cities and
+GET /api/geocode (ADL-54), turning QA's ATDD RED bar (this same PR, #466)
+green. New shared zCountryCodesList validator (malformed-code + 10-code-cap
+guards). schema.ts trip_countries doc-comment corrected (stale "derived"
+claim -> user-declared/editable).
+
+ACCEPTANCE CRITERIA:
+- QA's 5 RED tests now green: PASS
+- QA's 2 F1 empty-string guards now exercise the real empty->show-all path
+  (not vacuous): PASS
+- QA's 4 regression guards stay green: PASS
+- ADL-54 invalid-code rejection (not built by QA, per brief): PASS — new
+  guard tests in both ge20-*-country-codes-guards.test.ts files
+- ADL-54 D2 ~10-code cap (not built by QA, per brief): PASS — same files
+- schema.ts stale doc-comment fixed: PASS
+- Full backend suite green: PASS — 801/801
+- No QA test edited to pass (ATDD-first discipline): CONFIRMED — QA's two
+  files are byte-for-byte untouched (verified: git diff shows zero changes
+  to them from this thread); no QA test looked wrong, none needed flagging
+
+SECURITY CHECKLIST (OP-06) — both routes pre-existing, modified not new:
+1. Auth middleware — unchanged; both already sit under app-level
+   requireAuth (server.ts). No gate added or removed.
+2. userId scoping — N/A. country_codes narrows GLOBAL reference data
+   (cities/countries catalogues), not user-owned rows. GE-16 creator-
+   containment on cities search is orthogonal and preserved unchanged —
+   the new inArray joins the existing `conditions` array alongside
+   `containment`, doesn't replace or weaken it.
+3. New user-data FK .notNull() — N/A. No schema change, no new column.
+
+CI: PR #466 — will run scripts/ci-wait.sh after this report, per the git
+workflow (pushing next).
+
+OPEN ISSUES / BLOCKERS: none for this brief. Two items carried forward per
+the fresh-eyes review, for COO awareness when scoping Brief B:
+- F2 (fresh-eyes): GE-20's "cannot be bypassed" guarantee has no red test
+  until Brief B adds one pinning "country_codes is always sent on both
+  lookup paths" from the frontend. Recommend folding into Brief B's
+  dispatch as the brief itself already flagged.
+- F3 (fresh-eyes): BUG-90 must store codes in trip_countries that resolve
+  within cities.country_code's code-space — carry into BUG-90's brief,
+  not actionable here.
+Fresh-eyes P2 (Nominatim real multi-country countrycodes behaviour) — the
+dispatch brief stated this was independently COO-verified live against
+staging (gb,fr / fr) prior to this brief; not re-verified by this thread
+(firewall still blocks direct Nominatim access from this container, same
+as every prior geocode thread).
+
+WHAT IS NOW UNBLOCKED: Brief B (frontend wiring — AddPlaceFlow/
+MobileTripDetailView threading trip.countries as country_codes into
+useCitySearch + lookupCityCountry, the D5 "filtered by" note, the D3 zero-
+country prompt, the D4a off-country empty-state) can be dispatched against
+this now-documented, now-tested contract (jobs/backend/tech/20260307-api-
+reference.md v1.8).
+
+Full detail: jobs/backend/park-docs/20260808-BACKEND-bug87-ge20-park.txt

--- a/jobs/backend/context/current.txt
+++ b/jobs/backend/context/current.txt
@@ -1,3 +1,76 @@
+BACKEND CONTEXT — 2026-08-08 (BUG-87/GE-20 Brief A thread, latest)
+PROJECT: Travel Tracker
+CURRENT STATUS: implemented GE-20's country_codes read-path filter (BRD
+  v3.21, design ADL-54, fresh-eyes 20260808-ADL54-fresh-eyes-review.md) on
+  branch feat/bug87-ge20 — QA's own branch (QUAL/OP-35 ATDD-first), NOT a
+  new branch off main. This turns QA's PR #466 green rather than opening a
+  new PR.
+  1. New shared src/backend/validation/common.ts primitive
+     zCountryCodesList: comma-joined ISO alpha-2 list parser. undefined
+     (absent) vs [] (present-but-empty, `''`) are kept DISTINCT all the
+     way through — this is what F1 (fresh-eyes) needs: an empty set means
+     SHOW ALL (PO Q1), never inArray([]) -> sql`false`. Rejects malformed
+     codes (not 2-letter alpha) and caps at 10 distinct codes after
+     case-insensitive dedup (ADL-54 D2) — both guards QA's dispatch listed
+     as ADL-54 §4 implementation details, not part of the enumerated
+     7-item red bar, so built + tested here per the brief.
+  2. GET /api/cities (cities.ts): country_codes wired via
+     inArray(cities.countryCode, set), branched on set.length > 0 — the
+     F1 guard. Precedence when both country_code (singular, D12) and
+     country_codes (plural) are present: single wins (states the
+     cities-path contract fresh-eyes F4 flagged as unspecified; no
+     current caller sends both — grep-verified, useCities.ts sends only
+     `q`).
+  3. GET /api/geocode (geocode.ts): country_codes forwarded to
+     nominatimSearch as countrycodes, same F1 empty-set branch (falls
+     through to the existing unconstrained DISCOVERY path). D2 limit
+     tier: single-country set keeps CONSTRAINED_LIMIT (10), multi-country
+     set (>=2) uses DISCOVERY_LIMIT (40) — same reasoning BUG-79 already
+     established for the fully-unconstrained case. Same country_code-wins
+     precedence as cities.ts (this one WAS already stated in ADL-54 D1).
+  4. schema.ts:463-469 trip_countries doc-comment corrected — was stale
+     ("Derived from trip_places via city -> country_code"); now states
+     the live path (user-declared at trip creation, editable via
+     TripForm/the trip-countries sub-router), matching ADL-54 §1.1's
+     two-probe finding, itself re-verified by the fresh-eyes review (P1).
+  5. Tests: zCountryCodesList unit tests added to the existing
+     validation/__tests__/common.test.ts (undefined/empty/dedup/cap/
+     malformed-code cases). Two NEW backend-owned route-level guard
+     files — ge20-cities-country-codes-guards.test.ts and
+     ge20-geocode-country-codes-guards.test.ts — cover malformed-code
+     400s, the 10-code cap, the D2 limit tier, and both endpoints'
+     country_code-wins precedence contract. QA's two frozen ATDD files
+     (ge20-cities-country-filter.test.ts, ge20-geocode-country-filter.
+     test.ts) are UNTOUCHED — verified all 11 of their tests now pass
+     (5 RED->green, the 2 F1 guards now exercise the real path instead
+     of passing vacuously, 4 regression guards stay green).
+  Full backend suite: 801/801 green (768 QA baseline + 5 QA RED->green +
+  33 new guard/unit tests). type:check:all clean. biome clean (auto-
+  formatted the two new test files once, per its own fixer).
+  Security (OP-06): both routes already sit under app-level requireAuth
+  (server.ts); country_codes narrows GLOBAL reference data (cities/
+  countries catalogues), not user data — no new userId scoping is owed
+  (ADL-54 D9, re-verified fresh-eyes P3). GE-16 creator-containment on
+  cities search is orthogonal and preserved — the new inArray joins the
+  existing `conditions` array alongside `containment`, unchanged. No
+  schema change, no new user-referencing column — the `.notNull()` FK
+  checklist item is N/A.
+  NOT DONE THIS THREAD (frontend wiring is Brief B, separate, ATDD-first:
+  no per ADL-54 D10): AddPlaceFlow/MobileTripDetailView are not wired to
+  pass trip.countries as country_codes yet; the D5 "filtered by" note,
+  the D3 zero-country prompt, and the D4a off-country empty-state are
+  all frontend-only and not built here. Also carried forward, unresolved
+  by this thread (fresh-eyes P2, non-blocking): Nominatim's real
+  multi-country comma-list behaviour is UNVERIFIED from this container
+  (firewall) — the geocode double models the documented behaviour, not a
+  live probe. COO dispatch header stated this was independently
+  COO-probed live against staging (newport gb,fr / lyon fr) and confirmed
+  working — noting that here as the resolution QA/fresh-eyes both flagged
+  as outstanding.
+  Full detail: jobs/backend/park-docs/20260808-BACKEND-bug87-ge20-park.txt
+
+---
+
 BACKEND CONTEXT — 2026-08-07 (BUG-81 thread, latest)
 PROJECT: Travel Tracker
 CURRENT STATUS: implemented BUG-81 (P2 per brief, BRD GE-16) on branch

--- a/jobs/backend/park-docs/20260808-BACKEND-bug87-ge20-park.txt
+++ b/jobs/backend/park-docs/20260808-BACKEND-bug87-ge20-park.txt
@@ -1,0 +1,190 @@
+BACKEND PARK DOCUMENT — 2026-08-08
+Thread: BUG-87 / GE-20 — Brief A (backend contract), country_codes hard filter
+Branch: feat/bug87-ge20 (QA's own branch — NOT a new branch off main)
+PR: #466 (QA opened it holding the RED ATDD suite; this thread's commit turns it green)
+
+===============================================================================
+1. WHAT WAS BUILT
+===============================================================================
+
+GE-20's read-path filter: a new `country_codes` query param on both
+GET /api/cities and GET /api/geocode, hard-filtering results to the trip's
+declared country set (union across the set, nothing outside it). Design:
+jobs/architect/tech/ADL-54-trip-country-picker-filter.md. Fresh-eyes review:
+jobs/architect/tech/20260808-ADL54-fresh-eyes-review.md. QA's ATDD rationale:
+jobs/qa/tech/20260808-ge20-atdd-red-tests.md.
+
+Dispatch (COO): ATDD-first: yes (OP-35). Implement TO QA's tests, never edit
+them to fit the code. No QA test needed editing or looked wrong — the RED bar
+turned green exactly as designed.
+
+===============================================================================
+2. FILES CHANGED
+===============================================================================
+
+- src/backend/validation/common.ts — NEW export zCountryCodesList. A Zod
+  string().optional().transform() that:
+    * undefined -> undefined (absent)
+    * ''        -> [] (present, empty — F1's critical distinct case)
+    * "gb,fr"   -> ['GB','FR'] (trimmed, upcased, deduped)
+    * rejects any entry that isn't exactly 2 letters (custom issue, 400)
+    * rejects a deduped set > 10 distinct codes (ADL-54 D2, custom issue, 400)
+  Verified the zod v4 ctx.addIssue + z.NEVER pattern works as expected via a
+  standalone node -e probe before wiring it into the schemas (zod is v4.3.6
+  per package.json; this file had no prior addIssue/superRefine precedent to
+  copy, so I probed the API directly rather than assuming v3 semantics carried
+  over).
+
+- src/backend/validation/cities.schemas.ts — SearchCitiesQuerySchema gains
+  `country_codes: zCountryCodesList`.
+
+- src/backend/validation/geocode.schemas.ts — GeocodeQuerySchema gains
+  `country_codes: zCountryCodesList`.
+
+- src/backend/routes/cities.ts (GET /) — reads country_codes off req.query
+  (now string[] | undefined post-Zod-parse). Precedence: country_code
+  (singular) wins if present; else country_codes.length > 0 pushes
+  inArray(cities.countryCode, set) into the existing `conditions` array
+  (alongside, not replacing, GE-16 `containment`); else no filter at all
+  (covers both absent AND present-empty — the F1 branch).
+
+- src/backend/routes/geocode.ts (GET /) — same precedence; when an
+  "effective" set is non-empty, params.countrycodes = set.join(',').
+  toLowerCase() and params.limit follows D2 (CONSTRAINED_LIMIT for a
+  single-country effective set of exactly 1, DISCOVERY_LIMIT otherwise —
+  covers both "no set" and ">=2 countries").
+
+- src/backend/db/schema.ts:463-469 — trip_countries doc-comment corrected.
+  Was: "Derived from trip_places via city -> country_code." Now: user-
+  declared/editable, matching ADL-54 §1.1's two-probe finding (grep of every
+  writer of the junction table found only trips.ts create/PATCH and the
+  trip-countries sub-router, never places.ts; TripForm.tsx already renders
+  the country multi-select). Doc-comment only — no schema/migration change.
+
+- src/backend/validation/__tests__/common.test.ts — added a
+  describe('zCountryCodesList') block: undefined/empty/single/multi/trim/
+  dedup, the cap at exactly 10 vs rejecting 11 distinct, "11 raw entries but
+  1 distinct doesn't hit the cap", and malformed-code rejections (3-letter,
+  1-letter, numeric, trailing comma, one-bad-code-in-an-otherwise-good-list).
+
+- src/backend/routes/__tests__/ge20-cities-country-codes-guards.test.ts (NEW)
+  — backend-owned, real-DB (test-db.ts pattern, mirrors QA's own file's
+  setup rather than importing it — same "keep each ATDD suite byte-for-byte
+  independent" reasoning QA's file documents). Covers: malformed-code 400s
+  (3-letter, numeric, one-bad-in-a-list), the 11-over-cap 400, the
+  exactly-10 accept, and the F4 cities-path precedence contract (both
+  params present -> country_code wins).
+
+- src/backend/routes/__tests__/ge20-geocode-country-codes-guards.test.ts
+  (NEW) — same guard coverage for the geocode path (mocked nominatimSearch
+  at the service boundary, same pattern as QA's file), plus the D2 limit-
+  tier assertions (single-country set -> limit=10, multi-country ->
+  limit=40) and the geocode-path precedence contract.
+
+- jobs/backend/tech/20260307-api-reference.md — GET /api/cities and
+  GET /api/geocode sections gained `country_codes` documentation (params
+  table + prose): the empty-string-means-unconstrained contract, the
+  malformed/cap 400s, both endpoints' precedence rule, and the geocode
+  limit tier. Version bumped 1.7 -> 1.8 (document-lifecycle rule — this PR
+  changes a fact the doc asserts, same-PR update).
+
+QA's frozen files (untouched, verified via git diff against origin/main
+being empty for them beyond QA's own already-merged commits — i.e. no
+edits by this thread):
+  src/backend/routes/__tests__/ge20-cities-country-filter.test.ts
+  src/backend/routes/__tests__/ge20-geocode-country-filter.test.ts
+
+===============================================================================
+3. VERIFICATION
+===============================================================================
+
+QA's exact 2-file red-bar command, before and after:
+  BEFORE (confirmed on the QA-pushed branch before I touched anything):
+    Test Files  2 failed (2)
+         Tests  5 failed | 6 passed (11)
+  AFTER (this thread's implementation):
+    Test Files  2 passed (2)
+         Tests  11 passed (11)
+
+Full suites:
+  npm run check              -> 0 errors (biome auto-fixed my 2 new test
+                                 files' formatting once; the 5 remaining
+                                 "infos" are pre-existing, in a file this
+                                 thread never touched, cities.identity-
+                                 carry.test.ts — verified via git diff)
+  npm run type:check:all     -> clean
+  npm run test:backend       -> 801/801 passed (768 QA baseline + 5 RED->
+                                 green + 33 new: 14 zCountryCodesList unit
+                                 tests + 19 route-level guard tests across
+                                 the two new files)
+  npm run test:frontend      -> 365/365 passed (untouched by this thread —
+                                 confirms no cross-contamination)
+  npm run status:check       -> up to date
+  npm run tracker:check      -> OK, 282 items, no dup ids, brdRefs valid
+
+===============================================================================
+4. DECISIONS / JUDGMENT CALLS
+===============================================================================
+
+- zCountryCodesList as a SHARED primitive in common.ts, not duplicated per
+  schema file — matches the reuse-not-duplication standing preference and
+  the existing zCountryCode precedent living in the same file.
+- Dedup BEFORE the cap check (11 raw entries of the same code -> 1 distinct,
+  passes). ADL-54 D2's stated rationale for the cap is bounding the
+  Nominatim countrycodes param length and the DB IN list — both are sized
+  by DISTINCT codes, so this is the correct reading, not a loosening of the
+  guard.
+- Cities-path precedence (F4): stated it explicitly as "country_code wins",
+  mirroring the geocode-path precedence ADL-54 D1 already specifies, rather
+  than inventing a different rule for the two endpoints. Fresh-eyes F4 asked
+  Brief A to state SOME total contract, not a specific one; "match the
+  sibling endpoint" was the least-surprise option given F4 itself notes the
+  case is purely theoretical (no current caller sends both).
+- Two NEW backend-owned test files rather than adding to QA's frozen ones —
+  same precedent as cities.search-region-enrichment.test.ts alongside
+  adl46-access-model.test.ts (BUG-72 thread). QA's files stay byte-for-byte
+  as QA committed them; verified with git diff.
+- Did NOT touch the existing single-value zCountryCode (still just
+  length(2).toUpperCase(), no alpha-shape regex) — the brief's malformed-
+  code guard was scoped to the NEW country_codes param; tightening the
+  pre-existing single-value validator was out of scope and not requested.
+
+===============================================================================
+5. TWO-PROBE NOTES
+===============================================================================
+
+- "No current frontend caller sends country_code on GET /api/cities" —
+  grepped useCities.ts (the only file constructing that request) and its
+  full read: line 131 builds `/api/cities?q=...` only; other `country_code`
+  references in that file are response-reading (line 106) or POST-body
+  typing (line 193), not query construction. Two probes, same file, that
+  could fail differently (grep hit count vs full manual read) — both agree.
+- "zod v4's ctx.addIssue({code:'custom',...}) + z.NEVER produces a 400 via
+  this project's validateQuery, not a thrown exception" — verified two ways:
+  a standalone `node -e` probe against the installed zod package (shown in
+  §2 above) AND the actual route-level guard tests in this thread's own new
+  files returning 400 end-to-end through supertest. Both agree.
+
+===============================================================================
+6. WHAT IS NOT DONE / STILL OWED
+===============================================================================
+
+- Brief B (frontend wiring, ADL-54 §4, ATDD-first: no) is NOT built here:
+  AddPlaceFlow/MobileTripDetailView don't yet pass trip.countries as
+  country_codes to either lookup; the D5 "filtered by" note, D3 zero-
+  country prompt, and D4a off-country empty-state are all frontend/UX.
+  Fresh-eyes F2 flags that GE-20's "cannot be bypassed" guarantee has no
+  red test until Brief B adds one pinning "param is always sent on both
+  lookup paths" — carry that into Brief B's dispatch.
+- Fresh-eyes F3 (BUG-90 forward seam: whatever BUG-90 stores in
+  trip_countries must resolve to codes that exist in cities.country_code)
+  is a cross-bug invariant for BUG-90's future brief, not actionable here.
+- Fresh-eyes F6 (PR title said ADL-53, should say ADL-54) is on PR #463,
+  not this thread's PR — not touched.
+- Fresh-eyes P2 (Nominatim's real multi-country countrycodes comma-list
+  behaviour) — the dispatch brief stated the COO had independently verified
+  this live against staging (newport gb,fr / lyon fr, correct union
+  behaviour both times) as of 2026-08-08, closing the fresh-eyes P2 blind
+  spot. Noted here for the record; not re-verified by this thread (this
+  container's firewall still blocks reaching Nominatim directly, same
+  documented constraint as every prior geocode thread).

--- a/jobs/backend/tech/20260307-api-reference.md
+++ b/jobs/backend/tech/20260307-api-reference.md
@@ -1,7 +1,12 @@
 # Travel Tracker — Backend API Reference
 
-**Version:** 1.7
-**Date:** 2026-08-08 (updated: QUAL-07 docs-drift pass — `/api/categories` and
+**Version:** 1.8
+**Date:** 2026-08-08 (updated: GE-20/BUG-87, ADL-54 — `country_codes` documented on both
+`GET /api/cities` and `GET /api/geocode`: the trip-country-scoped picker hard filter, its
+empty-string-means-unconstrained contract, the malformed-code/10-code-cap guards, and both
+endpoints' `country_code`-wins precedence when the singular and plural params are both
+present)
+**Previously:** 1.7, 2026-08-08 (QUAL-07 docs-drift pass — `/api/categories` and
 `/api/activities` documented as their own routers (ADL-46, shipped 2026-08-01, PR #348);
 the stale `/api/admin/categories` / `/api/admin/activities` sections describing routes that
 no longer exist were removed; `GET /api/me` documented (was live, entirely undocumented,
@@ -1009,6 +1014,7 @@ Search cities by name. Returns local database results only (Nominatim is not que
 |-----------|------|----------|-------------|
 | `q` | string | **Yes** | Search string (minimum 2 characters). Case-insensitive substring match. |
 | `country_code` | string | No | ISO 3166-1 alpha-2 code (e.g. `"FR"`) to restrict results to a country |
+| `country_codes` | string | No | GE-20 (BUG-87, ADL-54) — comma-joined ISO 3166-1 alpha-2 codes (e.g. `"GB,FR"`), the trip's declared country filter SET. Hard filter (`inArray`), not a rank: results are the union across every code in the set, nothing outside it. **Distinct semantic from `country_code` above** — that one is the single D12 create-time constraint; this one is the trip-scoped picker filter (GE-20). **Precedence when both are present: `country_code` wins** and `country_codes` is ignored entirely (no current caller sends both). **Empty string (`country_codes=`) is valid and means UNCONSTRAINED** — distinct from the param being absent only in that it's explicit; both leave results unfiltered. This is deliberate (PO ruling): a trip with no declared countries shows all results rather than none. Malformed codes (not 2-letter alpha) → `400`. Capped at 10 distinct codes after case-insensitive dedup → over-cap is `400`. |
 
 **Response: `200 OK`**
 ```json
@@ -1707,7 +1713,7 @@ Rename a region.
 First-party backend proxy for Nominatim lookups (ADL-46 D7 §5.1). Added to this document
 2026-08-07 (BUG-76/BUG-74, ADL-51).
 
-### GET /api/geocode?q=...&country_code=...&region_iso=...
+### GET /api/geocode?q=...&country_code=...&region_iso=...&country_codes=...
 
 Auth: `requireAuth` (applied globally, `app.use('/api/', requireAuth)` in `server.ts`). No
 `userId` scoping — reads no user-owned table, it's a stateless Nominatim proxy.
@@ -1715,7 +1721,22 @@ Auth: `requireAuth` (applied globally, `app.use('/api/', requireAuth)` in `serve
 Query params: `q` (required, search text), `country_code` (optional, ISO 3166-1 alpha-2 —
 when supplied, constrains the Nominatim query and narrows candidates to that country),
 `region_iso` (optional, ISO 3166-2 — narrows `candidates` to matches after the fact, never
-fabricates a result when none match).
+fabricates a result when none match), `country_codes` (optional — see below, GE-20).
+
+**`country_codes` (GE-20, BUG-87, ADL-54)** — a comma-joined list of ISO 3166-1 alpha-2 codes
+(e.g. `"gb,fr"`), the trip's declared country filter SET. Forwarded to Nominatim as
+`countrycodes` (a native comma-list param) — a hard filter, not a rank; the union across every
+code in the set, nothing outside it. **Distinct semantic from `country_code`** — that one is
+the single D12 create-time constraint; **when both are present, `country_code` wins** and
+`country_codes` is ignored (no current caller sends both). **`country_codes=` (present, empty)
+is valid and means UNCONSTRAINED** — same as the param being absent — a deliberate PO ruling
+(Q1): a trip with no declared countries returns unfiltered results rather than none.
+Malformed codes (not 2-letter alpha) → `400`. Capped at 10 distinct codes after
+case-insensitive dedup → over-cap is `400`. **Limit tier:** a single-country set uses the same
+narrow `CONSTRAINED_LIMIT` (10) as the existing single `country_code` path; a multi-country set
+(2 or more codes) uses the wider `DISCOVERY_LIMIT` (40) — more countries means more legitimate
+same-name candidates for the picker to separate (same reasoning BUG-79 established for the
+fully-unconstrained case).
 
 Response body:
 

--- a/jobs/qa/context/current.txt
+++ b/jobs/qa/context/current.txt
@@ -319,3 +319,66 @@ NEXT STEPS (for incoming QA)
   lint notices in untouched files, confirmed pre-existing via diff against
   main). Full detail: jobs/qa/tech/20260808-qual-coverage-sweep.md
   Completion report: jobs/COO/inbox/
+
+================================================================================
+2026-08-08 — BUG-87 / GE-20 ATDD RED BAR (OP-35, trip-country picker filter)
+================================================================================
+
+  Branch: feat/bug87-ge20 (off main @ 4c38d90, pushed). PR opened, title
+  states "do not merge alone" per the ATDD handoff convention (CI shows the
+  new tests failing by design). Backend implements Brief A against this
+  branch next.
+
+  Turned ADL-54/GE-20's success criteria + the fresh-eyes review's F1/F2
+  edge cases into RED acceptance/integration tests BEFORE Backend writes
+  any implementation:
+    - src/backend/routes/__tests__/ge20-cities-country-filter.test.ts
+      (GET /api/cities?country_codes=, real migration-backed test DB)
+    - src/backend/routes/__tests__/ge20-geocode-country-filter.test.ts
+      (GET /api/geocode?country_codes=, fidelity-extended nominatim-client
+      double)
+
+  Result: 5/11 RED for the right reason (clean AssertionErrors — wrong
+  row/candidate counts, no import/exception noise) against main: single-
+  country narrow (cities), multi-country union (cities), off-country empty
+  (cities), client-args + union (geocode), off-country empty (geocode). 6/11
+  already pass on main — 4 genuine regression guards (absent-param
+  backward-compat ×2, the F4 seam vs the POST /api/cities D12 single
+  country_code create constraint ×2) and 2 F1 empty-string guards that pass
+  VACUOUSLY today (no filtering logic exists yet to trip the footgun) but
+  are kept and labelled honestly — they exist to catch the specific naive
+  `inArray(col, [])`-always-pushed implementation bug the fresh-eyes review
+  flagged as the most important non-blocking finding (F1: would silently
+  invert the PO's Q1 SHOW-ALL ruling). All 6 non-red tests are explicitly
+  labelled in-file (GUARD / REGRESSION GUARD), same discipline as the
+  BUG-76 ATDD precedent. No production code touched.
+
+  Mock-fidelity (OP-35/QUAL-22): the pre-existing nominatim-client.js
+  double in geocode.test.ts (BUG-79) is a dumb capture-and-return stub that
+  ignores countrycodes entirely — reusing it unmodified would have made
+  every GE-20 outcome-based geocode assertion pass vacuously. Extended it
+  in the new file: a small fixture candidate pool, filtered by countrycodes
+  as an allow-list (comma-split, case-insensitive), matching Nominatim's
+  documented behaviour — while still capturing raw call args for the
+  brief's explicit "assert on the CLIENT ARGS" instruction. Verified the
+  old double's lack of fidelity two ways (full file read + confirmed its
+  own 5 tests never branch on countrycodes) before deciding to extend
+  rather than reuse.
+
+  Full breakdown + design rationale: jobs/qa/tech/20260808-ge20-atdd-red-tests.md
+
+  NOTED GAP (not added to the red bar, flagging rather than silently
+  expanding scope): ADL-54 §4 recommends schema-level rejection of invalid
+  country_codes values and a ≤10-code cap as Brief A implementation
+  details; neither was in the dispatch's enumerated 7-item test list, so
+  neither is red-tested here. Also carrying forward the fresh-eyes
+  review's P2 (non-blocking): Nominatim's real multi-country countrycodes
+  behaviour is UNVERIFIED from this environment (firewall) — the geocode
+  double models documented behaviour, not a live probe. Recommend an early
+  real multi-country geocode check against staging before UAT trusts this.
+
+  NEXT: Backend implements against this branch until all 5 red assertions
+  are green, the 2 F1 guards still pass for the RIGHT reason (branching on
+  set.length, not accidental), and the 4 regression guards + full backend
+  suite stay green. type:check:all clean, no other suite regresses.
+  Completion report: jobs/COO/inbox/

--- a/jobs/qa/park-docs/20260808-QA-park.txt
+++ b/jobs/qa/park-docs/20260808-QA-park.txt
@@ -98,3 +98,86 @@ NEXT (for COO)
    finding 4 (cross-trip item isolation) was NOT touched by this thread,
    still open), QUAL-21 (pending -> done), QUAL-22 (pending -> done).
 3. Post-merge: scripts/ci-wait.sh branch main to confirm main stays green.
+
+================================================================================
+THREAD 2: BUG-87 / GE-20 — ATDD RED bar for the trip-country picker (OP-35)
+STATUS: COMPLETE — PR open, CI expected RED BY DESIGN (ATDD handoff, do not
+merge alone), not yet reviewed by COO/Backend
+
+WHAT WAS DONE
+--------------------------------------------------------------------------------
+Dispatched per OP-35 (ADL-54 Brief A marked ATDD-first: yes) — authored the RED
+acceptance/integration tests BEFORE Backend implements anything, so Backend
+cannot write its own certifying tests. Two new files:
+  - src/backend/routes/__tests__/ge20-cities-country-filter.test.ts
+  - src/backend/routes/__tests__/ge20-geocode-country-filter.test.ts
+
+Turned GE-20's BRD success criteria + the ADL-54 fresh-eyes review's F1/F2
+findings into 11 assertions across the two endpoints (GET /api/cities and
+GET /api/geocode, both taking a new country_codes read-path param). 5/11 RED
+for the right reason (clean AssertionErrors, wrong row/candidate counts, no
+import/exception noise) against main @ 4c38d90. 6/11 already pass — 4 genuine
+regression guards (backward-compat on absent param, and the F4 seam proving
+the POST /api/cities D12 single country_code create constraint has zero
+mechanical overlap with the new GET-path filter) and 2 F1 empty-string guards
+that pass VACUOUSLY today (no filtering logic exists yet on main to trip the
+footgun) but are kept and labelled honestly, because they are the only cases
+that will catch a naive `inArray(col, [])`-always-pushed implementation once
+Brief A lands — the fresh-eyes review's top non-blocking finding, since that
+bug would silently invert the PO's Q1 SHOW-ALL ruling with every other test
+green.
+
+MOCK-FIDELITY (QUAL-22): the pre-existing nominatim-client.js double in
+geocode.test.ts (BUG-79) is a dumb capture-and-return stub that ignores
+countrycodes entirely. Verified this two ways (full file read; confirmed its
+own 5 tests never branch on countrycodes) before deciding NOT to reuse it
+as-is. The new geocode test file's double is fidelity-extended: a small
+fixture candidate pool (3 countries' Newport + 1 Berlin), filtered by
+countrycodes as a real allow-list (comma-split, case-insensitive) — mirrors
+Nominatim's documented behaviour rather than ignoring the param — while still
+capturing raw call args for the brief's explicit "assert on the CLIENT ARGS"
+instruction (test 1).
+
+RESULT
+--------------------------------------------------------------------------------
+Full backend suite: 768 passed, 5 failed (exactly the RED ones), 0
+regressions against the pre-existing baseline. type:check:backend clean.
+biome clean (auto-formatted both new files once, re-verified RED count
+unchanged after formatting).
+
+Full detail + per-test table: jobs/qa/tech/20260808-ge20-atdd-red-tests.md
+
+NOTED GAPS (flagged, not silently added to the red bar)
+--------------------------------------------------------------------------------
+1. ADL-54 recommends schema-level rejection of invalid country_codes values
+   and a ~10-code cap as Brief A implementation details; neither was in the
+   dispatch's enumerated 7-item test list, so neither is red-tested. Backend
+   should still implement both per the ADL — just not ATDD-pinned by QA.
+2. Fresh-eyes P2 (non-blocking, carried forward unresolved): Nominatim's real
+   multi-country countrycodes behaviour is UNVERIFIED from this environment
+   (firewall blocks the live service). The geocode double models documented
+   behaviour, not a live probe. Recommend an early real multi-country geocode
+   check against staging before this feature is trusted in a UAT verdict.
+
+OPEN ISSUES / BLOCKERS
+--------------------------------------------------------------------------------
+None for this thread. The two noted gaps above are forward-looking
+recommendations, not blockers to Backend starting Brief A.
+
+ARTIFACTS
+--------------------------------------------------------------------------------
+- Branch: feat/bug87-ge20 (off main, pushed)
+- Tech doc: jobs/qa/tech/20260808-ge20-atdd-red-tests.md
+- Context updated: jobs/qa/context/current.txt (appended, not rewritten)
+- Completion report: jobs/COO/inbox/
+
+NEXT (for COO)
+--------------------------------------------------------------------------------
+1. Dispatch Backend to implement Brief A against feat/bug87-ge20, targeting
+   all 11 assertions green (5 currently red, 2 F1 guards must stay green for
+   the RIGHT reason — i.e. via an explicit set.length branch, not by luck).
+2. Do not merge this PR alone — it is the ATDD handoff artifact, CI is
+   expected red until Backend's commits land on the same branch.
+3. Consider the two noted gaps above when briefing Backend (cap + invalid-
+   code validation are ADL-recommended but not QA-pinned; the staging
+   multi-country geocode check is a pre-UAT action item, not a code task).

--- a/jobs/qa/tech/20260808-ge20-atdd-red-tests.md
+++ b/jobs/qa/tech/20260808-ge20-atdd-red-tests.md
@@ -1,0 +1,149 @@
+# BUG-87 / GE-20 — ATDD RED bar (OP-35), full detail
+
+**Date:** 2026-08-08 · **Author:** QA · **Branch:** `feat/bug87-ge20`
+**Tracker:** BUG-87 · **BRD:** GE-20 (approved v3.21)
+**Design:** `jobs/architect/tech/ADL-54-trip-country-picker-filter.md`
+**Fresh-eyes review:** `jobs/architect/tech/20260808-ADL54-fresh-eyes-review.md` (F1–F6, P1–P3)
+
+Purpose: turn ADL-54/GE-20's success criteria + the fresh-eyes F1/F2 edge cases into RED
+acceptance/integration tests — the executable definition of done for Backend's Brief A —
+BEFORE Backend writes any implementation code (OP-35 ATDD-first, Brief A marked `yes`).
+
+---
+
+## Files
+
+### `src/backend/routes/__tests__/ge20-cities-country-filter.test.ts`
+GET `/api/cities?q=...&country_codes=...` — real migration-backed `:memory:` DB (pattern
+mirrored from `cities.search-region-enrichment.test.ts`), real query execution. The whole
+point of GE-20's DB half is a WHERE-clause change, so a stubbed repository would prove
+nothing — the RED bar has to run the real query against real seeded rows.
+
+| # | Test | Status on main | Asserts |
+|---|---|---|---|
+| 1 | `country_codes=GB` single-country narrow | **RED** (3 rows returned, expected 1) | Only the GB Newport comes back; US and FR Newports excluded |
+| 2 | `country_codes=GB,FR` multi-country union | **RED** (3 rows, expected 2) | Union of GB+FR Newports; US excluded |
+| 3 | `country_codes=` (empty string) — F1 guard | **GUARD, passes today vacuously** | SHOW ALL, not zero rows — pins the `inArray(col, [])` → `sql\`false\`` footgun (fresh-eyes F1) for the empty-set case a zero-country trip's frontend actually sends (`[].join(',') === ''`) |
+| 4 | absent `country_codes` — regression guard | **PASS** (already true on main) | Unfiltered, backward-compatible |
+| 5 | off-country name (Berlin/DE, filter=GB) | **RED** (1 row, expected 0) | Empty array when the only match is outside the declared set |
+| 6a | seam (F4) — POST `/api/cities` with `country_code` (D12) | **PASS** (regression guard) | Create path unaffected by the new GET-path feature |
+| 6b | seam (F4) — POST `/api/cities` with an errant `country_codes` body field | **PASS** (regression guard, `.strict()` schema) | 400 — the two params cannot cross-talk even if a caller tries |
+
+### `src/backend/routes/__tests__/ge20-geocode-country-filter.test.ts`
+GET `/api/geocode?q=...&country_codes=...` — mocks `nominatimSearch` at the service
+boundary (matching the existing accepted pattern in `geocode.test.ts` /
+`bug76-geocode-contract.test.ts`), but with a **fidelity-extended double** (see Mock-Fidelity
+below).
+
+| # | Test | Status on main | Asserts |
+|---|---|---|---|
+| 1 | `country_codes=GB,FR` → client args + union | **RED** (`capturedParams.countrycodes` undefined; 3 candidates, expected 2) | `nominatimSearch` receives `countrycodes: 'gb,fr'` (CLIENT ARGS, per the brief's explicit instruction); response is the GB+FR union, no US |
+| 2 | `country_codes=` (empty string) — F1 guard | **GUARD, passes today vacuously** | No `countrycodes` forwarded at all; all 3 Newports returned |
+| 3 | absent `country_codes` — regression guard | **PASS** (already true on main) | Unconstrained DISCOVERY path unchanged |
+| 4 | off-country name (Berlin/DE, filter=GB) | **RED** (1 candidate, expected 0) | Empty `candidates` array |
+
+---
+
+## Confirmed RED (2026-08-08, against `main` @ `4c38d90`)
+
+```
+npx vitest run --config vitest.config.backend.ts \
+  src/backend/routes/__tests__/ge20-cities-country-filter.test.ts \
+  src/backend/routes/__tests__/ge20-geocode-country-filter.test.ts
+
+Test Files  2 failed (2)
+     Tests  5 failed | 6 passed (11)
+```
+
+All 5 failures are clean `AssertionError`s (wrong row/candidate counts) — no import errors,
+no thrown exceptions, no schema-validation 400s masking the real gap. This confirms the
+tests fail for the *right* reason: `country_codes` is currently a complete no-op (Zod
+silently strips the unrecognized query key; nothing downstream ever reads it).
+
+The 6 passing tests are **not** part of the red bar and are labelled explicitly (per the
+BUG-76 ATDD precedent — 8/18 tests passed on main there too, documented rather than
+miscounted): 4 are genuine regression guards for existing, unrelated-to-this-feature
+behaviour (absent-param backward-compat ×2, the POST `/api/cities` seam ×2); 2 (the F1
+empty-string cases) pass **vacuously** today because no filtering logic exists yet to trip
+the footgun — they exist to catch a specific naive-implementation failure mode once Brief A
+lands, not to prove anything about main.
+
+Full backend suite: `npm run test:backend` → **768 passed, 5 failed** (exactly these),
+**0 regressions** against the pre-existing 765(+ge20 additions) baseline.
+`type:check:backend` clean. `biome check` clean (auto-formatted both new files once).
+
+---
+
+## Mock-fidelity (QUAL-22)
+
+The pre-existing `nominatim-client.js` service-boundary double in `geocode.test.ts`
+(BUG-79) is a dumb capture-and-return stub — it records the params `nominatimSearch` was
+called with but returns a **fixed** candidate list regardless of `countrycodes`. That is
+faithful enough for BUG-79 (which only asserts on `limit`), but reusing it unmodified here
+would make every outcome-based GE-20 assertion (union, off-country-empty) pass **vacuously**:
+the response would look "correct" only because the double never modelled filtering, not
+because the route actually wired `country_codes` through to Nominatim.
+
+Per the dispatch brief's explicit instruction, the double in `ge20-geocode-country-filter.
+test.ts` is **extended, not reused as-is**: it holds a small fixture candidate pool (three
+countries' "Newport" + one lone "Berlin") and applies `countrycodes` as a real allow-list
+filter against that pool — comma-split, case-insensitive — mirroring Nominatim's documented
+`countrycodes` narrowing behaviour. It still captures the raw call params too, so the
+client-args assertion (test 1) is direct, not inferred from the outcome.
+
+**Honest limit, carried forward (fresh-eyes P2, non-blocking):** this double models what
+Nominatim's *documentation* says `countrycodes` does. It is **not** a live probe — this
+container's firewall blocks reaching the real service (the same constraint `geocode.test.ts`
+already documents). It proves the *route* wires `country_codes` → `countrycodes` correctly
+and reacts correctly to a filtered/unfiltered client response; it cannot prove Nominatim
+itself honours a multi-code comma list server-side. **Carrying the fresh-eyes recommendation
+forward to COO/Backend, unresolved by this thread:** run one real multi-country geocode
+against staging early, before this feature is trusted in a UAT verdict.
+
+---
+
+## Design choices and why
+
+- **Two files, not one** — mirrors the existing split between `cities.*.test.ts` and
+  `geocode.test.ts` / `bug76-geocode-*.test.ts`; the two endpoints have genuinely different
+  test infrastructure (real DB vs. mocked service boundary) and reuse audit pointed at
+  extending both existing patterns rather than inventing a third.
+- **Real DB for `/api/cities`, mocked service for `/api/geocode`** — not a stylistic choice:
+  the cities route's country filter is a Drizzle `WHERE` clause (worth proving against a real
+  query), while the geocode route's filter is a pass-through parameter to an external service
+  (worth proving via the client-args assertion the brief explicitly asked for, plus an
+  outcome check via the fidelity-extended double).
+- **F1 guard tests kept despite not being RED** — the brief flagged F1 as the single most
+  important non-blocking finding in the fresh-eyes review ("an implementation footgun that
+  inverts Q1"). A red bar that omitted the empty-string case entirely would let a naive
+  `inArray`-always-pushed implementation pass every other test while silently producing the
+  exact zero-rows-on-a-new-trip behaviour the PO rejected. Keeping it, labelled honestly as a
+  vacuous-pass guard rather than pretending it's RED, is the correct ATDD discipline — the
+  BUG-76 precedent (`jobs/qa/tech/20260807-bug76-atdd-red-tests.md`) does the same thing.
+- **Seam test (F4) scoped to POST `/api/cities`, not GET `/api/cities` both-params
+  precedence** — the fresh-eyes review explicitly left the GET-path precedence question
+  (both `country_code` singular and `country_codes` plural present simultaneously)
+  unspecified and assigned it to Brief A ("Brief A should state the cities-path contract
+  explicitly so the implementer doesn't guess" — F4). Pinning an undecided precedence in the
+  ATDD bar would have put words in Backend's mouth. What GE-20 does need proven — and what I
+  did prove — is that the D12 create-path constraint (a completely separate schema, body-only,
+  `.strict()`) has zero mechanical overlap with the new GET-path filter, which the `.strict()`
+  rejection test demonstrates structurally rather than by assumption.
+- **Not added:** an "invalid `country_codes` value → 400" test. ADL-54 §4 recommends schema-
+  level rejection of invalid codes and a ≤10 cap as Brief A implementation details, but neither
+  was in the dispatch's enumerated 7-item test list. Flagging this as a **noted gap**, not
+  silently adding scope to a bar Backend is meant to implement exactly against — see completion
+  report.
+
+---
+
+## Two-probe note (mock-fidelity claim)
+
+Claim: "the existing `nominatim-client.js` double in `geocode.test.ts` doesn't model
+`countrycodes`." Verified two ways that could fail differently: (1) read the file in full —
+`nominatimSearch: vi.fn(async (params) => { capturedParams = params; return nextResult; })`,
+where `nextResult` is a module-level fixed value never conditioned on `params`; (2) ran that
+exact file's existing test suite (`geocode.test.ts`, part of the full backend run above) and
+confirmed all 5 of its own tests still pass unmodified — meaning nothing in that file's
+double logic branches on `countrycodes` today. Both probes agree: the double is a dumb
+capture-and-return stub, hence the fidelity extension in this thread's new double.

--- a/src/backend/db/schema.ts
+++ b/src/backend/db/schema.ts
@@ -462,8 +462,16 @@ export const tripPlaceActivitiesMap = sqliteTable(
 
 /**
  * Trip ↔ Country junction — tracks which countries a trip visits (ADL-23).
- * Derived from trip_places via city → country_code, but stored explicitly for
- * efficient map shading queries without repeated aggregation joins.
+ * USER-DECLARED and editable, not derived (this comment was stale — corrected
+ * GE-20/ADL-54, verified by two independent probes: a grep of every writer
+ * of this table found only POST/PATCH /api/trips (trips.ts) and the
+ * trip-countries sub-router, never places.ts; and TripForm.tsx already
+ * renders a country multi-select submitting country_codes on both trip
+ * create and edit). The set is declared at trip creation and editable at any
+ * time via the trip form — it is the input to GE-20's picker filter, not an
+ * aggregation of already-added places' countries (that would make a hard
+ * filter circular: you couldn't add a place in a country until you'd already
+ * added a place in it).
  * Cascade delete: removing a trip removes its country associations.
  * RESTRICT on country: a country record must exist before it can be linked.
  */

--- a/src/backend/routes/__tests__/ge20-cities-country-codes-guards.test.ts
+++ b/src/backend/routes/__tests__/ge20-cities-country-codes-guards.test.ts
@@ -1,0 +1,165 @@
+/**
+ * GE-20 (BUG-87) — implementation guards for GET /api/cities?country_codes=...
+ * that QA's ATDD bar (ge20-cities-country-filter.test.ts) deliberately did
+ * NOT red-test (see jobs/qa/tech/20260808-ge20-atdd-red-tests.md, "Not
+ * added" section): ADL-54 §4 recommends schema-level rejection of malformed
+ * country codes and a ~10-code cap as Brief A IMPLEMENTATION DETAILS, not
+ * enumerated in QA's 7-item dispatch list. Backend owns these tests per the
+ * dispatch brief ("add them + your own tests").
+ *
+ * Also covers the fresh-eyes F4 seam: the cities-path precedence contract
+ * when BOTH country_code (singular, D12) and country_codes (plural, the
+ * trip filter set) are present on the SAME GET /api/cities request — the
+ * ADL states this precedence for /api/geocode but was silent for
+ * /api/cities; this backend brief states it explicitly (single wins).
+ *
+ * This is a NEW, backend-owned sibling file — QA's ge20-cities-country-
+ * filter.test.ts is a frozen ATDD suite and is not touched here (same
+ * precedent as cities.search-region-enrichment.test.ts alongside
+ * adl46-access-model.test.ts).
+ *
+ * Design: jobs/architect/tech/ADL-54-trip-country-picker-filter.md (D1/D2).
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as schema from '../../db/schema.js';
+import { createTestDb, type TestDb } from '../../repositories/__tests__/test-db.js';
+
+const USER_A_ID = 'ge20-guards-user-a-0000-0000-000000000000';
+
+let testDb: TestDb | null = null;
+
+vi.mock('../../db/index.js', async (importOriginal) => {
+  const real = await importOriginal<typeof import('../../db/index.js')>();
+  return {
+    ...real,
+    getDb: () => {
+      if (!testDb) throw new Error('[TEST] testDb not initialised');
+      return testDb;
+    },
+  };
+});
+
+vi.mock('../../middleware/auth.js', () => ({
+  requireAuth: (
+    req: import('express').Request,
+    _res: import('express').Response,
+    next: import('express').NextFunction,
+  ) => {
+    (req as import('express').Request & { user?: unknown }).user = {
+      id: USER_A_ID,
+      clerkId: 'clerk_ge20_guards_user_a',
+      email: 'ge20-guards-usera@example.com',
+      isOwner: 1,
+    };
+    next();
+  },
+}));
+
+const { default: app } = await import('../../server-test-app.js');
+const supertest = (await import('supertest')).default;
+
+async function seedUser(db: TestDb, userId: string, clerkId: string, email: string) {
+  const now = Date.now();
+  await db
+    .insert(schema.users)
+    .values({
+      id: userId,
+      clerkId,
+      email,
+      isOwner: 1,
+      createdAt: new Date(now),
+      updatedAt: new Date(now),
+    })
+    .onConflictDoNothing();
+}
+
+async function seedCountry(db: TestDb, countryCode: string, name: string) {
+  await db.insert(schema.countries).values({ countryCode, name }).onConflictDoNothing();
+}
+
+async function seedCity(
+  db: TestDb,
+  overrides: Partial<typeof schema.cities.$inferInsert> & { countryCode: string; name: string },
+) {
+  const inserted = await db
+    .insert(schema.cities)
+    .values({ geocodeStatus: 'resolved', ...overrides })
+    .returning();
+  return inserted[0];
+}
+
+beforeEach(async () => {
+  testDb = await createTestDb();
+  await seedUser(testDb, USER_A_ID, 'clerk_ge20_guards_user_a', 'ge20-guards-usera@example.com');
+});
+
+afterEach(() => {
+  testDb = null;
+  vi.clearAllMocks();
+});
+
+describe('GE-20 — GET /api/cities country_codes: malformed-code and cap guards (ADL-54 §4, not in QA red bar)', () => {
+  it('rejects a 3-letter code with 400 (not ISO alpha-2 shape)', async () => {
+    const res = await supertest(app)
+      .get('/api/cities')
+      .query({ q: 'Newport', country_codes: 'GBR' });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects a numeric code with 400', async () => {
+    const res = await supertest(app)
+      .get('/api/cities')
+      .query({ q: 'Newport', country_codes: '12' });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects one malformed code even alongside otherwise-valid ones (no silent partial drop)', async () => {
+    const res = await supertest(app)
+      .get('/api/cities')
+      .query({ q: 'Newport', country_codes: 'GB,XYZ' });
+    expect(res.status).toBe(400);
+  });
+
+  it('ADL-54 D2: rejects a set of 11 distinct codes (over the ~10 cap) with 400', async () => {
+    const codes = ['AA', 'BB', 'CC', 'DD', 'EE', 'FF', 'GG', 'HH', 'II', 'JJ', 'KK'].join(',');
+    const res = await supertest(app)
+      .get('/api/cities')
+      .query({ q: 'Newport', country_codes: codes });
+    expect(res.status).toBe(400);
+  });
+
+  it('ADL-54 D2: accepts a set of exactly 10 distinct codes (at the cap, not over it)', async () => {
+    await seedCountry(testDb!, 'GB', 'United Kingdom');
+    await seedCity(testDb!, { countryCode: 'GB', name: 'Newport' });
+    const codes = ['GB', 'BB', 'CC', 'DD', 'EE', 'FF', 'GG', 'HH', 'II', 'JJ'].join(',');
+    const res = await supertest(app)
+      .get('/api/cities')
+      .query({ q: 'Newport', country_codes: codes });
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(1);
+  });
+
+  // ----------------------------------------------------------------
+  // F4 — cities-path precedence when BOTH country_code and country_codes
+  // are present. The ADL states this contract for /api/geocode but was
+  // silent for /api/cities (fresh-eyes finding). This backend brief states
+  // it explicitly: the single, narrower, user-confirmed country_code wins.
+  // ----------------------------------------------------------------
+  it('F4 — when BOTH country_code and country_codes are present, the single country_code wins (cities-path precedence)', async () => {
+    await seedCountry(testDb!, 'GB', 'United Kingdom');
+    await seedCountry(testDb!, 'FR', 'France');
+    const gb = await seedCity(testDb!, { countryCode: 'GB', name: 'Newport' });
+    await seedCity(testDb!, { countryCode: 'FR', name: 'Newport' });
+
+    // country_code=GB (singular) should win over country_codes=FR (plural) —
+    // the GB row comes back, not the FR one.
+    const res = await supertest(app)
+      .get('/api/cities')
+      .query({ q: 'Newport', country_code: 'GB', country_codes: 'FR' });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(1);
+    expect(res.body[0].id).toBe(gb.id);
+  });
+});

--- a/src/backend/routes/__tests__/ge20-cities-country-filter.test.ts
+++ b/src/backend/routes/__tests__/ge20-cities-country-filter.test.ts
@@ -1,0 +1,281 @@
+/**
+ * GE-20 (BUG-87) — ATDD RED bar for the trip-country-scoped picker's DB
+ * search half: GET /api/cities?q=...&country_codes=...
+ *
+ * Design: jobs/architect/tech/ADL-54-trip-country-picker-filter.md (D1/D2/D3).
+ * Fresh-eyes review: jobs/architect/tech/20260808-ADL54-fresh-eyes-review.md
+ * (F1 — the inArray([]) empty-set footgun; F4 — the cities-path precedence
+ * seam vs the existing single `country_code`).
+ * BRD: GE-20 (approved v3.21), success criteria at _project/travel-tracker-BRD.md §5.1.
+ *
+ * Written BEFORE Backend implements anything (OP-35 ATDD-first — Brief A is
+ * marked ATDD-first: yes). Every test below that targets NEW behaviour is
+ * asserted against current `main`, where `country_codes` is not read by the
+ * route at all (SearchCitiesQuerySchema has no such field, so Zod strips it
+ * silently — no 400, just a no-op). Tests that pin EXISTING, unchanged
+ * behaviour are explicitly labelled REGRESSION GUARD and are expected to
+ * already pass on main; they are not part of the red bar, but they pin the
+ * "no interference" contract this feature must not break.
+ *
+ * DB pattern mirrored from cities.search-region-enrichment.test.ts (real
+ * migration-backed :memory: DB via test-db.ts, real query execution) rather
+ * than a query-builder mock — the whole point of GE-20 is a WHERE-clause
+ * change, so the RED bar has to be a real query against real seeded rows,
+ * not a stubbed repository.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as schema from '../../db/schema.js';
+import { createTestDb, type TestDb } from '../../repositories/__tests__/test-db.js';
+
+// ----------------------------------------------------------------
+// Test user constants
+// ----------------------------------------------------------------
+
+const USER_A_ID = 'ge20-user-a-0000-0000-0000-000000000000';
+
+// ----------------------------------------------------------------
+// Module-level mock control variables
+// ----------------------------------------------------------------
+
+let testDb: TestDb | null = null;
+
+// ----------------------------------------------------------------
+// Module mocks — must be declared before any imports that use them
+// ----------------------------------------------------------------
+
+vi.mock('../../db/index.js', async (importOriginal) => {
+  const real = await importOriginal<typeof import('../../db/index.js')>();
+  return {
+    ...real,
+    getDb: () => {
+      if (!testDb) throw new Error('[TEST] testDb not initialised');
+      return testDb;
+    },
+  };
+});
+
+vi.mock('../../middleware/auth.js', () => ({
+  requireAuth: (
+    req: import('express').Request,
+    _res: import('express').Response,
+    next: import('express').NextFunction,
+  ) => {
+    (req as import('express').Request & { user?: unknown }).user = {
+      id: USER_A_ID,
+      clerkId: 'clerk_ge20_user_a',
+      email: 'ge20-usera@example.com',
+      isOwner: 1,
+    };
+    next();
+  },
+}));
+
+const { default: app } = await import('../../server-test-app.js');
+const supertest = (await import('supertest')).default;
+
+// ----------------------------------------------------------------
+// Seed helpers — mirrored (not imported) from cities.search-region-
+// enrichment.test.ts / adl46-access-model.test.ts, same reasoning: keep
+// each frozen/independent ATDD suite byte-for-byte free of cross-imports.
+// ----------------------------------------------------------------
+
+async function seedUser(db: TestDb, userId: string, clerkId: string, email: string) {
+  const now = Date.now();
+  await db
+    .insert(schema.users)
+    .values({
+      id: userId,
+      clerkId,
+      email,
+      isOwner: 1,
+      createdAt: new Date(now),
+      updatedAt: new Date(now),
+    })
+    .onConflictDoNothing();
+}
+
+async function seedCountry(db: TestDb, countryCode: string, name: string) {
+  await db.insert(schema.countries).values({ countryCode, name }).onConflictDoNothing();
+}
+
+async function seedCity(
+  db: TestDb,
+  overrides: Partial<typeof schema.cities.$inferInsert> & { countryCode: string; name: string },
+) {
+  const inserted = await db
+    .insert(schema.cities)
+    .values({ geocodeStatus: 'resolved', ...overrides })
+    .returning();
+  return inserted[0];
+}
+
+// ----------------------------------------------------------------
+// Setup / teardown
+// ----------------------------------------------------------------
+
+beforeEach(async () => {
+  testDb = await createTestDb();
+  await seedUser(testDb, USER_A_ID, 'clerk_ge20_user_a', 'ge20-usera@example.com');
+});
+
+afterEach(() => {
+  testDb = null;
+  vi.clearAllMocks();
+});
+
+describe('GE-20 — GET /api/cities country_codes hard filter', () => {
+  // --------------------------------------------------------------
+  // Test 1 — single-country narrowing (GE-20 success criterion #1).
+  // "Newport" exists in GB, FR and US; a trip declaring only GB must see
+  // only the GB row.
+  // --------------------------------------------------------------
+  it('country_codes=GB returns only the GB Newport — no US or FR Newport (RED on main: param is a no-op today)', async () => {
+    await seedCountry(testDb!, 'GB', 'United Kingdom');
+    await seedCountry(testDb!, 'US', 'United States');
+    await seedCountry(testDb!, 'FR', 'France');
+    await seedCity(testDb!, { countryCode: 'GB', name: 'Newport' });
+    await seedCity(testDb!, { countryCode: 'US', name: 'Newport' });
+    await seedCity(testDb!, { countryCode: 'FR', name: 'Newport' });
+
+    const res = await supertest(app)
+      .get('/api/cities')
+      .query({ q: 'Newport', country_codes: 'GB' });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(1);
+    expect(res.body[0]).toMatchObject({ name: 'Newport', country_code: 'GB' });
+  });
+
+  // --------------------------------------------------------------
+  // Test 2 — multi-country UNION (GE-20 success criterion #2). Exactly the
+  // brief's example set: GB,FR must return the union of those two, and
+  // nothing from a third declared-absent country (US).
+  // --------------------------------------------------------------
+  it('country_codes=GB,FR returns the union of GB+FR Newports, excluding US (RED on main)', async () => {
+    await seedCountry(testDb!, 'GB', 'United Kingdom');
+    await seedCountry(testDb!, 'FR', 'France');
+    await seedCountry(testDb!, 'US', 'United States');
+    const gb = await seedCity(testDb!, { countryCode: 'GB', name: 'Newport' });
+    const fr = await seedCity(testDb!, { countryCode: 'FR', name: 'Newport' });
+    await seedCity(testDb!, { countryCode: 'US', name: 'Newport' });
+
+    const res = await supertest(app)
+      .get('/api/cities')
+      .query({ q: 'Newport', country_codes: 'GB,FR' });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(2);
+    const ids = res.body.map((r: { id: number }) => r.id).sort();
+    expect(ids).toEqual([gb.id, fr.id].sort());
+    expect(
+      res.body.every((r: { country_code: string }) => ['GB', 'FR'].includes(r.country_code)),
+    ).toBe(true);
+  });
+
+  // --------------------------------------------------------------
+  // Test 4 (cities half) — F1: present-but-EMPTY country_codes must SHOW
+  // ALL (PO Q1 ruling), NOT zero rows. This is the exact input a
+  // zero-country trip's frontend sends ([].join(',') === ''), and it is
+  // the ONE input that trips Drizzle's inArray(col, []) -> sql`false`
+  // footgun the fresh-eyes review flagged (F1). Deliberately DISTINCT from
+  // the absent-param case below (test 5) — an implementer who only
+  // branches on `req.query.country_codes === undefined` and pushes
+  // inArray unconditionally otherwise will pass test 5 but fail THIS one,
+  // silently inverting the PO's ruling.
+  //
+  // NOT RED on main — it passes today VACUOUSLY (main has no filtering
+  // logic at all yet, so "shows all" is trivially true regardless of what
+  // country_codes is set to). It stays in the suite anyway because it is
+  // the ONLY case in this file that would catch the specific F1 naive-
+  // implementation footgun once Brief A lands: an implementer who always
+  // pushes `inArray(cities.countryCode, set)` without branching on
+  // `set.length` would pass tests 1/2/6 (non-empty sets) and pass test 5
+  // (absent — never reaches the inArray branch) while silently returning
+  // ZERO rows here, inverting the PO's Q1 ruling with every other test
+  // still green. Per the BUG-76 ATDD precedent, a test that already holds
+  // on main is documented as a guard, not miscounted as part of the red
+  // bar.
+  // --------------------------------------------------------------
+  it('GUARD (passes today, vacuously) — country_codes="" (present, empty) returns ALL matches unfiltered, SHOW ALL not zero rows; pins the F1 inArray([])->false footgun for Brief A', async () => {
+    await seedCountry(testDb!, 'GB', 'United Kingdom');
+    await seedCountry(testDb!, 'US', 'United States');
+    await seedCountry(testDb!, 'FR', 'France');
+    await seedCity(testDb!, { countryCode: 'GB', name: 'Newport' });
+    await seedCity(testDb!, { countryCode: 'US', name: 'Newport' });
+    await seedCity(testDb!, { countryCode: 'FR', name: 'Newport' });
+
+    const res = await supertest(app).get('/api/cities?q=Newport&country_codes=');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(3);
+  });
+
+  // --------------------------------------------------------------
+  // Test 5 (cities half) — absent country_codes: unchanged/backward
+  // compatible. REGRESSION GUARD — already true on main (the param
+  // doesn't exist yet, so "absent" and "today's behaviour" are the same
+  // thing by construction). Kept as an explicit pin so a future
+  // implementation can't regress it while chasing tests 1/2/4 above.
+  // --------------------------------------------------------------
+  it('REGRESSION GUARD — no country_codes param at all returns every match, unfiltered (already true on main)', async () => {
+    await seedCountry(testDb!, 'GB', 'United Kingdom');
+    await seedCountry(testDb!, 'US', 'United States');
+    await seedCity(testDb!, { countryCode: 'GB', name: 'Newport' });
+    await seedCity(testDb!, { countryCode: 'US', name: 'Newport' });
+
+    const res = await supertest(app).get('/api/cities').query({ q: 'Newport' });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(2);
+  });
+
+  // --------------------------------------------------------------
+  // Test 6 (cities half) — off-country: a name whose only real match is
+  // outside the declared set returns empty (the D4a empty-state trigger;
+  // the empty-state UX itself is Brief B / frontend, out of scope here).
+  // --------------------------------------------------------------
+  it('a name that only exists outside the declared set returns an empty array (RED on main: unfiltered today would return the DE row)', async () => {
+    await seedCountry(testDb!, 'DE', 'Germany');
+    await seedCountry(testDb!, 'GB', 'United Kingdom');
+    await seedCity(testDb!, { countryCode: 'DE', name: 'Berlin' });
+
+    const res = await supertest(app).get('/api/cities').query({ q: 'Berlin', country_codes: 'GB' });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([]);
+  });
+
+  // --------------------------------------------------------------
+  // Test 7 — seam (fresh-eyes F4): the existing single-value D12 create
+  // constraint (POST /api/cities body.country_code) must be completely
+  // unaffected by this GET-path filter feature — separate params, no
+  // interference. Both assertions are REGRESSION GUARDS (true on main
+  // already): (a) create behaviour is untouched; (b) CreateCitySchema is
+  // `.strict()`, so an errant `country_codes` field on the create BODY is
+  // structurally rejected, not silently absorbed — the two concepts
+  // cannot bleed into each other even if a caller tried.
+  // --------------------------------------------------------------
+  describe('REGRESSION GUARD — seam vs the POST /api/cities D12 single country_code create constraint (F4)', () => {
+    it('POST /api/cities with body.country_code (D12) still creates a city scoped to that country, unaffected by the GET country_codes feature', async () => {
+      await seedCountry(testDb!, 'GB', 'United Kingdom');
+
+      const res = await supertest(app)
+        .post('/api/cities')
+        .send({ name: 'Cardiff', country_code: 'GB' });
+
+      expect(res.status).toBe(201);
+      expect(res.body).toMatchObject({ name: 'Cardiff', country_code: 'GB' });
+    });
+
+    it('POST /api/cities rejects an errant country_codes field in the body with 400 (.strict() schema — no cross-talk with the GET-path plural param)', async () => {
+      await seedCountry(testDb!, 'GB', 'United Kingdom');
+
+      const res = await supertest(app)
+        .post('/api/cities')
+        .send({ name: 'Cardiff', country_code: 'GB', country_codes: 'GB,FR' });
+
+      expect(res.status).toBe(400);
+    });
+  });
+});

--- a/src/backend/routes/__tests__/ge20-geocode-country-codes-guards.test.ts
+++ b/src/backend/routes/__tests__/ge20-geocode-country-codes-guards.test.ts
@@ -1,0 +1,148 @@
+/**
+ * GE-20 (BUG-87) — implementation guards for GET /api/geocode?country_codes=...
+ * that QA's ATDD bar (ge20-geocode-country-filter.test.ts) deliberately did
+ * NOT red-test (see jobs/qa/tech/20260808-ge20-atdd-red-tests.md, "Not
+ * added" section): malformed-code rejection and the ~10-code cap are
+ * ADL-54 §4 IMPLEMENTATION DETAILS, not enumerated in QA's 7-item dispatch
+ * list. Backend owns these tests per the dispatch brief.
+ *
+ * Also covers the D2 limit-tier decision: a single-country set keeps
+ * CONSTRAINED_LIMIT, a multi-country set (>=2) uses DISCOVERY_LIMIT —
+ * asserted via the client call args, same pattern as the existing
+ * geocode.test.ts BUG-79 limit-tier tests.
+ *
+ * This is a NEW, backend-owned sibling file — QA's
+ * ge20-geocode-country-filter.test.ts is a frozen ATDD suite and is not
+ * touched here.
+ *
+ * Design: jobs/architect/tech/ADL-54-trip-country-picker-filter.md (D1/D2).
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockUserId = 'ge20-geocode-guards-user-0000-0000-000000000000';
+
+let capturedParams: Record<string, string> | undefined;
+
+vi.mock('../../middleware/auth.js', () => ({
+  requireAuth: (
+    req: import('express').Request,
+    _res: import('express').Response,
+    next: import('express').NextFunction,
+  ) => {
+    (req as import('express').Request & { user?: unknown }).user = {
+      id: mockUserId,
+      clerkId: 'clerk_ge20_geocode_guards',
+      email: 'ge20-geocode-guards@example.com',
+      isOwner: 0,
+    };
+    next();
+  },
+}));
+
+vi.mock('../../services/nominatim-client.js', () => ({
+  nominatimSearch: vi.fn(async (params: Record<string, string>) => {
+    capturedParams = params;
+    return {
+      status: 'ok',
+      candidates: [
+        {
+          displayName: 'Newport, GB',
+          name: 'Newport',
+          latitude: 1,
+          longitude: 1,
+          countryCode: 'GB',
+          regionIso: null,
+        },
+      ],
+      truncated: false,
+    };
+  }),
+}));
+
+const { default: app } = await import('../../server-test-app.js');
+const supertest = (await import('supertest')).default;
+
+describe('GE-20 — GET /api/geocode country_codes: malformed-code and cap guards (ADL-54 §4, not in QA red bar)', () => {
+  beforeEach(() => {
+    capturedParams = undefined;
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('rejects a 3-letter code with 400 (not ISO alpha-2 shape)', async () => {
+    const res = await supertest(app)
+      .get('/api/geocode')
+      .query({ q: 'Newport', country_codes: 'GBR' });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects a numeric code with 400', async () => {
+    const res = await supertest(app)
+      .get('/api/geocode')
+      .query({ q: 'Newport', country_codes: '12' });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects one malformed code even alongside otherwise-valid ones', async () => {
+    const res = await supertest(app)
+      .get('/api/geocode')
+      .query({ q: 'Newport', country_codes: 'GB,XYZ' });
+    expect(res.status).toBe(400);
+  });
+
+  it('ADL-54 D2: rejects a set of 11 distinct codes (over the ~10 cap) with 400', async () => {
+    const codes = ['AA', 'BB', 'CC', 'DD', 'EE', 'FF', 'GG', 'HH', 'II', 'JJ', 'KK'].join(',');
+    const res = await supertest(app)
+      .get('/api/geocode')
+      .query({ q: 'Newport', country_codes: codes });
+    expect(res.status).toBe(400);
+  });
+
+  it('ADL-54 D2: accepts a set of exactly 10 distinct codes (at the cap) and forwards all 10', async () => {
+    const codes = ['GB', 'BB', 'CC', 'DD', 'EE', 'FF', 'GG', 'HH', 'II', 'JJ'];
+    const res = await supertest(app)
+      .get('/api/geocode')
+      .query({ q: 'Newport', country_codes: codes.join(',') });
+    expect(res.status).toBe(200);
+    expect(capturedParams?.countrycodes).toBe(codes.map((c) => c.toLowerCase()).join(','));
+  });
+
+  // ----------------------------------------------------------------
+  // D2 limit tier — single-country set keeps CONSTRAINED_LIMIT (10);
+  // multi-country set (>=2) uses DISCOVERY_LIMIT (40).
+  // ----------------------------------------------------------------
+  it('D2: a single-country country_codes set uses CONSTRAINED_LIMIT (10), same as the existing single country_code path', async () => {
+    const res = await supertest(app)
+      .get('/api/geocode')
+      .query({ q: 'Newport', country_codes: 'GB' });
+    expect(res.status).toBe(200);
+    expect(capturedParams?.limit).toBe('10');
+    expect(capturedParams?.countrycodes).toBe('gb');
+  });
+
+  it('D2: a multi-country country_codes set uses DISCOVERY_LIMIT (40)', async () => {
+    const res = await supertest(app)
+      .get('/api/geocode')
+      .query({ q: 'Newport', country_codes: 'GB,FR' });
+    expect(res.status).toBe(200);
+    expect(capturedParams?.limit).toBe('40');
+    expect(capturedParams?.countrycodes).toBe('gb,fr');
+  });
+
+  // ----------------------------------------------------------------
+  // Precedence when both country_code (singular) and country_codes
+  // (plural) are present — the ADL states this contract for /api/geocode
+  // (D1: single wins).
+  // ----------------------------------------------------------------
+  it('precedence — the single country_code wins over country_codes when both are present', async () => {
+    const res = await supertest(app)
+      .get('/api/geocode')
+      .query({ q: 'Newport', country_code: 'gb', country_codes: 'FR,US' });
+    expect(res.status).toBe(200);
+    expect(capturedParams?.countrycodes).toBe('gb');
+    expect(capturedParams?.limit).toBe('10');
+  });
+});

--- a/src/backend/routes/__tests__/ge20-geocode-country-filter.test.ts
+++ b/src/backend/routes/__tests__/ge20-geocode-country-filter.test.ts
@@ -1,0 +1,193 @@
+/**
+ * GE-20 (BUG-87) — ATDD RED bar for the trip-country-scoped picker's
+ * geocode-discovery half: GET /api/geocode?q=...&country_codes=...
+ *
+ * Design: jobs/architect/tech/ADL-54-trip-country-picker-filter.md (D1/D2/D3).
+ * Fresh-eyes review: jobs/architect/tech/20260808-ADL54-fresh-eyes-review.md
+ * (F1 — the empty-set footgun; P2 — Nominatim's real multi-code comma-list
+ * behaviour is UNVERIFIED from this environment, see the mock-fidelity note
+ * below).
+ * BRD: GE-20 (approved v3.21).
+ *
+ * MOCK BOUNDARY: mocks `nominatimSearch` at the SERVICE boundary (matching
+ * the existing, accepted pattern in geocode.test.ts / bug76-geocode-
+ * contract.test.ts — NOT the `fetch` boundary; bug76-geocode-e2e.test.ts
+ * already owns the real-fetch/real-parse path and this file has no reason
+ * to duplicate it).
+ *
+ * MOCK-FIDELITY (QUAL-22, fresh-eyes-flagged): the geocode ROUTE (geocode.ts)
+ * does no country filtering itself — it only forwards `countrycodes` to
+ * nominatimSearch and returns whatever comes back. The pre-existing double in
+ * geocode.test.ts (BUG-79) is a dumb capture-and-return stub: it records the
+ * params it was called with but returns a FIXED candidate list regardless of
+ * `countrycodes` — faithful enough for BUG-79 (which only asserts on
+ * `limit`), but a double that ignores `countrycodes` here would make every
+ * outcome-based assertion below (tests 3/4/6) pass VACUOUSLY: the response
+ * would be "correct" only because the double never modelled filtering, not
+ * because the route correctly wired the param through. So THIS file's double
+ * is deliberately smarter: it holds a small candidate POOL (three countries'
+ * worth of "Newport", one lone "Berlin") and applies `countrycodes` as an
+ * allow-list filter against it, exactly mirroring Nominatim's documented
+ * `countrycodes` narrowing behaviour (comma-separated ISO codes, case-
+ * insensitive). It still captures the raw call params too, so test 3 can
+ * assert on the CLIENT ARGS directly, not just the filtered outcome.
+ *
+ * HONEST LIMIT (carried from the fresh-eyes review's P2, non-blocking): this
+ * models what Nominatim's docs say `countrycodes` does — it is NOT a live
+ * probe of the real service (this container's firewall blocks reaching it,
+ * same constraint geocode.test.ts's own docstring already states). It proves
+ * the ROUTE wires `country_codes` -> `countrycodes` correctly and reacts
+ * correctly to a filtered/unfiltered client response; it cannot prove
+ * Nominatim itself honours a multi-code comma list. The fresh-eyes review's
+ * recommendation (an early real multi-country geocode check against staging)
+ * is carried forward in this thread's completion report, not answered here.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockUserId = 'ge20-geocode-user-0000-0000-000000000000';
+
+let capturedParams: Record<string, string> | undefined;
+
+/** A tiny fixture pool: three countries' "Newport" plus one lone "Berlin". */
+const POOL: Array<{ name: string; countryCode: string }> = [
+  { name: 'Newport', countryCode: 'GB' },
+  { name: 'Newport', countryCode: 'FR' },
+  { name: 'Newport', countryCode: 'US' },
+  { name: 'Berlin', countryCode: 'DE' },
+];
+
+function toCandidate(p: { name: string; countryCode: string }) {
+  return {
+    displayName: `${p.name}, ${p.countryCode}`,
+    name: p.name,
+    latitude: 1,
+    longitude: 1,
+    countryCode: p.countryCode,
+    regionIso: null,
+  };
+}
+
+vi.mock('../../middleware/auth.js', () => ({
+  requireAuth: (
+    req: import('express').Request,
+    _res: import('express').Response,
+    next: import('express').NextFunction,
+  ) => {
+    (req as import('express').Request & { user?: unknown }).user = {
+      id: mockUserId,
+      clerkId: 'clerk_ge20_geocode',
+      email: 'ge20-geocode@example.com',
+      isOwner: 0,
+    };
+    next();
+  },
+}));
+
+// Fidelity-extended double (see file header) — applies `countrycodes` as a
+// real allow-list filter against POOL, matching Nominatim's documented
+// behaviour, instead of ignoring the param the way the BUG-79 double does.
+vi.mock('../../services/nominatim-client.js', () => ({
+  nominatimSearch: vi.fn(async (params: Record<string, string>) => {
+    capturedParams = params;
+    const q = (params.q ?? '').toLowerCase();
+    let matches = POOL.filter((c) => c.name.toLowerCase().includes(q));
+    if (params.countrycodes) {
+      const allowed = new Set(
+        params.countrycodes
+          .split(',')
+          .map((c) => c.trim().toLowerCase())
+          .filter(Boolean),
+      );
+      matches = matches.filter((c) => allowed.has(c.countryCode.toLowerCase()));
+    }
+    return { status: 'ok', candidates: matches.map(toCandidate), truncated: false };
+  }),
+}));
+
+const { default: app } = await import('../../server-test-app.js');
+const supertest = (await import('supertest')).default;
+
+describe('GE-20 — GET /api/geocode country_codes hard filter (discovery lookup)', () => {
+  beforeEach(() => {
+    capturedParams = undefined;
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // --------------------------------------------------------------
+  // Test 3 — the nominatim-client receives countrycodes=gb,fr, asserted on
+  // the CLIENT ARGS (not just the response). Also proves the multi-country
+  // UNION at the geocode endpoint (GE-20 criterion #2 applies to BOTH
+  // lookups, not just the DB search) — GB+FR come back, US does not.
+  // RED on main: geocode.ts today never reads req.query.country_codes, so
+  // capturedParams.countrycodes stays undefined and all 3 Newports return.
+  // --------------------------------------------------------------
+  it('country_codes=GB,FR is forwarded to nominatimSearch as countrycodes=gb,fr, and the response is the GB+FR union (no US)', async () => {
+    const res = await supertest(app)
+      .get('/api/geocode')
+      .query({ q: 'Newport', country_codes: 'GB,FR' });
+
+    expect(res.status).toBe(200);
+    expect(capturedParams).toBeDefined();
+    expect(capturedParams?.countrycodes).toBe('gb,fr');
+
+    expect(res.body.candidates).toHaveLength(2);
+    const countries = res.body.candidates
+      .map((c: { country_code: string }) => c.country_code)
+      .sort();
+    expect(countries).toEqual(['FR', 'GB']);
+  });
+
+  // --------------------------------------------------------------
+  // Test 4 (geocode half) — F1: present-but-EMPTY country_codes must SHOW
+  // ALL (no countrycodes forwarded at all), NOT an empty/degenerate
+  // request. Distinct from the absent-param case (test 5).
+  //
+  // NOT RED on main — passes today vacuously (geocode.ts never reads
+  // country_codes at all yet, so capturedParams.countrycodes is undefined
+  // regardless of what's sent). Kept for the same reason as its cities-
+  // file twin: it is the one case that catches an implementer who
+  // forwards `countrycodes = country_codes` unconditionally instead of
+  // branching on a non-empty set — that naive version would forward
+  // `countrycodes=` (empty string) to nominatimSearch, which this double
+  // (and real Nominatim) would treat as "match no country", silently
+  // inverting the SHOW-ALL ruling with tests 3/5/6 unaffected.
+  // --------------------------------------------------------------
+  it('GUARD (passes today, vacuously) — country_codes="" (present, empty) forwards NO countrycodes param and returns every Newport unfiltered; pins the F1 footgun on the geocode path', async () => {
+    const res = await supertest(app).get('/api/geocode?q=Newport&country_codes=');
+
+    expect(res.status).toBe(200);
+    expect(capturedParams?.countrycodes).toBeUndefined();
+    expect(res.body.candidates).toHaveLength(3);
+  });
+
+  // --------------------------------------------------------------
+  // Test 5 (geocode half) — absent country_codes: unconstrained DISCOVERY
+  // path unchanged. REGRESSION GUARD — already true on main.
+  // --------------------------------------------------------------
+  it('REGRESSION GUARD — no country_codes param at all leaves the discovery lookup unconstrained (already true on main)', async () => {
+    const res = await supertest(app).get('/api/geocode').query({ q: 'Newport' });
+
+    expect(res.status).toBe(200);
+    expect(capturedParams?.countrycodes).toBeUndefined();
+    expect(res.body.candidates).toHaveLength(3);
+  });
+
+  // --------------------------------------------------------------
+  // Test 6 (geocode half) — off-country: a name whose only real match
+  // (Berlin, DE) is outside the declared set (GB) returns an empty
+  // candidate list from the API. RED on main: today's unfiltered call
+  // returns the DE candidate regardless of country_codes.
+  // --------------------------------------------------------------
+  it('a name whose only match is outside the declared set returns candidates:[] (RED on main: unfiltered today returns the DE Berlin candidate)', async () => {
+    const res = await supertest(app)
+      .get('/api/geocode')
+      .query({ q: 'Berlin', country_codes: 'GB' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.candidates).toEqual([]);
+  });
+});

--- a/src/backend/routes/cities.ts
+++ b/src/backend/routes/cities.ts
@@ -44,13 +44,34 @@ citiesRouter.get(
   '/',
   validateQuery(SearchCitiesQuerySchema),
   asyncHandler(async (req, res) => {
-    const { q, country_code } = req.query as { q: string; country_code?: string };
+    const { q, country_code, country_codes } = req.query as {
+      q: string;
+      country_code?: string;
+      country_codes?: string[];
+    };
     const userId = req.user!.id;
 
     const db = getDb();
 
     const conditions = [like(cities.name, `%${q}%`)];
-    if (country_code) conditions.push(eq(cities.countryCode, country_code));
+    // GE-20 (ADL-54 D1/D2, fresh-eyes F4): country_code (singular, D12) and
+    // country_codes (plural, the trip filter SET) are separate params.
+    // Cities-path precedence contract (F4 — unspecified by the ADL, stated
+    // here per the fresh-eyes recommendation): the single explicit
+    // country_code wins when both are present, matching the geocode-path
+    // precedence D1 already states. No current caller sends both (verified:
+    // useCities.ts sends only `q`), so this branch is defensive totality,
+    // not a live path.
+    if (country_code) {
+      conditions.push(eq(cities.countryCode, country_code));
+    } else if (country_codes && country_codes.length > 0) {
+      // F1 (fresh-eyes, load-bearing): only push inArray when the set is
+      // NON-EMPTY. A present-but-empty country_codes ('' -> []) means
+      // "not yet constrained" (PO Q1 ruling) and must fall through to no
+      // filter at all — inArray(col, []) compiles to SQL `false`, which
+      // would silently return zero rows and invert that ruling.
+      conditions.push(inArray(cities.countryCode, country_codes));
+    }
 
     // ADL-46 GE-16 / D5 containment (§4.4): a 'pending' city is visible only in
     // its creator's own searches; it becomes globally visible once 'resolved'.

--- a/src/backend/routes/geocode.ts
+++ b/src/backend/routes/geocode.ts
@@ -70,17 +70,42 @@ geocodeRouter.get(
   '/',
   validateQuery(GeocodeQuerySchema),
   asyncHandler(async (req, res) => {
-    const { q, country_code, region_iso } = req.query as {
+    const { q, country_code, region_iso, country_codes } = req.query as {
       q: string;
       country_code?: string;
       region_iso?: string;
+      country_codes?: string[];
     };
 
+    // GE-20 (ADL-54 D1/D2): country_code (singular, D12 create-time constraint)
+    // and country_codes (plural, the trip's declared filter SET) are separate
+    // params. Precedence when both are present (D1): the single explicit
+    // country_code wins (narrower, user-confirmed) — never hit by any current
+    // caller (discovery supplies the set, create supplies the single), but the
+    // contract is stated so it's total.
+    //
+    // F1 (fresh-eyes, load-bearing): only forward `countrycodes` when the set
+    // is NON-EMPTY. A present-but-empty country_codes ('' -> []) means
+    // "not yet constrained" (PO Q1 ruling) and must fall through to the fully
+    // unconstrained DISCOVERY path — forwarding `countrycodes=` (empty string)
+    // would tell Nominatim "match no country", silently inverting that ruling.
+    const effectiveCodes = country_code
+      ? [country_code]
+      : country_codes && country_codes.length > 0
+        ? country_codes
+        : null;
+
+    // D2 limit tier: a single-country set keeps the original narrow
+    // CONSTRAINED_LIMIT (countrycodes already restricts the search space to
+    // one country). A multi-country set (>=2) uses DISCOVERY_LIMIT instead —
+    // more countries means more legitimate same-name candidates to separate
+    // in the picker, the same reasoning BUG-79 already established for the
+    // fully-unconstrained case.
     const params: Record<string, string> = {
       q,
-      limit: country_code ? CONSTRAINED_LIMIT : DISCOVERY_LIMIT,
+      limit: effectiveCodes && effectiveCodes.length === 1 ? CONSTRAINED_LIMIT : DISCOVERY_LIMIT,
     };
-    if (country_code) params.countrycodes = country_code.toLowerCase();
+    if (effectiveCodes) params.countrycodes = effectiveCodes.join(',').toLowerCase();
 
     const result = await nominatimSearch(params);
     let candidates = result.status === 'ok' ? result.candidates : [];

--- a/src/backend/validation/__tests__/common.test.ts
+++ b/src/backend/validation/__tests__/common.test.ts
@@ -11,6 +11,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   zCountryCode,
+  zCountryCodesList,
   zHexColor,
   zId,
   zIsoDate,
@@ -179,6 +180,76 @@ describe('zCountryCode', () => {
 
   it('rejects a single letter', () => {
     fails(zCountryCode, 'F');
+  });
+});
+
+// ----------------------------------------------------------------
+// zCountryCodesList (GE-20, ADL-54 D1/D2 — implementation guards QA's ATDD
+// bar did not red-test: malformed-code rejection and the ~10-code cap. The
+// SHOW-ALL-on-empty / branch-on-length behaviour itself (F1) is proven at
+// the route level in ge20-cities-country-filter.test.ts /
+// ge20-geocode-country-filter.test.ts — this file covers the schema's own
+// parsing contract in isolation.)
+// ----------------------------------------------------------------
+
+describe('zCountryCodesList', () => {
+  it('accepts undefined (param absent)', () => {
+    expect(passes(zCountryCodesList, undefined)).toBeUndefined();
+  });
+
+  it('parses an empty string to an empty array (param present but empty — distinct from absent)', () => {
+    expect(passes(zCountryCodesList, '')).toEqual([]);
+  });
+
+  it('parses a single code, upcasing it', () => {
+    expect(passes(zCountryCodesList, 'gb')).toEqual(['GB']);
+  });
+
+  it('parses a comma-joined multi-code list', () => {
+    expect(passes(zCountryCodesList, 'gb,fr,us')).toEqual(['GB', 'FR', 'US']);
+  });
+
+  it('trims whitespace around each code', () => {
+    expect(passes(zCountryCodesList, ' gb , fr ')).toEqual(['GB', 'FR']);
+  });
+
+  it('deduplicates case-insensitively', () => {
+    expect(passes(zCountryCodesList, 'gb,GB,Gb')).toEqual(['GB']);
+  });
+
+  it('ADL-54 D2: accepts exactly 10 distinct codes (the cap)', () => {
+    const codes = ['AA', 'BB', 'CC', 'DD', 'EE', 'FF', 'GG', 'HH', 'II', 'JJ'];
+    expect(passes(zCountryCodesList, codes.join(','))).toEqual(codes);
+  });
+
+  it('ADL-54 D2: rejects 11 distinct codes (over the cap)', () => {
+    const codes = ['AA', 'BB', 'CC', 'DD', 'EE', 'FF', 'GG', 'HH', 'II', 'JJ', 'KK'];
+    fails(zCountryCodesList, codes.join(','));
+  });
+
+  it('does not count duplicate codes against the cap (11 raw entries, 1 distinct)', () => {
+    const codes = Array(11).fill('GB');
+    expect(passes(zCountryCodesList, codes.join(','))).toEqual(['GB']);
+  });
+
+  it('rejects a 3-letter code (not ISO alpha-2 shape)', () => {
+    fails(zCountryCodesList, 'gb,fra');
+  });
+
+  it('rejects a single-letter code', () => {
+    fails(zCountryCodesList, 'g');
+  });
+
+  it('rejects a numeric code', () => {
+    fails(zCountryCodesList, '12');
+  });
+
+  it('rejects a trailing comma (empty entry in the middle of a real list)', () => {
+    fails(zCountryCodesList, 'gb,');
+  });
+
+  it('rejects one malformed code even alongside otherwise-valid ones', () => {
+    fails(zCountryCodesList, 'gb,fr,xyz');
   });
 });
 

--- a/src/backend/validation/cities.schemas.ts
+++ b/src/backend/validation/cities.schemas.ts
@@ -3,7 +3,7 @@
  */
 
 import { z } from 'zod';
-import { zCountryCode } from './common.js';
+import { zCountryCode, zCountryCodesList } from './common.js';
 
 /** BUG-75 v3 §2.3/§B1 — the carried OSM identity pair. */
 const zOsmType = z.enum(['node', 'way', 'relation']);
@@ -34,6 +34,12 @@ export const CreateCitySchema = z
 export const SearchCitiesQuerySchema = z.object({
   q: z.string().trim().min(2, 'Search query must be at least 2 characters'),
   country_code: zCountryCode.optional(),
+  // GE-20 (ADL-54 D1) — the trip's declared country filter SET, distinct from
+  // the single country_code above. Cities-path precedence contract (fresh-eyes
+  // F4, never hit by any current caller — grep-verified): if BOTH are present,
+  // the single explicit country_code wins (narrower, matches the geocode-path
+  // precedence D1 already states) and country_codes is ignored entirely.
+  country_codes: zCountryCodesList,
 });
 
 export const CityItemsQuerySchema = z.object({

--- a/src/backend/validation/common.ts
+++ b/src/backend/validation/common.ts
@@ -33,6 +33,56 @@ export const zRating = z.number().int().min(1).max(5);
 /** ISO 3166-1 alpha-2 country code */
 export const zCountryCode = z.string().trim().length(2).toUpperCase();
 
+/**
+ * GE-20 (ADL-54 D1) — a comma-joined list of ISO 3166-1 alpha-2 country codes,
+ * e.g. "gb,fr". Distinct from `zCountryCode` (the single D12 create-time
+ * constraint / geocode narrow-by-one param) — this is the trip's declared
+ * FILTER SET, a different semantic (ADL-54 D1).
+ *
+ * Parses `undefined` -> `undefined` (param absent — caller must treat as
+ * unconstrained) and `''` -> `[]` (param present but EMPTY — ALSO
+ * unconstrained; this is the exact input a zero-country trip's frontend
+ * sends, `[].join(',') === ''`). Both are distinct from a non-empty array,
+ * which is the actual hard-filter set. Callers MUST branch on
+ * `set.length > 0` before pushing an `inArray`/`countrycodes` constraint —
+ * `inArray(col, [])` compiles to SQL `false`, silently inverting the PO's
+ * Q1 SHOW-ALL ruling for a zero-country trip (ADL-54 fresh-eyes F1).
+ *
+ * Each code must be ISO alpha-2 shape (2 letters) — a malformed code is a
+ * 400, never silently dropped or passed through. Deduplicated
+ * case-insensitively, then capped at 10 distinct codes (ADL-54 D2 — a trip
+ * realistically spans a handful; the cap bounds both the Nominatim
+ * `countrycodes` param length and the DB `IN` list).
+ */
+export const zCountryCodesList = z
+  .string()
+  .optional()
+  .transform((val, ctx): string[] | undefined => {
+    if (val === undefined) return undefined;
+    if (val === '') return [];
+    const codes: string[] = [];
+    for (const raw of val.split(',')) {
+      const code = raw.trim();
+      if (!/^[A-Za-z]{2}$/.test(code)) {
+        ctx.addIssue({
+          code: 'custom',
+          message: `country_codes: "${code}" is not a valid ISO 3166-1 alpha-2 country code`,
+        });
+        return z.NEVER;
+      }
+      codes.push(code.toUpperCase());
+    }
+    const deduped = Array.from(new Set(codes));
+    if (deduped.length > 10) {
+      ctx.addIssue({
+        code: 'custom',
+        message: 'country_codes: at most 10 distinct country codes are accepted',
+      });
+      return z.NEVER;
+    }
+    return deduped;
+  });
+
 /** Item type enum */
 export const zItemType = z.enum([
   'restaurant',

--- a/src/backend/validation/geocode.schemas.ts
+++ b/src/backend/validation/geocode.schemas.ts
@@ -3,7 +3,7 @@
  */
 
 import { z } from 'zod';
-import { zCountryCode } from './common.js';
+import { zCountryCode, zCountryCodesList } from './common.js';
 
 export const GeocodeQuerySchema = z.object({
   q: z.string().trim().min(2, 'Search query must be at least 2 characters'),
@@ -12,4 +12,8 @@ export const GeocodeQuerySchema = z.object({
   country_code: zCountryCode.optional(),
   // Optional ISO 3166-2 subdivision (e.g. 'US-CO') to prefer a region (D12 step 2).
   region_iso: z.string().trim().min(2).optional(),
+  // GE-20 (ADL-54 D1) — the trip's declared country filter SET, distinct from
+  // the single country_code above (the D12 create-time constraint). Precedence
+  // when both are present (ADL-54 D1): the single country_code wins.
+  country_codes: zCountryCodesList,
 });


### PR DESCRIPTION
Closes #BUG-87 (partial — this PR is the ATDD handoff, not the fix)
BRD §5.1 GE-20 (approved v3.21)

## What this is

Per OP-35 (ATDD-first), QA authors the RED acceptance/integration tests for
GE-20's success criteria + the ADL-54 fresh-eyes review's F1/F2 edge cases
BEFORE Backend implements Brief A, so Backend cannot write its own
certifying tests. This PR is that ATDD bar.

**CI will show the new tests FAILING — that is expected and correct.**
5 of 11 new assertions are RED against `main` by design; do not merge this
PR alone. Backend implements against this branch until all 11 pass, then
the PR is retitled/updated for the real merge.

## Files

- `src/backend/routes/__tests__/ge20-cities-country-filter.test.ts` —
  `GET /api/cities?country_codes=` (real migration-backed test DB)
- `src/backend/routes/__tests__/ge20-geocode-country-filter.test.ts` —
  `GET /api/geocode?country_codes=` (fidelity-extended nominatim-client
  double, QUAL-22 — filters a candidate pool by `countrycodes` like the
  real client, not a dumb capture-and-return stub)

## Result against main

```
Test Files  2 failed (2)
     Tests  5 failed | 6 passed (11)
```

5 RED for the right reason (clean AssertionErrors — wrong row/candidate
counts, no import/exception noise): single-country narrow, multi-country
union, off-country-empty (×2, one per endpoint), geocode client-args +
union. 6 pass — 4 genuine regression guards (absent-param backward-compat,
the F4 seam vs the POST /api/cities D12 single `country_code` create
constraint) and 2 F1 empty-string guards that pass **vacuously** today
(no filtering exists yet to trip the footgun) but are kept and labelled
honestly — they're the only cases that will catch a naive
`inArray(col, [])`-always-pushed implementation once Brief A lands
(fresh-eyes F1: would silently invert the PO's Q1 SHOW-ALL ruling).

Full backend suite: 768 passed, 5 failed (exactly these), 0 regressions.
`type:check:backend` clean. `biome check` clean.

Full breakdown + design rationale:
`jobs/qa/tech/20260808-ge20-atdd-red-tests.md`

## Noted gaps (flagged, not silently added to the bar)

1. ADL-54 recommends schema-level rejection of invalid `country_codes`
   values and a ~10-code cap as Brief A implementation details — neither
   was in the dispatch's enumerated 7-item test list, so neither is
   red-tested here.
2. Fresh-eyes P2 (non-blocking): Nominatim's real multi-country
   `countrycodes` behaviour is UNVERIFIED from this environment (firewall).
   The geocode double models documented behaviour, not a live probe.
   Recommend an early real multi-country geocode check against staging
   before UAT trusts this feature.