### PR TITLE
fix: stale firewall allowlist in CLAUDE.md (root of recurring 'X is blocked')

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -469,7 +469,14 @@ input to weigh, not as a settled recommendation to rubber-stamp.
 ## Environment
 - Running inside a devcontainer (Docker) — workspace at `/workspace`
 - Claude config dir: `/home/node/.claude`
-- Firewall allows: GitHub, npm registry, Anthropic API only
+- Firewall: outbound egress is restricted, but the **canonical allowlist is
+  `.devcontainer/init-firewall.sh`** — do not enumerate it here (this line spent months
+  claiming "GitHub, npm, Anthropic only" while ADL-33/34/49 had already added **Turso,
+  Railway and Nominatim**; the enumeration rotted and agents inherited a false "X is
+  blocked"). Reachability is **point-in-time, not a fact** — the allowlist is IP-matched
+  (QUAL-28) and egress intermittently drops and self-heals — so **probe before declaring
+  any host unreachable**, and never inherit a "firewall blocks X" claim from a doc, a code
+  comment, or another agent. The negative-findings two-probe rule binds here specifically.
 - `.env.local` holds secrets — never commit it
 
 ## Schema changes (Drizzle ORM)


### PR DESCRIPTION
PO-surfaced: agents keep declaring hosts firewall-blocked without probing because they READ a stale claim on init. CLAUDE.md said "Firewall allows: GitHub, npm registry, Anthropic API only" — rotted across ADL-33/34/49 (real allowlist = 14 hosts incl Nominatim/Railway/Turso). Replaced the rotting enumeration with a pointer to the canonical `.devcontainer/init-firewall.sh` + the re-probe discipline.

Code-comment siblings (geocode.ts:43 — the exact comment the BUG-87 reviewer cited; build-info.ts:27; CODEBASE.md:468) will be swept right after the live BUG-87 backend PR (#466) merges, to avoid a geocode.ts collision. Memory recorded so agents probe instead of inherit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)