### PR TITLE
fix: remove stale firewall-block claims + drop unsupported 'intermittent' story

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -469,14 +469,7 @@ input to weigh, not as a settled recommendation to rubber-stamp.
 ## Environment
 - Running inside a devcontainer (Docker) — workspace at `/workspace`
 - Claude config dir: `/home/node/.claude`
-- Firewall: outbound egress is restricted, but the **canonical allowlist is
-  `.devcontainer/init-firewall.sh`** — do not enumerate it here (this line spent months
-  claiming "GitHub, npm, Anthropic only" while ADL-33/34/49 had already added **Turso,
-  Railway and Nominatim**; the enumeration rotted and agents inherited a false "X is
-  blocked"). Reachability is **point-in-time, not a fact** — the allowlist is IP-matched
-  (QUAL-28) and egress intermittently drops and self-heals — so **probe before declaring
-  any host unreachable**, and never inherit a "firewall blocks X" claim from a doc, a code
-  comment, or another agent. The negative-findings two-probe rule binds here specifically.
+- Firewall: egress is restricted; the allowlist is `.devcontainer/init-firewall.sh` (the canonical source — never enumerate it elsewhere, it rots). A "host X is blocked" report is almost always an **untried or mis-run probe, not a fact** — probe it yourself (one well-behaved request) before believing it, and never inherit a firewall-block claim from a doc, comment, or another agent.
 - `.env.local` holds secrets — never commit it
 
 ## Schema changes (Drizzle ORM)

--- a/src/backend/routes/geocode.ts
+++ b/src/backend/routes/geocode.ts
@@ -39,10 +39,10 @@
  * restricts Nominatim's search space.
  *
  * 40 was chosen for the discovery limit as a meaningfully larger, but not
- * extreme, value. Nominatim's actual maximum `limit` is UNVERIFIED from this
- * environment — the firewall blocks reaching the service directly, and this
- * session made three independent failed attempts (see the brief for GitHub
- * #379). The code does not assume 40 is honoured: `truncated` below is
+ * extreme, value. Nominatim's actual maximum `limit` is not asserted here — do
+ * NOT assume Nominatim is unreachable from this environment: it is allowlisted
+ * (`.devcontainer/init-firewall.sh`) and reachable; probe if you need to confirm
+ * a limit. The code does not assume 40 is honoured regardless: `truncated` below is
  * computed against whatever was actually requested, and everything downstream
  * (settlement filtering, D14 narrowing) already handles an arbitrary
  * candidate count. If the real cap is lower, Nominatim simply returns fewer

--- a/src/backend/services/build-info.ts
+++ b/src/backend/services/build-info.ts
@@ -24,8 +24,8 @@
  *                                  layer: the Railway service-variable API does not
  *                                  enumerate platform-injected variables, so their presence
  *                                  at RUNTIME could not be confirmed from inside the
- *                                  devcontainer (the deployed origin is firewall-blocked
- *                                  here). If step 2 turns out to be empty at runtime, the
+ *                                  devcontainer — confirming it would require running
+ *                                  inside the deployed process. If step 2 turns out to be empty at runtime, the
  *                                  build-time capture still answers the question.
  *   4. `null`                    — reported honestly as 'unknown'. Never a stale hardcoded
  *                                  value, which would be worse than no value at all.


### PR DESCRIPTION
PO-directed. (1) CLAUDE.md → single-line pointer to init-firewall.sh + 'probe before believing blocked' (dropped the enumerated allowlist and the unverified 'egress intermittently self-heals' claim). (2) Deleted the stale 'firewall blocks X' assertions in geocode.ts:43 and build-info.ts:27. Memories corrected. CODEBASE.md:468 (Clerk JWKS) deferred to a separate probe — won't assert reachability without testing.

Comment/doc-only; no logic change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)