### PR TITLE
feat(BUG-87): GE-20 — thread trip-country filter into the add-place picker

### DIFF
--- a/jobs/COO/inbox/20260808_2500-FRONTEND-bug87-ge20-brief-b-complete.txt
+++ b/jobs/COO/inbox/20260808_2500-FRONTEND-bug87-ge20-brief-b-complete.txt
@@ -1,0 +1,40 @@
+Tracker: BUG-87 / GE-20 · PR #469 · BRD §5.1 GE-20 (v3.21) · Branch: feat/bug87-ge20-picker-country-filter
+
+WHAT WAS BUILT
+Brief B (final BUG-87 build piece): threaded trip.countries into AddPlaceFlow
+(the single shared component behind both TripDetail (desktop) and
+MobileTripDetailView (mobile)) so useCitySearch and lookupCityCountry always
+send the trip's declared country_codes on both lookup paths, plus the
+filtered-by note, zero-country prompt, and off-country empty-state UI.
+
+ACCEPTANCE CRITERIA
+- country_codes sent on BOTH /api/cities and /api/geocode lookups: PASS
+- Visible "filtered by trip's countries" note: PASS ("Filtered to: ...",
+  truncated per Q3)
+- Zero-country trip -> show-all + prompt to add countries (Q1): PASS
+- Off-country search -> empty-state linking trip's country editor (Q2): PASS
+  (reuses existing TripForm edit modal, not a new editor)
+- F2 test pinning the param is sent on both paths (mandatory): PASS
+  (AddPlaceFlow.ge20-country-filter.test.tsx + hook-level tests)
+- Full frontend suite green: PASS (388/388, +23 new)
+
+CI: gh pr checks 469 — all 18 checks green (scripts/ci-wait.sh pr 469 -> PASS)
+
+OPEN ISSUES / BLOCKERS (flagged, not fixed — see PR description + park doc)
+1. ChangeCityModal's re-point city-search is NOT filtered — GE-20's text and
+   ADL-54 D6 both scope this to "adding a place," a different operation.
+2. The "+Add new" city-creation form's manual country <select> is NOT
+   restricted to the trip's declared set — a narrow, real way the "cannot be
+   bypassed from within the picker" criterion could still be circumvented
+   (manual creation in any country). Neither ADL-54 nor the fresh-eyes review
+   scoped "the picker" to include this manual fallback, so left as-is;
+   flagging for a COO/PO scope call, not assumed either way.
+3. Carried forward from the ADL-54 fresh-eyes review (not this thread's to
+   close): Nominatim's real multi-country `countrycodes` behaviour is
+   UNVERIFIED from this sandboxed container — worth an early real
+   multi-country geocode check on staging before UAT fully trusts this.
+
+WHAT IS NOW UNBLOCKED
+GE-20's full BRD success-criteria list is built end-to-end (backend Brief A +
+frontend Brief B) — ready for a UAT pass once merged. BUG-87 tracker status
+flip to done/done_pending_uat is COO's job at merge, per standing pattern.

--- a/jobs/frontend/context/current.txt
+++ b/jobs/frontend/context/current.txt
@@ -1,3 +1,117 @@
+FRONTEND CONTEXT — as of 2026-08-08 (BUG-87/GE-20 Brief B — trip-country
+picker filter, feat/bug87-ge20-picker-country-filter branch, PR #469)
+
+STATUS: feat/bug87-ge20-picker-country-filter branch off main, PR #469 open,
+  CI green (18/18 checks — scripts/ci-wait.sh pr 469 → PASS). Brief B, the
+  final BUG-87 build piece — the backend contract (Brief A, country_codes on
+  GET /api/cities and GET /api/geocode) was already merged to main before
+  this thread started. Governing docs: jobs/architect/tech/ADL-54-trip-
+  country-picker-filter.md (design + COO Q1/Q2/Q3 adjudication) and
+  jobs/architect/tech/20260808-ADL54-fresh-eyes-review.md (F1/F2 findings).
+  Full detail in the 2026-08-08 (this thread) park doc.
+
+  WHAT WAS BUILT: threaded trip.countries into AddPlaceFlow.tsx (the ONE
+  shared component both TripDetail.tsx (desktop) and MobileTripDetailView.tsx
+  (mobile) render — there is no separate "mobile twin" component, just two
+  call sites) so useCitySearch and lookupCityCountry both ALWAYS send the
+  trip's declared country_codes, present-but-empty for a zero-country trip
+  (backend's documented unconstrained contract, PO Q1). New AddPlaceFlow
+  props: tripCountries ({country_code, name}[], sourced straight off
+  trip.countries — already on the payload, no extra fetch) and
+  onManageCountries (closes the flow, opens the existing TripForm edit modal
+  — the "trip country editor" GE-20 refers to — via a new
+  useTripDetailController.handleManageCountries handler shared by both call
+  sites, reused rather than building a second editor).
+
+  UI: a "Filtered to: United Kingdom, France +2" note above the search input
+  (Q3 copy, truncated via new shared util formatCountriesFilterNote.ts) when
+  the trip has declared countries; a "no countries yet" unconstrained prompt
+  with an "Add countries" action in its place when it doesn't (D3/Q1); an
+  off-country empty-state ("No matches in United Kingdom.") with an "Add a
+  different country to this trip" action when a filtered search comes back
+  empty (D4a/Q2) — "+ Add new" stays available alongside it, since an empty
+  DB search can't distinguish "not in the catalogue yet" (still addable, still
+  in-set) from "genuinely outside the trip's countries."
+
+  F2 (fresh-eyes finding, MANDATORY per the brief): new
+  AddPlaceFlow.ge20-country-filter.test.tsx pins that country_codes is sent
+  on BOTH lookup paths — the executable guard for GE-20's "cannot be bypassed
+  from within the picker" success criterion, since Brief B carries no other
+  red test for it (ATDD-first: no per ADL-54 D10). Also covered at the hook
+  level (useCities.citySearch.test.tsx — new file; useCities.geocode.test.tsx
+  — extended).
+
+  DESIGN CALL — useCitySearch/lookupCityCountry default countryCodes to []:
+  ChangeCityModal.tsx's re-point-flow city search also calls useCitySearch
+  and was NOT touched — GE-20's text and ADL-54 D6 both scope the filter to
+  "adding a place to a trip," a different operation from re-pointing an
+  existing place's city. The [] default keeps that call site's existing
+  unconstrained behaviour with zero call-site edit required, rather than
+  forcing every non-GE-20 caller to pass an empty array explicitly.
+
+  FLAGGED, NOT FIXED (see PR #469 description "Deliberately not done"): the
+  "+Add new" city-creation form's manual country <select> (lists every
+  country) is NOT restricted to the trip's declared set. Neither ADL-54 nor
+  the fresh-eyes review scope "the picker" to include this manual fallback —
+  F2 explicitly frames the "cannot be bypassed" guarantee as the two
+  AUTOMATED lookup paths, not manual entry. This is a real, if narrow, way a
+  determined user could still create a city in an out-of-trip country today
+  (bypassing the DB-search/geocode filters entirely via manual creation) —
+  flagged to COO/PO as a scope decision, not assumed in or out of this brief.
+
+  VERIFICATION: npm run check — clean (5 pre-existing infos in a backend test
+  file this thread never touched, same count prior threads have noted).
+  npm run type:check:all — clean. npm run test:backend — 801/801 (unaffected,
+  no backend files touched). npm run test:frontend — 388/388 (+23 new: 2
+  useCities.geocode, 5 useCities.citySearch [new file], 6
+  formatCountriesFilterNote [new file], 9 AddPlaceFlow.ge20-country-filter
+  [new file], 1 useTripDetailController). npm run status:check /
+  npm run tracker:check — clean (no tracker.json edit made this thread —
+  BUG-87 status flip is COO's job at merge, per this file's established
+  pattern). npm audit — 6 pre-existing MODERATE findings (esbuild/drizzle-kit,
+  react-router), unrelated (no package.json/package-lock.json change),
+  flagged per frameworks.txt rule 20, not fixed here.
+
+  KEY FILE LOCATIONS (new/changed this thread)
+    src/frontend/hooks/useCities.ts (useCitySearch, lookupCityCountry,
+      fetchGeocodeResultWithRetry — country_codes threading)
+    src/frontend/hooks/__tests__/useCities.citySearch.test.tsx (new)
+    src/frontend/hooks/__tests__/useCities.geocode.test.tsx (+2 tests)
+    src/frontend/utils/formatCountriesFilterNote.ts (new)
+    src/frontend/utils/__tests__/formatCountriesFilterNote.test.ts (new)
+    src/frontend/components/TripDetail/AddPlaceFlow.tsx (tripCountries/
+      onManageCountries props, note/prompt/empty-state UI)
+    src/frontend/components/TripDetail/__tests__/
+      AddPlaceFlow.ge20-country-filter.test.tsx (new, includes F2)
+    src/frontend/components/TripDetail/__tests__/AddPlaceFlow*.test.tsx
+      (6 pre-existing files — renderFlow() call sites updated with the two
+      new required props, tripCountries={[]}, behaviour otherwise unchanged)
+    src/frontend/components/TripDetail/useTripDetailController.ts
+      (handleManageCountries handler, shared by both call sites)
+    src/frontend/components/TripDetail/__tests__/
+      useTripDetailController.test.tsx (+1 test)
+    src/frontend/components/TripDetail/TripDetail.tsx (desktop call site —
+      tripCountries={trip.countries}, onManageCountries={c.handleManageCountries})
+    src/frontend/components/TripDetail/MobileTripDetailView.tsx (mobile call
+      site — same two new props)
+
+  NEXT STEPS (when resumed)
+    COO: review PR #469, merge via /coo-merge-and-close when ready, flip
+    BUG-87 tracker status to done/done_pending_uat with the PR number. Decide
+    on the two flagged-not-fixed scope questions above (ChangeCityModal
+    filtering, manual country <select> restriction) — follow-up briefs if
+    wanted, not assumed here. PO: the ADL-54 fresh-eyes review's P2 finding
+    (Nominatim's real multi-country countrycodes behaviour is UNVERIFIED from
+    this container — firewall) still wants an early real multi-country
+    geocode check on staging before UAT trusts this feature, per that
+    review's recommendation — unrelated to this frontend thread's own scope,
+    carried forward as a reminder.
+
+========================================================================
+PRIOR THREAD — retained in full below per this file's established
+newest-first pattern.
+========================================================================
+
 FRONTEND CONTEXT — as of 2026-08-08 (BUG-58/86/91/93 + UX-14 Scotland
 dogfood UAT fixes, fix/uat-0808-selection-picker-map-dates branch)
 

--- a/jobs/frontend/park-docs/20260808-FRONTEND-bug87-ge20-country-filter-park.txt
+++ b/jobs/frontend/park-docs/20260808-FRONTEND-bug87-ge20-country-filter-park.txt
@@ -1,0 +1,216 @@
+PARK DOCUMENT — FRONTEND
+Date: 2026-08-08
+Thread: BUG-87 / GE-20 Brief B — trip-country picker filter (frontend wiring)
+Branch: feat/bug87-ge20-picker-country-filter
+PR: #469 (CI green, 18/18)
+
+=========================================================================
+SCOPE
+=========================================================================
+Brief B — the final BUG-87 build piece. Backend contract (Brief A —
+country_codes on GET /api/cities and GET /api/geocode) was already merged to
+main before this thread started (PR #466 chain, ATDD-first per OP-35).
+Governing docs: jobs/architect/tech/ADL-54-trip-country-picker-filter.md
+(design + COO Q1/Q2/Q3 adjudication) and
+jobs/architect/tech/20260808-ADL54-fresh-eyes-review.md (F1-F6 findings).
+
+Dispatch success criteria: country_codes sent on both lookup paths; a
+visible "filtered by trip's countries" note; zero-country trip -> show-all +
+prompt (Q1); off-country search -> empty-state linking the trip's country
+editor (Q2); the F2 test pinning the param is sent on both paths (mandatory).
+
+=========================================================================
+PREMISE VERIFICATION (before touching anything)
+=========================================================================
+Two-probe check on trip.countries actually being on the TripDetail payload,
+per the brief's explicit instruction not to assume the ADL's claim:
+  1. Read src/frontend/types/api.ts:290-309 — TripSummary carries
+     `countries: { country_code: string; name: string }[]`; TripDetail
+     `extends TripSummary`, so it inherits the field. Confirmed present,
+     both code AND name — no extra fetch needed for the "Filtered to:
+     United Kingdom" note.
+  2. Read src/backend/routes/trips.ts — GET /api/trips/:id assembles
+     `countries: countriesRows` (line ~275) from the same trip-countries
+     join POST/PATCH write through (tripRepository.setCountries). Matches
+     the ADL's §1.1 claim exactly; nothing further to verify.
+
+Also confirmed (single AddPlaceFlow, not two "twins"): AddPlaceFlow.tsx is
+ONE component, imported by both TripDetail.tsx (desktop) and
+MobileTripDetailView.tsx (mobile) — the brief's "mobile twin" language
+refers to the second CALL SITE, not a second component to build or edit
+in parallel. Both call sites needed the same two new props threaded through.
+
+=========================================================================
+IMPLEMENTATION
+=========================================================================
+
+1. useCities.ts — country_codes threading
+   useCitySearch(query, countryCodes = []) and
+   lookupCityCountry(cityName, countryCodes = [])
+   (-> fetchGeocodeResultWithRetry) now always send `country_codes`
+   (comma-joined, URL-encoded via URLSearchParams so a comma becomes %2C —
+   matches the backend doc's own "gb,fr" -> "countrycodes=gb%2Cfr" example)
+   on every request, including an EXPLICIT empty string when the caller
+   passes no codes or an empty array. This is deliberate, not an oversight:
+   the backend's documented contract distinguishes "present-but-empty
+   (country_codes=)" = unconstrained (PO Q1) from "absent entirely" =
+   legacy/unchanged caller — sending the empty param is what lets a
+   zero-country trip's picker still participate in the "cannot be bypassed"
+   guarantee (it sends the filter, the filter just happens to admit
+   everything).
+
+   Both default to `[]` rather than being made required, specifically so
+   ChangeCityModal.tsx's existing `useCitySearch(debouncedQuery)` call
+   (the "Change City" re-point flow, BUG-75/UX-12) keeps compiling AND
+   keeps its exact pre-GE-20 behaviour with ZERO call-site edit — see
+   "Deliberately not done" below for why that flow is out of scope.
+
+2. formatCountriesFilterNote.ts (new util)
+   One shared formatter for both the "Filtered to: ..." note and the
+   off-country empty-state's country list, so the truncation rule (name up
+   to 2 countries in full, then "+N") can't drift between the two call
+   sites — same precedent as the existing formatCitySubtitle.ts. Matches
+   the COO's adjudicated Q3 example exactly: 4 countries ->
+   "United Kingdom, France +2".
+
+3. AddPlaceFlow.tsx — two new props, three new UI states
+   - tripCountries: { country_code, name }[] — countryCodes derived via
+     `.map(c => c.country_code)`, passed into BOTH useCitySearch and the
+     lookupCityCountry call inside handleOpenNewCityForm (this is the F2
+     guarantee — see TESTS below).
+   - onManageCountries: () => void — opens the trip's country editor. This
+     IS the existing TripForm edit modal (already renders the country
+     multi-select, TripForm.tsx:56/115) via a new
+     useTripDetailController.handleManageCountries handler
+     (setShowAddPlace(false); setShowEdit(true)) — reused, per the ADL's
+     explicit "reuse the trip form" instruction, not a new editor. Shared
+     by both TripDetail.tsx and MobileTripDetailView.tsx rather than
+     duplicating the same two-line callback at each call site.
+   - D5/Q3 note: "Filtered to: <names>" above the search input, only in
+     the search step (!showNewCityForm), when tripCountries.length > 0.
+   - D3/Q1 prompt: replaces the note when tripCountries.length === 0 —
+     "This trip has no countries yet — results aren't filtered." + an
+     "Add countries" button calling onManageCountries. The lookups still
+     run (unconstrained, via the empty country_codes described above).
+   - D4a/Q2 empty-state: when a debounced search (>=2 chars) settles with
+     zero results AND the trip has declared countries, a message "No
+     matches in <names>." + "Add a different country to this trip" button,
+     rendered ABOVE the existing "+ Add new" row (which stays untouched —
+     an empty DB search can't distinguish "not in the catalogue yet,
+     still in-set" from "genuinely outside the trip's countries", so this
+     informs without blocking the addable path).
+
+=========================================================================
+F2 — THE MANDATORY TEST (fresh-eyes finding, verbatim from the brief)
+=========================================================================
+"Cannot be bypassed from within the picker" is a GE-20 success criterion
+whose enforcement straddles both briefs: Brief A (backend) only filters
+WHEN the param is present (ATDD-tested there); Brief B (frontend) must
+ALWAYS SEND it. Brief B is marked ATDD-first: no, so this link had no red
+test before this thread — the fresh-eyes review's #1 recommendation.
+
+New AddPlaceFlow.ge20-country-filter.test.tsx pins this directly: spies on
+useCitySearch and lookupCityCountry (NOT the ignore-second-arg style mocks
+the six PRE-EXISTING AddPlaceFlow test files use — see below), asserts
+both are called with the trip's countryCodes array on a real search +
+"+Add new" interaction, for both a non-empty and a zero-country trip.
+Also covered one layer down, at the hook level (URL construction, not the
+component contract): useCities.citySearch.test.tsx (new) and
+useCities.geocode.test.tsx (extended) assert the literal query string
+sent to apiGet, including the GB%2CFR percent-encoding and the
+query-key-changes-on-filter-change refetch behaviour.
+
+=========================================================================
+EXISTING TEST FILES TOUCHED (mechanical prop-threading, not behaviour)
+=========================================================================
+AddPlaceFlow.bug71/bug72/bug78-79/city-picker/geocodeFailure/picker-
+precedence.test.tsx (6 files, one renderFlow() call site each) and
+AddPlaceFlow.test.tsx (4 direct render() call sites) all render
+<AddPlaceFlow> without the two new required props — TypeScript would
+otherwise fail to compile once tripCountries/onManageCountries stopped
+being optional. Added `tripCountries={[]} onManageCountries={vi.fn()}` at
+every site — `[]` was chosen deliberately (not a placeholder guess) since
+none of these pre-GE-20 tests exercise country filtering, their
+lookupCityCountry/useCitySearch mocks already ignore any second argument
+by declared signature, and `[]` is the closest match to these tests'
+original pre-GE-20 "unconstrained" behaviour. Confirmed via a full
+test:frontend run that this added zero new failures and no unexpected DOM
+collisions with the new zero-country prompt these tests now also render
+(it doesn't intersect with any of their existing assertions).
+
+=========================================================================
+DELIBERATELY NOT DONE — flagged to COO/PO, not assumed
+=========================================================================
+1. ChangeCityModal.tsx's city search (the "Change City" re-point flow) is
+   NOT filtered by trip countries. GE-20's own text ("When a user adds a
+   place to a trip...") and ADL-54 D6 ("GE-16 re-point: unaffected") both
+   scope this feature to adding a NEW place, a different operation from
+   re-pointing an existing place's city to a different catalogue row. Left
+   untouched; its useCitySearch call keeps compiling unchanged via the []
+   default described above.
+
+2. The "+Add new" city-creation form's manual country <select> (lists
+   every country via useCountries(), unfiltered) is NOT restricted to the
+   trip's declared set. This is a genuine, if narrow, way GE-20's "cannot
+   be bypassed from within the picker" criterion could still be
+   circumvented today: a determined user CAN manually pick any country
+   from that dropdown and create a city there, regardless of the trip's
+   filter. Neither ADL-54 nor the fresh-eyes review scope "the picker" to
+   include this manual fallback — F2 explicitly frames the guarantee as
+   the two AUTOMATED lookup paths (search dropdown, geocode discovery),
+   and D4a's "off-country add" design assumes the user's *primary* path
+   there is editing the trip's countries first, not the manual dropdown.
+   Restricting it would also be a bigger, more opinionated UI change than
+   anything the dispatch gate's 5 IMPLEMENT bullets asked for. Raised here
+   and in the PR description as a scope question for COO/PO, not built.
+
+=========================================================================
+VERIFICATION
+=========================================================================
+npm run check — clean (5 pre-existing infos in
+  geocoding.resolveByOsmId.test.ts, a backend test file this thread never
+  touched — same count/file every recent park doc in this file has noted).
+  Two NEW formatting errors this thread introduced (line length / quote
+  style in the two new test files) were caught by this same command and
+  fixed via a SCOPED `npx biome check --write` on just those two files
+  (never a bare repo-root --write — see this file's dedup-sweep entry
+  below for why that matters).
+npm run type:check:all — clean.
+npm run test:backend — 801/801 (unaffected; this thread never touches
+  src/backend/**).
+npm run test:frontend — 388/388 (+23 new: 2 useCities.geocode, 5
+  useCities.citySearch [new file], 6 formatCountriesFilterNote [new file],
+  9 AddPlaceFlow.ge20-country-filter [new file], 1
+  useTripDetailController).
+npm run status:check / npm run tracker:check — clean; no tracker.json edit
+  made this thread (BUG-87 status flip is COO's job at merge).
+npm audit — 6 pre-existing MODERATE findings (esbuild/drizzle-kit via
+  drizzle-kit's transitive dep chain; react-router CVE-2025-68470-adjacent)
+  — confirmed pre-existing, no package.json/package-lock.json change in
+  this diff, flagged per frameworks.txt rule 20, not fixed here.
+CI: PR #469, all 18 checks green (scripts/ci-wait.sh pr 469 -> PASS),
+  including E2E and Contract Tests (both require the live-backend contract
+  Brief A already shipped).
+
+=========================================================================
+BUGS DISCOVERED (framework standard #30)
+=========================================================================
+None. This was a pure feature-wiring thread against an already-merged,
+already-tested backend contract — no defects surfaced during
+implementation or verification.
+
+=========================================================================
+NEXT STEPS
+=========================================================================
+COO: review PR #469, merge via /coo-merge-and-close when ready. Flip
+BUG-87 tracker status to done/done_pending_uat with the PR number (GE-20's
+full BRD success-criteria list is now built — worth a UAT pass, per this
+project's mandatory UAT-before-phase-close gate). Decide the two
+"deliberately not done" scope questions above (own follow-up briefs, if
+wanted). PO/COO: the fresh-eyes review's P2 finding — Nominatim's real
+multi-country `countrycodes` behaviour is UNVERIFIED from this sandboxed
+container (firewall blocks direct reach) — still wants an early real
+multi-country geocode check on staging before UAT fully trusts this
+feature; that's a staging-environment check, not something this frontend
+thread could close itself, carried forward as a reminder per the review's
+own recommendation.

--- a/jobs/frontend/tech/20260808-bug87-ge20-country-filter.md
+++ b/jobs/frontend/tech/20260808-bug87-ge20-country-filter.md
@@ -1,0 +1,119 @@
+# AddPlaceFlow trip-country filter (BUG-87 / GE-20)
+
+New shared util: `src/frontend/utils/formatCountriesFilterNote.ts`
+Changed: `src/frontend/hooks/useCities.ts`, `AddPlaceFlow.tsx`,
+`useTripDetailController.ts`, `TripDetail.tsx`, `MobileTripDetailView.tsx`
+
+## Problem it solves
+
+The add-place picker's two lookups — the DB city search (`GET /api/cities`)
+and the geocode discovery lookup that auto-populates country/region on
+"+Add new" (`GET /api/geocode`) — were unfiltered by the trip's declared
+countries. Searching "Newport" on a UK-only trip returned USA Newports.
+Backend contract (`country_codes` on both endpoints, comma-joined ISO
+alpha-2, present-but-empty = unconstrained) already shipped; this thread is
+the frontend consumer.
+
+## `useCities.ts` API changes
+
+```ts
+useCitySearch(query: string, countryCodes: string[] = []): UseQueryResult<City[]>
+lookupCityCountry(cityName: string, countryCodes: string[] = []): Promise<{...}>
+```
+
+Both send `country_codes=<countryCodes.join(',')>` on every request —
+**always present**, even as an empty string. This is the mechanism behind
+GE-20's "cannot be bypassed from within the picker" guarantee: a
+zero-country trip still sends the filter param, it just resolves to
+unconstrained on the backend (documented contract), rather than the
+frontend silently omitting it.
+
+`countryCodes` defaults to `[]` so callers outside GE-20's scope —
+`ChangeCityModal.tsx`'s `useCitySearch(debouncedQuery)` call, the "Change
+City" re-point flow — keep compiling and keep their exact pre-existing
+unconstrained behaviour with zero call-site change required.
+
+## `AddPlaceFlow.tsx` new props
+
+```ts
+interface AddPlaceFlowProps {
+  // ...existing props...
+  tripCountries: { country_code: string; name: string }[]; // trip.countries, already on the payload
+  onManageCountries: () => void; // opens the trip's country editor
+}
+```
+
+`countryCodes = tripCountries.map(c => c.country_code)` is derived once per
+render and passed into both `useCitySearch` and the `lookupCityCountry` call
+inside `handleOpenNewCityForm` — this is the one code path both lookups
+share, so there is no way to update one without the other.
+
+Three render states above the search input (search step only,
+`!showNewCityForm`):
+- `tripCountries.length > 0` → "Filtered to: `<names>`" note
+  (`formatCountriesFilterNote`).
+- `tripCountries.length === 0` → unconstrained prompt + "Add countries"
+  button (`onManageCountries`).
+- A settled, non-loading, zero-result search with `tripCountries.length > 0`
+  → "No matches in `<names>`." + "Add a different country to this trip"
+  button, rendered above the existing "+ Add new" row (which stays
+  functional — an empty DB search can't tell "not catalogued yet, still
+  in-set" apart from "genuinely out of set").
+
+## `formatCountriesFilterNote(countries)`
+
+```ts
+function formatCountriesFilterNote(
+  countries: { country_code: string; name: string }[],
+): string
+```
+
+`''` for zero countries. Full names joined by `", "` for up to 2 countries.
+Beyond 2, the first 2 names plus a `+N` count for the remainder — e.g. 4
+declared countries render as `"United Kingdom, France +2"`. One formatter
+shared by both the note and the empty-state so the truncation rule can't
+drift between the two render sites (same precedent as
+`formatCitySubtitle.ts`).
+
+## `useTripDetailController.handleManageCountries`
+
+```ts
+const handleManageCountries = useCallback(() => {
+  setShowAddPlace(false);
+  setShowEdit(true);
+}, []);
+```
+
+Closes `AddPlaceFlow`, opens the existing `TripForm` edit modal — that modal
+already renders the country multi-select (`TripForm.tsx:56/115`), so this is
+the "trip's country editor" GE-20 refers to. Reused, not duplicated: both
+`TripDetail.tsx` (desktop) and `MobileTripDetailView.tsx` (mobile) pass
+`c.handleManageCountries` as `AddPlaceFlow`'s `onManageCountries`, rather
+than each defining its own two-line inline callback.
+
+## Call sites
+
+- `src/frontend/components/TripDetail/TripDetail.tsx` — desktop.
+- `src/frontend/components/TripDetail/MobileTripDetailView.tsx` — mobile.
+
+There is one `AddPlaceFlow` component, not two "twins" — both call sites
+render the same component with `tripCountries={trip.countries}` and
+`onManageCountries={c.handleManageCountries}`.
+
+## Known scope boundaries (not bugs — deliberate, flagged to COO/PO)
+
+- `ChangeCityModal.tsx` (the "Change City" re-point flow) is **not**
+  filtered — GE-20 and ADL-54 D6 both scope this feature to adding a new
+  place, not re-pointing an existing one.
+- The "+Add new" city-creation form's manual country `<select>` (every
+  country, unfiltered) is **not** restricted to the trip's declared set —
+  a narrow way a determined user could still create an out-of-trip-country
+  city today. Neither ADL-54 nor its fresh-eyes review scoped "the picker"
+  to include this manual fallback.
+
+## Extending this
+
+Adding a third lookup surface that should honour the trip's country filter:
+compute its `countryCodes` the same way (`tripCountries.map(c =>
+c.country_code)`) and pass it through, rather than re-deriving from
+`trip.countries` inline at a new call site.

--- a/src/frontend/components/TripDetail/AddPlaceFlow.tsx
+++ b/src/frontend/components/TripDetail/AddPlaceFlow.tsx
@@ -33,6 +33,9 @@ import { decideCityDisambiguation } from '../../utils/decideCityDisambiguation';
 // surface reuses the same formatter instead of a second one drifting out of
 // sync — see formatCitySubtitle.ts's doc comment for the full behaviour.
 import { formatCitySubtitle } from '../../utils/formatCitySubtitle';
+// GE-20 (BUG-87, ADL-54 D5/Q3): one shared formatter for the "filtered to"
+// note and the off-country empty-state's country list — see its doc comment.
+import { formatCountriesFilterNote } from '../../utils/formatCountriesFilterNote';
 import { capitalizeFirst } from '../../utils/textFormat';
 import { CarryForwardModal } from '../CarryForward/CarryForwardModal';
 import { CityPicker } from '../shared/CityPicker';
@@ -53,6 +56,27 @@ interface AddPlaceFlowProps {
    * (works unchanged once ADL-41's one-row-per-visit migration lands, Wave 2).
    */
   isFirstPlace: boolean;
+  /**
+   * GE-20 (BUG-87, ADL-54) — the trip's declared countries (`trip.countries`,
+   * already on the trip payload — no extra fetch). Threaded into BOTH the
+   * city-database search (useCitySearch) and the geocode discovery lookup
+   * (lookupCityCountry) as `country_codes` so neither can surface a
+   * candidate outside this set (the GE-20 "cannot be bypassed from within
+   * the picker" guarantee — see the F2 fresh-eyes finding). An empty array
+   * (a trip with no declared countries yet) is sent through unchanged — the
+   * backend's documented contract treats a present-but-empty set as
+   * unconstrained (PO Q1) — and renders the zero-country prompt instead of
+   * the "filtered to" note.
+   */
+  tripCountries: { country_code: string; name: string }[];
+  /**
+   * GE-20 (ADL-54 D3/D4a) — opens the trip's country editor. Wired by every
+   * caller to `useTripDetailController`'s `handleManageCountries` (closes
+   * this flow, opens the existing TripForm edit modal) rather than a new
+   * dedicated editor, per the ADL's explicit reuse instruction. Used by both
+   * the zero-country prompt (Q1) and the off-country empty-state (Q2).
+   */
+  onManageCountries: () => void;
 }
 
 /** Debounce delay for city search (ms). */
@@ -68,7 +92,14 @@ export function AddPlaceFlow({
   tripStartDate,
   tripEndDate,
   isFirstPlace,
+  tripCountries,
+  onManageCountries,
 }: AddPlaceFlowProps) {
+  // GE-20 (BUG-87, ADL-54 D1): the filter set both lookups are constrained
+  // to. Recomputed each render from the `tripCountries` prop rather than
+  // memoised — `.join(',')` inside the hooks below gives React Query a
+  // stable-by-value cache key regardless of this array's reference identity.
+  const countryCodes = tripCountries.map((c) => c.country_code);
   const [query, setQuery] = useState('');
   const [debouncedQuery, setDebouncedQuery] = useState('');
   const [showNewCityForm, setShowNewCityForm] = useState(false);
@@ -170,7 +201,11 @@ export function AddPlaceFlow({
 
   const debounceTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const { data: searchResults = [], isLoading: searching } = useCitySearch(debouncedQuery);
+  // GE-20: country_codes always sent, per countryCodes above.
+  const { data: searchResults = [], isLoading: searching } = useCitySearch(
+    debouncedQuery,
+    countryCodes,
+  );
   const { data: countries = [] } = useCountries();
 
   // Derive the selected country's tier config to conditionally show region dropdown
@@ -367,7 +402,10 @@ export function AddPlaceFlow({
     setCreationStatusMessage(null);
     if (cityName.trim().length >= 2) {
       setCountryLookupPending(true);
-      lookupCityCountry(cityName.trim())
+      // GE-20: same country_codes filter as the search above, so the
+      // discovery lookup that auto-populates country/region can never
+      // suggest a country outside the trip's declared set.
+      lookupCityCountry(cityName.trim(), countryCodes)
         .then(({ countryCode, regionIso, candidates, failed, truncated }) => {
           // BUG-73: a failed lookup (retries exhausted) never reaches the D14
           // disambiguation logic below — there's no country/candidates to
@@ -509,6 +547,26 @@ export function AddPlaceFlow({
 
       {!showNewCityForm ? (
         <>
+          {/* GE-20 (BUG-87, ADL-54 D5/D3/Q1/Q3): the "filtered by" note, or —
+              on a trip with no declared countries yet — the unconstrained
+              prompt in its place. Rendered above the search input per D5. */}
+          {tripCountries.length > 0 ? (
+            <p className="mb-2 text-xs text-gray-500">
+              Filtered to: {formatCountriesFilterNote(tripCountries)}
+            </p>
+          ) : (
+            <div className="mb-2 px-2.5 py-2 bg-blue-50 border border-blue-200 rounded-md text-blue-800 text-xs flex items-center justify-between gap-2">
+              <span>This trip has no countries yet — results aren't filtered.</span>
+              <button
+                type="button"
+                onClick={onManageCountries}
+                className="shrink-0 text-teal-700 font-semibold underline hover:text-teal-800 cursor-pointer"
+              >
+                Add countries
+              </button>
+            </div>
+          )}
+
           <input
             className={inputClass}
             placeholder="Search city name…"
@@ -523,6 +581,26 @@ export function AddPlaceFlow({
 
           {debouncedQuery.length >= 2 && (
             <div className="border border-gray-200 rounded-md mt-2 overflow-hidden">
+              {/* GE-20 (ADL-54 D4a/Q2): a filtered search that came back empty
+                  gets a static, non-blank explanation naming the trip's
+                  countries and a discoverable path to widen them — never a
+                  silent empty list. "+ Add new" below stays available
+                  regardless (a genuinely new in-set city is still addable
+                  this way — this message can't tell "not in the catalogue
+                  yet" apart from "genuinely outside the trip's countries",
+                  so it informs without blocking). */}
+              {!searching && searchResults.length === 0 && tripCountries.length > 0 && (
+                <div className="px-3 py-2.5 text-xs text-gray-600 bg-gray-50 border-b border-gray-100">
+                  No matches in {formatCountriesFilterNote(tripCountries)}.{' '}
+                  <button
+                    type="button"
+                    onClick={onManageCountries}
+                    className="text-teal-600 font-semibold underline hover:text-teal-800 cursor-pointer"
+                  >
+                    Add a different country to this trip
+                  </button>
+                </div>
+              )}
               {searchResults.map((city) => (
                 <div
                   key={city.id}

--- a/src/frontend/components/TripDetail/MobileTripDetailView.tsx
+++ b/src/frontend/components/TripDetail/MobileTripDetailView.tsx
@@ -283,6 +283,8 @@ export function MobileTripDetailView({ trip, onBack }: MobileTripDetailViewProps
           tripStartDate={trip.start_date}
           tripEndDate={trip.end_date}
           isFirstPlace={trip.places.length === 0}
+          tripCountries={trip.countries}
+          onManageCountries={c.handleManageCountries}
         />
       )}
 

--- a/src/frontend/components/TripDetail/TripDetail.tsx
+++ b/src/frontend/components/TripDetail/TripDetail.tsx
@@ -278,6 +278,8 @@ export function TripDetail({ trip }: TripDetailProps) {
           tripStartDate={trip.start_date}
           tripEndDate={trip.end_date}
           isFirstPlace={trip.places.length === 0}
+          tripCountries={trip.countries}
+          onManageCountries={c.handleManageCountries}
         />
       )}
 

--- a/src/frontend/components/TripDetail/__tests__/AddPlaceFlow.bug71.test.tsx
+++ b/src/frontend/components/TripDetail/__tests__/AddPlaceFlow.bug71.test.tsx
@@ -99,6 +99,8 @@ function renderFlow() {
       tripStartDate="2026-01-01"
       tripEndDate="2026-01-10"
       isFirstPlace={false}
+      tripCountries={[]}
+      onManageCountries={vi.fn()}
     />,
   );
 }

--- a/src/frontend/components/TripDetail/__tests__/AddPlaceFlow.bug72.test.tsx
+++ b/src/frontend/components/TripDetail/__tests__/AddPlaceFlow.bug72.test.tsx
@@ -85,6 +85,8 @@ function renderFlow() {
       tripStartDate="2026-01-01"
       tripEndDate="2026-01-10"
       isFirstPlace={false}
+      tripCountries={[]}
+      onManageCountries={vi.fn()}
     />,
   );
 }

--- a/src/frontend/components/TripDetail/__tests__/AddPlaceFlow.bug78-79.test.tsx
+++ b/src/frontend/components/TripDetail/__tests__/AddPlaceFlow.bug78-79.test.tsx
@@ -162,6 +162,8 @@ function renderFlow() {
       tripStartDate="2026-01-01"
       tripEndDate="2026-01-10"
       isFirstPlace={false}
+      tripCountries={[]}
+      onManageCountries={vi.fn()}
     />,
   );
 }

--- a/src/frontend/components/TripDetail/__tests__/AddPlaceFlow.city-picker.test.tsx
+++ b/src/frontend/components/TripDetail/__tests__/AddPlaceFlow.city-picker.test.tsx
@@ -133,6 +133,8 @@ function renderFlow() {
       tripStartDate="2026-01-01"
       tripEndDate="2026-01-10"
       isFirstPlace={false}
+      tripCountries={[]}
+      onManageCountries={vi.fn()}
     />,
   );
 }

--- a/src/frontend/components/TripDetail/__tests__/AddPlaceFlow.ge20-country-filter.test.tsx
+++ b/src/frontend/components/TripDetail/__tests__/AddPlaceFlow.ge20-country-filter.test.tsx
@@ -1,0 +1,210 @@
+/**
+ * AddPlaceFlow — GE-20 (BUG-87, ADL-54) trip-country picker filter.
+ *
+ * Covers Brief B's success criteria (dispatch gate, jobs/architect/tech/
+ * ADL-54-trip-country-picker-filter.md §3):
+ *   - F2 (fresh-eyes, MANDATORY): the picker sends `country_codes` — the
+ *     trip's declared countries — on BOTH lookup paths (useCitySearch AND
+ *     lookupCityCountry). This is the executable guard for GE-20's "cannot
+ *     be bypassed from within the picker" criterion; Brief B carries no
+ *     other red test for it (ADL-54 D10 marks this brief ATDD-first: no).
+ *   - D5/Q3: the "filtered by" note, naming the countries and truncating a
+ *     large set ("United Kingdom, France +2").
+ *   - D3/Q1: a trip with zero declared countries shows an unconstrained
+ *     prompt instead of the note, and still sends a present-but-empty
+ *     `country_codes` (the backend's documented unconstrained contract).
+ *   - D4a/Q2: a filtered search that comes back empty shows a static
+ *     empty-state naming the trip's countries with a link to the trip's
+ *     country editor — never a silent blank.
+ *
+ * Mocks: useCitySearch/lookupCityCountry (hooks/useCities) are spies that
+ * capture their call arguments, distinct from the pre-GE-20 test files in
+ * this directory (which don't care about the country_codes argument and mock
+ * these functions to ignore it).
+ *
+ * Source: src/frontend/components/TripDetail/AddPlaceFlow.tsx
+ */
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { City } from '../../../types/api';
+import { AddPlaceFlow } from '../AddPlaceFlow';
+
+const mockUseCitySearch = vi.fn();
+const mockLookupCityCountry = vi.fn();
+
+vi.mock('../../../hooks/useCities', () => ({
+  useCitySearch: (query: string, countryCodes: string[]) => mockUseCitySearch(query, countryCodes),
+  lookupCityCountry: (cityName: string, countryCodes: string[]) =>
+    mockLookupCityCountry(cityName, countryCodes),
+  useCreateCity: () => ({ mutateAsync: vi.fn(), isPending: false, error: null }),
+  useCarryForwardCandidates: () => ({ data: [], isFetched: false }),
+}));
+
+vi.mock('../../../hooks/useAdmin', () => ({
+  useCountries: () => ({ data: [] }),
+  useCountryRegions: () => ({ data: [] }),
+}));
+
+vi.mock('../../../hooks/usePlaces', () => ({
+  useAddPlace: () => ({ mutateAsync: vi.fn(), isPending: false, error: null }),
+}));
+
+const uk = { country_code: 'GB', name: 'United Kingdom' };
+const fr = { country_code: 'FR', name: 'France' };
+const es = { country_code: 'ES', name: 'Spain' };
+const it_ = { country_code: 'IT', name: 'Italy' };
+
+function baseProps() {
+  return {
+    tripId: 1,
+    onClose: vi.fn(),
+    tripStartDate: '2026-01-01',
+    tripEndDate: '2026-01-10',
+    isFirstPlace: false,
+  };
+}
+
+async function typeQuery(user: ReturnType<typeof userEvent.setup>, query: string) {
+  const input = screen.getByPlaceholderText('Search city name…');
+  await user.type(input, query);
+}
+
+describe('AddPlaceFlow — GE-20 country filter', () => {
+  beforeEach(() => {
+    mockUseCitySearch.mockReset();
+    mockUseCitySearch.mockReturnValue({ data: [], isLoading: false });
+    mockLookupCityCountry.mockReset();
+    mockLookupCityCountry.mockResolvedValue({
+      countryCode: null,
+      regionIso: null,
+      candidates: [],
+      failed: false,
+      truncated: false,
+    });
+  });
+
+  it("F2 (mandatory): sends the trip's country_codes on the DB search path (useCitySearch)", async () => {
+    const user = userEvent.setup();
+    render(<AddPlaceFlow {...baseProps()} tripCountries={[uk, fr]} onManageCountries={vi.fn()} />);
+
+    await typeQuery(user, 'newport');
+
+    await waitFor(() => {
+      const lastCall = mockUseCitySearch.mock.calls.at(-1);
+      expect(lastCall?.[0]).toBe('newport');
+      expect(lastCall?.[1]).toEqual(['GB', 'FR']);
+    });
+  });
+
+  it("F2 (mandatory): sends the trip's country_codes on the geocode discovery path (lookupCityCountry)", async () => {
+    const user = userEvent.setup();
+    render(<AddPlaceFlow {...baseProps()} tripCountries={[uk, fr]} onManageCountries={vi.fn()} />);
+
+    await typeQuery(user, 'newport');
+    const addNew = await screen.findByText('+ Add new: "newport"', {}, { timeout: 2000 });
+    await user.click(addNew);
+
+    await waitFor(() => {
+      expect(mockLookupCityCountry).toHaveBeenCalledWith('newport', ['GB', 'FR']);
+    });
+  });
+
+  it('sends a present-but-empty country_codes on both paths for a trip with no declared countries', async () => {
+    const user = userEvent.setup();
+    render(<AddPlaceFlow {...baseProps()} tripCountries={[]} onManageCountries={vi.fn()} />);
+
+    await typeQuery(user, 'newport');
+
+    await waitFor(() => {
+      const lastCall = mockUseCitySearch.mock.calls.at(-1);
+      expect(lastCall?.[0]).toBe('newport');
+      expect(lastCall?.[1]).toEqual([]);
+    });
+
+    const addNew = await screen.findByText('+ Add new: "newport"', {}, { timeout: 2000 });
+    await user.click(addNew);
+
+    await waitFor(() => {
+      expect(mockLookupCityCountry).toHaveBeenCalledWith('newport', []);
+    });
+  });
+
+  it('D5/Q3: shows the "Filtered to" note naming a single declared country', () => {
+    render(<AddPlaceFlow {...baseProps()} tripCountries={[uk]} onManageCountries={vi.fn()} />);
+    expect(screen.getByText('Filtered to: United Kingdom')).toBeInTheDocument();
+  });
+
+  it('D5/Q3: truncates a large declared set to "Name, Name +N" (COO adjudication example)', () => {
+    render(
+      <AddPlaceFlow
+        {...baseProps()}
+        tripCountries={[uk, fr, es, it_]}
+        onManageCountries={vi.fn()}
+      />,
+    );
+    expect(screen.getByText('Filtered to: United Kingdom, France +2')).toBeInTheDocument();
+  });
+
+  it('D3/Q1: a zero-country trip shows the unconstrained prompt instead of the "Filtered to" note', () => {
+    const onManageCountries = vi.fn();
+    render(
+      <AddPlaceFlow {...baseProps()} tripCountries={[]} onManageCountries={onManageCountries} />,
+    );
+
+    expect(screen.getByText(/no countries yet/i)).toBeInTheDocument();
+    expect(screen.queryByText(/^Filtered to:/)).not.toBeInTheDocument();
+  });
+
+  it('D3/Q1: the zero-country prompt\'s "Add countries" action calls onManageCountries', async () => {
+    const user = userEvent.setup();
+    const onManageCountries = vi.fn();
+    render(
+      <AddPlaceFlow {...baseProps()} tripCountries={[]} onManageCountries={onManageCountries} />,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Add countries' }));
+
+    expect(onManageCountries).toHaveBeenCalledTimes(1);
+  });
+
+  it("D4a/Q2: an empty filtered search shows a static empty-state naming the trip's countries", async () => {
+    mockUseCitySearch.mockReturnValue({ data: [] as City[], isLoading: false });
+    const user = userEvent.setup();
+    render(<AddPlaceFlow {...baseProps()} tripCountries={[uk]} onManageCountries={vi.fn()} />);
+
+    await typeQuery(user, 'boston');
+
+    await waitFor(() => {
+      expect(screen.getByText(/No matches in United Kingdom\./)).toBeInTheDocument();
+    });
+    // "+ Add new" stays available — a genuinely new in-set city is still addable.
+    expect(screen.getByText('+ Add new: "boston"')).toBeInTheDocument();
+  });
+
+  it('D4a/Q2: the empty-state\'s action calls onManageCountries and does not block "+ Add new"', async () => {
+    mockUseCitySearch.mockReturnValue({ data: [] as City[], isLoading: false });
+    const user = userEvent.setup();
+    const onManageCountries = vi.fn();
+    render(
+      <AddPlaceFlow {...baseProps()} tripCountries={[uk]} onManageCountries={onManageCountries} />,
+    );
+
+    await typeQuery(user, 'boston');
+    await screen.findByText(/No matches in United Kingdom\./);
+
+    await user.click(screen.getByRole('button', { name: 'Add a different country to this trip' }));
+
+    expect(onManageCountries).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not show the off-country empty-state while results are still loading', async () => {
+    mockUseCitySearch.mockReturnValue({ data: [] as City[], isLoading: true });
+    const user = userEvent.setup();
+    render(<AddPlaceFlow {...baseProps()} tripCountries={[uk]} onManageCountries={vi.fn()} />);
+
+    await typeQuery(user, 'boston');
+
+    expect(screen.queryByText(/No matches in/)).not.toBeInTheDocument();
+  });
+});

--- a/src/frontend/components/TripDetail/__tests__/AddPlaceFlow.geocodeFailure.test.tsx
+++ b/src/frontend/components/TripDetail/__tests__/AddPlaceFlow.geocodeFailure.test.tsx
@@ -70,6 +70,8 @@ function renderFlow() {
       tripStartDate="2026-01-01"
       tripEndDate="2026-01-10"
       isFirstPlace={false}
+      tripCountries={[]}
+      onManageCountries={vi.fn()}
     />,
   );
 }

--- a/src/frontend/components/TripDetail/__tests__/AddPlaceFlow.picker-precedence.test.tsx
+++ b/src/frontend/components/TripDetail/__tests__/AddPlaceFlow.picker-precedence.test.tsx
@@ -93,6 +93,8 @@ function renderFlow() {
       tripStartDate="2026-01-01"
       tripEndDate="2026-01-10"
       isFirstPlace={false}
+      tripCountries={[]}
+      onManageCountries={vi.fn()}
     />,
   );
 }

--- a/src/frontend/components/TripDetail/__tests__/AddPlaceFlow.test.tsx
+++ b/src/frontend/components/TripDetail/__tests__/AddPlaceFlow.test.tsx
@@ -139,6 +139,8 @@ describe('AddPlaceFlow — ADL-46 D14 region selector narrowing', () => {
         tripStartDate="2026-01-01"
         tripEndDate="2026-01-10"
         isFirstPlace={false}
+        tripCountries={[]}
+        onManageCountries={vi.fn()}
       />,
     );
 
@@ -191,6 +193,8 @@ describe('AddPlaceFlow — ADL-46 D14 region selector narrowing', () => {
         tripStartDate="2026-01-01"
         tripEndDate="2026-01-10"
         isFirstPlace={false}
+        tripCountries={[]}
+        onManageCountries={vi.fn()}
       />,
     );
 
@@ -274,6 +278,8 @@ describe('AddPlaceFlow — ADL-46 F1/F2 parity: distinct-region computation matc
         tripStartDate="2026-01-01"
         tripEndDate="2026-01-10"
         isFirstPlace={false}
+        tripCountries={[]}
+        onManageCountries={vi.fn()}
       />,
     );
 
@@ -306,6 +312,8 @@ describe('AddPlaceFlow — ADL-46 F1/F2 parity: distinct-region computation matc
         tripStartDate="2026-01-01"
         tripEndDate="2026-01-10"
         isFirstPlace={false}
+        tripCountries={[]}
+        onManageCountries={vi.fn()}
       />,
     );
 

--- a/src/frontend/components/TripDetail/__tests__/useTripDetailController.test.tsx
+++ b/src/frontend/components/TripDetail/__tests__/useTripDetailController.test.tsx
@@ -148,3 +148,18 @@ describe('useTripDetailController — backward status transitions never navigate
     expect(mockNavigate).not.toHaveBeenCalled();
   });
 });
+
+describe('useTripDetailController — handleManageCountries (GE-20, BUG-87, ADL-54 D4a)', () => {
+  it('closes the add-place flow and opens the trip edit modal (the reused country editor)', () => {
+    const { result } = renderController(makeTrip());
+
+    act(() => result.current.setShowAddPlace(true));
+    expect(result.current.showAddPlace).toBe(true);
+    expect(result.current.showEdit).toBe(false);
+
+    act(() => result.current.handleManageCountries());
+
+    expect(result.current.showAddPlace).toBe(false);
+    expect(result.current.showEdit).toBe(true);
+  });
+});

--- a/src/frontend/components/TripDetail/useTripDetailController.ts
+++ b/src/frontend/components/TripDetail/useTripDetailController.ts
@@ -51,6 +51,19 @@ export function useTripDetailController(trip: TripDetail) {
   // BUG-18: memoised so AddPlaceFlow's useEffect dep on onClose is stable
   const handleAddPlaceClose = useCallback(() => setShowAddPlace(false), []);
 
+  // GE-20 (BUG-87, ADL-54 D4a): the add-place picker's zero-country prompt and
+  // off-country empty-state both link to "the trip's country editor" — reused
+  // rather than building a second one, per the ADL's explicit reuse
+  // instruction. That editor IS the existing TripForm edit modal (already
+  // renders the country multi-select), so this just closes AddPlaceFlow and
+  // opens it, exactly like the header's Edit button already does. Shared here
+  // (not duplicated per call site) since both TripDetail and
+  // MobileTripDetailView need the identical behaviour.
+  const handleManageCountries = useCallback(() => {
+    setShowAddPlace(false);
+    setShowEdit(true);
+  }, []);
+
   const nextStep = NEXT_STATUS[trip.status];
 
   const handleNextStep = async () => {
@@ -131,6 +144,7 @@ export function useTripDetailController(trip: TripDetail) {
     isDeleting,
     deleteError,
     handleAddPlaceClose,
+    handleManageCountries,
     nextStep,
     handleNextStep,
     handleUnlockBar,

--- a/src/frontend/hooks/__tests__/useCities.citySearch.test.tsx
+++ b/src/frontend/hooks/__tests__/useCities.citySearch.test.tsx
@@ -1,0 +1,78 @@
+/**
+ * Tests for useCitySearch's query-param construction (GET /api/cities?q=...).
+ *
+ * GE-20 (BUG-87, ADL-54) — F2 (fresh-eyes finding): the "cannot be bypassed
+ * from within the picker" guarantee depends on this hook ALWAYS forwarding a
+ * `country_codes` param, present-but-empty when the caller passes none (the
+ * backend's documented "unconstrained" contract, PO Q1) — never simply
+ * omitted, since omission and empty-string are declared distinct contracts
+ * on the backend (see jobs/backend/tech/20260307-api-reference.md §Cities).
+ * Pinned here at the lowest level, and again at the AddPlaceFlow integration
+ * level (AddPlaceFlow.ge20-country-filter.test.tsx).
+ *
+ * Source: src/frontend/hooks/useCities.ts
+ */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { apiGet } from '../../utils/apiClient';
+import { useCitySearch } from '../useCities';
+
+vi.mock('../../utils/apiClient', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../utils/apiClient')>();
+  return {
+    ...actual,
+    apiGet: vi.fn(),
+  };
+});
+
+function wrapper({ children }: { children: ReactNode }) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+}
+
+describe('useCitySearch', () => {
+  beforeEach(() => {
+    vi.mocked(apiGet).mockReset();
+    vi.mocked(apiGet).mockResolvedValue([]);
+  });
+
+  it('is disabled below the 2-character minimum (no fetch issued)', () => {
+    renderHook(() => useCitySearch('p'), { wrapper });
+    expect(apiGet).not.toHaveBeenCalled();
+  });
+
+  it('sends an empty country_codes when none is passed (default [], unconstrained)', async () => {
+    renderHook(() => useCitySearch('paris'), { wrapper });
+    await waitFor(() => expect(apiGet).toHaveBeenCalled());
+    expect(apiGet).toHaveBeenCalledWith('/api/cities?q=paris&country_codes=');
+  });
+
+  it('GE-20/F2: forwards a non-empty country_codes list, comma-joined', async () => {
+    renderHook(() => useCitySearch('newport', ['GB', 'FR']), { wrapper });
+    await waitFor(() => expect(apiGet).toHaveBeenCalled());
+    expect(apiGet).toHaveBeenCalledWith('/api/cities?q=newport&country_codes=GB%2CFR');
+  });
+
+  it('GE-20: an explicit empty array is sent the same way as the default (present-but-empty = unconstrained)', async () => {
+    renderHook(() => useCitySearch('paris', []), { wrapper });
+    await waitFor(() => expect(apiGet).toHaveBeenCalled());
+    expect(apiGet).toHaveBeenCalledWith('/api/cities?q=paris&country_codes=');
+  });
+
+  it('refetches when the country filter changes (country_codes is part of the query key)', async () => {
+    const { rerender } = renderHook(({ codes }) => useCitySearch('newport', codes), {
+      wrapper,
+      initialProps: { codes: ['GB'] },
+    });
+    await waitFor(() =>
+      expect(apiGet).toHaveBeenCalledWith('/api/cities?q=newport&country_codes=GB'),
+    );
+
+    rerender({ codes: ['GB', 'FR'] });
+    await waitFor(() =>
+      expect(apiGet).toHaveBeenCalledWith('/api/cities?q=newport&country_codes=GB%2CFR'),
+    );
+  });
+});

--- a/src/frontend/hooks/__tests__/useCities.geocode.test.tsx
+++ b/src/frontend/hooks/__tests__/useCities.geocode.test.tsx
@@ -32,13 +32,30 @@ describe('lookupCityCountry', () => {
     vi.mocked(apiGet).mockReset();
   });
 
-  it('calls GET /api/geocode with the city name as the q param', async () => {
+  it('calls GET /api/geocode with the city name as the q param and an empty country_codes when none is passed', async () => {
     const result: GeocodeResult = { candidates: [], country_code: null, region_iso: null };
     vi.mocked(apiGet).mockResolvedValue(result);
 
     await lookupCityCountry('Springfield');
 
-    expect(apiGet).toHaveBeenCalledWith('/api/geocode?q=Springfield');
+    // GE-20 (BUG-87, ADL-54): country_codes defaults to [] (unconstrained) —
+    // callers outside GE-20's scope (e.g. ChangeCityModal) keep this exact
+    // pre-GE-20 request shape, just with the new always-present empty param.
+    expect(apiGet).toHaveBeenCalledWith('/api/geocode?q=Springfield&country_codes=');
+  });
+
+  // GE-20 (BUG-87, ADL-54) — F2 (fresh-eyes finding): the "cannot be
+  // bypassed from within the picker" guarantee depends on this lookup path
+  // ALWAYS forwarding the trip's declared countries. Pinned here at the
+  // lowest level (the function that builds the request), and again at the
+  // AddPlaceFlow integration level (AddPlaceFlow.ge20-country-filter.test.tsx).
+  it('GE-20/F2: forwards a non-empty country_codes list, comma-joined, on the geocode request', async () => {
+    const result: GeocodeResult = { candidates: [], country_code: null, region_iso: null };
+    vi.mocked(apiGet).mockResolvedValue(result);
+
+    await lookupCityCountry('Newport', ['GB', 'FR']);
+
+    expect(apiGet).toHaveBeenCalledWith('/api/geocode?q=Newport&country_codes=GB%2CFR');
   });
 
   it('returns the top candidate country/region and the full candidate list on success', async () => {

--- a/src/frontend/hooks/useCities.ts
+++ b/src/frontend/hooks/useCities.ts
@@ -37,9 +37,20 @@ function delay(ms: number): Promise<void> {
 /**
  * Calls GET /api/geocode, retrying transient failures up to
  * GEOCODE_RETRY_ATTEMPTS times before rethrowing the last error.
+ *
+ * @param countryCodes - GE-20 (BUG-87, ADL-54): the trip's declared country
+ *   filter set, ISO alpha-2. ALWAYS sent, even when empty — a present-but-
+ *   empty `country_codes` is the backend's documented "unconstrained" signal
+ *   (PO Q1 ruling), distinct from omitting the param entirely (legacy/
+ *   unchanged callers). Defaults to `[]` so callers that don't pass a trip
+ *   filter (e.g. ChangeCityModal's re-point flow, out of GE-20's scope —
+ *   ADL-54 D6) keep today's unconstrained behaviour unchanged.
  */
-async function fetchGeocodeResultWithRetry(cityName: string): Promise<GeocodeResult> {
-  const params = new URLSearchParams({ q: cityName });
+async function fetchGeocodeResultWithRetry(
+  cityName: string,
+  countryCodes: string[] = [],
+): Promise<GeocodeResult> {
+  const params = new URLSearchParams({ q: cityName, country_codes: countryCodes.join(',') });
   let lastError: unknown;
   for (let attempt = 0; attempt <= GEOCODE_RETRY_ATTEMPTS; attempt++) {
     try {
@@ -76,6 +87,13 @@ async function fetchGeocodeResultWithRetry(cityName: string): Promise<GeocodeRes
  * caller that needs to be honest with the user in AddPlaceFlow.tsx now checks it.
  *
  * @param cityName - The city name to look up.
+ * @param countryCodes - GE-20 (BUG-87, ADL-54): the trip's declared country
+ *   filter set, ISO alpha-2 codes. Always forwarded to the backend (see
+ *   fetchGeocodeResultWithRetry's doc comment) so the "cannot be bypassed
+ *   from within the picker" guarantee holds on this lookup path too — the
+ *   discovery call that auto-populates country/region can never surface a
+ *   candidate outside the trip's declared countries. Defaults to `[]`
+ *   (unconstrained) for callers outside GE-20's scope.
  * @returns Upper-cased country code (e.g. "FR"), region ISO (e.g. "US-CA"),
  *   both nullable, the full candidate list (empty on any failure), `failed` —
  *   true when retries were exhausted without a successful response, OR
@@ -87,7 +105,10 @@ async function fetchGeocodeResultWithRetry(cityName: string): Promise<GeocodeRes
  *   more matches than `candidates` shows, false on any failure (nothing was
  *   truncated; nothing was returned at all).
  */
-export async function lookupCityCountry(cityName: string): Promise<{
+export async function lookupCityCountry(
+  cityName: string,
+  countryCodes: string[] = [],
+): Promise<{
   countryCode: string | null;
   regionIso: string | null;
   candidates: GeocodeCandidate[];
@@ -95,7 +116,7 @@ export async function lookupCityCountry(cityName: string): Promise<{
   truncated: boolean;
 }> {
   try {
-    const result = await fetchGeocodeResultWithRetry(cityName);
+    const result = await fetchGeocodeResultWithRetry(cityName, countryCodes);
     // BUG-74: an upstream geocoder failure ('error') or a disabled geocoder
     // ('disabled') is a failed lookup for the caller's purposes — same
     // user-visible banner as a retries-exhausted network failure — even
@@ -123,12 +144,24 @@ export async function lookupCityCountry(cityName: string): Promise<{
  * Minimum 2 characters required; query is disabled below that.
  *
  * @param query - Search string (minimum 2 chars to activate).
+ * @param countryCodes - GE-20 (BUG-87, ADL-54): the trip's declared country
+ *   filter set, ISO alpha-2 codes. ALWAYS sent as `country_codes` (even when
+ *   empty — the backend's documented "present-but-empty means unconstrained"
+ *   contract, PO Q1), included in the query key so a filter change refetches
+ *   rather than serving a stale cached page. Defaults to `[]` so callers
+ *   outside GE-20's scope (e.g. ChangeCityModal's re-point flow, ADL-54 D6)
+ *   keep today's unconstrained behaviour with no change required at the call
+ *   site.
  * @returns React Query result containing City[].
  */
-export function useCitySearch(query: string) {
+export function useCitySearch(query: string, countryCodes: string[] = []) {
+  const codesParam = countryCodes.join(',');
   return useQuery({
-    queryKey: ['cities', 'search', query],
-    queryFn: () => apiGet<City[]>(`/api/cities?q=${encodeURIComponent(query)}`),
+    queryKey: ['cities', 'search', query, codesParam],
+    queryFn: () =>
+      apiGet<City[]>(
+        `/api/cities?q=${encodeURIComponent(query)}&country_codes=${encodeURIComponent(codesParam)}`,
+      ),
     enabled: query.trim().length >= 2,
     // Keep previous results visible while the new search is in flight
     placeholderData: (prev) => prev,

--- a/src/frontend/utils/__tests__/formatCountriesFilterNote.test.ts
+++ b/src/frontend/utils/__tests__/formatCountriesFilterNote.test.ts
@@ -1,0 +1,38 @@
+/**
+ * Unit tests for formatCountriesFilterNote (GE-20, BUG-87, ADL-54 D5/Q3).
+ *
+ * Source: src/frontend/utils/formatCountriesFilterNote.ts
+ */
+import { describe, expect, it } from 'vitest';
+import { formatCountriesFilterNote } from '../formatCountriesFilterNote';
+
+const uk = { country_code: 'GB', name: 'United Kingdom' };
+const fr = { country_code: 'FR', name: 'France' };
+const es = { country_code: 'ES', name: 'Spain' };
+const it_ = { country_code: 'IT', name: 'Italy' };
+
+describe('formatCountriesFilterNote', () => {
+  it('returns an empty string for zero countries', () => {
+    expect(formatCountriesFilterNote([])).toBe('');
+  });
+
+  it('names a single country in full', () => {
+    expect(formatCountriesFilterNote([uk])).toBe('United Kingdom');
+  });
+
+  it('names two countries in full, joined by a comma', () => {
+    expect(formatCountriesFilterNote([uk, fr])).toBe('United Kingdom, France');
+  });
+
+  it('truncates three countries to the first two plus a "+1" count', () => {
+    expect(formatCountriesFilterNote([uk, fr, es])).toBe('United Kingdom, France +1');
+  });
+
+  it('truncates four countries to the first two plus a "+2" count (COO Q3 adjudication example)', () => {
+    expect(formatCountriesFilterNote([uk, fr, es, it_])).toBe('United Kingdom, France +2');
+  });
+
+  it('preserves input order rather than sorting', () => {
+    expect(formatCountriesFilterNote([fr, uk])).toBe('France, United Kingdom');
+  });
+});

--- a/src/frontend/utils/formatCountriesFilterNote.ts
+++ b/src/frontend/utils/formatCountriesFilterNote.ts
@@ -1,0 +1,45 @@
+/**
+ * formatCountriesFilterNote — renders a trip's declared country set as a
+ * short, human-readable list for the add-place picker's affordances (GE-20,
+ * BUG-87, ADL-54 D5/Q3).
+ *
+ * Used in two places in AddPlaceFlow.tsx: the persistent "Filtered to: …"
+ * note above the search input, and the off-country empty-state's "No matches
+ * in …" message. Extracted to one shared formatter (rather than two ad-hoc
+ * `.join(', ')` calls) so the truncation rule can't drift between the two
+ * call sites — same precedent as formatCitySubtitle.ts.
+ *
+ * Truncation (COO Q3 adjudication, adopting the ADL-54 author's
+ * recommendation): name up to MAX_NAMED countries in full, then append a
+ * "+N" count for the remainder rather than listing an unbounded set. Example
+ * from the adjudication: four declared countries render as
+ * "United Kingdom, France +2".
+ */
+
+/** How many country names to spell out before truncating to "+N". */
+const MAX_NAMED = 2;
+
+/**
+ * Formats a trip's declared countries for display.
+ *
+ * @param countries - The trip's declared countries (`trip.countries`, already
+ *   `{ country_code, name }[]` on the trip payload — no extra fetch needed).
+ * @returns `''` for an empty set (callers render the zero-country prompt
+ *   instead, per D3 — this function is never called for that case, but
+ *   returns an explicit empty string rather than throwing if it is);
+ *   otherwise every name joined by ", " when the set is small, or the first
+ *   `MAX_NAMED` names plus a "+N" count for a larger set.
+ */
+export function formatCountriesFilterNote(
+  countries: { country_code: string; name: string }[],
+): string {
+  if (countries.length === 0) return '';
+  if (countries.length <= MAX_NAMED) {
+    return countries.map((c) => c.name).join(', ');
+  }
+  const named = countries
+    .slice(0, MAX_NAMED)
+    .map((c) => c.name)
+    .join(', ');
+  return `${named} +${countries.length - MAX_NAMED}`;
+}


### PR DESCRIPTION
Brief B — the final BUG-87/GE-20 build piece. Backend contract (Brief A, PR #466/#462-ish
chain, `country_codes` on `GET /api/cities` and `GET /api/geocode`) is already on `main`.

- **Tracker:** BUG-87
- **BRD:** GE-20 (approved, v3.21), §5.1
- **Reference:** `jobs/architect/tech/ADL-54-trip-country-picker-filter.md` +
  `jobs/architect/tech/20260808-ADL54-fresh-eyes-review.md` (F2 in particular)

Closes #BUG-87

## What this does

Wires the trip's declared country codes into `AddPlaceFlow` (shared by both the desktop
`TripDetail` and mobile `MobileTripDetailView` call sites — there is one component, not
two twins) so the add-place picker can no longer surface a candidate outside the trip's
declared countries.

- **`useCities.ts`** — `useCitySearch` and `lookupCityCountry`/
  `fetchGeocodeResultWithRetry` now always send `country_codes` (comma-joined ISO alpha-2),
  even when empty — the backend's documented "present-but-empty = unconstrained" contract
  (PO Q1). Both default to `[]` so `ChangeCityModal`'s re-point flow (out of GE-20's scope
  per ADL-54 D6 — a different operation from "adding a place") keeps its unconstrained
  behaviour unchanged with no call-site edit required.
- **`AddPlaceFlow.tsx`** — new `tripCountries` / `onManageCountries` props:
  - **D5/Q3** — a "Filtered to: United Kingdom, France +2" note above the search input
    (truncated per the COO's adjudicated example), via a new shared
    `formatCountriesFilterNote` util.
  - **D3/Q1** — a trip with zero declared countries shows an unconstrained prompt
    ("this trip has no countries yet") in place of the note, and still sends a
    present-but-empty `country_codes` on both lookups.
  - **D4a/Q2** — a filtered search that returns nothing shows a static empty-state naming
    the trip's countries with a link to the trip's country editor — never a silent blank.
    "+ Add new" stays available alongside it (a genuinely new in-set city is still
    addable this way).
  - The "editor" link is the *existing* `TripForm` edit modal (already has the country
    multi-select) via a new `useTripDetailController.handleManageCountries` — reused, not
    duplicated, per the ADL's explicit instruction.
- **F2 (mandatory, fresh-eyes finding)** — `AddPlaceFlow.ge20-country-filter.test.tsx` pins
  that `country_codes` is sent on **both** lookup paths (the DB search and the geocode
  discovery lookup), the executable guard for GE-20's "cannot be bypassed from within the
  picker" criterion. Also covered at the hook level in
  `useCities.citySearch.test.tsx` / `useCities.geocode.test.tsx`.

## Deliberately not done

`ChangeCityModal.tsx`'s city search (the "Change City" re-point flow, BUG-75/UX-12) is
**not** filtered — GE-20's text and ADL-54 D6 both scope this to "adding a place to a
trip," a different operation from re-pointing an existing place. Flagging this scope
boundary explicitly rather than silently expanding into it; happy to take a follow-up
brief if the COO/PO wants it in scope too.

The "+Add new" city-creation form's manual country `<select>` (today, lists every country)
is **not** restricted to the trip's declared set. Neither ADL-54 nor the fresh-eyes review
scope "the picker" to include this manual fallback dropdown — F2 explicitly frames the
guarantee as the two automated lookup paths. Flagging as a genuine, if narrow, way GE-20's
"cannot be bypassed" criterion could still be circumvented today (a determined user can
manually create a city in any country via the fallback form) — a decision for COO/PO on
whether that's in scope for a follow-up, not assumed here.

## Verification

- `npm run check` — clean (only 5 pre-existing infos in a backend test file this thread
  never touched)
- `npm run type:check:all` — clean
- `npm run test:backend` — 801/801 (unaffected — no backend files touched)
- `npm run test:frontend` — 388/388 (+23 new: 2 useCities.geocode, 5
  useCities.citySearch, 6 formatCountriesFilterNote, 9 AddPlaceFlow.ge20-country-filter,
  1 useTripDetailController)
- `npm run status:check` / `npm run tracker:check` — clean
- `npm audit` — 6 pre-existing MODERATE findings (esbuild/drizzle-kit, react-router),
  unrelated (no package.json/package-lock.json change in this diff), not fixed here

🤖 Generated with [Claude Code](https://claude.com/claude-code)