### PR TITLE
fix(CODEBASE.md): Clerk JWKS reachable (verified), not firewall-blocked

### DIFF
--- a/CODEBASE.md
+++ b/CODEBASE.md
@@ -464,8 +464,10 @@ drives.
 - **Schema changes:** always `db:generate` → `db:migrate`. `db:push` is disabled (see `patches/`).
 - **Branching:** `feat/`, `fix/`, `chore/` prefixes. Never commit directly to `main`.
 - **PRs:** COO reviews and merges. Squash merge is standard.
-- **Auth in local dev:** set `BYPASS_AUTH=true` in `.env.local` — the devcontainer
-  firewall cannot reach Clerk's JWKS endpoint.
+- **Auth in local dev:** set `BYPASS_AUTH=true` in `.env.local` to work without a
+  signed-in Clerk session. (Clerk's JWKS host is allowlisted and **reachable** from the
+  container — verified 2026-08-08, returns keys — so this is a dev convenience, not a
+  firewall limitation. Probe before re-asserting otherwise.)
 - **Two-panel layout (desktop, ≥768px):** left panel is the trip list; right panel
   (`data-testid="trip-detail-panel"`) is the `<Outlet />` (`DesktopTripsLayout.tsx`).
   Below 768px, `MobileTripsLayout.tsx` (WP-04) renders a single-panel list/detail


### PR DESCRIPTION
Probed the app's actual CLERK_JWKS_URI — reachable, returns keys. The 'firewall can't reach Clerk JWKS' claim was stale (only Clerk's control-plane is excluded, ADL-33 §4). Doc-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)