### PR TITLE
refactor(QUAL-43): Stage 0 — userId-scoping chokepoint (ADL-53 §6)

### DIFF
--- a/.claude/skills/pre-push/SKILL.md
+++ b/.claude/skills/pre-push/SKILL.md
@@ -12,7 +12,15 @@ npm run test:backend       # Backend unit tests
 npm run test:frontend      # Frontend unit tests
 npm run status:check       # _project/STATUS.md in sync with tracker.json
 npm run tracker:check      # tracker.json integrity — no duplicate IDs, brdRefs valid
+npm run scope:check        # userId-scoping chokepoint — no hand-authored ownership in repositories/
 ```
+
+If `scope:check` fails it has found an ownership expression in
+`src/backend/repositories/**` that does not resolve through
+`repositories/scope.ts` (QUAL-43 / ADL-53 §6 Stage 0) — either an
+`eq(<table>.userId, …)` predicate or an ownership comparison written in
+application code. Route it through `scopeToUser`/`ownedAnd` (predicate) or
+`assertOwned`/`assertWritable` (existence check); do not exempt the site.
 
 If `status:check` fails, run `npm run status` and commit the regenerated
 `_project/STATUS.md` alongside your change — STATUS.md is generated, never hand-edited.

--- a/jobs/COO/inbox/20260810_1500-BACKEND-qual43-stage0-complete.txt
+++ b/jobs/COO/inbox/20260810_1500-BACKEND-qual43-stage0-complete.txt
@@ -1,0 +1,99 @@
+TO: COO
+FROM: Backend
+DATE: 2026-08-10
+TRACKER: QUAL-43 · PR #487 · GitHub issue: none (see note) · BRD: n/a
+BRANCH: feat/qual43-stage0-scope-chokepoint (off main @ 178f41d)
+SPEC: ADL-53 §6 Stage 0 + the §R2 F1/F2/F3 folds
+
+WHAT WAS BUILT
+Created src/backend/repositories/scope.ts — the single definition of row
+ownership — and routed every ownership expression in the production repository
+sources through it (34 predicate sites + both JS-comparison write gates).
+Landed scripts/scope-completeness-check.sh as a committed, re-runnable exit
+check, wired into /pre-push.
+
+ACCEPTANCE CRITERIA
+1. scope.ts exports scopeToUser/ownedAnd/assertOwned per §2 ......... PASS
+   (assertWritable too; UserOwnedTable compile constraint PROBE-VERIFIED —
+   tsc accepted `trips`, emitted TS2345 for `cities` and `countries`)
+2. Every ownership expression in repositories/** routes through it .. PASS
+   (34 predicates + places.ts/items.ts assertWritable JS gates)
+3. Completeness check exits clean, sole match = scope.ts's own def ... PASS
+4. npm run test:backend 808/808, unchanged from baseline ............ PASS
+   (baseline re-run by me on main before any edit: 51 files / 808 tests.
+   No test file modified; no assertion relaxed)
+5. Part F still green ............................................... PASS (7/7)
+6. Zero call-site behaviour change .................................. PASS
+
+Also green: frontend 388/388, type:check:all, biome ci, status:check,
+tracker:check, scope:check. Full /pre-push clean.
+
+SECURITY CHECKLIST (OP-06) — userId scoping IS the subject
+1. Auth middleware — no route added or modified; every existing
+   requireAuth/requireOwner binding untouched.
+2. Repository query scoping — strengthened: all 34 predicate sites and both
+   write gates now resolve through one definition, machine-verified by
+   scope:check rather than by convention.
+3. FK .notNull() — no schema change, no new user-data column.
+Write-gate semantics preserved exactly, ordering included: a non-owner of a
+LOCKED trip still receives 404, never the lock error (SE-05 opacity).
+
+FULL-FILE REWRITES (OP-28)
+None. Every existing source file was changed by targeted edit. scope.ts and
+scope-completeness-check.sh are new files.
+
+FINDINGS THAT CONTRADICT OR QUALIFY ADL-53
+A. [MOST IMPORTANT] Four hand-written ownership predicates live in
+   src/backend/services/shading.service.ts (:169, :209, :247, :291), and NO
+   ADL-53 stage owns them. Two probes that fail differently: (1) grepping
+   ADL-53 for "services/" yields only cityIdentityService (a new Stage-2
+   file), a passing remark that shading sits "behind shading.service" used to
+   argue map.ts is safe, and a test-coverage note — no stage assignment;
+   (2) reading §6's stage table end to end — Stage 0 = repositories,
+   Stages 2/3/4 = routes/**, Stage 5 = guard flip; nothing names services/**.
+   CONSEQUENCE: D1/D7's "single Phase-3 change-point" is NOT reached by the
+   current staging even after Stage 5 — a sharing change would still have to
+   find and edit shading.service.ts separately. This is structurally the SAME
+   shape as the F1 finding the second fresh-eyes review caught (ownership
+   expressed in a second place the stage's grep never looks at), one directory
+   over. NOT a bleed: all four are correct today and
+   services/__tests__/shading.user-scope.test.ts covers cross-user isolation.
+   It is a completeness gap in the PLAN. Needs a COO/Architect stage
+   assignment; I did not absorb it — it is outside this brief's scope
+   (repositories/**) and widening scope silently is the failure mode OP-32
+   rule 4 exists to stop.
+B. assertOwned ships with no production caller and therefore no test
+   coverage. Two probes: grep across all of src/ finds only its definition
+   and doc mentions; enumerating all seven importers of ./scope.js shows none
+   imports it. Its first caller is Stage 4's tripPlaceActivitiesMap join
+   reads. It ships because §2 and success criterion (1) both name it as part
+   of the contract. RECOMMEND Stage 4's brief carry direct coverage for it.
+C. I added NO new tests, deliberately: criterion (4) fixed the bar at exactly
+   808/808 "unchanged from baseline", and a scope.ts unit suite would have
+   moved that number. scopeToUser/ownedAnd/assertWritable are covered
+   transitively and heavily. If you would rather have direct unit coverage of
+   scope.ts, that is a one-line call and I will add it.
+D. Line-number drift confirmed, as your brief predicted: the JS gates cited at
+   places.ts:273 / items.ts:95 were at :281 / :103. Located by content. Every
+   §5.1 site falling inside repositories/** was found; nothing cited was
+   missing.
+E. Confirming your resolution 3 from a third angle: the getDb-in-routes guard
+   genuinely does not exist yet, and no stage CREATES it — §3 describes it in
+   recommendation voice, Stage 5 only "flips" it. Stage 5's brief will need to
+   author it, not merely flip it.
+
+OPEN ISSUES / BLOCKERS
+None blocking. Two follow-ups you own:
+- Wire scope:check into CI (deliberately out of scope this stage, per brief).
+- Assign a stage for finding A (services/** ownership predicates).
+Document lifecycle: ADL-53 §10 assigns the OP-06 §2.1 / HC-05/10/11 updates to
+the Stage 2 and Stage 4 PRs specifically, so Stage 0 changes no status/verdict
+document. Flagging so the omission reads as deliberate, not missed.
+
+WHAT IS NOW UNBLOCKED
+Stage 0 was the substrate blocking Stages 2, 3 and 4 — all three can now
+compose the helper. Stages 4 and 5 can re-verify the invariant identically by
+re-running npm run scope:check, which is why it shipped as a committed script
+rather than a one-time grep.
+
+CI: PR #487 — all checks green (scripts/ci-wait.sh pr 487).

--- a/jobs/backend/context/current.txt
+++ b/jobs/backend/context/current.txt
@@ -1,3 +1,57 @@
+BACKEND CONTEXT — 2026-08-10 (QUAL-43 / ADL-53 Stage 0 thread, latest)
+PROJECT: Travel Tracker
+CURRENT STATUS: shipped the userId-scoping chokepoint (ADL-53 §6 Stage 0) on
+  branch feat/qual43-stage0-scope-chokepoint. Pure DRY refactor of
+  src/backend/repositories/** — zero behaviour change, 808/808 backend tests
+  unchanged, no test edited.
+  1. NEW src/backend/repositories/scope.ts — the single definition of row
+     ownership. Two mechanisms, one definition (ADL-53 F2):
+     - scopeToUser(table, userId) / ownedAnd(table, userId, ...extra) — the
+       ownership PREDICATE, for tables carrying a user_id column. The
+       UserOwnedTable union (activities, companions, items, mapShadingConfig,
+       tripCategories, tripPlaces, trips) makes passing a global reference
+       table a COMPILE ERROR — verified by probe, not assumed: a throwaway
+       module passing `cities`/`countries` produced TS2345 on exactly those
+       two lines while `trips` compiled.
+     - assertOwned(userId, tripId) / assertWritable(userId, tripId) — the
+       ownership ASSERTION, as an existence check composed from scopeToUser.
+       assertOwned has NO production caller yet (its first is Stage 4's
+       join-table relocations); it exists because §2 defines it as part of
+       the chokepoint contract. Deliberate, flagged to COO.
+  2. 34 predicate sites across 7 repositories now compose the helper. Argument
+     ORDER was preserved at each site (scope-first sites use ownedAnd,
+     scope-last sites keep `and(eq(id,…), scopeToUser(…))`) so the generated
+     SQL is byte-identical — the cheapest possible equivalence argument.
+  3. BOTH JS-comparison write gates folded in (the ADL-53 F1 gap):
+     placeRepository.assertWritable and itemRepository.assertWritable no
+     longer re-derive ownership in application code; they delegate to
+     scope.assertWritable. Lock check preserved EXACTLY, including ordering —
+     a non-owner still gets 404 and never learns a trip is locked. Still one
+     query per call (status is selected alongside the scoped existence check
+     rather than assertOwned + a second read).
+  4. ADL-53 F3 (Drizzle .where() REPLACES, does not append) handled in
+     tripRepository.findAll: the scope is re-composed into the filtered
+     branch. Composing into the first .where() only would have dropped the
+     scope on the status-filtered path — invisible to every existing test.
+  5. NEW scripts/scope-completeness-check.sh (npm run scope:check), wired into
+     /pre-push. Matches BOTH ownership forms; predicate permitted only in
+     scope.ts, application-comparison permitted NOWHERE (including scope.ts).
+     Also fails if scope.ts is missing or no longer defines the predicate, so
+     deleting the chokepoint cannot make it pass vacuously. Proven fail-closed
+     against four injected residuals, not merely observed to pass.
+  6. Scanned production repository sources only (excluding __tests__) per COO
+     decision — repositories/__tests__/shadingConfig.test.ts has two
+     legitimate userId assertions that are test assertions, not ownership
+     logic. Those tests were NOT edited.
+  KNOWN BLIND SPOT of the check: it matches text, not syntax, so a comment
+  quoting either pattern trips it. Deliberate (fails closed); the fix is to
+  reword the comment, never to widen the exemption (OP-30).
+  OUT OF SCOPE and untouched: routes/** (Stages 2/3/4), the getDb-in-routes
+  guard (Stage 5, and it does not exist yet — no stage owns its creation),
+  services/shading.service.ts (4 ownership predicates live there, outside the
+  ADL's Stage-0 charter — flagged to COO).
+
+=== PRIOR STATUS: BUG-87/GE-20 Brief A thread ===
 BACKEND CONTEXT — 2026-08-08 (BUG-87/GE-20 Brief A thread, latest)
 PROJECT: Travel Tracker
 CURRENT STATUS: implemented GE-20's country_codes read-path filter (BRD

--- a/jobs/backend/park-docs/20260810-BACKEND-qual43-stage0-park.txt
+++ b/jobs/backend/park-docs/20260810-BACKEND-qual43-stage0-park.txt
@@ -1,0 +1,194 @@
+BACKEND PARK DOCUMENT — 2026-08-10
+THREAD: QUAL-43 / ADL-53 §6 Stage 0 — the userId-scoping chokepoint
+BRANCH: feat/qual43-stage0-scope-chokepoint (off main @ 178f41d)
+TRACKER: QUAL-43 · BRD: n/a (internal structural refactor)
+GITHUB ISSUE: none. QUAL-43 is tracker-only — two probes that fail
+  differently: (1) `gh issue list --state all --search "QUAL-43"` returned
+  nothing and a title scan of all open issues found no scoping/chokepoint
+  issue; (2) the tracker entry's own notes carry no issue number, which the
+  CLAUDE.md cross-referencing rule requires when one exists. PR body therefore
+  references QUAL-43 + ADL-53 §6 Stage 0 rather than "Closes #N".
+
+================================================================
+1. WHAT SHIPPED
+================================================================
+
+NEW  src/backend/repositories/scope.ts
+NEW  scripts/scope-completeness-check.sh   (npm run scope:check)
+MOD  src/backend/repositories/{trips,items,places,companions,activities,
+       tripCategories,shadingConfig}.ts
+MOD  package.json                          (scope:check script)
+MOD  .claude/skills/pre-push/SKILL.md      (scope:check wired into /pre-push)
+
+No file was rewritten wholesale. Every source change was a targeted edit;
+scope.ts and the check script are new files. (OP-28 declaration: no full-file
+rewrite of any existing source file occurred in this thread.)
+
+================================================================
+2. THE CHOKEPOINT — WHAT IT ACTUALLY IS
+================================================================
+
+Two mechanisms, ONE definition (ADL-53 F2). Stated precisely because the ADL
+itself had to be corrected on this point:
+
+  scopeToUser(table, userId) -> SQL
+      The ownership PREDICATE. For tables carrying their own user_id column.
+  ownedAnd(table, userId, ...extra) -> SQL
+      scopeToUser composed with caller conditions, ownership first.
+  assertOwned(userId, tripId) -> Promise<void>
+      The ownership ASSERTION as an EXISTENCE CHECK composed from
+      scopeToUser. 404 (NotFoundError), opaque per SE-05, never 403.
+  assertWritable(userId, tripId) -> Promise<void>
+      assertOwned + the locked-trip check. One query, not two.
+
+UserOwnedTable = activities | companions | items | mapShadingConfig |
+                 tripCategories | tripPlaces | trips
+
+That union is exactly the set of tables in schema.ts carrying a user_id
+column (verified by grepping schema.ts for userId column definitions: lines
+201, 228, 254, 287, 325, 426, 562 — seven tables, seven union members).
+
+THE COMPILE-TIME CONSTRAINT IS VERIFIED, NOT ASSUMED. A throwaway module
+(src/backend/__scope-negative-probe.ts, created and deleted) passed `trips`,
+`cities` and `countries` to scopeToUser. tsc accepted `trips` and emitted
+TS2345 on exactly the `cities` and `countries` lines. Passing a global
+reference table is a compile error, as ADL-53 §2 claims.
+
+================================================================
+3. HOW EQUIVALENCE WAS PROTECTED
+================================================================
+
+The brief's equivalence bar was 808/808 with no test edited. Three things
+kept that honest rather than lucky:
+
+(a) ARGUMENT ORDER PRESERVED AT EVERY SITE. Where the ownership predicate
+    came first, the site became ownedAnd(...). Where it came last, it stayed
+    `and(eq(id, …), scopeToUser(…))`. The AND terms are emitted in the same
+    order as before, so the generated SQL is byte-identical. Reordering
+    would almost certainly have been harmless — but "almost certainly" is
+    not an equivalence argument, and this cost nothing.
+
+(b) THE .where() FOOTGUN (ADL-53 F3) WAS HANDLED EXPLICITLY.
+    tripRepository.findAll builds a $dynamic() query: the first .where()
+    carries the scope, and the status-filtered branch RE-APPLIES it because
+    Drizzle's .where() REPLACES rather than appends. Both terminal .where()
+    calls now carry scopeToUser. This is the one site in the refactor where
+    a natural-looking simplification (compose into the first .where() only)
+    would have silently dropped the scope on the filtered path — and every
+    existing test would still have passed. A comment at the site records
+    why, so the next reader does not "clean it up".
+
+(c) THE WRITE GATES KEEP THEIR EXACT SEMANTICS. The old code selected
+    {status, userId} by trip id, then checked existence, then ownership,
+    then lock. The new code selects {status} by (id AND scope), then checks
+    existence, then lock. Both produce: missing -> 404, other user's ->
+    404, locked -> LockError, and critically a NON-OWNER OF A LOCKED TRIP
+    STILL GETS 404, never the lock error. Still exactly one query.
+
+Result: 808/808 backend (identical to the pre-Stage-0 baseline I re-ran
+myself on main before touching anything), 388/388 frontend, Part F 7/7.
+No test file was modified. No test assertion was relaxed.
+
+================================================================
+4. THE COMPLETENESS CHECK — AND WHY IT IS NOT VACUOUS
+================================================================
+
+scripts/scope-completeness-check.sh, exit-non-zero on any residual.
+
+Scans src/backend/repositories/*.ts at maxdepth 1 — production sources only,
+which excludes __tests__/ by construction rather than by a name filter.
+
+TWO regexes, because ownership was written two ways (ADL-53 F1):
+  predicate   eq\([A-Za-z_$][A-Za-z0-9_$]*\.userId
+  comparison  \.userId[[:space:]]*[!=]==
+
+The predicate is permitted ONLY in scope.ts. The comparison is permitted
+NOWHERE — including scope.ts — because the chokepoint expresses ownership as
+SQL, never as an application-layer compare. That is a deliberate tightening
+beyond the ADL's wording and it is free.
+
+A check that only ever passes is worse than no check, so I mutation-tested
+it. FOUR injected failures, each of which it caught (exit 1):
+  A. a predicate residual in a non-scope repository file        -> FAIL
+  B. an application-comparison residual                         -> FAIL
+  C. scope.ts deleted entirely                                  -> FAIL
+  D. scope.ts present but no longer defining the predicate      -> FAIL
+C and D matter: without them, deleting or gutting the chokepoint would make
+every other assertion pass vacuously.
+
+BLIND SPOT, STATED: it matches TEXT, not syntax. A comment quoting either
+pattern trips it. That is deliberate — it fails closed. The remedy is to
+reword the comment (OP-30: fix your own text first), never to add an
+exemption. scope.ts's own header says so, so the next author does not learn
+this by tripping it.
+
+Wired into /pre-push, NOT into CI. Per the brief, CI wiring is a follow-up.
+
+================================================================
+5. FINDINGS THAT QUALIFY ADL-53 (read these before Stage 4)
+================================================================
+
+F-A. FOUR OWNERSHIP PREDICATES LIVE IN services/, AND NO ADL-53 STAGE OWNS
+     THEM. src/backend/services/shading.service.ts:169, 209, 247, 291 each
+     write eq(trips.userId, userId) by hand. They are outside this brief's
+     scope (repositories/**) and outside the completeness check's scope —
+     correctly, per the brief. But they are also outside EVERY ADL-53 stage.
+     Two probes that fail differently: (1) grepping ADL-53 for "services/"
+     yields only cityIdentityService (a NEW Stage-2 file), a passing remark
+     that shading sits "behind shading.service" used to argue map.ts is
+     safe, and a test-coverage note — no stage assignment; (2) reading the
+     §6 stage table end to end: Stage 0 = repositories, Stages 2/3/4 =
+     routes/**, Stage 5 = the guard flip. Nothing names services/**.
+     CONSEQUENCE: ADL-53's D1/D7 "single Phase-3 change-point" is NOT
+     reached by the current staging even after Stage 5 — a sharing change
+     would still have to find and edit shading.service.ts separately. This
+     is structurally the SAME shape as the F1 finding the second fresh-eyes
+     review caught (ownership expressed in a second place that the stage's
+     grep never looks at), one directory over. Not a bleed: all four
+     predicates are present and correct today, and
+     services/__tests__/shading.user-scope.test.ts covers cross-user
+     isolation. It is a completeness gap in the PLAN, needing a COO/Architect
+     stage assignment — not something an implementation brief should absorb
+     unilaterally.
+
+F-B. assertOwned SHIPS WITH NO PRODUCTION CALLER. Two probes that fail
+     differently: (1) grep for assertOwned across all of src/ returns only
+     its own definition and two doc-comment mentions; (2) enumerating every
+     importer of ./scope.js shows all seven import scopeToUser/ownedAnd/
+     assertWritable and none imports assertOwned. Its first caller is Stage
+     4's tripPlaceActivitiesMap join reads. It ships now because ADL-53 §2
+     and the brief's success criterion (1) both name it as part of the
+     chokepoint contract. It therefore also has no direct test coverage.
+
+F-C. NO NEW TESTS WERE ADDED, DELIBERATELY. Success criterion (4) fixed the
+     bar at exactly 808/808 "unchanged from the pre-Stage-0 baseline". Adding
+     a scope.ts unit suite would have moved that number and made the
+     equivalence claim harder to read, so I did not. scopeToUser, ownedAnd
+     and assertWritable are covered transitively and heavily (every
+     repository suite plus Part F). assertOwned is not covered at all — see
+     F-B. Recommend Stage 4's brief carry direct coverage for it.
+
+F-D. LINE NUMBERS IN ADL-53 HAVE DRIFTED, AS THE BRIEF WARNED. The two
+     JS-comparison gates the ADL cites at places.ts:273 / items.ts:95 were
+     at places.ts:281 / items.ts:103. Both were located by content. Every
+     predicate site named in §5.1 that falls inside repositories/** was
+     found; nothing cited was missing.
+
+================================================================
+6. STATE AT PARK
+================================================================
+
+Branch feat/qual43-stage0-scope-chokepoint, two commits (source +
+housekeeping), working tree clean, PR open against main, CI green.
+Nothing left uncommitted. PR not merged — COO merges.
+
+WHAT THIS UNBLOCKS: Stages 2, 3 and 4 can now compose the helper (Stage 0
+was the substrate blocking all three). Stage 4 additionally re-runs
+npm run scope:check as part of its own exit criteria, as does Stage 5.
+
+WHAT IT DOES NOT DO: no route was touched; no citiesRepository,
+referenceRepository or cityIdentityService exists; the getDb-in-routes guard
+still does not exist (no ADL-53 stage creates it — §3 describes it in
+recommendation voice and Stage 5 only "flips" it; the COO reached the same
+conclusion independently before dispatch). Stage 5 will need to create it,
+not merely flip it.

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "status": "node scripts/status.js",
     "status:check": "node scripts/status.js --check",
     "tracker:check": "node scripts/tracker-check.js",
+    "scope:check": "bash scripts/scope-completeness-check.sh",
     "test:backend": "vitest run --config vitest.config.backend.ts",
     "test:backend:watch": "vitest --config vitest.config.backend.ts",
     "test:frontend": "vitest run --config vitest.config.frontend.ts",

--- a/scripts/scope-completeness-check.sh
+++ b/scripts/scope-completeness-check.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# Scope completeness check — QUAL-43 / ADL-53 §6 "Stage 0 detail" (the F1 fold).
+#
+# Asserts ZERO residual hand-authored userId ownership logic in the production
+# repository sources. Every ownership expression must resolve through the
+# chokepoint in `src/backend/repositories/scope.ts` (`scopeToUser` / `ownedAnd`
+# / `assertOwned` / `assertWritable`), so that "who may see this row" has exactly
+# one definition — the property Phase-3 sharing (ADL-53 D7/§7) depends on.
+#
+# TWO patterns are matched, because ownership was expressed two ways (ADL-53 F1)
+# and a predicate-only grep sails straight past the second:
+#
+#   1. SQL predicate    — `eq(<table>.userId, ...)`
+#   2. JS comparison    — `<expr>.userId === / !== <expr>`   (a write-gate check
+#                         re-deriving ownership in application code instead of
+#                         composing the predicate)
+#
+# Without pattern 2, a grep-driven refactor collapses the predicates and silently
+# leaves the write gates as a SECOND, independent definition of "owned".
+#
+# PERMITTED MATCHES
+#   Pattern 1 is permitted ONLY in `scope.ts`, which necessarily contains the one
+#   definition. Pattern 2 is permitted NOWHERE, including `scope.ts` — the
+#   chokepoint expresses ownership as SQL, never as an application-layer compare.
+#
+# SCOPE — production repository sources only: `src/backend/repositories/*.ts`,
+#   excluding `__tests__/`. COO decision (2026-08-10): the intent is "zero
+#   hand-authored PRODUCTION ownership logic". Test files legitimately assert on
+#   a row's userId (e.g. `repositories/__tests__/shadingConfig.test.ts`) — those
+#   are assertions about data, not ownership logic, and rewriting them to satisfy
+#   a grep would weaken the tests to flatter the check. The exclusion stops at
+#   `__tests__`: anything else that matches is a residual to FIX, not to exempt
+#   (OP-30 — widening a scanner's suppression is not an implementer's call).
+#
+# BLIND SPOT (stated, not silently accepted): this matches TEXT, not syntax, so a
+# comment quoting either pattern trips it. That is deliberate — it fails closed.
+# The fix is to reword the comment (OP-30: fix your own text), never to add an
+# exemption here.
+#
+# Re-run by Stages 4 and 5, which must re-verify this same invariant.
+# Usage: scripts/scope-completeness-check.sh [repo-root]
+
+set -euo pipefail
+
+ROOT="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+REPO_DIR="$ROOT/src/backend/repositories"
+CHOKEPOINT="scope.ts"
+
+PREDICATE_RE='eq\([A-Za-z_$][A-Za-z0-9_$]*\.userId'
+JS_COMPARE_RE='\.userId[[:space:]]*[!=]=='
+
+if [ ! -d "$REPO_DIR" ]; then
+  echo "scope-completeness-check: FAIL — repository directory not found: $REPO_DIR" >&2
+  exit 1
+fi
+
+# Production repository sources only — `find -maxdepth 1` excludes `__tests__/`.
+mapfile -t FILES < <(find "$REPO_DIR" -maxdepth 1 -name '*.ts' -type f | sort)
+
+if [ "${#FILES[@]}" -eq 0 ]; then
+  echo "scope-completeness-check: FAIL — no repository sources found under $REPO_DIR" >&2
+  exit 1
+fi
+
+# The chokepoint must exist and must actually define the predicate. Without this,
+# deleting scope.ts would make every other check pass vacuously.
+if [ ! -f "$REPO_DIR/$CHOKEPOINT" ]; then
+  echo "scope-completeness-check: FAIL — the chokepoint $CHOKEPOINT is missing." >&2
+  exit 1
+fi
+if ! grep -Eq "$PREDICATE_RE" "$REPO_DIR/$CHOKEPOINT"; then
+  echo "scope-completeness-check: FAIL — $CHOKEPOINT no longer defines the ownership" >&2
+  echo "  predicate. The chokepoint is the ONE place ownership may be written by hand;" >&2
+  echo "  if it moved, update this check and ADL-53 §2 together." >&2
+  exit 1
+fi
+
+residuals=0
+
+for f in "${FILES[@]}"; do
+  rel="${f#"$ROOT"/}"
+  base="$(basename "$f")"
+
+  # Pattern 1 — SQL predicate. Permitted only in the chokepoint itself.
+  if [ "$base" != "$CHOKEPOINT" ]; then
+    while IFS=: read -r lineno text; do
+      [ -n "$lineno" ] || continue
+      echo "RESIDUAL $rel:$lineno — hand-authored ownership predicate"
+      echo "    ${text#"${text%%[![:space:]]*}"}"
+      echo "    → compose the chokepoint instead: scopeToUser(<table>, userId)"
+      echo "      or ownedAnd(<table>, userId, ...conditions)  [scope.ts]"
+      residuals=$((residuals + 1))
+    done < <(grep -nE "$PREDICATE_RE" "$f" || true)
+  fi
+
+  # Pattern 2 — application-layer ownership comparison. Permitted nowhere.
+  while IFS=: read -r lineno text; do
+    [ -n "$lineno" ] || continue
+    echo "RESIDUAL $rel:$lineno — ownership re-derived in application code"
+    echo "    ${text#"${text%%[![:space:]]*}"}"
+    echo "    → express it as an existence check through the chokepoint:"
+    echo "      assertOwned(userId, tripId) / assertWritable(userId, tripId)  [scope.ts]"
+    residuals=$((residuals + 1))
+  done < <(grep -nE "$JS_COMPARE_RE" "$f" || true)
+done
+
+if [ "$residuals" -gt 0 ]; then
+  echo ""
+  echo "scope-completeness-check: FAIL — $residuals residual ownership site(s) outside the chokepoint."
+  echo "  ADL-53 §6 Stage 0: every ownership expression in src/backend/repositories/**"
+  echo "  must resolve through src/backend/repositories/scope.ts."
+  exit 1
+fi
+
+echo "scope-completeness-check: PASS — ${#FILES[@]} production repository source(s) scanned;"
+echo "  every ownership expression resolves through repositories/$CHOKEPOINT."

--- a/src/backend/repositories/activities.ts
+++ b/src/backend/repositories/activities.ts
@@ -17,6 +17,7 @@ import { and, asc, eq, inArray } from 'drizzle-orm';
 import { activities, getDb } from '../db/index.js';
 import type { Activity } from '../db/schema.js';
 import { ACTIVITIES } from '../db/seed-data.js';
+import { ownedAnd, scopeToUser } from './scope.js';
 
 export const activityRepository = {
   /**
@@ -43,7 +44,7 @@ export const activityRepository = {
     const rows = await db
       .select({ id: activities.id })
       .from(activities)
-      .where(eq(activities.userId, userId))
+      .where(scopeToUser(activities, userId))
       .limit(1);
     if (!rows.length) {
       await activityRepository.seedDefaults(userId);
@@ -56,7 +57,7 @@ export const activityRepository = {
     return db
       .select()
       .from(activities)
-      .where(eq(activities.userId, userId))
+      .where(scopeToUser(activities, userId))
       .orderBy(asc(activities.name));
   },
 
@@ -66,7 +67,7 @@ export const activityRepository = {
     return db
       .select()
       .from(activities)
-      .where(and(eq(activities.userId, userId), eq(activities.isActive, 1)))
+      .where(ownedAnd(activities, userId, eq(activities.isActive, 1)))
       .orderBy(asc(activities.name));
   },
 
@@ -76,7 +77,7 @@ export const activityRepository = {
     const rows = await db
       .select()
       .from(activities)
-      .where(and(eq(activities.id, id), eq(activities.userId, userId)))
+      .where(and(eq(activities.id, id), scopeToUser(activities, userId)))
       .limit(1);
     return rows[0] ?? null;
   },
@@ -110,7 +111,7 @@ export const activityRepository = {
     const updated = await db
       .update(activities)
       .set(updates)
-      .where(and(eq(activities.id, id), eq(activities.userId, userId)))
+      .where(and(eq(activities.id, id), scopeToUser(activities, userId)))
       .returning();
     return updated[0] ?? null;
   },
@@ -141,7 +142,7 @@ export const activityRepository = {
     const rows = await db
       .select({ id: activities.id })
       .from(activities)
-      .where(and(eq(activities.userId, userId), inArray(activities.id, activityIds)));
+      .where(ownedAnd(activities, userId, inArray(activities.id, activityIds)));
     const validIds = new Set(rows.map((r) => r.id));
     return activityIds.filter((id) => !validIds.has(id));
   },

--- a/src/backend/repositories/companions.ts
+++ b/src/backend/repositories/companions.ts
@@ -9,6 +9,7 @@
 import { and, asc, eq, inArray } from 'drizzle-orm';
 import { companions, getDb } from '../db/index.js';
 import type { Companion } from '../db/schema.js';
+import { ownedAnd, scopeToUser } from './scope.js';
 
 export const companionRepository = {
   /** Returns all companions owned by userId (active + inactive), name ascending. */
@@ -17,7 +18,7 @@ export const companionRepository = {
     return db
       .select()
       .from(companions)
-      .where(eq(companions.userId, userId))
+      .where(scopeToUser(companions, userId))
       .orderBy(asc(companions.name));
   },
 
@@ -27,7 +28,7 @@ export const companionRepository = {
     return db
       .select()
       .from(companions)
-      .where(and(eq(companions.userId, userId), eq(companions.isActive, 1)))
+      .where(ownedAnd(companions, userId, eq(companions.isActive, 1)))
       .orderBy(asc(companions.name));
   },
 
@@ -37,7 +38,7 @@ export const companionRepository = {
     const rows = await db
       .select()
       .from(companions)
-      .where(and(eq(companions.id, id), eq(companions.userId, userId)))
+      .where(and(eq(companions.id, id), scopeToUser(companions, userId)))
       .limit(1);
     return rows[0] ?? null;
   },
@@ -71,7 +72,7 @@ export const companionRepository = {
     const updated = await db
       .update(companions)
       .set(updates)
-      .where(and(eq(companions.id, id), eq(companions.userId, userId)))
+      .where(and(eq(companions.id, id), scopeToUser(companions, userId)))
       .returning();
     return updated[0] ?? null;
   },
@@ -101,7 +102,7 @@ export const companionRepository = {
     const rows = await db
       .select({ id: companions.id })
       .from(companions)
-      .where(and(eq(companions.userId, userId), inArray(companions.id, companionIds)));
+      .where(ownedAnd(companions, userId, inArray(companions.id, companionIds)));
     const validIds = new Set(rows.map((r) => r.id));
     return companionIds.filter((id) => !validIds.has(id));
   },

--- a/src/backend/repositories/items.ts
+++ b/src/backend/repositories/items.ts
@@ -16,12 +16,12 @@ import {
   itemHotels,
   itemRestaurants,
   items,
-  trips,
 } from '../db/index.js';
 import type { Item } from '../db/schema.js';
-import { LockError, NotFoundError } from '../errors.js';
+import { NotFoundError } from '../errors.js';
 import { fetchItemsWithExtensions } from '../routes/items-helper.js';
 import { ensureExperienceExtension } from '../services/items.service.js';
+import { assertWritable as assertTripWritable, scopeToUser } from './scope.js';
 
 // ----------------------------------------------------------------
 // Repository
@@ -44,7 +44,7 @@ export const itemRepository = {
       minRating?: number;
     },
   ): Promise<Record<string, unknown>[]> {
-    const conditions: SQL[] = [eq(items.tripId, tripId), eq(items.userId, userId)];
+    const conditions: SQL[] = [eq(items.tripId, tripId), scopeToUser(items, userId)];
     if (filters?.placeId) conditions.push(eq(items.tripPlaceId, Number(filters.placeId)));
     if (filters?.type) conditions.push(eq(items.itemType, filters.type));
     if (filters?.status) conditions.push(eq(items.status, filters.status));
@@ -62,7 +62,7 @@ export const itemRepository = {
    */
   async findById(userId: string, itemId: number): Promise<Record<string, unknown> | null> {
     const results = await fetchItemsWithExtensions(
-      and(eq(items.id, itemId), eq(items.userId, userId)),
+      and(eq(items.id, itemId), scopeToUser(items, userId)),
     );
     return results[0] ?? null;
   },
@@ -77,7 +77,7 @@ export const itemRepository = {
     const rows = await db
       .select()
       .from(items)
-      .where(and(eq(items.id, itemId), eq(items.tripId, tripId), eq(items.userId, userId)))
+      .where(and(eq(items.id, itemId), eq(items.tripId, tripId), scopeToUser(items, userId)))
       .limit(1);
     if (!rows.length) throw new NotFoundError('Item');
     return rows[0];
@@ -91,17 +91,16 @@ export const itemRepository = {
    * Verifies the trip exists, is owned by userId, and is not locked.
    * Mirrors placeRepository.assertWritable — child inserts (items) carry no
    * userId scoping of their own, so the owning trip must be checked before create.
+   *
+   * ADL-53 Stage 0 (F1): ownership is no longer re-derived here. It is delegated
+   * to the chokepoint's assertion helper, which expresses it as an existence
+   * check composed from `scopeToUser` — so this write gate and every read share
+   * one definition of "owned". Behaviour is unchanged: NotFoundError (404,
+   * opaque per SE-05) when missing or owned by another user, LockError when
+   * locked.
    */
   async assertWritable(userId: string, tripId: number): Promise<void> {
-    const db = getDb();
-    const rows = await db
-      .select({ status: trips.status, userId: trips.userId })
-      .from(trips)
-      .where(eq(trips.id, tripId))
-      .limit(1);
-    if (!rows.length) throw new NotFoundError('Trip');
-    if (rows[0].userId !== userId) throw new NotFoundError('Trip');
-    if (rows[0].status === 'locked') throw new LockError();
+    await assertTripWritable(userId, tripId);
   },
 
   async create(
@@ -173,7 +172,7 @@ export const itemRepository = {
     await db
       .update(items)
       .set(baseUpdates)
-      .where(and(eq(items.id, itemId), eq(items.tripId, tripId), eq(items.userId, userId)));
+      .where(and(eq(items.id, itemId), eq(items.tripId, tripId), scopeToUser(items, userId)));
 
     await updateExtension(itemType, itemId, extensionBody);
 
@@ -189,7 +188,7 @@ export const itemRepository = {
     const db = getDb();
     const deleted = await db
       .delete(items)
-      .where(and(eq(items.id, itemId), eq(items.tripId, tripId), eq(items.userId, userId)))
+      .where(and(eq(items.id, itemId), eq(items.tripId, tripId), scopeToUser(items, userId)))
       .returning({ id: items.id });
     return deleted.length > 0;
   },

--- a/src/backend/repositories/places.ts
+++ b/src/backend/repositories/places.ts
@@ -17,7 +17,8 @@ import {
   trips,
 } from '../db/index.js';
 import type { TripPlace } from '../db/schema.js';
-import { ConflictError, LockError, NotFoundError } from '../errors.js';
+import { ConflictError, NotFoundError } from '../errors.js';
+import { assertWritable as assertTripWritable, scopeToUser } from './scope.js';
 
 // ----------------------------------------------------------------
 // Types
@@ -67,7 +68,7 @@ export const placeRepository = {
     const tripRows = await db
       .select({ id: trips.id })
       .from(trips)
-      .where(and(eq(trips.id, tripId), eq(trips.userId, userId)))
+      .where(and(eq(trips.id, tripId), scopeToUser(trips, userId)))
       .limit(1);
     if (!tripRows.length) throw new NotFoundError('Trip');
 
@@ -138,7 +139,7 @@ export const placeRepository = {
     const rows = await db
       .select({ p: tripPlaces })
       .from(tripPlaces)
-      .innerJoin(trips, and(eq(trips.id, tripPlaces.tripId), eq(trips.userId, userId)))
+      .innerJoin(trips, and(eq(trips.id, tripPlaces.tripId), scopeToUser(trips, userId)))
       .where(eq(tripPlaces.id, placeId))
       .limit(1);
     return rows[0]?.p ?? null;
@@ -269,16 +270,15 @@ export const placeRepository = {
    *
    * Used directly by route handlers that need to verify writeability before
    * any nested operation (carry-forward, activity tagging, etc.).
+   *
+   * ADL-53 Stage 0 (F1): ownership is no longer re-derived here. It is delegated
+   * to the chokepoint's assertion helper, which expresses it as an existence
+   * check composed from `scopeToUser` — so this write gate and every read share
+   * one definition of "owned". Behaviour is unchanged: a trip owned by another
+   * user is indistinguishable from a missing one (404, opaque per SE-05), and a
+   * non-owner never learns that a trip is locked.
    */
   async assertWritable(userId: string, tripId: number): Promise<void> {
-    const db = getDb();
-    const rows = await db
-      .select({ status: trips.status, userId: trips.userId })
-      .from(trips)
-      .where(eq(trips.id, tripId))
-      .limit(1);
-    if (!rows.length) throw new NotFoundError('Trip');
-    if (rows[0].userId !== userId) throw new NotFoundError('Trip');
-    if (rows[0].status === 'locked') throw new LockError();
+    await assertTripWritable(userId, tripId);
   },
 };

--- a/src/backend/repositories/scope.ts
+++ b/src/backend/repositories/scope.ts
@@ -1,0 +1,121 @@
+/**
+ * Travel Tracker — The userId-scoping chokepoint (ADL-53 §2, QUAL-43 Stage 0)
+ *
+ * This module is the SINGLE place row ownership is defined. Every ownership
+ * expression in `src/backend/repositories/**` resolves through it — no
+ * repository writes `eq(<table>.userId, userId)` by hand, and none re-derives
+ * ownership by comparing a selected user id in JavaScript.
+ *
+ * The chokepoint is honestly TWO mechanisms sharing ONE definition (ADL-53 F2):
+ *
+ *   1. `scopeToUser` / `ownedAnd` — the ownership PREDICATE, for a table that
+ *      carries its own `user_id` column. Composed into the query's WHERE / JOIN
+ *      condition.
+ *   2. `assertOwned` / `assertWritable` — the ownership ASSERTION, for a target
+ *      that carries no `user_id` column of its own (a derived or join-table read
+ *      such as `trip_place_activities_map`), or for a write gate that must reject
+ *      a non-owner opaquely. It expresses ownership as an EXISTENCE CHECK routed
+ *      through `scopeToUser` — never as an application-layer comparison — so both
+ *      mechanisms share one definition of "owned".
+ *
+ * Phase-3 sharing (ADL-53 D7/§7) edits `scopeToUser` and nothing else: the
+ * assertion helpers pick the change up because they call it.
+ *
+ * MAINTENANCE NOTE: `scripts/scope-completeness-check.sh` greps this directory
+ * for hand-authored ownership logic and permits the predicate form ONLY in this
+ * file. It matches text, not syntax, so do not quote either flagged pattern in a
+ * comment inside a repository source file — reword instead (OP-30: fix your own
+ * text rather than weakening the scanner).
+ */
+
+import { and, eq, type SQL } from 'drizzle-orm';
+import {
+  type activities,
+  type companions,
+  getDb,
+  type items,
+  type mapShadingConfig,
+  type tripCategories,
+  type tripPlaces,
+  trips,
+} from '../db/index.js';
+import { LockError, NotFoundError } from '../errors.js';
+
+/**
+ * The user-owned tables — every table in `schema.ts` carrying a `user_id`
+ * column. A table not in this union cannot be passed to `scopeToUser`, so
+ * "is this table user data?" is answered once, in the type system, rather than
+ * re-litigated at each call site. Passing a global reference table (`cities`,
+ * `countries`, `regions`) is a compile error by construction.
+ */
+export type UserOwnedTable =
+  | typeof activities
+  | typeof companions
+  | typeof items
+  | typeof mapShadingConfig
+  | typeof tripCategories
+  | typeof tripPlaces
+  | typeof trips;
+
+/**
+ * The single ownership predicate. Phase-3 sharing changes ONLY this function
+ * (`owner` → `owner OR shared-with(user, resource)`).
+ */
+export function scopeToUser(table: UserOwnedTable, userId: string): SQL {
+  return eq(table.userId, userId);
+}
+
+/**
+ * Composes the ownership predicate with caller conditions — the shape
+ * repositories actually use. Ownership comes first, matching the `and(...)`
+ * ordering the repositories already had.
+ */
+export function ownedAnd(
+  table: UserOwnedTable,
+  userId: string,
+  ...extra: (SQL | undefined)[]
+): SQL {
+  return and(scopeToUser(table, userId), ...extra)!;
+}
+
+/**
+ * Asserts a trip exists and is owned by `userId`.
+ *
+ * Ownership is an existence check composed from `scopeToUser`, so a trip owned
+ * by someone else is indistinguishable from one that does not exist: both raise
+ * `NotFoundError` (404, opaque per SE-05 — never 403).
+ *
+ * `trips` is the only owning row this assertion is needed for today: the
+ * child tables that lack their own scope (`trip_place_activities_map`) hang off
+ * a trip. A future owning class adds a sibling function here rather than a
+ * second, independent definition of ownership elsewhere.
+ */
+export async function assertOwned(userId: string, tripId: number): Promise<void> {
+  const db = getDb();
+  const rows = await db
+    .select({ id: trips.id })
+    .from(trips)
+    .where(and(eq(trips.id, tripId), scopeToUser(trips, userId)))
+    .limit(1);
+  if (!rows.length) throw new NotFoundError('Trip');
+}
+
+/**
+ * Asserts a trip exists, is owned by `userId`, AND is not locked — the write
+ * gate. This is `assertOwned` plus the lock check; the two are done in one
+ * query rather than two so the write path costs exactly what it did before.
+ *
+ * Throws `NotFoundError` (404) when the trip is missing or owned by another
+ * user, `LockError` (403) when it is locked. Order matters and is preserved:
+ * a non-owner never learns that a trip is locked.
+ */
+export async function assertWritable(userId: string, tripId: number): Promise<void> {
+  const db = getDb();
+  const rows = await db
+    .select({ status: trips.status })
+    .from(trips)
+    .where(and(eq(trips.id, tripId), scopeToUser(trips, userId)))
+    .limit(1);
+  if (!rows.length) throw new NotFoundError('Trip');
+  if (rows[0].status === 'locked') throw new LockError();
+}

--- a/src/backend/repositories/shadingConfig.ts
+++ b/src/backend/repositories/shadingConfig.ts
@@ -8,10 +8,11 @@
  * is idempotent and safe to call defensively.
  */
 
-import { and, eq } from 'drizzle-orm';
+import { eq } from 'drizzle-orm';
 import { getDb, mapShadingConfig } from '../db/index.js';
 import type { MapShadingConfig } from '../db/schema.js';
 import { MAP_SHADING_CONFIG } from '../db/seed-data.js';
+import { ownedAnd, scopeToUser } from './scope.js';
 
 /** Default seed values for the 6 shading states (MP-05: 'never_visited' excluded). */
 const DEFAULT_SHADING_CONFIG: Array<{ stateKey: string; displayName: string; colorHex: string }> =
@@ -24,11 +25,14 @@ export const shadingConfigRepository = {
    */
   async findAll(userId: string): Promise<MapShadingConfig[]> {
     const db = getDb();
-    let rows = await db.select().from(mapShadingConfig).where(eq(mapShadingConfig.userId, userId));
+    let rows = await db
+      .select()
+      .from(mapShadingConfig)
+      .where(scopeToUser(mapShadingConfig, userId));
 
     if (rows.length === 0) {
       await shadingConfigRepository.seedDefaults(userId);
-      rows = await db.select().from(mapShadingConfig).where(eq(mapShadingConfig.userId, userId));
+      rows = await db.select().from(mapShadingConfig).where(scopeToUser(mapShadingConfig, userId));
     }
 
     return rows;
@@ -45,7 +49,7 @@ export const shadingConfigRepository = {
       db
         .select()
         .from(mapShadingConfig)
-        .where(and(eq(mapShadingConfig.userId, userId), eq(mapShadingConfig.stateKey, stateKey)))
+        .where(ownedAnd(mapShadingConfig, userId, eq(mapShadingConfig.stateKey, stateKey)))
         .limit(1);
 
     let rows = await select();
@@ -53,7 +57,7 @@ export const shadingConfigRepository = {
       const anyRows = await db
         .select()
         .from(mapShadingConfig)
-        .where(eq(mapShadingConfig.userId, userId))
+        .where(scopeToUser(mapShadingConfig, userId))
         .limit(1);
       if (!anyRows.length) {
         await shadingConfigRepository.seedDefaults(userId);
@@ -82,7 +86,7 @@ export const shadingConfigRepository = {
     const updated = await db
       .update(mapShadingConfig)
       .set(updates)
-      .where(and(eq(mapShadingConfig.userId, userId), eq(mapShadingConfig.stateKey, stateKey)))
+      .where(ownedAnd(mapShadingConfig, userId, eq(mapShadingConfig.stateKey, stateKey)))
       .returning();
     return updated[0] ?? null;
   },

--- a/src/backend/repositories/tripCategories.ts
+++ b/src/backend/repositories/tripCategories.ts
@@ -17,6 +17,7 @@ import { and, asc, eq, inArray } from 'drizzle-orm';
 import { getDb, tripCategories } from '../db/index.js';
 import type { TripCategory } from '../db/schema.js';
 import { TRIP_CATEGORIES } from '../db/seed-data.js';
+import { ownedAnd, scopeToUser } from './scope.js';
 
 export const tripCategoryRepository = {
   /**
@@ -45,7 +46,7 @@ export const tripCategoryRepository = {
     const rows = await db
       .select({ id: tripCategories.id })
       .from(tripCategories)
-      .where(eq(tripCategories.userId, userId))
+      .where(scopeToUser(tripCategories, userId))
       .limit(1);
     if (!rows.length) {
       await tripCategoryRepository.seedDefaults(userId);
@@ -58,7 +59,7 @@ export const tripCategoryRepository = {
     return db
       .select()
       .from(tripCategories)
-      .where(eq(tripCategories.userId, userId))
+      .where(scopeToUser(tripCategories, userId))
       .orderBy(asc(tripCategories.name));
   },
 
@@ -68,7 +69,7 @@ export const tripCategoryRepository = {
     return db
       .select()
       .from(tripCategories)
-      .where(and(eq(tripCategories.userId, userId), eq(tripCategories.isActive, 1)))
+      .where(ownedAnd(tripCategories, userId, eq(tripCategories.isActive, 1)))
       .orderBy(asc(tripCategories.name));
   },
 
@@ -78,7 +79,7 @@ export const tripCategoryRepository = {
     const rows = await db
       .select()
       .from(tripCategories)
-      .where(and(eq(tripCategories.id, id), eq(tripCategories.userId, userId)))
+      .where(and(eq(tripCategories.id, id), scopeToUser(tripCategories, userId)))
       .limit(1);
     return rows[0] ?? null;
   },
@@ -112,7 +113,7 @@ export const tripCategoryRepository = {
     const updated = await db
       .update(tripCategories)
       .set(updates)
-      .where(and(eq(tripCategories.id, id), eq(tripCategories.userId, userId)))
+      .where(and(eq(tripCategories.id, id), scopeToUser(tripCategories, userId)))
       .returning();
     return updated[0] ?? null;
   },
@@ -143,7 +144,7 @@ export const tripCategoryRepository = {
     const rows = await db
       .select({ id: tripCategories.id })
       .from(tripCategories)
-      .where(and(eq(tripCategories.userId, userId), inArray(tripCategories.id, categoryIds)));
+      .where(ownedAnd(tripCategories, userId, inArray(tripCategories.id, categoryIds)));
     const validIds = new Set(rows.map((r) => r.id));
     return categoryIds.filter((id) => !validIds.has(id));
   },

--- a/src/backend/repositories/trips.ts
+++ b/src/backend/repositories/trips.ts
@@ -27,6 +27,7 @@ import type { Trip } from '../db/schema.js';
 import { NotFoundError, ValidationError } from '../errors.js';
 import { activityRepository } from './activities.js';
 import { companionRepository } from './companions.js';
+import { ownedAnd, scopeToUser } from './scope.js';
 import { tripCategoryRepository } from './tripCategories.js';
 
 // ----------------------------------------------------------------
@@ -58,10 +59,14 @@ export const tripRepository = {
   async findAll(userId: string, filters?: TripFilters): Promise<Trip[]> {
     const db = getDb();
 
-    let query = db.select().from(trips).where(eq(trips.userId, userId)).$dynamic();
+    // ADL-53 F3: Drizzle's `.where()` REPLACES the predicate, it does not append.
+    // On this `$dynamic()` builder the scope must therefore be re-composed into
+    // the filtered branch below — carrying it only on the first `.where()` would
+    // silently drop it whenever a status filter is supplied.
+    let query = db.select().from(trips).where(scopeToUser(trips, userId)).$dynamic();
 
     if (filters?.status) {
-      query = query.where(and(eq(trips.userId, userId), eq(trips.status, filters.status)));
+      query = query.where(ownedAnd(trips, userId, eq(trips.status, filters.status)));
     }
 
     const allTrips = await query.orderBy(desc(trips.startDate));
@@ -115,7 +120,7 @@ export const tripRepository = {
     const rows = await db
       .select()
       .from(trips)
-      .where(and(eq(trips.id, tripId), eq(trips.userId, userId)))
+      .where(and(eq(trips.id, tripId), scopeToUser(trips, userId)))
       .limit(1);
     return rows[0] ?? null;
   },
@@ -185,7 +190,7 @@ export const tripRepository = {
     const updated = await db
       .update(trips)
       .set(updates)
-      .where(and(eq(trips.id, tripId), eq(trips.userId, userId)))
+      .where(and(eq(trips.id, tripId), scopeToUser(trips, userId)))
       .returning();
     return updated[0] ?? null;
   },
@@ -198,7 +203,7 @@ export const tripRepository = {
     const db = getDb();
     const deleted = await db
       .delete(trips)
-      .where(and(eq(trips.id, tripId), eq(trips.userId, userId)))
+      .where(and(eq(trips.id, tripId), scopeToUser(trips, userId)))
       .returning({ id: trips.id });
     return deleted.length > 0;
   },


### PR DESCRIPTION
Tracker: **QUAL-43** · Spec: **ADL-53 §6 Stage 0** (+ the F1/F2/F3 folds in §R2) · BRD: n/a (internal structural refactor)

QUAL-43 is tracker-only, so there is no `Closes #N` — established by two probes that fail differently: `gh issue list --state all` finds no matching issue, and the tracker entry's own notes carry no issue number (which the CLAUDE.md cross-referencing rule requires when one exists).

## What this does

Introduces `src/backend/repositories/scope.ts` as the single definition of row ownership, and routes **every** ownership expression in the production repository sources through it. Pure DRY refactor: same queries, same results, same error types and status codes.

The chokepoint is honestly **two mechanisms sharing one definition** (ADL-53 F2):

- `scopeToUser(table, userId)` / `ownedAnd(table, userId, ...extra)` — the ownership **predicate**, for tables carrying a `user_id` column. The `UserOwnedTable` union makes passing a global reference table a **compile error** — verified by probe, not assumed: a throwaway module passing `cities`/`countries` produced `TS2345` on exactly those lines while `trips` compiled.
- `assertOwned(userId, tripId)` / `assertWritable(userId, tripId)` — the ownership **assertion**, expressed as an existence check composed from `scopeToUser`. 404 (opaque per SE-05), never 403.

**Both JS-comparison write gates are folded in** — the ADL-53 **F1** gap. `placeRepository.assertWritable` and `itemRepository.assertWritable` no longer re-derive ownership in application code. The locked-trip check is preserved exactly, *including its ordering*: a non-owner still gets 404 and never learns a trip is locked. Still one query per call.

**ADL-53 F3 handled explicitly.** Drizzle's `.where()` *replaces* rather than appends, so `tripRepository.findAll` re-composes the scope into its status-filtered branch. Composing into the first `.where()` only would have silently dropped the scope on that path — and every existing test would still have passed. A comment at the site records why, so it doesn't get "cleaned up" later.

## The completeness exit-check

`scripts/scope-completeness-check.sh` (`npm run scope:check`), wired into `/pre-push`. Matches **both** ownership forms — the `eq(<table>.userId, …)` predicate and the application-layer comparison. The predicate is permitted only in `scope.ts`; the comparison is permitted **nowhere, including `scope.ts`**.

A check that only ever passes is worse than none, so it was mutation-tested against four injected failures, each caught: a predicate residual, a comparison residual, `scope.ts` deleted, and `scope.ts` present but no longer defining the predicate. The last two matter — without them, gutting the chokepoint would make every other assertion pass vacuously.

Scope is production repository sources only (`src/backend/repositories/*.ts`, excluding `__tests__`), per COO decision: `__tests__/shadingConfig.test.ts` holds legitimate userId *test assertions*, not ownership logic. Those tests were not touched. Blind spot, stated in the script header: it matches text, not syntax, so a comment quoting either pattern trips it — deliberate, it fails closed, and the remedy is to reword the comment rather than widen the exemption (OP-30).

Not wired into CI in this stage — flagged as a follow-up.

## Verification

- `npm run test:backend` — **808/808**, identical to the pre-Stage-0 baseline re-run on `main` @ `178f41d` before any edit. **No test file was modified and no assertion relaxed.**
- Part F (cross-tenant isolation matrix, PR #484) — **7/7 green**.
- `npm run test:frontend` 388/388 · `type:check:all` clean · `biome ci` clean · `status:check`, `tracker:check`, `scope:check` all pass.
- Argument order was preserved at every one of the 34 predicate sites, so the emitted SQL is byte-identical.

## Security checklist (OP-06) — userId scoping IS the subject

1. **Auth middleware** — no route added or modified; every existing `requireAuth`/`requireOwner` binding is untouched.
2. **Repository query scoping** — strengthened, which is the point: all 34 predicate sites plus both write gates now resolve through one definition, machine-verified by `scope:check` rather than by convention.
3. **FK `.notNull()`** — no schema change; no new user-data column.

## Out of scope (untouched)

`routes/**` (Stages 2/3/4), `citiesRepository`/`referenceRepository`/`cityIdentityService` (Stages 2/3), and the `getDb`-in-routes guard (Stage 5).

## Findings for the COO

Detail in `jobs/COO/inbox/20260810_1500-BACKEND-qual43-stage0-complete.txt`. The load-bearing one: **four hand-written ownership predicates live in `src/backend/services/shading.service.ts` (:169, :209, :247, :291), and no ADL-53 stage owns them** — so the "single Phase-3 change-point" is not reached by the current staging even after Stage 5. Not a bleed (all four are correct today and covered by `shading.user-scope.test.ts`); a completeness gap in the plan needing a stage assignment.