### PR TITLE
fix(QUAL-46): ci-wait.sh must re-resolve the PR head before reporting PASS

### DIFF
--- a/_project/STATUS.md
+++ b/_project/STATUS.md
@@ -124,7 +124,7 @@ _Tracker last updated: 2026-07-28 (B9 merged — QUAL-03 + QUAL-11 done, PR #292
 |---|---|---|---|---|
 | feature | `█████████████░░░░░░░` 37/57 | 37 | 20 | 4 |
 | requirement | `███████████████████░` 32/33 | 32 | 1 | 6 |
-| bug | `██████████████░░░░░░` 61/86 | 61 | 25 | 3 |
+| bug | `██████████████░░░░░░` 62/87 | 62 | 25 | 3 |
 | task | `██████████████████░░` 11/12 | 11 | 1 | 0 |
 | chore | `███████████░░░░░░░░░` 32/60 | 32 | 28 | 1 |
 
@@ -160,4 +160,4 @@ _Tracker last updated: 2026-07-28 (B9 merged — QUAL-03 + QUAL-11 done, PR #292
 
 ---
 
-_181 done · 9 deferred · 5 closed · 84 open — 279 tracked items_
+_182 done · 9 deferred · 5 closed · 84 open — 280 tracked items_

--- a/_project/tracker.json
+++ b/_project/tracker.json
@@ -2904,6 +2904,17 @@
     },
 
     {
+      "id": "QUAL-46",
+      "type": "bug",
+      "title": "ci-wait.sh reports PASS against a stale head SHA — fail-open on the primary CI gate",
+      "status": "done",
+      "owner": "coo",
+      "priority": "P1",
+      "brdRefs": [],
+      "phase": 6,
+      "notes": "Promoted from open-dialogue D-24 on 2026-08-10 after a CONFIRMED recurrence (D-24 filed 2026-08-04 as watch-if-recurs; its stated trigger was 'if it recurs, file it'). D-24 entry deleted from open-dialogues.md per the delete-on-resolution rule. RECURRENCE (captured, PR #491): after `git push` updated the branch, `ci-wait.sh pr 491` printed 'PASS - all 18 checks green @ 617d6fa' while the PR head was actually 17b8cdf. Verified by comparing `git rev-parse` on the pushed local ref against `gh pr view --json headRefOid` immediately after: they matched each other and BOTH differed from the SHA ci-wait reported. ROOT CAUSE (read, not inferred): ci-wait.sh:123 resolves head_sha ONCE before the watch begins and the PASS line at :205 prints that same pinned value; a push whose PR-head propagation lands a moment after that read leaves the entire watch - and its verdict - describing the PREVIOUS commit. This is a fail-OPEN on the project's primary CI gate: the caller reads 'all green' and merges code nothing tested. Note it is NOT caught by the post-merge main-CI check (BUG-24 rule) in the dangerous case, because that check runs after the merge has already landed. FIX (exactly the remedy D-24 predicted): re-resolve the PR head AFTER the watch completes and compare against the watched SHA; a moved head exits 1 with both SHAs printed and an explicit 'do NOT merge on the strength of this run'. Failure to re-resolve exits 2 (fail-closed, same discipline as the existing unparseable-rollup path). ALSO FIXED in the same change, from a second observation the same day on PR #456: the FAIL path printed a bare count with an empty finding list when a duplicate-trigger run was still in flight, making a transient indistinguishable from a real failure - it now says so explicitly. Branch mode was left unchanged: it filters runs by headSha at :231/:244/:267, so it already compares rather than assuming. Files: scripts/ci-wait.sh."
+    },
+    {
       "id": "QUAL-45",
       "type": "chore",
       "title": "Admin name-list BACKEND consolidation — repo+router factory keeping validateOwnership explicit (QUAL-29 part b)",

--- a/jobs/COO/open-dialogues.md
+++ b/jobs/COO/open-dialogues.md
@@ -153,24 +153,6 @@ down and handed over its PR). No standing rule; the fix if ever adopted is track
 + a per-session worktree rather than sharing `/workspace`. Revisit if concurrent COO sessions become
 normal rather than a one-off.
 
-### D-24: `ci-wait.sh` reported PASS against a stale SHA — watch
-2026-08-04. One instance: `ci-wait.sh pr 398` reported green against the pre-push head seconds after
-a push moved it; caught by re-checking the real head before merge, and it behaved correctly on three
-later runs the same session. Most likely a race between `git push` and PR-head propagation — but it
-is a **fail-open** on the project's primary CI gate (QUAL-27 cousin). If it recurs, file it; the fix
-would re-resolve and compare the head SHA *after* the watch completes rather than pinning it at start.
-
-> **Related but NOT a recurrence — observed 2026-08-10 (PR #456).** `ci-wait.sh` reported
-> `FAIL — 1 check(s) not green` and then printed **nothing after the colon**; an immediate re-run on
-> the *same* SHA reported `PASS — all 18 green`, and a direct check-runs query showed all 18 already
-> `success`. This is the **opposite direction** from D-24 — fail-*closed* on a transient (almost
-> certainly one of the duplicate-trigger runs still in flight), which is the gate behaving as
-> designed ("absence of evidence is treated as failure"). Logging it only because the **empty finding
-> list** is a real diagnostic weakness: a genuine failure and a transient look identical at the
-> point of failure, so the reader's only recourse is to re-run and see if it sticks. Not filed as a
-> defect — the gate's verdict was safe, and D-03's precedent says one contained instance is not a
-> rule. If it recurs, the fix is to print *which* check was not green, not to change the verdict.
-
 ### D-26: Declare a spike's effort-box / kill-criterion up front — watch
 2026-08-05. Proposed after the GE-17 spike ran ~4 days / ~15 design-review PRs with zero shipped code
 before being killed. Deferred, not adopted: the team is already process-rich, and **OP-33** (the

--- a/scripts/ci-wait.sh
+++ b/scripts/ci-wait.sh
@@ -201,12 +201,38 @@ if [ "$MODE" = "pr" ]; then
         exit 1
     fi
 
+    # STALE-HEAD GUARD (QUAL-46, open dialogue D-24 — recurred 2026-08-10, PR #491).
+    # head_sha was pinned once, before the watch. A `git push` whose PR-head propagation
+    # lands a moment later leaves this whole watch reporting on the PREVIOUS commit — and
+    # the PASS line above would confirm a SHA nobody asked about. That is a fail-OPEN on
+    # the project's primary CI gate: the caller reads "all green" and merges untested code.
+    # So re-resolve the head AFTER the watch and compare. A moved head is not a pass.
+    final_head=$(gh pr view "$TARGET" --repo "$REPO" --json headRefOid --jq '.headRefOid' 2>/dev/null)
+    if ! is_sha "$final_head"; then
+        # Fail closed: unable to confirm what we just tested (same discipline as $rollup above).
+        echo "[ci-wait] FAIL — could not re-resolve the head of PR #$TARGET to confirm" >&2
+        echo "[ci-wait]        the watched commit is still current. Refusing to report PASS." >&2
+        exit 2
+    fi
+    if [ "$final_head" != "$head_sha" ]; then
+        echo "[ci-wait] FAIL — PR #$TARGET head MOVED during the watch." >&2
+        echo "[ci-wait]        watched:  $head_sha" >&2
+        echo "[ci-wait]        head now: $final_head" >&2
+        echo "[ci-wait]        The result above describes a commit that is no longer the head." >&2
+        echo "[ci-wait]        Re-run ci-wait.sh; do NOT merge on the strength of this run." >&2
+        exit 1
+    fi
+
     if [ "$rollup" -eq 0 ]; then
         echo "[ci-wait] PASS — all $check_count check(s) green on PR #$TARGET @ $head_sha."
         exit 0
     else
         echo "[ci-wait] FAIL — $rollup check(s) not green on PR #$TARGET @ $head_sha:" >&2
+        # Name them. A bare count with an empty list is indistinguishable from a transient
+        # (observed 2026-08-10 on PR #456), which leaves the reader nothing to act on.
         gh pr checks "$TARGET" --repo "$REPO" 2>&1 | grep -v $'\tpass\t' >&2 || true
+        echo "[ci-wait]        (If nothing is listed above, a duplicate-trigger run was still" >&2
+        echo "[ci-wait]         in flight — re-run to distinguish a transient from a real failure.)" >&2
         exit 1
     fi
 fi


### PR DESCRIPTION
Closes the fail-open that D-24 predicted. Promoted from open-dialogue D-24 after a **confirmed recurrence** today — D-24's stated trigger was "if it recurs, file it", so the entry is deleted from `open-dialogues.md` per the delete-on-resolution rule and now lives as tracker **QUAL-46**.

## The recurrence, captured

On PR #491, after a push updated the branch:

```
[ci-wait] PASS — all 18 check(s) green on PR #491 @ 617d6fa
```

The PR head at that moment was **17b8cdf**. Verified by comparing `git rev-parse` on the pushed local ref against `gh pr view --json headRefOid` — those two matched each other and **both differed** from the SHA ci-wait reported.

## Root cause — read, not inferred

`ci-wait.sh:123` resolves `head_sha` **once**, before the watch starts, and the PASS line at `:205` prints that same pinned value. A `git push` whose PR-head propagation lands a moment after that read leaves the entire watch — and its verdict — describing the **previous commit**.

This is a **fail-open on the project's primary CI gate**: the caller reads "all green" and merges code nothing tested. Worth being explicit that the post-merge main-CI check (the BUG-24 rule) does **not** cover it in the dangerous case, because that check runs *after* the merge has already landed.

## The fix

Exactly the remedy D-24 predicted: **re-resolve the head after the watch and compare.**

- Head moved → exit 1, printing both SHAs and `do NOT merge on the strength of this run`.
- Cannot re-resolve → exit 2, fail-closed, matching the existing unparseable-rollup discipline.
- **Branch mode left unchanged** — it already filters runs by `headSha` (`:231`/`:244`/`:267`), so it compares rather than assumes.

Also fixed, from a second observation the same day on PR #456: the FAIL path printed a bare count with an **empty finding list** when a duplicate-trigger run was still in flight, making a transient indistinguishable from a real failure. It now says so.

Tracker QUAL-46 added; `tracker:check` and `status:check` green.