### PR TITLE
refactor(QUAL-43): Stage 5 — guard contract, both promotions enforced (ADL-53 §6)

### DIFF
--- a/.claude/skills/pre-push/SKILL.md
+++ b/.claude/skills/pre-push/SKILL.md
@@ -16,25 +16,28 @@ npm run scope:check        # backend scope guards — ownership chokepoint + get
 ```
 
 `scope:check` runs **two** checks and also runs in CI (QUAL-43 Stage 3), so a
-failure here is a failure there.
+failure here is a failure there. **Both checks are enforced** — as of QUAL-43
+Stage 5 (2026-08-10) there is no warn tier left in either one.
 
-**Check 1 — ownership completeness.** It scans all of `src/backend/**` (minus
-`__tests__`) for ownership expressed by hand — either an `eq(<table>.userId, …)`
-predicate or an ownership comparison written in application code. Route the site
-through `scopeToUser`/`ownedAnd` (predicate) or `assertOwned`/`assertWritable`
-(existence check); **do not exempt it**.
+**Check 1 — ownership completeness** (`RESIDUAL`). It scans all of
+`src/backend/**` (minus `__tests__`) for ownership expressed by hand — either an
+`eq(<table>.userId, …)` predicate or an ownership comparison written in
+application code. Route the site through `scopeToUser`/`ownedAnd` (predicate) or
+`assertOwned`/`assertWritable` (existence check); **do not exempt it**. The
+predicate form is permitted *only* in `repositories/scope.ts`; the JS-comparison
+form is permitted nowhere, including there.
 
-Two zones while the QUAL-43 migration is in flight (ADL-53 §6):
-`src/backend/repositories/*.ts` is **enforced** — a residual there fails the
-build. The rest of `src/backend/**` is **reported** (`WARN-RESIDUAL`) but does
-not fail, because Stages 2 and 4 have not finished relocating those reads yet.
-A warn is a real residual, not an exemption; Stage 5 promotes Zone B to enforced.
+> Until Stage 5 this had two zones — `repositories/` enforced, the rest of
+> `src/backend/**` warn-only — because Stages 2/4 were still relocating reads out
+> of `routes/**` and failing on them would have red-ed `main` (ADL-47
+> expand/contract). Both are enforced now.
 
-**Check 2 — `getDb` in routes** (`WARN-GETDB`, warn-only until ADL-53 §6 Stage 5).
-Route handlers must not be able to obtain a DB handle. It counts *mentions* of
-the literal string, not just `const db = getDb()` call sites, and tags each match
-`[call-site|type-ref|import|comment]` — a `comment` tag means reword the comment
-(OP-30: fix your own text), not that work is owed.
+**Check 2 — `getDb` in routes** (`GETDB`). Route handlers must not be able to
+obtain a DB handle at all, so the required count is **zero**. It counts *mentions*
+of the literal string, not just `const db = getDb()` call sites, and tags each
+match `[call-site|type-ref|import|comment]` — a `comment` tag means reword the
+comment (OP-30: fix your own text) and you are done; any other tag means a read
+needs relocating into a repository.
 
 If either check flags something you just wrote, fix your code or your text —
 never add an exclusion to the script (OP-30: scanner suppressions need COO

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,9 +24,11 @@ jobs:
         run: npm run tracker:check
       # QUAL-43 / ADL-53: backend scope guards. Was pre-push-only, which is a
       # local pre-filter CI never runs — a guard living only there is bypassed by
-      # anyone who skips the checklist. Fails the build on hand-authored ownership
-      # in src/backend/repositories/; warns (by design, until ADL-53 §6 Stage 5)
-      # on the widened scan and on `getDb` in routes.
+      # anyone who skips the checklist. FULLY ENFORCED since ADL-53 §6 Stage 5
+      # (2026-08-10): fails the build on hand-authored ownership anywhere in
+      # src/backend/** and on any mention of `getDb` in src/backend/routes/**.
+      # Both were warn-only while Stages 2/3/4 were relocating reads; neither is
+      # now. Do not add exclusions to turn this green (OP-30).
       - name: Backend scope guards
         run: npm run scope:check
 

--- a/jobs/COO/inbox/20260810_1745-BACKEND-qual43-stage5-complete.txt
+++ b/jobs/COO/inbox/20260810_1745-BACKEND-qual43-stage5-complete.txt
@@ -1,0 +1,82 @@
+QUAL-43 Stage 5 (guard contract) · PR #495 · BRD n/a · feat/qual43-stage5-guard-contract
+
+WHAT WAS BUILT
+Both backend scope guards in scripts/scope-completeness-check.sh flipped from warn to
+enforced — the contract half of ADL-47's expand/contract, and the last stage of QUAL-43.
+Zero production behaviour change; counts were already zero and I verified that before
+touching anything.
+
+ACCEPTANCE CRITERIA
+1. Check 2 (getDb in routes/**) is an error, non-zero on any mention — PASS
+2. Check 1 Zone B promoted warn -> enforced — PASS
+3. Both promotions verified fail-closed by injected fault — PASS
+4. test:backend 827/827, zero test files modified — PASS
+5. Full /pre-push green; CI 18/18 green at a31406b — PASS
+6. ZERO src/backend logic change — PASS (one COMMENT-ONLY edit, declared below)
+
+SECURITY CHECKLIST — n/a, no routes added or modified. No route gained or lost auth
+middleware. No scanner suppression, allowlist, nosemgrep, lint-disable or regex
+narrowing added or widened (OP-30).
+
+INJECTED FAULTS — all on a COPIED src/backend (script takes a repo-root arg), never the
+working tree, never git stash. Control passed first, so each failure is attributable.
+ALL EXIT 1: predicate in repositories/ · predicate in services/ (the Zone B promotion) ·
+.userId !== comparison in a repository AND separately inside scope.ts · getDb() call site
+in a route · getDb in a route COMMENT only · scope.ts deleted · scope.ts gutted · both
+invariants at once (both reported, no short-circuit) · repositories/ removed · Zone A find
+pattern broken · Zone B exclusion over-widened.
+EXIT 0: residual under __tests__ — the one documented exclusion, as designed.
+
+CI OUTPUT CONFIRMED, NOT INFERRED. Pulled run 31446277953 via gh api .../logs and read the
+Biome job: "scope-completeness-check: PASS / Check 1 (ownership, enforced) — 0 residuals
+across 53 backend source(s) / Check 2 (getDb in routes, enforced) — 0 mention(s) across 12
+route file(s)." Same counts as locally. gh run view --log-failed not used (QUAL-27).
+
+DOC LIFECYCLE (OP-09, same PR)
+ADL-53 §3 item 1 stamped BUILT AND ENFORCED · §6 Stage 5 row stamped SHIPPED, single-flip
+wording corrected, detail note added for the second promotion · OP-06 HC-10/HC-11
+STRENGTHENED, VERDICTS UNCHANGED (both still PASS) · OP-06 HC-05 checked and deliberately
+NOT changed (router-level tier gate, untouched by QUAL-43 — Stage 4's finding still holds)
+· /pre-push skill and ci.yml comment both said warn-only, corrected · scope.ts header note
+said the guard greps "this directory" (false since Stage 3), corrected.
+tracker.json NOT touched — its QUAL-43 notes are your chronological log; Stage 4 did the
+same. The Stage 5 entry is yours to append.
+
+FULL-FILE REWRITES (OP-28): NONE. Every change was an Edit, including the script itself
+where a rewrite would have been permitted — the door-completeness and mentions-not-call-
+sites reasoning is still correct and was preserved, warn-only passages stamped not deleted.
+The single src/backend edit is comment-only in scope.ts's file header; git diff on that
+file is one comment hunk.
+
+COO ADDITIONS — WHAT I'D CHALLENGE
+Both of your additions were right and I took them. The "two promotions" framing is correct
+for a reason the ADL never wrote down: Check 1 and Check 2 have the SAME expand/contract
+shape, and only one was named in the contract step. The injected-fault requirement earned
+its keep twice — it caught nothing wrong in the flip, but forcing it made me probe my OWN
+justification for keeping the enumeration split, which I had reasoned about rather than
+tested.
+
+ONE DEVIATION, declared: the script's header predicted the two zones would "collapse into
+one" on promotion. The POLICY collapsed (one label, one verdict, one strength); the
+ENUMERATION did not. Each half carries a non-emptiness assertion that catches a future edit
+to the script's own find predicates — merged, either mistake would leave the check scanning
+a fraction of the tree and printing PASS. Verified by injecting exactly those two edits
+(last two faults above) rather than asserting it. If you want the literal collapse instead,
+it is a small change, but I'd be removing a self-test to satisfy a sentence.
+
+OPEN ISSUES
+- The guard is regex-shaped and that is now load-bearing: Check 1 matches `.userId`, so an
+  ownership column named otherwise is invisible. The pass on cities.createdByUserId is
+  correct (global reference data) but it is a near-miss with build consequences now. Keep
+  naming ownership columns userId. Recorded in the park doc and the cities-module doc.
+- assertOwned still has no production caller (re-verified, two probes that fail differently:
+  grep across src returns only scope.ts's export + two comments; separately, all ten
+  importers of scope.js name scopeToUser/ownedAnd/assertWritable, none names assertOwned).
+  Stage 4 declined to manufacture one and was right. Not a defect — a caller count.
+- Stage 4's pre-existing itemRepository.update / updateExtension gap is untouched and still
+  open. Unreachable via HTTP. Belongs to whoever owns the next items pass.
+
+NOW UNBLOCKED
+QUAL-43 / ADL-53 is built through Stage 5. Stage 6 (the Phase-3 scopeToUserOrShared seam)
+is design-only. The invariant Phase-3 sharing depends on — one definition of "who may see
+this row" — is now machine-enforced on every push and in CI rather than remembered.

--- a/jobs/architect/tech/ADL-53-userid-scoping-chokepoint.md
+++ b/jobs/architect/tech/ADL-53-userid-scoping-chokepoint.md
@@ -322,6 +322,26 @@ This is the load-bearing engineering call and the one the brief presses hardest 
    > are unexported, there is no `export const db`), so a route cannot obtain the handle without the
    > literal string `getDb` appearing. The door is complete; the map of rooms behind it was drawn
    > one route too small.
+
+   > **BUILT AND ENFORCED (2026-08-10, Stage 5 — PR #495).** This item is no longer a
+   > recommendation. The guard is `scripts/scope-completeness-check.sh` Check 2 (`npm run
+   > scope:check`, wired into `/pre-push` and the CI Biome job). It was **authored** warn-only by
+   > Stage 3 — nothing in §6 chartered its creation, only its flip, which the Stage 0 agent caught —
+   > and Stage 5 has now flipped it to an **error**: any occurrence of the literal string `getDb`
+   > under `src/backend/routes/**` (excluding `__tests__`) fails the build. Verified fail-closed by
+   > injection, not assumed: a re-introduced `getDb()` call site in `routes/trips.ts` exits 1, as
+   > does a comment merely *mentioning* it (the guard matches text, not syntax — deliberate, and the
+   > remedy is to reword the comment, never to exempt it).
+   >
+   > **Stage 5 flipped TWO guards, not one.** Check 1 (ownership completeness) had the same
+   > expand/contract shape: Stage 3 widened its scan from `repositories/` to all of
+   > `src/backend/**` but landed the widened half warn-only, because `routes/**` still held
+   > user-owned predicates Stage 4 was chartered to relocate. Stage 4 emptied it; Stage 5 promoted
+   > it. A hand-written ownership predicate anywhere in the production backend — including
+   > `services/**`, the directory whose four unowned predicates §7's CORRECTION records — now fails
+   > the build rather than printing a warning. Without that second promotion the §7 gap class would
+   > have remained permanently un-enforced, which is the condition that let it open in the first
+   > place.
 2. **ATDD cross-tenant isolation matrix (mandatory, OP-35 red bar).** For **every** user-data
    route, seed a row owned by USER_A, authenticate as USER_B, assert USER_B cannot read or mutate
    it (empty list / 404 — opaque per SE-05, never 403). This is the behavioural net that closes
@@ -508,7 +528,7 @@ where noted.
 | **Stage 2 — Cities extraction** | `citiesRepository` + `cityIdentityService` extracted from `cities.ts`; logic moved verbatim, handlers thin. Its two user-owned joins (`:703`/`:766`) compose `scopeToUser` | **yes** (identity/data-integrity invariants; **mock-fidelity**: exercise the real `insertCityOrReuse` catch-path + partial unique indexes, not a vacuous stub — QUAL-22) | GE-16 **containment** (global data — *not* vacuous ownership); the two user-owned joins covered by S1 | existing cities/adl46 suites + S1 | Yes |
 | **Stage 3 — Global-read consolidation (the SAFE half)** | Global reference reads relocated out of routes into `referenceRepository`: `map.ts:113/154`, `admin.ts:73/91/135/177/217`, `places.ts:74/163` (cities-identity global reads land in Stage 2). **No cross-tenant axis — global tables** | **no** (mechanical; failure visible; existing suites are the net) | **No** — global reference data, no ownership to assert | existing suites | Yes |
 | **Stage 4 — User-owned-read relocation (the DANGEROUS half)** | User-owned raw reads relocated into repositories, **each by its §5.1 mechanism (F2):** *predicate-composed* reads compose `scopeToUser` — `items-helper.ts:87` (→ `userId` becomes a **required** method parameter), the items reads inside `trips.ts:198`/`places.ts:231`; *assertion-guarded* reads route through `assertOwned`/`assertWritable` and **inherit** isolation (compose nothing) — the `tripPlaceActivitiesMap` join reads at `places.ts:289/352` and `trips.ts:207-216`. Each relocation staged **expand → switch** with the S1 matrix green before *and* after every switch | **yes** (access-matrix; dropping an `eq(userId)` predicate *or* a prior ownership assertion is silent-and-plausible) | **Yes** — the S1 matrix asserts each relocated path per its class (seed USER_A, call as USER_B, expect **empty** for reads / **404** for mutations) | S1 matrix + existing suites | Yes (each switch independently green) |
-| **Stage 5 — Guard contract** | Flip the `getDb`-in-routes guard to **error**. Introduced warn-only earlier (expand); flipped here (contract). **Strictly last** — only valid once Stages 2 + 3 + 4 leave `routes/**` `getDb`-free | **no** (the guard is its own test) | n/a | guard green + full suite | Yes — may ride the last relocation PR |
+| **Stage 5 — Guard contract** — **SHIPPED 2026-08-10 (PR #495)** | ~~Flip the `getDb`-in-routes guard to **error**.~~ **Flipped BOTH guards to error** (see the Stage 5 note below — this row understated the work by one promotion). Introduced warn-only earlier (expand); flipped here (contract). **Strictly last** — only valid once Stages 2 + 3 + 4 leave `routes/**` `getDb`-free | **no** (the guard is its own test) | n/a | guard green + full suite | Yes — may ride the last relocation PR |
 | **Stage 6 — Phase-3 seam** | *(Design only — not built now)* `scopeToUser` → `scopeToUserOrShared`. Deferred to Phase-3/SE-01 | — | — | — | — |
 
 **Stage 0 detail — completeness exit-check + the `.where()` footgun (REVISED 2026-08-10, F1/F3):**
@@ -536,6 +556,24 @@ where noted.
   invalid while *any* route still holds `getDb`; flipping after "cities only" (the old S3) would go
   **CI-red on `main`** against `places.ts`/`trips.ts`/`map.ts`/`admin.ts`/`items-helper.ts` — the
   broken-trunk state ADL-47's discipline exists to prevent. This is the deployability half of B1.
+
+**Stage 5 detail — the contract step flipped TWO guards, not one (recorded 2026-08-10, PR #495):**
+- The row above, and §3 item 1, describe **one** flip: `getDb`-in-routes warn → error. That is what
+  shipped as **Check 2** of `scripts/scope-completeness-check.sh`.
+- **Check 1 (ownership completeness) needed the same promotion and this plan did not name it.** Stage 0
+  built it enforced over `repositories/**`; Stage 3, absorbing §7's CORRECTION, *widened* its scan to all
+  of `src/backend/**` but landed the widened half **warn-only** — for the same ADL-47 reason as Check 2,
+  since `routes/**` still held the user-owned predicates Stage 4 was chartered to relocate, and enforcing
+  then would have red-ed `main`. Stage 4 took that count to zero. **Stage 5 promoted it.** Left
+  warn-only, a new hand-written predicate in `services/**` — exactly §7's `shading.service.ts` gap, the
+  reason the scan was widened at all — would have printed a warning forever.
+- Net effect: **every** ownership expression in the production backend, and **any** route-layer mention of
+  `getDb`, now fails the build. Both promotions were verified fail-closed by injected fault (Zone A
+  predicate, `services/**` predicate, JS `.userId !==` comparison including inside `scope.ts` itself,
+  `getDb` call site *and* bare comment mention in a route, `scope.ts` deleted, `scope.ts` gutted) — each
+  exits 1. The one documented exclusion, `__tests__`, still passes, as designed.
+- **Not a new invariant — the same invariant, made permanent.** Nothing in `src/backend/**` changed in
+  this stage; the counts were already zero. What changed is that they can no longer drift back.
 
 **Old→new stage mapping (for anyone who read the superseded plan):** old S0 → Stage 0 (unchanged);
 old S1 → Stage 1 (unchanged, now *must name* the user-owned paths); old S2 → Stage 2 (unchanged);

--- a/jobs/architect/tech/OP-06-hardening-checklist.md
+++ b/jobs/architect/tech/OP-06-hardening-checklist.md
@@ -820,6 +820,12 @@ the WHERE clause includes both `trip_id = ?` and `user_id = ?`.
 > ran user-owned reads on a raw DB handle, so every path this item covers now reaches the database
 > through a repository. Machine-checked on every push and in CI by
 > `scripts/scope-completeness-check.sh` (`npm run scope:check`).
+>
+> **STRENGTHENED 2026-08-10 (Stage 5, PR #495).** Verdict still unchanged (PASS). That
+> machine-check is now **enforced rather than advisory**: a hand-authored ownership predicate
+> anywhere in `src/backend/**`, or any mention of `getDb` in a route file, fails the build.
+> Until this stage the route-layer half of it only printed a warning, so the sentence above
+> described a mechanism slightly stronger than the one that was running. It no longer does.
 
 **Verification:**
 - Contract test: Authenticate as user-A; request a trip belonging to user-B; confirm 404.
@@ -844,6 +850,11 @@ A new user with no trips receives `[]`.
 > `.where(...)`. Stage 4 extended the same property to the list reads that used to run in route
 > handlers: `fetchItemsWithExtensions` now takes `userId` as a **required** parameter and composes
 > ownership itself, so an item list cannot be produced unscoped.
+>
+> **STRENGTHENED 2026-08-10 (Stage 5, PR #495).** Verdict unchanged (PASS). `npm run scope:check`
+> now **fails** the build on a hand-authored ownership predicate anywhere in `src/backend/**`
+> (previously only inside `repositories/`), so a future list endpoint cannot reintroduce a
+> per-repository scoping term without CI rejecting it.
 
 **Verification:**
 - Contract test: Authenticate as a fresh user with no trips; GET `/api/trips` → `200 []`.

--- a/jobs/backend/context/current.txt
+++ b/jobs/backend/context/current.txt
@@ -772,3 +772,74 @@ FINDINGS / JUDGEMENT CALLS worth carrying forward:
     also stamped: Stage 3 relocated those sites but never stamped the
     inventory, and leaving the table asserting live getDb sites that no longer
     exist is the stale-status failure the lifecycle rule exists to stop.
+
+================================================================
+2026-08-10 — QUAL-43 Stage 5: guard contract (ADL-53 §6) — FINAL STAGE
+Branch: feat/qual43-stage5-guard-contract
+================================================================
+The contract half of ADL-47's expand/contract. Nothing in src/backend
+changed; the counts were already zero. What changed is that they can no
+longer drift back.
+
+TWO PROMOTIONS, NOT ONE. ADL-53 §6 Stage 5 describes a single flip. The COO
+brief added the second and was right — I probed it before accepting.
+  Check 2 (getDb in routes/**): warn -> ERROR. Required count zero.
+  Check 1 Zone B (ownership outside repositories/): warn -> ENFORCED.
+Stage 3 built Check 1 with two zones for the same ADL-47 reason Check 2 was
+warn-only: routes/ still held predicates Stage 4 was chartered to relocate,
+and enforcing then would have red-ed main. Stage 4 emptied it. Left
+warn-only, a new hand-written predicate in services/** — exactly the
+shading.service.ts gap ADL-53 §7's CORRECTION records, and the reason the
+scan was widened at all — would have printed a warning forever.
+
+DESIGN CALL: the enumeration stays split in two even though the POLICY
+collapsed into one (the script's own header predicted "the two zones
+collapse into one"). Zone A/Zone B no longer differ in strength — one
+verdict covers both. They stay separately enumerated because each half
+carries its own non-emptiness assertion, and those assertions are what
+catch a future edit to the script's own `find` predicates. Under a single
+merged `find`, a broken pattern or an over-wide exclusion would leave the
+check scanning a fraction of the tree and reporting PASS. I verified this
+by injection rather than reasoning: breaking the Zone A pattern
+(*.ts -> *.tsx) and over-widening the Zone B exclusion each produce exit 1
+on an otherwise-clean tree. Header records both probes.
+
+Also: both checks now report before exiting, rather than the first failure
+short-circuiting. An implementer who fixes what the output named, pushes,
+and fails again on the half it withheld stops trusting the guard.
+
+INJECTED-FAULT MATRIX (scratch copy of src/backend, never the working tree,
+never git stash — the script takes a repo-root argument, so a copied tree is
+enough). Control passed first, so every failure is attributable to its fault:
+  predicate in repositories/                          exit 1
+  predicate in services/  (THE ZONE B PROMOTION)      exit 1
+  rows[0].userId !== userId in a repository           exit 1
+  same comparison INSIDE scope.ts (permitted nowhere) exit 1
+  getDb() call site in routes/  (THE FLIP)            exit 1
+  getDb in a routes/ COMMENT (text-match, by design)  exit 1
+  scope.ts DELETED                                    exit 1
+  scope.ts GUTTED                                     exit 1
+  both invariants at once -> BOTH reported            exit 1
+  repositories/ dir removed                           exit 1
+  residual under __tests__ (documented exclusion)     exit 0  <- as designed
+No exclusion, allowlist or regex narrowing was added anywhere (OP-30).
+
+BLIND SPOT worth carrying: the guard is regex-shaped. It matches `.userId`,
+so an ownership column named anything else is invisible to it — the pass on
+cities.createdByUserId is correct (global reference data) but it is a
+near-miss, and post-flip the margin has build consequences. Keep naming
+ownership columns userId. That is a reason to hold the naming convention,
+not to loosen the regex.
+
+DOCS (same-PR, OP-09): ADL-53 §3 item 1 + §6 Stage 5 stamped enforced and
+corrected to record BOTH promotions (the plan understated the work by one);
+OP-06 HC-10/HC-11 STRENGTHENED — verdicts unchanged, both still PASS, but
+HC-10's existing note claimed "machine-checked" for a route-layer half that
+was only warning, which is now true; HC-05 checked and deliberately NOT
+changed (it passes on the router-level tier gate, which QUAL-43 never
+touched); /pre-push skill and the ci.yml comment both described the guards
+as warn-only and were corrected; scope.ts's header note said the guard greps
+"this directory" when it has scanned all of src/backend/** since Stage 3.
+
+QUAL-43 / ADL-53 is now complete through Stage 5. Stage 6 (the Phase-3
+scopeToUserOrShared seam) is design-only and not built.

--- a/jobs/backend/park-docs/20260810-BACKEND-qual43-stage5-park.txt
+++ b/jobs/backend/park-docs/20260810-BACKEND-qual43-stage5-park.txt
@@ -1,0 +1,199 @@
+================================================================
+PARK DOCUMENT — Backend — 2026-08-10
+QUAL-43 Stage 5: guard contract (ADL-53 §6) — FINAL STAGE
+Branch: feat/qual43-stage5-guard-contract
+================================================================
+
+STATUS: complete. QUAL-43 / ADL-53 is built through Stage 5. Stage 6
+(the Phase-3 scopeToUserOrShared seam) is design-only and untouched.
+
+----------------------------------------------------------------
+1. WHAT THIS STAGE IS
+----------------------------------------------------------------
+The contract half of ADL-47's expand/contract. Both guards in
+scripts/scope-completeness-check.sh landed warn-first while Stages 2/3/4
+relocated reads out of routes/**; Stage 4 drove both counts to zero; this
+stage makes zero permanent.
+
+ZERO production behaviour change. The only edit under src/backend/** is a
+stale sentence in scope.ts's header comment (declared in §5 below). The
+counts were already zero before I touched anything — I verified that first,
+per the brief, because flipping a guard over a non-empty residual set would
+red main.
+
+Baseline at b0a9937, before any change:
+  Check 1 Zone A clean · Zone B 0 residuals · Check 2 0 mentions.
+
+----------------------------------------------------------------
+2. TWO PROMOTIONS, NOT ONE — the COO addition, probed and accepted
+----------------------------------------------------------------
+ADL-53 §6 Stage 5 describes ONE flip: getDb-in-routes warn -> error. The COO
+brief added a second — Check 1 Zone B — flagged it explicitly as COO-added
+and told me to push back if wrong. It is right, for a reason the ADL never
+wrote down:
+
+Stage 3 absorbed §7's CORRECTION (four hand-written ownership predicates
+sitting unowned in services/shading.service.ts, missed by TWO hand
+inventories) by WIDENING Check 1's scan from repositories/ to all of
+src/backend/**. But it landed the widened half warn-only, for exactly the
+same ADL-47 reason Check 2 was warn-only: routes/** still held user-owned
+predicates Stage 4 was chartered to relocate, and enforcing then would have
+failed the build on residuals a later stage was already going to remove.
+
+So the two guards have the SAME expand/contract shape and only one of them
+was named in the contract step. Left warn-only, the next hand-written
+predicate in services/** — the precise gap class that motivated the
+widening — would have printed a warning forever, which is functionally
+where it started.
+
+Both promotions shipped. Check 1 now has one verdict covering all of
+src/backend/** minus __tests__; Check 2 requires zero.
+
+----------------------------------------------------------------
+3. THE ONE DESIGN CALL I MADE AGAINST THE SCRIPT'S OWN PLAN
+----------------------------------------------------------------
+The script's Stage-3 header predicted that on promotion "the two zones
+collapse into one". The POLICY collapsed — one label (RESIDUAL), one
+verdict, one strength. The ENUMERATION did not, deliberately.
+
+Zone A and Zone B each carry a non-emptiness assertion ("repositories/
+yielded sources", "the widened scan yielded sources outside repositories/").
+Merged into a single find, either assertion is satisfiable by whatever half
+still matches, so a future edit to the script's own find predicates — a
+pattern that stops matching, an exclusion that widens past its target —
+could leave the check scanning a fraction of the tree and printing PASS.
+
+I did not assume that; I injected it. Breaking the Zone A pattern
+(*.ts -> *.tsx) and over-widening the Zone B exclusion each produce exit 1
+with the matching "enumeration is broken" message on an otherwise-clean
+tree. Both probes are recorded in the script header, because a justification
+that is only in a park doc does not survive the next refactor.
+
+Note the two assertions are NOT reachable by tree mutation alone — the
+directory-existence and chokepoint checks fire first. They protect against
+edits to the guard, not to the codebase. The header says so rather than
+implying broader coverage.
+
+Second, smaller call: both checks now report before exiting, instead of
+Check 1 short-circuiting. An implementer who fixes only what the output
+named, pushes, and fails again on the half it withheld learns to distrust
+the guard.
+
+----------------------------------------------------------------
+4. INJECTED-FAULT VERIFICATION
+----------------------------------------------------------------
+Method: the script takes a repo-root argument, so faults went into a COPIED
+src/backend under the scratch dir — the worktree was never dirtied and
+git stash was never used (refs/stash is shared across worktrees, OP-20).
+A control run on the pristine copy passed FIRST, so every failure below is
+attributable to its fault and not to the copy.
+
+  1  eq(items.userId, userId) in repositories/items.ts        exit 1
+  2  eq(trips.userId, userId) in services/shading.service.ts  exit 1   <- Zone B promotion
+  3  rows[0].userId !== userId in repositories/trips.ts       exit 1
+  3b same comparison INSIDE scope.ts (permitted nowhere)      exit 1
+  4  const db = getDb() in routes/trips.ts                    exit 1   <- the flip
+  4b getDb named in a routes/ COMMENT only                    exit 1   <- text-match, by design
+  5  scope.ts DELETED                                         exit 1
+  6  scope.ts GUTTED (emptied in place)                       exit 1
+  7  faults 1 + 4 together -> BOTH reported, then exit        exit 1
+  8  residual under repositories/__tests__/                   exit 0   <- documented exclusion, as designed
+  9  repositories/ directory removed                          exit 1
+ 10  Zone A find pattern broken (guard self-edit)             exit 1
+ 11  Zone B exclusion over-widened (guard self-edit)          exit 1
+
+Fault 8 is the only pass and it is the single documented exclusion, argued
+in the script header (test files legitimately assert on a row's userId and
+legitimately quote the patterns in comments describing coverage; rewriting
+them to satisfy a grep would weaken the tests to flatter the check).
+
+NO exclusion, allowlist, nosemgrep, lint-disable or regex narrowing was
+added or widened anywhere in this stage (OP-30).
+
+CI: confirmed by pulling the run log, not inferred from a green tick — see
+the completion report for the run id and the emitted PASS lines.
+
+----------------------------------------------------------------
+5. FULL-FILE REWRITES AND SOURCE EDITS (OP-28 declaration)
+----------------------------------------------------------------
+NONE. Every change was an Edit, including scripts/scope-completeness-check.sh
+(a source file, where a rewrite would have been permitted) — the header's
+door-completeness argument and mentions-not-call-sites reasoning are still
+correct and were preserved, with the superseded warn-only passages stamped
+rather than deleted.
+
+The single src/backend/** edit is COMMENT-ONLY, in scope.ts's file header:
+it said the guard "greps this directory", which has been false since Stage 3
+widened the scan to all of src/backend/**. Corrected under the doc-lifecycle
+rule; no code, no imports, no behaviour. `git diff` on that file shows one
+comment hunk and nothing else.
+
+----------------------------------------------------------------
+6. DOCS UPDATED IN THIS PR (same-PR lifecycle, OP-09)
+----------------------------------------------------------------
+- ADL-53 §3 item 1 — stamped BUILT AND ENFORCED, recording that the guard
+  was AUTHORED by Stage 3 (no stage chartered its creation; the Stage 0
+  agent caught that) and flipped here, and that Stage 5 flipped TWO guards.
+- ADL-53 §6 — Stage 5 row stamped SHIPPED with its "flip the guard"
+  wording struck and corrected; a "Stage 5 detail" note added after the
+  ordering constraints explaining the second promotion and why the plan
+  missed it.
+- OP-06 HC-10 and HC-11 — STRENGTHENED notes. Verdicts UNCHANGED (both
+  remain PASS). HC-10's existing Stage-0–4 note already claimed the
+  invariant was "machine-checked on every push and in CI"; that was
+  slightly stronger than the mechanism, since the route-layer half only
+  warned. It is now exactly true.
+- OP-06 HC-05 — CHECKED AND DELIBERATELY NOT CHANGED. Stage 4 recorded that
+  HC-05/10/11 cite the chokepoint with no verdict change; the brief asked me
+  to confirm that still holds rather than assume it. It does. HC-05 passes on
+  the router-level requireOwner tier gate, which QUAL-43 never touched, and
+  its note makes no machine-enforcement claim for this stage to strengthen.
+- .claude/skills/pre-push/SKILL.md — described both checks as warn-tiered.
+  Corrected; the warn history is kept as a stamped blockquote.
+- .github/workflows/ci.yml — its step comment said the guard "warns (by
+  design, until ADL-53 §6 Stage 5)". Corrected.
+- jobs/backend/tech/20260810-cities-module-boundary.md — added the
+  regex-margin note (below).
+- _project/tracker.json — NOT touched. Its QUAL-43 notes are a COO-maintained
+  chronological log and the COO appends the per-stage entry; Stage 4 did the
+  same. Flagged in the completion report instead.
+
+----------------------------------------------------------------
+7. THINGS THE NEXT AGENT SHOULD KNOW
+----------------------------------------------------------------
+- THE GUARD IS REGEX-SHAPED AND THAT IS NOW LOAD-BEARING. Check 1 matches
+  `.userId`. An ownership column named anything else is invisible to it. The
+  pass on cities.createdByUserId is CORRECT (cities is global reference data,
+  createdByUserId is deliberately outside the ownership axis) but it is a
+  near-miss, and post-flip the margin has build consequences rather than
+  warning consequences. Keep naming ownership columns `userId`. If the guard
+  ever goes quiet on a table you expect it to cover, suspect the column name
+  before suspecting the codebase.
+
+- BOTH CHECKS MATCH TEXT, NOT SYNTAX, AND BOTH NOW FAIL THE BUILD. A comment
+  that merely quotes `getDb` in a route file, or quotes the predicate form in
+  any backend source, reds CI. Verified (fault 4b). This is deliberate and
+  fails closed. THE FIX IS TO REWORD YOUR OWN COMMENT (OP-30) — routes/trips.ts
+  already carries a worked example of describing the rule instead of quoting
+  it. Never add an exclusion.
+
+- assertOwned STILL has no production caller. Carried forward from Stage 4 and
+  RE-VERIFIED here with two probes that fail differently, rather than inherited:
+  (a) `grep -rn assertOwned src` returns three hits, all inside scope.ts — one
+  export, two comments — and nothing anywhere else, tests included; (b) the
+  independent angle, `grep -rn "scope.js'" src/backend`, lists all ten importers
+  of the chokepoint and every one names scopeToUser / ownedAnd / assertWritable,
+  none names assertOwned. A stale grep pattern could produce (a) but not (b).
+  Stage 4 declined to manufacture a caller and was right; nothing in Stage 5
+  changes that. It remains
+  the correct shape for a read-gate on a trip whose owner is not otherwise
+  looked up — that site does not exist yet. Its correctness is not in doubt,
+  only its caller count.
+
+- The pre-existing itemRepository.update / updateExtension gap flagged by
+  Stage 4 is UNTOUCHED and still open. It is unreachable via HTTP. Whoever
+  owns the next items pass should read Stage 4's park doc §4.
+
+- If you need to test a change to this guard, copy src/backend into a scratch
+  dir and pass the copy's root as $1. Do not use git stash (refs/stash is
+  shared across worktrees) and do not mutate the working tree.

--- a/jobs/backend/tech/20260810-cities-module-boundary.md
+++ b/jobs/backend/tech/20260810-cities-module-boundary.md
@@ -42,6 +42,14 @@ They look alike and are not alike:
 `scripts/scope-completeness-check.sh` passes on this file because its regex matches `.userId` and
 the column is `.createdByUserId`. That is a correct pass, but note it is regex-shaped.
 
+> **UPDATED 2026-08-10 (QUAL-43 Stage 5, PR #495).** That check is now **enforced** rather than
+> warn-only, across all of `src/backend/**`. The pass above is still correct — `cities` is global
+> reference data and `createdByUserId` is deliberately outside the ownership axis — but the
+> regex-shaped margin now has build consequences rather than warning consequences. If a genuinely
+> user-owned column is ever named such that the regex misses it, the guard goes quiet rather than
+> loud; that is the blind spot to watch, and it is a reason to keep naming ownership columns
+> `userId`, not a reason to loosen the regex.
+
 ## Testing this logic directly
 
 `src/backend/services/__tests__/cityIdentityService.test.ts` is the direct unit suite (19 tests).

--- a/scripts/scope-completeness-check.sh
+++ b/scripts/scope-completeness-check.sh
@@ -9,6 +9,19 @@
 #   CHECK 1 — Ownership completeness  (ADL-53 §6 Stage 0, widened by Stage 3)
 #   CHECK 2 — No `getDb` in routes    (ADL-53 §3 item 1, authored by Stage 3)
 #
+# BOTH CHECKS ARE FULLY ENFORCED (2026-08-10, ADL-53 §6 Stage 5). Any match in
+# either one fails the build. Both landed warn-first on purpose — the QUAL-43
+# migration was mid-flight and failing on a residual a later stage was chartered
+# to remove would have red-ed the trunk (ADL-47 expand/contract). Stage 5 is the
+# CONTRACT half: Stages 2/3/4 drove both residual counts to zero, and this is the
+# step that makes zero permanent. The per-check sections below keep the
+# warn-first history stamped rather than deleted, because the reason a guard was
+# once weaker is the thing a future reader needs when tempted to weaken it again.
+#
+# NOTHING HERE IS AN ALLOWLIST. There is exactly one exclusion — `__tests__` —
+# argued for in CHECK 1 below. Adding a second is a scanner suppression and needs
+# COO sign-off (OP-30); the fix for a false positive is to reword your own text.
+#
 # Usage: scripts/scope-completeness-check.sh [repo-root]
 #
 # ================================================================
@@ -57,26 +70,47 @@
 #   `__tests__`: anything else that matches is a residual to FIX, not to exempt
 #   (OP-30 — widening a scanner's suppression is not an implementer's call).
 #
-# TWO ZONES (expand/contract, ADL-47) — the widened scope lands warn-first.
+# ONE ENFORCED SCOPE — the whole of `src/backend/**` (minus `__tests__`).
 #
-#   ZONE A — ENFORCED (fail-closed, exits non-zero):
-#     `src/backend/repositories/*.ts`. This invariant is TRUE today and must stay
-#     true; it is the Stage 0 exit-check, unchanged in strength.
+#   > SUPERSEDED (2026-08-10) by ADL-53 §6 Stage 5 — retained for history. This
+#   > section previously described TWO ZONES of differing strength: Zone A
+#   > (`repositories/*.ts`) ENFORCED, Zone B (the rest of `src/backend/**`)
+#   > warn-only, "promoted once the count reaches zero — at which point the two
+#   > zones collapse into one". Stage 4 drove Zone B to zero and Stage 5 has made
+#   > the promotion. A residual ANYWHERE under `src/backend/**` now fails.
 #
-#   ZONE B — REPORTED (warn-only, does NOT fail the build):
-#     the rest of `src/backend/**`. This invariant is NOT true yet: the QUAL-43
-#     migration is mid-flight and `routes/**` still holds user-owned reads that
-#     Stages 2 and 4 relocate into repositories. Failing the build on them now
-#     would red the trunk — the broken-intermediate-state ADL-47's expand/contract
-#     discipline exists to prevent.
+#   The two-zone split existed for one reason and that reason is spent: while
+#   Stages 2/3/4 were still relocating user-owned reads out of `routes/**`, an
+#   enforced Zone B would have failed the build on residuals a later stage was
+#   already chartered to remove. That is the broken-intermediate-state ADL-47's
+#   expand/contract discipline exists to prevent — not a judgement that ownership
+#   written by hand outside `repositories/` was ever acceptable.
 #
-#   Zone B is a WARN TIER, NOT AN ALLOWLIST: every residual is named, located and
-#   counted on every run. Nothing is exempted or hidden. Stage 5 (the contract
-#   step) promotes Zone B to enforced once the count reaches zero — at which point
-#   the two zones collapse into one.
+#   WHY THE ENUMERATION IS STILL SPLIT IN TWO despite the policy collapsing into
+#   one. The zones no longer differ in STRENGTH — both fail the build, and one
+#   verdict covers them. They stay separately enumerated because each half
+#   carries its own NON-EMPTINESS assertion (below): "`repositories/` yielded
+#   production sources" and "the widened scan yielded sources outside
+#   `repositories/`".
+#
+#   What those assertions actually protect against is a future EDIT TO THIS
+#   SCRIPT'S OWN ENUMERATION — a `find` predicate that stops matching, an
+#   exclusion that widens past its target. (A moved or missing directory is
+#   already caught by the directory-existence checks further down; these two are
+#   the layer behind that.) Under a single merged `find`, either mistake would
+#   leave the check scanning a fraction of the tree and reporting PASS, because a
+#   merged enumeration is satisfied by whatever half still matches. Split, each
+#   half must independently prove it found something.
+#
+#   Both were verified by injection rather than assumed (2026-08-10): breaking the
+#   Zone A pattern (`*.ts` → `*.tsx`) and over-widening the Zone B exclusion each
+#   produced exit 1 with the corresponding "enumeration is broken" message, on a
+#   tree that is otherwise clean. Same fail-closed reasoning as the chokepoint
+#   existence + definition checks below: a guard that can pass while inspecting
+#   nothing is not a guard.
 #
 # ================================================================
-# CHECK 2 — No `getDb` in routes  (WARN-ONLY in this stage)
+# CHECK 2 — No `getDb` in routes  (ENFORCED)
 # ================================================================
 #
 # ADL-53 §3 item 1: once every route is repo-routed, the route layer physically
@@ -88,22 +122,33 @@
 # db`), so a route cannot obtain the handle without the literal string `getDb`
 # appearing.
 #
-# WARN-ONLY HERE, BY DESIGN (ADL-53 §6 Stage 5 = "introduced warn-only earlier
-# (expand); flipped here (contract)"). Routes legitimately still hold `getDb`
-# until Stages 2 and 4 finish; making this an error now would red the trunk. The
-# count and the offending files are printed so Stages 4 and 5 can watch it reach
-# zero.
+# ENFORCED (2026-08-10, ADL-53 §6 Stage 5 — "introduced warn-only earlier
+# (expand); flipped here (contract)").
 #
-# MENTIONS, NOT CALL SITES — a deliberate choice, stated because Stage 5 flips
-# this to an error and will inherit it.
+#   > SUPERSEDED (2026-08-10) — retained for history. This check was authored
+#   > warn-only by Stage 3: routes legitimately still held `getDb` until Stages 2
+#   > and 4 relocated those reads, and erroring then would have red-ed the trunk.
+#   > Stage 4 took the count to zero across all 12 route files; Stage 5 flips it.
+#
+# The flip is what converts the door-completeness argument above from a
+# description into a guarantee. Warn-only, it merely narrated a route acquiring a
+# DB handle; enforced, "a route handler ran an unscoped query against a user
+# table" is not mergeable, because the route layer cannot obtain the handle at all.
+#
+# MENTIONS, NOT CALL SITES — a deliberate choice, restated here because this check
+# is now an error and every future reader inherits the consequence.
 #
 #   This check counts every occurrence of the literal string `getDb` in
 #   `src/backend/routes/**`, NOT just `const db = getDb()` call sites. Three
 #   classes of match are therefore counted that are not themselves unscoped
-#   queries: import bindings, `ReturnType<typeof getDb>` TYPE references
-#   (`cities.ts`), and comments asserting "No direct getDb()" (`items.ts`,
-#   `trips.ts`, `places.ts` headers). ADL-53 §5.1 flags exactly this as a
-#   counting trap, so the decision is made explicitly rather than by accident:
+#   queries: import bindings, `ReturnType<typeof getDb>` TYPE references, and
+#   comments asserting a route holds no direct handle. (Live examples of all three
+#   existed in `cities.ts`/`items.ts`/`trips.ts`/`places.ts` when this was written;
+#   Stages 2–4 removed every one, and the surviving route comments now DESCRIBE
+#   the rule rather than quote the string — e.g. `routes/trips.ts`. The classes are
+#   documented because they will recur, not because any instance is live.)
+#   ADL-53 §5.1 flags exactly this as a counting trap, so the decision is made
+#   explicitly rather than by accident:
 #
 #     - Counting call sites would make the guard EVADABLE and forfeit its whole
 #       claim. `const d = getDb()`, `const { select } = getDb()`, or passing
@@ -112,15 +157,18 @@
 #       of the STRING, and the string is the only thing that makes this a
 #       one-line fail-closed check rather than an AST rule (ADL-53 OQ-1).
 #     - The false positives are cheap and self-clearing. A comment is reworded
-#       (OP-30: fix your own text, never weaken the scanner) and the type refs
-#       leave `routes/` anyway when Stage 2 moves the helpers that use them into
-#       `citiesRepository`.
+#       (OP-30: fix your own text, never weaken the scanner); the type refs left
+#       `routes/` when Stage 2 moved the helpers using them into
+#       `citiesRepository`. Both predictions held — the count reached zero without
+#       a single exemption being added.
 #     - It matches the sibling check above, which also matches TEXT, not syntax,
 #       for the same fail-closed reason.
 #
 #   To keep that honest rather than merely strict, the output CLASSIFIES each
-#   match (call-site / type-ref / import / comment / mention) so Stage 5 can see
-#   at a glance what is real work and what is a rewording.
+#   match (call-site / type-ref / import / comment / mention). Now that the check
+#   is an error, the tag is the first thing to read on a failure: `comment` means
+#   reword your own prose and you are done; the other tags mean a read needs
+#   relocating into a repository. Neither ever means adding an exemption here.
 #
 # BLIND SPOT (stated, not silently accepted): both checks match TEXT, not syntax,
 # so a comment quoting any pattern trips them. That is deliberate — it fails
@@ -168,6 +216,11 @@ fi
 # ----------------------------------------------------------------
 # File enumeration
 # ----------------------------------------------------------------
+# Zone A and Zone B are ENFORCED IDENTICALLY (Stage 5) — the names survive only
+# because each half carries its own non-emptiness assertion, which is what stops
+# a broken `find` passing the check vacuously. Together they cover exactly
+# `src/backend/**/*.ts` minus `__tests__/`, with no overlap.
+#
 # Zone A — production repository sources (`-maxdepth 1` excludes `__tests__/`).
 mapfile -t ZONE_A_FILES < <(find "$REPO_DIR" -maxdepth 1 -name '*.ts' -type f | sort)
 
@@ -237,14 +290,18 @@ scan_ownership() {
   done
 }
 
+# Both scans carry the same label and the same weight (Stage 5); the counts stay
+# separate only so the PASS line can report the coverage of each enumeration.
 scan_ownership "RESIDUAL" "${ZONE_A_FILES[@]}"
 zone_a_residuals="$scan_hits"
 
-scan_ownership "WARN-RESIDUAL" "${ZONE_B_FILES[@]}"
+scan_ownership "RESIDUAL" "${ZONE_B_FILES[@]}"
 zone_b_residuals="$scan_hits"
 
+ownership_residuals=$((zone_a_residuals + zone_b_residuals))
+
 # ----------------------------------------------------------------
-# CHECK 2 — `getDb` in routes (warn-only)
+# CHECK 2 — `getDb` in routes (enforced)
 # ----------------------------------------------------------------
 getdb_hits=0
 getdb_files=0
@@ -263,7 +320,7 @@ for f in "${ROUTE_FILES[@]}"; do
       *'getDb()'*) kind="call-site" ;;
       *) kind="mention" ;;
     esac
-    echo "WARN-GETDB $rel:$lineno [$kind]"
+    echo "GETDB $rel:$lineno [$kind]"
     echo "    $stripped"
     getdb_hits=$((getdb_hits + 1))
     file_hits=$((file_hits + 1))
@@ -272,42 +329,46 @@ for f in "${ROUTE_FILES[@]}"; do
 done
 
 # ----------------------------------------------------------------
-# Verdicts
+# Verdicts — BOTH checks are enforced (ADL-53 §6 Stage 5)
 # ----------------------------------------------------------------
-if [ "$zone_b_residuals" -gt 0 ]; then
+# Every failure is reported before exiting. A run that breaks both invariants
+# must show both, not just the first: an implementer who fixes only what the
+# output named, pushes, and fails again on the half it withheld learns to
+# distrust the guard.
+failed=0
+
+if [ "$ownership_residuals" -gt 0 ]; then
   echo ""
-  echo "########################################################################"
-  echo "# WARNING (not a failure) — CHECK 1, ZONE B"
-  echo "# $zone_b_residuals hand-authored ownership site(s) outside src/backend/repositories/."
-  echo "# These are REAL residuals, listed above as WARN-RESIDUAL. They do not fail"
-  echo "# the build only because the QUAL-43 migration is mid-flight (ADL-53 §6"
-  echo "# Stages 2/4 relocate them). Stage 5 promotes Zone B to enforced."
-  echo "# This is a warn tier, NOT an allowlist — nothing here is exempt."
-  echo "########################################################################"
+  echo "scope-completeness-check: FAIL — CHECK 1"
+  echo "  $ownership_residuals hand-authored ownership site(s) in src/backend/**"
+  echo "  ($zone_a_residuals in repositories/, $zone_b_residuals elsewhere), listed above as RESIDUAL."
+  echo "  ADL-53 §6: every ownership expression in the production backend must resolve"
+  echo "  through src/backend/repositories/scope.ts — scopeToUser/ownedAnd for a"
+  echo "  predicate, assertOwned/assertWritable for an existence check. That single"
+  echo "  definition is what Phase-3 sharing (ADL-53 D7/§7) changes in one place."
+  echo "  Route the site through the chokepoint. Do NOT exempt it here (OP-30)."
+  failed=1
 fi
 
 if [ "$getdb_hits" -gt 0 ]; then
   echo ""
-  echo "########################################################################"
-  echo "# WARNING (not a failure) — CHECK 2"
-  echo "# 'getDb' appears $getdb_hits time(s) across $getdb_files route file(s)."
-  echo "# Target is ZERO (ADL-53 §3 item 1). Counted as MENTIONS, not call sites —"
-  echo "# see this script's header for why, and the [kind] tag on each line above"
-  echo "# for what is real relocation work vs. a rewording."
-  echo "# Warn-only until ADL-53 §6 Stage 5 flips it to an error."
-  echo "########################################################################"
+  echo "scope-completeness-check: FAIL — CHECK 2"
+  echo "  'getDb' appears $getdb_hits time(s) across $getdb_files route file(s)."
+  echo "  ADL-53 §3 item 1: the route layer holds no DB handle, so an unscoped query"
+  echo "  against a user table cannot be written there. Required count is ZERO."
+  echo "  Counted as MENTIONS, not call sites (see this script's header for why)."
+  echo "  Read the [kind] tag on each line above: 'comment' means reword your own"
+  echo "  prose; anything else means move the read into a repository. Neither means"
+  echo "  adding an exclusion here (OP-30)."
+  failed=1
 fi
 
-if [ "$zone_a_residuals" -gt 0 ]; then
-  echo ""
-  echo "scope-completeness-check: FAIL — $zone_a_residuals residual ownership site(s) outside the chokepoint."
-  echo "  ADL-53 §6 Stage 0: every ownership expression in src/backend/repositories/**"
-  echo "  must resolve through src/backend/repositories/scope.ts."
+if [ "$failed" -ne 0 ]; then
   exit 1
 fi
 
 echo ""
 echo "scope-completeness-check: PASS"
-echo "  Check 1 (ownership) — ${#ZONE_A_FILES[@]} enforced source(s) in repositories/ clean;"
-echo "    ${#ZONE_B_FILES[@]} further backend source(s) scanned, $zone_b_residuals warn-residual(s)."
-echo "  Check 2 (getDb in routes, warn-only) — $getdb_hits mention(s) across ${#ROUTE_FILES[@]} route file(s)."
+echo "  Check 1 (ownership, enforced) — 0 residuals across $((${#ZONE_A_FILES[@]} + ${#ZONE_B_FILES[@]})) backend source(s)"
+echo "    (${#ZONE_A_FILES[@]} in repositories/, ${#ZONE_B_FILES[@]} elsewhere; __tests__ excluded)."
+echo "  Check 2 (getDb in routes, enforced) — 0 mention(s) across ${#ROUTE_FILES[@]} route file(s)."

--- a/src/backend/repositories/scope.ts
+++ b/src/backend/repositories/scope.ts
@@ -21,11 +21,14 @@
  * Phase-3 sharing (ADL-53 D7/§7) edits `scopeToUser` and nothing else: the
  * assertion helpers pick the change up because they call it.
  *
- * MAINTENANCE NOTE: `scripts/scope-completeness-check.sh` greps this directory
- * for hand-authored ownership logic and permits the predicate form ONLY in this
- * file. It matches text, not syntax, so do not quote either flagged pattern in a
- * comment inside a repository source file — reword instead (OP-30: fix your own
- * text rather than weakening the scanner).
+ * MAINTENANCE NOTE: `scripts/scope-completeness-check.sh` greps ALL of
+ * `src/backend/**` (minus `__tests__`) for hand-authored ownership logic and
+ * permits the predicate form ONLY in this file; the JS-comparison form is
+ * permitted nowhere, including here. Widened from this directory alone by QUAL-43
+ * Stage 3 and ENFORCED build-wide by Stage 5 — a residual anywhere now fails the
+ * build rather than warning. It matches text, not syntax, so do not quote either
+ * flagged pattern in a comment in any backend source file — reword instead
+ * (OP-30: fix your own text rather than weakening the scanner).
  */
 
 import { and, eq, type SQL } from 'drizzle-orm';


### PR DESCRIPTION
Tracker: **QUAL-43** · Spec: **ADL-53 §6 Stage 5** (`jobs/architect/tech/ADL-53-userid-scoping-chokepoint.md`) · BRD: n/a (internal refactor)

The contract half of ADL-47's expand/contract, and the last stage of QUAL-43. Stages 2/3/4 drove both guard counts to zero; this makes zero permanent.

**Zero production behaviour change.** The only edit under `src/backend/**` is comment-only — `scope.ts`'s header said the guard "greps this directory", which has been false since Stage 3 widened the scan to all of `src/backend/**`.

## Two promotions, not one

ADL-53 §6 Stage 5 names a single flip. There were two guards with the same expand/contract shape:

| Check | Was | Now |
|---|---|---|
| **2** — `getDb` in `src/backend/routes/**` | warn-only | **error**, required count zero |
| **1 Zone B** — ownership outside `repositories/` | warn-only | **enforced** |

Stage 3 widened Check 1's scan from `repositories/` to all of `src/backend/**` (absorbing §7's CORRECTION — four hand-written predicates sitting unowned in `services/shading.service.ts`, missed by two hand inventories) but landed the widened half warn-only, for exactly the reason Check 2 was warn-only: `routes/**` still held predicates Stage 4 was chartered to relocate, and enforcing then would have red-ed `main`. Left warn-only, the next hand-written predicate in `services/**` — the precise gap class that motivated the widening — would print a warning forever.

## Injected-fault verification

Faults applied to a **copied** `src/backend` (the script takes a repo-root argument), never the working tree and never `git stash`. A control run on the pristine copy passed first, so each failure is attributable to its fault.

| Fault | Exit |
|---|---|
| `eq(items.userId, …)` in `repositories/` | 1 |
| `eq(trips.userId, …)` in `services/` — **the Zone B promotion** | 1 |
| `rows[0].userId !== userId` in a repository | 1 |
| same comparison **inside `scope.ts`** (permitted nowhere) | 1 |
| `const db = getDb()` in `routes/trips.ts` — **the flip** | 1 |
| `getDb` named in a route **comment** only | 1 |
| `scope.ts` **deleted** | 1 |
| `scope.ts` **gutted** | 1 |
| both invariants at once → **both reported** | 1 |
| `repositories/` directory removed | 1 |
| Zone A `find` pattern broken (guard self-edit) | 1 |
| Zone B exclusion over-widened (guard self-edit) | 1 |
| residual under `__tests__` — the one documented exclusion | **0**, as designed |

No exclusion, allowlist, `nosemgrep`, lint-disable or regex narrowing was added or widened (OP-30).

## Design call worth review

The script's own header predicted the two zones would "collapse into one" on promotion. The **policy** collapsed — one label, one verdict, one strength. The **enumeration** stays split, because each half carries a non-emptiness assertion that catches a future edit to the script's own `find` predicates; merged, either mistake would leave the check scanning a fraction of the tree and printing PASS. Verified by injecting exactly those two edits (last two rows above) rather than reasoned about. Recorded in the header.

Both checks also now report before exiting rather than Check 1 short-circuiting — an implementer who fixes what the output named, pushes, and fails again on the half it withheld learns to distrust the guard.

## Document lifecycle (OP-09)

- **ADL-53 §3 item 1** stamped BUILT AND ENFORCED; **§6 Stage 5** row stamped SHIPPED with its single-flip wording corrected, plus a detail note recording the second promotion.
- **OP-06 HC-10 / HC-11** STRENGTHENED — **verdicts unchanged, both still PASS**. HC-10 already claimed the invariant was "machine-checked on every push and in CI"; that ran slightly ahead of the mechanism while the route-layer half only warned, and is now exactly true.
- **OP-06 HC-05** checked and deliberately **not** changed — it passes on the router-level `requireOwner` tier gate, which QUAL-43 never touched.
- `/pre-push` skill and the `ci.yml` step comment both described the guards as warn-only; corrected.
- `tracker.json` untouched — its QUAL-43 notes are a COO-maintained chronological log, appended per stage by the COO, as in Stage 4.

## Verification

`test:backend` 827/827 (52 files, identical to baseline, **zero test files modified**) · `test:frontend` 388/388 · `type:check:all` clean · `check` (biome) clean · `status:check`, `tracker:check`, `scope:check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
