### PR TITLE
feat(QUAL-47): build-enforce ownership classification for every user-FK table

### DIFF
--- a/.claude/skills/pre-push/SKILL.md
+++ b/.claude/skills/pre-push/SKILL.md
@@ -12,12 +12,13 @@ npm run test:backend       # Backend unit tests
 npm run test:frontend      # Frontend unit tests
 npm run status:check       # _project/STATUS.md in sync with tracker.json
 npm run tracker:check      # tracker.json integrity — no duplicate IDs, brdRefs valid
-npm run scope:check        # backend scope guards — ownership chokepoint + getDb-in-routes
+npm run scope:check        # backend scope guards — ownership chokepoint, getDb-in-routes, table classification
 ```
 
-`scope:check` runs **two** checks and also runs in CI (QUAL-43 Stage 3), so a
-failure here is a failure there. **Both checks are enforced** — as of QUAL-43
-Stage 5 (2026-08-10) there is no warn tier left in either one.
+`scope:check` runs **three** checks and also runs in CI (QUAL-43 Stage 3), so a
+failure here is a failure there. **All three are enforced** — as of QUAL-43
+Stage 5 (2026-08-10) there is no warn tier left in Check 1 or 2, and Check 3
+(QUAL-47) landed enforced.
 
 **Check 1 — ownership completeness** (`RESIDUAL`). It scans all of
 `src/backend/**` (minus `__tests__`) for ownership expressed by hand — either an
@@ -38,6 +39,19 @@ of the literal string, not just `const db = getDb()` call sites, and tags each
 match `[call-site|type-ref|import|comment]` — a `comment` tag means reword the
 comment (OP-30: fix your own text) and you are done; any other tag means a read
 needs relocating into a repository.
+
+**Check 3 — ownership classification** (`CLASSIFY`, QUAL-47). Every table in
+`schema.ts` must be classified exactly once in `src/backend/db/ownership.ts` —
+user data owned by its own `user_id` column, user data scoped through a named
+parent, global reference data, or the identity table — and each classification is
+verified against the real schema (Drizzle's table metadata, not a grep). **If you
+added a table, this is why the build is red: add its entry in the same PR.** It
+also fails when an `owned-by-column` table's ownership column is not named
+`user_id` (Check 1's regex would not see it), when a table carrying a `users.id`
+foreign key that is not user-owned has no stated reason (`cities` is the worked
+example — provenance, not ownership), or when a derived-ownership chain does not
+reach an owned table. The manifest is a classification, **not an allowlist**:
+reclassifying a table to clear a failure is the one thing never to do.
 
 If either check flags something you just wrote, fix your code or your text —
 never add an exclusion to the script (OP-30: scanner suppressions need COO

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,13 +22,17 @@ jobs:
         run: npm run status:check
       - name: tracker.json integrity
         run: npm run tracker:check
-      # QUAL-43 / ADL-53: backend scope guards. Was pre-push-only, which is a
-      # local pre-filter CI never runs — a guard living only there is bypassed by
-      # anyone who skips the checklist. FULLY ENFORCED since ADL-53 §6 Stage 5
-      # (2026-08-10): fails the build on hand-authored ownership anywhere in
-      # src/backend/** and on any mention of `getDb` in src/backend/routes/**.
-      # Both were warn-only while Stages 2/3/4 were relocating reads; neither is
-      # now. Do not add exclusions to turn this green (OP-30).
+      # QUAL-43 / ADL-53 (+ QUAL-47): backend scope guards. Was pre-push-only,
+      # which is a local pre-filter CI never runs — a guard living only there is
+      # bypassed by anyone who skips the checklist. THREE CHECKS, ALL ENFORCED:
+      # fails the build on hand-authored ownership anywhere in src/backend/**, on
+      # any mention of `getDb` in src/backend/routes/**, and on any table in
+      # schema.ts not classified in src/backend/db/ownership.ts. Checks 1 and 2
+      # were warn-only while Stages 2/3/4 were relocating reads; neither is now,
+      # and Check 3 landed enforced. Do not add exclusions to turn this green
+      # (OP-30) — Check 3's manifest in particular is a classification, not an
+      # allowlist, and reclassifying a table to dodge a failure is worse than the
+      # failure.
       - name: Backend scope guards
         run: npm run scope:check
 

--- a/CODEBASE.md
+++ b/CODEBASE.md
@@ -185,6 +185,10 @@ src/
     ├── errors.ts               Typed error classes
     ├── db/
     │   ├── schema.ts           Drizzle schema — single source of truth for DB shape
+    │   ├── ownership.ts        Classifies EVERY table in schema.ts — user data (own user_id column
+    │   │                       / scoped through a named parent), global reference data, or identity.
+    │   │                       Source of the UserOwnedTable constraint on scopeToUser; a new table
+    │   │                       classified nowhere fails the build (QUAL-47, scope guard CHECK 3)
     │   ├── index.ts            DB client singleton
     │   ├── seed.ts             Seed runner
     │   ├── seed-data.ts        Default category/activity data + map shading defaults (companions

--- a/jobs/COO/inbox/20260810_2100-BACKEND-qual47-ownership-classification-complete.txt
+++ b/jobs/COO/inbox/20260810_2100-BACKEND-qual47-ownership-classification-complete.txt
@@ -46,7 +46,10 @@ with a real parent FK passes. Both are now written claims, not omissions.
 
 FULL-FILE REWRITES (OP-28): none. Two new files; every existing file amended with Edit.
 
-CI: PR #497 — scripts/ci-wait.sh pr 497 (see below).
+CI: PR #497 GREEN — ci-wait.sh: "PASS — all 18 check(s) green @ 2a7e0e0". Check 3's OUTPUT
+confirmed from the run log itself (gh api .../actions/runs/31456411692/logs), not inferred from a
+tick: "Check 3 (ownership classification, enforced) — 21 schema table(s) classified ... 8 carry a
+users.id foreign key, each either owned-by-column or explained."
 
 OPEN ITEMS
 - QUAL-47 has no tracker entry and no GitHub issue. Two probes: grep of tracker.json found

--- a/jobs/COO/inbox/20260810_2100-BACKEND-qual47-ownership-classification-complete.txt
+++ b/jobs/COO/inbox/20260810_2100-BACKEND-qual47-ownership-classification-complete.txt
@@ -1,0 +1,57 @@
+QUAL-47 · PR #497 (no GitHub issue exists) · BRD n/a · feat/qual47-schema-ownership-classification
+
+WHAT WAS BUILT
+CHECK 3 in scripts/scope-completeness-check.sh: every table in schema.ts must be classified
+exactly once in src/backend/db/ownership.ts, and each classification is verified against the
+real schema via Drizzle's table metadata rather than a grep.
+
+ACCEPTANCE CRITERIA
+1. Check 3 asserts every user-FK table is consciously classified ...... PASS (widened — see below)
+2. Fails on neither / both / stale-listing .......................... PASS (11 injected faults)
+3. Exits 0 on main as it stands ..................................... PASS (21 tables, 8 user-FK)
+4. Verified by injected faults with exit codes ...................... PASS (all 1; control 0)
+5. No production behaviour change ................................... PASS (type-only import)
+6. 827 backend tests, no test file modified; type:check:all clean .... PASS
+7. /pre-push fully green ............................................ PASS
+8. Docs updated same-PR (scope.ts, schema.ts, pre-push skill, ci.yml, CODEBASE.md) . PASS
+
+WHERE I DIFFER FROM YOUR PROPOSED DESIGN — you asked me to probe it, so:
+- TWO LISTS -> ONE MANIFEST OVER EVERY TABLE. Your trigger ("carries a users.id FK") covers 8 of
+  this schema's 18 user-data tables. TEN carry no users.id FK at all — the 5 item extension
+  tables and 5 junctions, scoped through a parent. A new table of that shape would be invisible
+  to the two-list check. Trigger is now "a table exists". Cost: one line per table.
+- "IN BOTH LISTS" IS NO LONGER EXPRESSIBLE. UserOwnedTable is now DERIVED from the manifest's
+  owned-by-column entries, so there is one list, not two. I removed the failure mode instead of
+  detecting it. "Classified twice" remains and is fault-tested.
+- TEXTUAL -> STRUCTURAL. getTableConfig reads the built table object; formatting, line breaks and
+  aliases cannot hide an FK. Needs TS, so the implementation is a .ts file — NOT a second
+  instrument: no npm script, no CI step, run from the one guard, one verdict.
+- PLACEMENT: db/ownership.ts, not scope.ts. It is a statement about the schema. scope.ts imports
+  the type ONLY and re-exports it, so runtime is untouched and callers are unaffected.
+- ADDED, unbriefed: the ownership COLUMN NAME (user_id) is now enforced. That is what converts
+  CHECK 1's regex from a convention into a guarantee, and it is the motivating case's second net.
+Your ground truth was correct — 8 user-FK tables, 7 already owned + cities. Verified three ways
+(full read of schema.ts, grep for users.id, structural introspection).
+
+INJECTED FAULTS (copied tree, no git stash) — control exit 0; all eleven exit 1:
+unclassified new table · ownership column named owner_id · classified twice · entry for a deleted
+table · owned-by-column with its user FK removed · cities userFkNote emptied · entry for a table
+outside schema.ts · parent with no FK to it · chain ending in global reference data · tsx absent ·
+check implementation deleted. The last two prove it fails closed, not open (QUAL-27 shape).
+
+LIMIT, stated: CHECK 3 proves a decision was recorded and is consistent with the schema. It cannot
+prove the decision was RIGHT — user data can still be classified global-reference with a plausible
+sentence. Corollary dodge: an oddly-named ownership column on a table classified owned-via-parent
+with a real parent FK passes. Both are now written claims, not omissions.
+
+FULL-FILE REWRITES (OP-28): none. Two new files; every existing file amended with Edit.
+
+CI: PR #497 — scripts/ci-wait.sh pr 497 (see below).
+
+OPEN ITEMS
+- QUAL-47 has no tracker entry and no GitHub issue. Two probes: grep of tracker.json found
+  nothing; gh issue list --search returned only an unrelated 2026-07-30 issue. Max is QUAL-46.
+- No scanner suppression was added anywhere (OP-30).
+
+UNBLOCKED: adding a table now forces the ownership question at build time, in one place, for
+Phase-3 sharing and for anyone writing a new user-data table.

--- a/jobs/backend/context/current.txt
+++ b/jobs/backend/context/current.txt
@@ -843,3 +843,45 @@ as warn-only and were corrected; scope.ts's header note said the guard greps
 
 QUAL-43 / ADL-53 is now complete through Stage 5. Stage 6 (the Phase-3
 scopeToUserOrShared seam) is design-only and not built.
+
+
+================================================================
+2026-08-10 — QUAL-47: build-enforced ownership classification (CHECK 3)
+================================================================
+Branch feat/qual47-schema-ownership-classification. Closes the blind spot
+the Stage-5 entry above carried forward: CHECK 1 is regex-shaped and matches
+the ownership column by NAME, so its protection rested on the unwritten
+convention that every user-owned table calls that column userId.
+
+CHECK 3 requires every table in schema.ts to be classified exactly once in
+src/backend/db/ownership.ts (owned-by-column / owned-via-parent /
+global-reference / user-identity) and checks each claim against the real
+schema via Drizzle's getTableConfig — structural, not a grep of schema.ts.
+Today: 21 tables, 7 owned-by-column, 10 owned-via-parent, 3 global-reference,
+1 user-identity; 8 carry a users.id FK.
+
+Two deviations from the brief, both deliberate — see the completion report:
+ (1) classification covers EVERY table, not only the 8 with a user FK. Ten
+     user-data tables carry no users.id FK at all, so a user-FK trigger
+     cannot see them. Trigger is now 'a table exists'.
+ (2) ONE manifest, not two lists. UserOwnedTable is DERIVED from it, so
+     'a table is in both lists' is no longer expressible — the failure mode
+     is removed rather than detected.
+
+The ownership-column NAME (user_id) is now build-enforced for every
+owned-by-column table, which is what makes CHECK 1's regex safe rather than
+conventional.
+
+Verified by 11 injected faults on a copied tree (no git stash), all exit 1,
+control exit 0 — including tsx absent and the check file deleted, which
+confirms it fails closed rather than skipping. scope.ts's compile-time
+rejection of cities/tripCountries re-probed after the derivation change
+(TS2345, both).
+
+LIMIT, stated honestly: CHECK 3 proves a decision was recorded and is
+consistent with the schema. It cannot prove the decision was right — a table
+holding user data can still be classified global-reference with a plausible
+sentence. What it removes is the silent case: a table nobody classified.
+
+827/827 backend tests unchanged, zero test files modified. No production
+behaviour change — ownership.ts is imported type-only by scope.ts.

--- a/jobs/backend/park-docs/20260810-BACKEND-qual47-park.txt
+++ b/jobs/backend/park-docs/20260810-BACKEND-qual47-park.txt
@@ -1,0 +1,160 @@
+PARK DOCUMENT — BACKEND — QUAL-47
+Date: 2026-08-10
+Branch: feat/qual47-schema-ownership-classification
+Tracker: QUAL-47 (no tracker entry or GitHub issue existed at dispatch — see OPEN ITEMS)
+Related: QUAL-43 / ADL-53 (all six stages, merged earlier today)
+
+================================================================
+1. WHAT THE BRIEF ASKED FOR, AND WHAT I BUILT INSTEAD
+================================================================
+The COO proposed a TWO-LIST design: every table carrying a users.id foreign key
+must appear in exactly one of (a) UserOwnedTable, or (b) a new explicitly-reasoned
+non-ownership list; fail when a table is in neither, in both, or is listed but no
+longer exists. The brief explicitly invited a better expression of the invariant.
+
+I built ONE MANIFEST covering EVERY table, not two lists covering eight. Both
+differences are answers to questions the brief itself raised.
+
+DEVIATION 1 — the trigger is "a table exists", not "a table has a user FK".
+  The brief asked: could a user-owned table exist WITHOUT a users.id FK, and slip
+  past entirely? Yes — and not hypothetically. TEN of this schema's user-data
+  tables carry no users.id FK at all: the five item extension tables
+  (item_flights/hotels/car_rentals/restaurants/experiences) and five junctions
+  (trip_categories_map, trip_companions_map, trip_activities_map, trip_countries,
+  trip_place_activities_map). They are scoped through a parent via
+  assertOwned/assertWritable. A user-FK-triggered check covers 8 of this schema's
+  18 user-data tables and would be blind to a new table of that second shape.
+  Classifying every table makes the trigger something nothing can be added
+  without. Cost: one line per table, once.
+
+DEVIATION 2 — one manifest, and UserOwnedTable is DERIVED from it.
+  The brief's "in both lists" failure mode only exists because there are two
+  lists. TABLE_CLASSIFICATION is the single list; UserOwnedTable — the compile-time
+  constraint on scopeToUser — is extracted from its owned-by-column entries:
+
+      export type UserOwnedTable = Extract<
+        (typeof TABLE_CLASSIFICATION)[number],
+        { kind: 'owned-by-column' }
+      >['table'];
+
+  Two lists can disagree; one cannot. CHECK 3 therefore does not test for "in both
+  lists" — it tests for "classified twice", which is the residue of that failure
+  mode once the lists are merged (and which IS injected-fault verified).
+
+DEVIATION 3 — structural schema reading, not textual.
+  The brief flagged parsing schema.ts textually as fragile and asked for a sounder
+  enumeration if one existed. Drizzle's getTableConfig reads the BUILT table
+  object, so line breaks, import aliases, formatting and helper functions cannot
+  hide a foreign key. That needs TypeScript, hence the check's implementation is a
+  .ts file — but it is NOT a second instrument: no npm script, no CI step, run
+  from scope-completeness-check.sh, verdict folded into the one verdict.
+
+DEVIATION 4 — placement. The brief's instinct was scope.ts. The manifest is in
+  src/backend/db/ownership.ts instead: it is a statement about the SCHEMA (which
+  tables exist, what their user FKs mean), so it belongs beside schema.ts, and
+  scope.ts stays about the predicate. scope.ts imports the derived type TYPE-ONLY
+  and re-exports it, so callers still find UserOwnedTable where they always did
+  and the module contributes nothing at runtime.
+
+================================================================
+2. THE CLASSES, AND WHY EACH IS CHECKED
+================================================================
+owned-by-column   user data with its own user_id column; the tables scopeToUser
+                  accepts. CHECK: must really carry a users.id FK, AND that
+                  column must be NAMED user_id.
+owned-via-parent  user data with no ownership column; scoped through `parent`.
+                  CHECK: must really have an FK to the parent it names, and the
+                  chain must terminate in an owned-by-column table without cycling.
+global-reference  not user data. CHECK: non-empty `why`; and if it carries a
+                  users.id FK, a non-empty `userFkNote` saying what that key means.
+user-identity     the users table itself. CHECK: non-empty `why`.
+
+THE COLUMN-NAME CHECK IS THE POINT. CHECK 1 finds hand-authored ownership by
+matching the userId column name. Enforcing that every owned-by-column table
+actually uses user_id is what converts CHECK 1's coverage from a convention into
+a guarantee. The motivating case — a new table with `ownerId` — now fails twice:
+unclassified (3.1) or classified-and-misnamed (3.3).
+
+NOT AN ALLOWLIST (OP-30), and the code says so in three places. Nothing is
+exempted; each entry makes a claim the build tests against the schema, so a WRONG
+entry fails louder than no entry. No suppression was added anywhere.
+
+================================================================
+3. FAULT INJECTION — 11 FAULTS, ALL EXIT 1; CONTROL EXIT 0
+================================================================
+Method: tar-copy of the worktree (node_modules symlinked) into scratch, one fault
+per fresh copy, guard run against the copy root. No git stash, no dirty tree.
+Harness: scratchpad/inject.sh + apply-fault.mjs (scratch, not committed).
+
+  control (clean copy)                                         exit 0
+  new table with a users.id FK, classified nowhere             exit 1  [3.1]
+  same table classified owned-by-column, column named owner_id exit 1  [3.3]
+  trips classified twice (owned-by-column + global-reference)  exit 1  [3.1]
+  manifest entry for a table deleted from schema.ts            exit 1  [module load fails]
+  trips still owned-by-column after its users.id FK removed    exit 1  [3.3]
+  cities' userFkNote emptied while its user FK remains         exit 1  [3.4]
+  entry for a table defined outside schema.ts                  exit 1  [3.2]
+  item_flights claiming a parent it has no FK to               exit 1  [3.5]
+  trip_countries chain terminating in global reference data    exit 1  [3.5]
+  node_modules/.bin/tsx absent                                 exit 1  [fail-closed]
+  scripts/ownership-classification-check.ts deleted            exit 1  [fail-closed]
+
+The last two matter most. A guard whose runner is missing must FAIL, not skip —
+QUAL-27 is the local precedent for a tool that exits 0 with empty output and reads
+as "nothing failed". Both paths are explicit branches in the shell script.
+
+The deleted-table fault surfaces as a Node module-load error rather than a
+formatted message. That is by design and is documented: the manifest holds table
+OBJECTS, not names, so an entry for a deleted table cannot go stale quietly — it
+breaks the type check AND the module load. CHECK 3.2 catches the case objects
+cannot: an entry for a table defined somewhere other than schema.ts.
+
+Compile-time constraint RE-PROBED after switching UserOwnedTable to a derived
+type (it was originally probe-verified at Stage 0 against the hand-written union;
+a derivation change invalidates that evidence): scopeToUser(cities, …) and
+scopeToUser(tripCountries, …) both TS2345.
+
+================================================================
+4. LIMITS OF THE CHECK — STATED, NOT IMPLIED AWAY
+================================================================
+(a) It proves a decision was RECORDED and is CONSISTENT with the schema. It
+    cannot prove the decision was RIGHT. A table holding user data can still be
+    classified global-reference with a plausible sentence and nothing here
+    catches it. What is removed is the silent case: a table nobody classified.
+(b) Corollary dodge: a new user-data table with an oddly-named ownership column
+    could be classified owned-via-parent with a real parent FK, satisfying every
+    check while its own user column goes unscoped. That is now a deliberate
+    written claim rather than an omission — the best a static check can do.
+(c) CHECK 3 says nothing about whether a QUERY is scoped. That is CHECK 1's job.
+    The two are complementary: CHECK 3 makes sure CHECK 1 is looking at the right
+    set of columns; CHECK 1 makes sure ownership is expressed in one place.
+(d) `why` / `userFkNote` are checked for non-emptiness only. Reason QUALITY is a
+    review matter; a length or keyword rule would be theatre.
+
+================================================================
+5. FILES
+================================================================
+NEW   src/backend/db/ownership.ts                  the manifest + derived UserOwnedTable
+NEW   scripts/ownership-classification-check.ts    CHECK 3's implementation
+EDIT  scripts/scope-completeness-check.sh          CHECK 3 section + runner + verdict
+EDIT  src/backend/repositories/scope.ts            UserOwnedTable now imported/re-exported
+EDIT  src/backend/db/schema.ts                     header: adding a table means classifying it
+EDIT  tsconfig.backend.json                        include scripts/**/*.ts (type-check the checker)
+EDIT  .github/workflows/ci.yml                     step comment: two invariants -> three
+EDIT  .claude/skills/pre-push/SKILL.md             CHECK 3 documented
+EDIT  CODEBASE.md                                  db/ownership.ts in the repo map
+
+No file was rewritten wholesale. ownership.ts and the checker are new files;
+every existing file was amended with Edit.
+
+================================================================
+6. OPEN ITEMS FOR THE COO
+================================================================
+- QUAL-47 has NO tracker entry and NO GitHub issue. Two probes that fail
+  differently: grep of _project/tracker.json for "QUAL-47" returned nothing, and
+  `gh issue list --search QUAL-47 --state all` returned only an unrelated 2026-07-30
+  issue. Highest existing id is QUAL-46, so QUAL-47 is free. The PR therefore
+  carries no "Closes #N" line. Tracker entry is the COO's to write.
+- The pre-push skill lives in .claude/skills/, which is repo-tracked; the copy the
+  running session loads is /workspace/.claude/skills/. The edit is committed on the
+  branch and takes effect for everyone on merge.

--- a/scripts/ownership-classification-check.ts
+++ b/scripts/ownership-classification-check.ts
@@ -1,0 +1,409 @@
+/**
+ * CHECK 3 of the backend scope guard — ownership classification completeness.
+ * QUAL-47, extending QUAL-43 / ADL-53.
+ *
+ * THIS IS NOT A SECOND INSTRUMENT. It has no npm script and no CI step of its
+ * own: `scripts/scope-completeness-check.sh` runs it and folds its verdict into
+ * the one verdict, exactly as it does for CHECK 1 and CHECK 2. It lives in its own
+ * file for one reason — it reads the schema STRUCTURALLY (Drizzle's own table
+ * metadata) rather than by grepping `schema.ts`, and that requires TypeScript.
+ *
+ * WHY STRUCTURAL AND NOT TEXTUAL. CHECKS 1 and 2 match text because the property
+ * they assert IS textual ("this string appears nowhere"). This one asserts a
+ * property of the SCHEMA — which tables exist and which foreign keys they carry —
+ * and a regex over `schema.ts` answers that only for as long as everyone keeps
+ * writing `.references(() => users.id` on one line, in that spelling, inside a
+ * recognisable `export const X = sqliteTable(` block. Drizzle's `getTableConfig`
+ * reads the built table object, so line breaks, import aliases, formatting and
+ * helper functions cannot hide a foreign key from it.
+ *
+ * WHAT IT ENFORCES (each failure names the table and the fix):
+ *
+ *   3.1 COMPLETENESS   Every table exported by `schema.ts` is classified in
+ *                      `src/backend/db/ownership.ts` exactly once. A new table
+ *                      nobody classified fails the build. (Being in "both lists"
+ *                      is not expressible — see 3.6.)
+ *   3.2 NO PHANTOMS    Every manifest entry names a table the schema still
+ *                      exports. Note that the manifest holds table OBJECTS, not
+ *                      names, so an entry for a DELETED table cannot go stale
+ *                      quietly — it stops the type check and stops this module
+ *                      loading, which the shell guard reports as a failure
+ *                      (verified by injection). What 3.2 catches on top of that is
+ *                      an entry for a table defined somewhere other than
+ *                      `schema.ts` — classified, but outside the set this check
+ *                      reasons about.
+ *   3.3 OWNERSHIP IS   Every `owned-by-column` table really carries a `users.id`
+ *       REAL           foreign key, on a column named `user_id`. The NAME is
+ *                      load-bearing: CHECK 1 finds hand-authored ownership by
+ *                      matching that name, so an ownership column called
+ *                      `owner_id` would be invisible to it. This is the motivating
+ *                      case for the whole check.
+ *   3.4 EVERY OTHER    Any table carrying a `users.id` foreign key that is NOT
+ *       USER FK IS     `owned-by-column` must state what that key means instead
+ *       EXPLAINED      (`cities.created_by_user_id` is provenance, not ownership).
+ *   3.5 DERIVED        Every `owned-via-parent` table really carries a foreign key
+ *       OWNERSHIP      to the parent it names, and that chain terminates in an
+ *       IS FOUNDED     `owned-by-column` table without cycling.
+ *   3.6 REASONS EXIST  Declared reasons are non-empty. Their QUALITY is a review
+ *                      matter, not a machine one — this only stops a blank string.
+ *
+ * FAIL-CLOSED SETUP ASSERTIONS. Every check below is of the form "for each table
+ * that ...", so a broken enumeration makes all of them vacuously true. Three
+ * assertions run first and fail the check if they do not hold: the schema module
+ * yielded tables at all; the manifest is non-empty; and a table named `users` with
+ * an `id` column exists and is the target of at least one foreign key. That last
+ * one is the one that matters — every question this check asks is phrased in terms
+ * of `users.id`, so if the identity table were renamed, "tables carrying a
+ * `users.id` foreign key" would silently become the empty set and this file would
+ * report PASS while inspecting nothing.
+ *
+ * NOTHING HERE IS AN ALLOWLIST (OP-30). See the header of `db/ownership.ts`.
+ */
+
+import { is } from 'drizzle-orm';
+import { getTableConfig, SQLiteTable } from 'drizzle-orm/sqlite-core';
+import { TABLE_CLASSIFICATION } from '../src/backend/db/ownership.js';
+import * as schema from '../src/backend/db/schema.js';
+
+const IDENTITY_TABLE = 'users';
+const IDENTITY_COLUMN = 'id';
+const OWNERSHIP_COLUMN = 'user_id';
+
+const failures: string[] = [];
+const fail = (message: string, ...detail: string[]): void => {
+  failures.push([`CLASSIFY ${message}`, ...detail.map((d) => `    ${d}`)].join('\n'));
+};
+
+// ----------------------------------------------------------------
+// Schema enumeration (structural — Drizzle's own table metadata)
+// ----------------------------------------------------------------
+
+type ForeignKeyEdge = { columns: string[]; target: string; targetColumns: string[] };
+type SchemaTable = {
+  exportName: string;
+  sqlName: string;
+  columns: string[];
+  foreignKeys: ForeignKeyEdge[];
+};
+
+/** Keyed by SQL table name — the identity the manifest and the schema share. */
+const schemaTables = new Map<string, SchemaTable>();
+/** Table object → SQL name, so a manifest entry can be resolved by identity. */
+const tableNames = new Map<SQLiteTable, string>();
+
+for (const [exportName, value] of Object.entries(schema)) {
+  if (!is(value, SQLiteTable)) continue;
+  const config = getTableConfig(value);
+  const entry: SchemaTable = {
+    exportName,
+    sqlName: config.name,
+    columns: config.columns.map((column) => column.name),
+    foreignKeys: config.foreignKeys.map((foreignKey) => {
+      const reference = foreignKey.reference();
+      return {
+        columns: reference.columns.map((column) => column.name),
+        target: getTableConfig(reference.foreignTable).name,
+        targetColumns: reference.foreignColumns.map((column) => column.name),
+      };
+    }),
+  };
+  schemaTables.set(entry.sqlName, entry);
+  tableNames.set(value, entry.sqlName);
+}
+
+/** The columns by which `table` points at `users.id`. Empty = no such foreign key. */
+const identityForeignKeyColumns = (table: SchemaTable): string[] =>
+  table.foreignKeys
+    .filter((fk) => fk.target === IDENTITY_TABLE && fk.targetColumns.includes(IDENTITY_COLUMN))
+    .flatMap((fk) => fk.columns);
+
+// ----------------------------------------------------------------
+// Fail-closed setup assertions
+// ----------------------------------------------------------------
+
+if (schemaTables.size === 0) {
+  fail(
+    '— the schema enumeration found no tables.',
+    'Every check below is "for each table that ...", so an empty enumeration would',
+    'report PASS while inspecting nothing. Fix the enumeration, not this assertion.',
+  );
+}
+
+// The `as const` manifest makes this provably non-empty at compile time too; the
+// widening cast is what lets the runtime assertion coexist with that proof, and it
+// keeps holding if the manifest ever stops being a const tuple.
+if ((TABLE_CLASSIFICATION as readonly unknown[]).length === 0) {
+  fail(
+    '— the classification manifest is empty.',
+    'src/backend/db/ownership.ts must classify every table in the schema.',
+  );
+}
+
+const identityTable = schemaTables.get(IDENTITY_TABLE);
+if (!identityTable || !identityTable.columns.includes(IDENTITY_COLUMN)) {
+  fail(
+    `— no table named '${IDENTITY_TABLE}' with an '${IDENTITY_COLUMN}' column exists.`,
+    'This check asks every one of its questions in terms of a foreign key into',
+    `${IDENTITY_TABLE}.${IDENTITY_COLUMN}. If the identity table were renamed, that set would`,
+    'silently be empty and this check would pass vacuously. If the rename is deliberate,',
+    'update IDENTITY_TABLE/IDENTITY_COLUMN here and in db/ownership.ts together.',
+  );
+}
+
+const tablesWithIdentityFk = [...schemaTables.values()].filter(
+  (table) => identityForeignKeyColumns(table).length > 0,
+);
+
+if (identityTable && tablesWithIdentityFk.length === 0) {
+  fail(
+    `— no table carries a foreign key into ${IDENTITY_TABLE}.${IDENTITY_COLUMN}.`,
+    'This schema has user-owned tables, so an empty result means the foreign-key',
+    'enumeration is broken, not that ownership vanished.',
+  );
+}
+
+// ----------------------------------------------------------------
+// 3.1 / 3.2 — the manifest covers the schema exactly once
+// ----------------------------------------------------------------
+
+type ResolvedEntry = {
+  kind: (typeof TABLE_CLASSIFICATION)[number]['kind'];
+  sqlName: string;
+  table: SchemaTable;
+  parentName?: string;
+  why?: string;
+  userFkNote?: string;
+};
+
+const classified = new Map<string, ResolvedEntry>();
+
+for (const entry of TABLE_CLASSIFICATION) {
+  const sqlName = tableNames.get(entry.table);
+  const table = sqlName ? schemaTables.get(sqlName) : undefined;
+
+  // 3.2 — a manifest entry naming something the schema no longer exports.
+  if (!sqlName || !table) {
+    fail(
+      `${entry.kind} entry names a table that schema.ts does not export.`,
+      'The table was removed or is no longer exported. Delete the entry in the same PR',
+      'that removed the table — a manifest that keeps entries for tables that no longer',
+      'exist stops being a statement about the current schema.',
+    );
+    continue;
+  }
+
+  // 3.1 (duplicate half) — the same table classified twice.
+  if (classified.has(sqlName)) {
+    fail(
+      `${sqlName} is classified more than once in db/ownership.ts.`,
+      `First as '${classified.get(sqlName)?.kind}', again as '${entry.kind}'.`,
+      'A table has exactly one classification. Delete the entry that is wrong.',
+    );
+    continue;
+  }
+
+  classified.set(sqlName, {
+    kind: entry.kind,
+    sqlName,
+    table,
+    parentName: 'parent' in entry ? tableNames.get(entry.parent) : undefined,
+    why: 'why' in entry ? entry.why : undefined,
+    userFkNote: 'userFkNote' in entry ? entry.userFkNote : undefined,
+  });
+}
+
+// 3.1 (completeness half) — the real target: a new table nobody classified.
+for (const table of schemaTables.values()) {
+  if (classified.has(table.sqlName)) continue;
+  const identityColumns = identityForeignKeyColumns(table);
+  fail(
+    `${table.sqlName} (exported as '${table.exportName}') is not classified.`,
+    'Every table in schema.ts must be classified in src/backend/db/ownership.ts —',
+    'whose data is this, and how is that expressed. Add ONE entry:',
+    "  owned-by-column   — user data with its own user_id column (scopeToUser accepts it)",
+    '  owned-via-parent  — user data scoped through a parent (assertOwned/assertWritable)',
+    '  global-reference  — not user data; readable by everyone',
+    identityColumns.length > 0
+      ? `NOTE: this table already points at ${IDENTITY_TABLE}.${IDENTITY_COLUMN} via ` +
+        `${identityColumns.join(', ')} — decide whether that column is OWNERSHIP or something else.`
+      : 'This table carries no user foreign key, so decide how it is scoped before adding it.',
+  );
+}
+
+// ----------------------------------------------------------------
+// 3.3 / 3.4 — every user foreign key is either ownership or explained
+// ----------------------------------------------------------------
+
+for (const entry of classified.values()) {
+  const identityColumns = identityForeignKeyColumns(entry.table);
+
+  if (entry.kind === 'owned-by-column') {
+    if (identityColumns.length === 0) {
+      fail(
+        `${entry.sqlName} is classified 'owned-by-column' but carries no foreign key into ` +
+          `${IDENTITY_TABLE}.${IDENTITY_COLUMN}.`,
+        'scopeToUser composes an ownership predicate on that column, so the classification',
+        'claims something the schema does not provide. Either add the column, or classify',
+        'the table as owned-via-parent (scoped through a parent) or global-reference.',
+      );
+      continue;
+    }
+    if (!identityColumns.includes(OWNERSHIP_COLUMN)) {
+      fail(
+        `${entry.sqlName} carries its user foreign key on '${identityColumns.join(', ')}', not ` +
+          `'${OWNERSHIP_COLUMN}'.`,
+        'This is the case this check exists for. CHECK 1 of this guard finds hand-authored',
+        `ownership by matching the ${OWNERSHIP_COLUMN} column name, so an ownership column`,
+        'called anything else is invisible to it — ownership could then be written by hand',
+        'anywhere in the backend and nothing would object.',
+        `Rename the column to '${OWNERSHIP_COLUMN}' (a migration), or, if it is not ownership,`,
+        'reclassify the table and state what the key means in userFkNote.',
+      );
+    }
+    continue;
+  }
+
+  // 3.4 — not owned-by-column, yet points at a user. Say what it means.
+  if (identityColumns.length > 0 && !(entry.userFkNote ?? '').trim()) {
+    fail(
+      `${entry.sqlName} is classified '${entry.kind}' and carries a foreign key into ` +
+        `${IDENTITY_TABLE}.${IDENTITY_COLUMN} via ${identityColumns.join(', ')}, with no userFkNote.`,
+      'A user reference on a table that is not owned-by-column means something other than',
+      'ownership — provenance, authorship, a last-editor stamp. State which, in userFkNote,',
+      "so the next reader does not have to guess (cities.created_by_user_id is the worked",
+      'example). If it IS ownership, classify the table owned-by-column instead.',
+    );
+  }
+}
+
+// ----------------------------------------------------------------
+// 3.5 — derived ownership is founded on a real foreign-key chain
+// ----------------------------------------------------------------
+
+for (const entry of classified.values()) {
+  if (entry.kind !== 'owned-via-parent') continue;
+
+  if (!entry.parentName) {
+    fail(
+      `${entry.sqlName} names a parent that schema.ts does not export.`,
+      'Point it at a table that exists.',
+    );
+    continue;
+  }
+
+  const hasEdge = entry.table.foreignKeys.some((fk) => fk.target === entry.parentName);
+  if (!hasEdge) {
+    fail(
+      `${entry.sqlName} claims ownership through '${entry.parentName}' but has no foreign key ` +
+        'to it.',
+      'Derived ownership is only as real as the foreign key it travels along. Name the parent',
+      'this table actually references, or give the table its own user_id column and classify',
+      'it owned-by-column.',
+    );
+    continue;
+  }
+
+  // Walk to an owned-by-column root. A cycle, an unclassified link, or a terminus
+  // that is not user-owned all mean the claim of derived ownership never resolves
+  // to an owner — the rows would have nothing to be scoped to.
+  const immediateParent = classified.get(entry.parentName);
+  if (!immediateParent) {
+    fail(
+      `${entry.sqlName} claims ownership through '${entry.parentName}', which is not classified.`,
+      'Classify the parent first — an unclassified parent cannot establish an owner.',
+    );
+    continue;
+  }
+
+  let cursor: ResolvedEntry = immediateParent;
+  const seen = new Set<string>([entry.sqlName]);
+  let resolved = false;
+  let cycled = false;
+  let terminus = cursor;
+
+  while (true) {
+    if (cursor.kind === 'owned-by-column') {
+      resolved = true;
+      break;
+    }
+    if (cursor.kind !== 'owned-via-parent' || seen.has(cursor.sqlName)) {
+      cycled = seen.has(cursor.sqlName);
+      terminus = cursor;
+      break;
+    }
+    seen.add(cursor.sqlName);
+    const next: ResolvedEntry | undefined = cursor.parentName
+      ? classified.get(cursor.parentName)
+      : undefined;
+    if (!next) {
+      terminus = cursor;
+      break;
+    }
+    cursor = next;
+  }
+
+  if (cycled) {
+    fail(
+      `${entry.sqlName}'s ownership chain cycles at '${terminus.sqlName}'.`,
+      'A chain that loops never reaches an owner, so nothing scopes these rows.',
+    );
+  } else if (!resolved) {
+    fail(
+      `${entry.sqlName}'s ownership chain stops at '${terminus.sqlName}' (classified ` +
+        `'${terminus.kind}') without reaching an owned-by-column table.`,
+      'Derived ownership must terminate in a table with its own user_id column. Stopping at',
+      'global reference data, at the identity table, or at a link whose own parent is missing',
+      'means these rows have no owner to be scoped to.',
+    );
+  }
+}
+
+// ----------------------------------------------------------------
+// 3.6 — declared reasons are actually declared
+// ----------------------------------------------------------------
+
+for (const entry of classified.values()) {
+  if ((entry.kind === 'global-reference' || entry.kind === 'user-identity') && !entry.why?.trim()) {
+    fail(
+      `${entry.sqlName} is classified '${entry.kind}' with an empty reason.`,
+      'State why this table is not user data. The reason is what a future reader checks',
+      'against the schema when they are tempted to read user rows out of it.',
+    );
+  }
+  if (entry.userFkNote !== undefined && !entry.userFkNote.trim()) {
+    fail(`${entry.sqlName} has an empty userFkNote.`, 'State what the user foreign key means.');
+  }
+}
+
+// ----------------------------------------------------------------
+// Verdict
+// ----------------------------------------------------------------
+
+if (failures.length > 0) {
+  for (const failure of failures) console.log(failure);
+  console.log('');
+  console.log('scope-completeness-check: FAIL — CHECK 3');
+  console.log(`  ${failures.length} ownership-classification problem(s), listed above.`);
+  console.log('  QUAL-47: every table in schema.ts is classified in src/backend/db/ownership.ts,');
+  console.log('  and the classification is checked against the real schema. Fix the entry or the');
+  console.log('  schema — do NOT delete the check or reclassify a table to dodge it (OP-30).');
+  process.exit(1);
+}
+
+const counts = new Map<string, number>();
+for (const entry of classified.values()) {
+  counts.set(entry.kind, (counts.get(entry.kind) ?? 0) + 1);
+}
+const summary = [...counts.entries()]
+  .sort(([a], [b]) => a.localeCompare(b))
+  .map(([kind, count]) => `${count} ${kind}`)
+  .join(', ');
+
+console.log(
+  `  Check 3 (ownership classification, enforced) — ${classified.size} schema table(s) ` +
+    `classified (${summary});`,
+);
+console.log(
+  `    ${tablesWithIdentityFk.length} carry a ${IDENTITY_TABLE}.${IDENTITY_COLUMN} foreign key, ` +
+    'each either owned-by-column or explained.',
+);

--- a/scripts/scope-completeness-check.sh
+++ b/scripts/scope-completeness-check.sh
@@ -1,16 +1,19 @@
 #!/usr/bin/env bash
-# Backend scope guards — QUAL-43 / ADL-53.
+# Backend scope guards — QUAL-43 / ADL-53, extended by QUAL-47.
 #
-# ONE instrument, TWO invariants. They are deliberately in the same script
-# rather than two: they are adjacent assertions about the same property (where
-# ownership may be expressed, and where the DB handle may be obtained), and two
-# scripts asserting adjacent invariants is how they drift apart.
+# ONE instrument, THREE invariants. They are deliberately in the same script
+# rather than three: they are adjacent assertions about the same property (where
+# ownership may be expressed, where the DB handle may be obtained, and which
+# tables ownership is even a question for), and separate scripts asserting
+# adjacent invariants is how they drift apart.
 #
 #   CHECK 1 — Ownership completeness  (ADL-53 §6 Stage 0, widened by Stage 3)
 #   CHECK 2 — No `getDb` in routes    (ADL-53 §3 item 1, authored by Stage 3)
+#   CHECK 3 — Ownership classification completeness (QUAL-47)
 #
-# BOTH CHECKS ARE FULLY ENFORCED (2026-08-10, ADL-53 §6 Stage 5). Any match in
-# either one fails the build. Both landed warn-first on purpose — the QUAL-43
+# ALL THREE CHECKS ARE FULLY ENFORCED. Checks 1 and 2 were flipped to enforced
+# on 2026-08-10 (ADL-53 §6 Stage 5); Check 3 landed enforced. Any match in
+# either of the first two fails the build. Both landed warn-first on purpose — the QUAL-43
 # migration was mid-flight and failing on a residual a later stage was chartered
 # to remove would have red-ed the trunk (ADL-47 expand/contract). Stage 5 is the
 # CONTRACT half: Stages 2/3/4 drove both residual counts to zero, and this is the
@@ -170,10 +173,60 @@
 #   reword your own prose and you are done; the other tags mean a read needs
 #   relocating into a repository. Neither ever means adding an exemption here.
 #
-# BLIND SPOT (stated, not silently accepted): both checks match TEXT, not syntax,
-# so a comment quoting any pattern trips them. That is deliberate — it fails
-# closed. The fix is to reword the comment (OP-30: fix your own text), never to
-# add an exemption here.
+# BLIND SPOT (stated, not silently accepted): checks 1 and 2 match TEXT, not
+# syntax, so a comment quoting any pattern trips them. That is deliberate — it
+# fails closed. The fix is to reword the comment (OP-30: fix your own text), never
+# to add an exemption here.
+#
+# ================================================================
+# CHECK 3 — Ownership classification completeness  (ENFORCED)
+# ================================================================
+#
+# QUAL-47. Closes the soft edge Check 1 leaves behind, recorded as a carry-forward
+# when Checks 1 and 2 were flipped to enforced: CHECK 1 IS REGEX-SHAPED, and it
+# matches the ownership column by NAME. Its protection therefore rests on an
+# unwritten convention — that every user-owned table calls its ownership column
+# `userId`. A table whose ownership column were called `ownerId` would be
+# invisible to Check 1, would not be in the type union `scopeToUser` accepts, and
+# so would be pulled through no chokepoint and flagged by no guard. The near-miss
+# is already in the schema: `cities.created_by_user_id` exists and is correctly
+# NOT ownership (global reference data, provenance), which proves the naming
+# pattern occurs here rather than being hypothetical.
+#
+# WHAT CHECK 3 ASSERTS: every table in `schema.ts` is classified, exactly once, in
+# `src/backend/db/ownership.ts` — as user data owned by its own `user_id` column,
+# as user data scoped through a named parent, as global reference data, or as the
+# identity table. Each classification is then verified against the real schema:
+# an `owned-by-column` table must actually carry a `users.id` foreign key on a
+# column named `user_id`; an `owned-via-parent` table must actually reference the
+# parent it names, along a chain that terminates in an owned table; and any other
+# table carrying a `users.id` foreign key must state what that key means instead.
+#
+# A NEW TABLE NOBODY CLASSIFIED FAILS THE BUILD. That is the point — the check
+# does not try to decide whether a user foreign key means ownership (no static
+# rule can: `cities.created_by_user_id` is exactly that judgement). It forces
+# someone to decide, once, in writing, and fails closed until they do.
+#
+# IT IS NOT AN ALLOWLIST (OP-30). Nothing in the manifest is exempted from
+# anything, and no entry silences a check. Each entry makes a claim the build
+# tests against the schema; a wrong entry fails louder than no entry. The one
+# thing to never do is reclassify a table to make a failure go away.
+#
+# WHY CHECK 3 IS A SEPARATE FILE AND CHECKS 1/2 ARE NOT. It reads the schema
+# STRUCTURALLY — Drizzle's own table metadata via `getTableConfig` — instead of
+# grepping `schema.ts`, because "which tables carry which foreign keys" is a
+# property of the schema, not of its formatting. A regex answers it only while
+# everyone keeps writing the reference on one line, in one spelling, inside a
+# recognisable table block. That needs TypeScript, hence
+# `scripts/ownership-classification-check.ts`. It is NOT a second instrument: it
+# has no npm script and no CI step of its own, it is run from here, and its
+# verdict is folded into the one verdict below.
+#
+# BLIND SPOT (stated, not silently accepted): Check 3 proves a decision was
+# recorded and is consistent with the schema. It cannot prove the decision was
+# RIGHT — a table holding user data can still be classified `global-reference`
+# with a plausible sentence, and nothing here will catch that. What it removes is
+# the silent case: a table nobody classified at all.
 
 set -euo pipefail
 
@@ -329,7 +382,34 @@ for f in "${ROUTE_FILES[@]}"; do
 done
 
 # ----------------------------------------------------------------
-# Verdicts — BOTH checks are enforced (ADL-53 §6 Stage 5)
+# CHECK 3 — ownership classification (enforced)
+# ----------------------------------------------------------------
+# Runs the TypeScript implementation and captures its verdict. Every failure
+# path here is fail-closed: a missing implementation, a missing toolchain, or a
+# crash is a FAILURE, never a silent skip. A guard that quietly does nothing when
+# its runner is absent is worse than no guard, because the green tick still
+# appears (QUAL-27 is the local precedent for a tool that fails open).
+TSX_BIN="$ROOT/node_modules/.bin/tsx"
+CHECK3_SCRIPT="$ROOT/scripts/ownership-classification-check.ts"
+
+check3_rc=0
+check3_out=""
+
+if [ ! -f "$CHECK3_SCRIPT" ]; then
+  check3_out="CLASSIFY — CHECK 3's implementation is missing: scripts/ownership-classification-check.ts
+    It is not optional and it is not a second instrument; restore it (QUAL-47)."
+  check3_rc=1
+elif [ ! -x "$TSX_BIN" ]; then
+  check3_out="CLASSIFY — cannot run CHECK 3: no executable at node_modules/.bin/tsx
+    Run 'npm install' (a fresh worktree does not inherit node_modules). Treated as a
+    FAILURE rather than a skip so a missing toolchain cannot pass this guard."
+  check3_rc=1
+else
+  check3_out="$("$TSX_BIN" "$CHECK3_SCRIPT" 2>&1)" || check3_rc=$?
+fi
+
+# ----------------------------------------------------------------
+# Verdicts — ALL THREE checks are enforced (ADL-53 §6 Stage 5; QUAL-47)
 # ----------------------------------------------------------------
 # Every failure is reported before exiting. A run that breaks both invariants
 # must show both, not just the first: an implementer who fixes only what the
@@ -363,6 +443,12 @@ if [ "$getdb_hits" -gt 0 ]; then
   failed=1
 fi
 
+if [ "$check3_rc" -ne 0 ]; then
+  echo ""
+  echo "$check3_out"
+  failed=1
+fi
+
 if [ "$failed" -ne 0 ]; then
   exit 1
 fi
@@ -372,3 +458,4 @@ echo "scope-completeness-check: PASS"
 echo "  Check 1 (ownership, enforced) — 0 residuals across $((${#ZONE_A_FILES[@]} + ${#ZONE_B_FILES[@]})) backend source(s)"
 echo "    (${#ZONE_A_FILES[@]} in repositories/, ${#ZONE_B_FILES[@]} elsewhere; __tests__ excluded)."
 echo "  Check 2 (getDb in routes, enforced) — 0 mention(s) across ${#ROUTE_FILES[@]} route file(s)."
+echo "$check3_out"

--- a/src/backend/db/ownership.ts
+++ b/src/backend/db/ownership.ts
@@ -1,0 +1,200 @@
+/**
+ * Travel Tracker — Table ownership classification (QUAL-47, extending QUAL-43 / ADL-53)
+ *
+ * EVERY table defined in `schema.ts` is classified here, exactly once. This file
+ * answers one question, in writing, for every table in the database:
+ *
+ *     "Whose data is this, and how is that expressed?"
+ *
+ * `scripts/scope-completeness-check.sh` CHECK 3 enforces the answer exists and is
+ * consistent with the schema — a table added to `schema.ts` and not classified here
+ * FAILS THE BUILD.
+ *
+ * ────────────────────────────────────────────────────────────────────────────
+ * THIS IS NOT AN ALLOWLIST (OP-30)
+ * ────────────────────────────────────────────────────────────────────────────
+ * Nothing here is exempted from scrutiny and nothing here turns a check green by
+ * silencing it. An entry is a CLASSIFICATION, and the classification is what the
+ * check verifies against the real schema:
+ *
+ *   - an `owned-by-column` entry is checked to actually carry a `user_id` foreign
+ *     key into `users.id` — claiming ownership you do not have fails;
+ *   - an `owned-via-parent` entry is checked to actually carry a foreign key to the
+ *     `parent` it names, and that chain is walked until it terminates in an
+ *     `owned-by-column` table — an unfounded claim of derived ownership fails;
+ *   - a table carrying a `users.id` foreign key that is NOT `owned-by-column` must
+ *     state, in `userFkNote`, what that foreign key means instead.
+ *
+ * Adding an entry therefore makes a claim the build tests. Deleting or weakening a
+ * check because an entry is inconvenient is a scanner suppression and needs COO
+ * sign-off; reclassifying a table to dodge a failure is worse, because it is a
+ * claim in writing that someone will later rely on.
+ *
+ * ────────────────────────────────────────────────────────────────────────────
+ * WHY THE CLASSIFICATION COVERS EVERY TABLE, NOT ONLY THE USER-FK ONES
+ * ────────────────────────────────────────────────────────────────────────────
+ * Ten of this schema's user-data tables carry NO `users.id` foreign key at all —
+ * the item extension tables and the junction tables own no user column and are
+ * scoped through their parent (`assertOwned`/`assertWritable` in
+ * `repositories/scope.ts`). A check triggered only by "carries a `users.id` FK"
+ * cannot see them, so a new table of that shape would be unclassified, unscoped
+ * and invisible. Classifying every table closes that by construction: the trigger
+ * is "a table exists", which nothing can be added without.
+ *
+ * ────────────────────────────────────────────────────────────────────────────
+ * THE OWNERSHIP LIST IS DERIVED FROM THIS MANIFEST, NOT MAINTAINED BESIDE IT
+ * ────────────────────────────────────────────────────────────────────────────
+ * `UserOwnedTable` — the compile-time constraint on `scopeToUser` — is extracted
+ * from the `owned-by-column` entries below rather than hand-written as a second
+ * union. Two lists can disagree; one list cannot. "This table is in both lists" is
+ * therefore not a failure this codebase can express, which is why CHECK 3 does not
+ * test for it.
+ */
+
+import type { SQLiteTable } from 'drizzle-orm/sqlite-core';
+import {
+  activities,
+  cities,
+  companions,
+  countries,
+  itemCarRentals,
+  itemExperiences,
+  itemFlights,
+  itemHotels,
+  itemRestaurants,
+  items,
+  mapShadingConfig,
+  regions,
+  tripActivitiesMap,
+  tripCategories,
+  tripCategoriesMap,
+  tripCompanionsMap,
+  tripCountries,
+  tripPlaceActivitiesMap,
+  tripPlaces,
+  trips,
+  users,
+} from './schema.js';
+
+/**
+ * Common to every entry.
+ *
+ * `userFkNote` is REQUIRED — enforced by CHECK 3, not by the type, because the
+ * requirement depends on the schema rather than on the entry — whenever the table
+ * carries a `users.id` foreign key AND is not `owned-by-column`. A user reference
+ * on a table that is not user-owned-by-column always means something other than
+ * ownership, and that meaning has to be stated rather than assumed by the next
+ * reader. It is available on every kind so that stating it is never blocked by the
+ * shape of the manifest; today only `cities` needs one.
+ */
+type EntryBase = { table: SQLiteTable; userFkNote?: string };
+
+/**
+ * User data whose ownership is carried by its OWN `user_id` column.
+ *
+ * These are the tables `scopeToUser` accepts. The column MUST be named `user_id`
+ * (`userId` in Drizzle) — CHECK 1 of the scope guard finds hand-authored ownership
+ * by matching that name, so an ownership column called anything else would be
+ * invisible to it. CHECK 3 enforces the name.
+ */
+type OwnedByColumnEntry = EntryBase & { kind: 'owned-by-column' };
+
+/**
+ * User data that carries no ownership column of its own — a junction row or an
+ * item extension row. Ownership is asserted through `parent` (see `assertOwned` /
+ * `assertWritable`). `parent` must be a real foreign-key target of this table, and
+ * the chain must terminate in an `owned-by-column` table.
+ */
+type OwnedViaParentEntry = EntryBase & { kind: 'owned-via-parent'; parent: SQLiteTable };
+
+/** Not user data. Global reference data, readable by everyone. */
+type GlobalReferenceEntry = EntryBase & { kind: 'global-reference'; why: string };
+
+/** The identity table itself — the target every user foreign key points at. */
+type UserIdentityEntry = EntryBase & { kind: 'user-identity'; why: string };
+
+export type TableClassificationEntry =
+  | OwnedByColumnEntry
+  | OwnedViaParentEntry
+  | GlobalReferenceEntry
+  | UserIdentityEntry;
+
+/**
+ * The manifest. One entry per table in `schema.ts`, in schema-file order.
+ *
+ * ADDING A TABLE: add an entry here in the same PR. The build fails until you do,
+ * and the failure names the table.
+ */
+export const TABLE_CLASSIFICATION = [
+  // ── Geographic hierarchy — global reference data (GE-04/05/06, GE-11/12/13) ──
+  {
+    kind: 'global-reference',
+    table: countries,
+    why: 'Seeded ISO 3166-1 country list plus per-country display config. Identical for every user.',
+  },
+  {
+    kind: 'global-reference',
+    table: regions,
+    why: 'Seeded state/province tier for countries that enable it. Identical for every user.',
+  },
+  {
+    kind: 'global-reference',
+    table: cities,
+    why:
+      'Global gazetteer. A city created on demand by one user is immediately usable by every ' +
+      'other user, and city rows outlive the account that first referenced them (ADL-46 D5, GE-16).',
+    userFkNote:
+      'created_by_user_id is PROVENANCE, not ownership: "which account first caused this row to ' +
+      'exist". It is deliberately NULLABLE (seeded and pre-column rows have no creator) and ' +
+      'ON DELETE SET NULL, because deleting a user must never delete shared city rows other ' +
+      "users' trips depend on. It also participates in uniq_cities_pending_per_creator so two " +
+      'users can each hold their own pending row for the same place. It must never be used to ' +
+      'restrict reads — doing so would hide half the gazetteer from everyone (ADL-46 §9.2).',
+  },
+
+  // ── Per-user admin lists (ADL-28 AD-07/AD-08, ADL-46 AD-09/D3) ──
+  { kind: 'owned-by-column', table: tripCategories },
+  { kind: 'owned-by-column', table: activities },
+  { kind: 'owned-by-column', table: companions },
+  { kind: 'owned-by-column', table: mapShadingConfig },
+
+  // ── Trips and their junctions ──
+  { kind: 'owned-by-column', table: trips },
+  { kind: 'owned-via-parent', table: tripCategoriesMap, parent: trips },
+  { kind: 'owned-via-parent', table: tripCompanionsMap, parent: trips },
+  { kind: 'owned-via-parent', table: tripActivitiesMap, parent: trips },
+  { kind: 'owned-via-parent', table: tripCountries, parent: trips },
+
+  // ── Places ──
+  { kind: 'owned-by-column', table: tripPlaces },
+  { kind: 'owned-via-parent', table: tripPlaceActivitiesMap, parent: tripPlaces },
+
+  // ── Items and their per-type extension tables (ADL-11 Option B) ──
+  { kind: 'owned-by-column', table: items },
+  { kind: 'owned-via-parent', table: itemFlights, parent: items },
+  { kind: 'owned-via-parent', table: itemHotels, parent: items },
+  { kind: 'owned-via-parent', table: itemCarRentals, parent: items },
+  { kind: 'owned-via-parent', table: itemRestaurants, parent: items },
+  { kind: 'owned-via-parent', table: itemExperiences, parent: items },
+
+  // ── Identity ──
+  {
+    kind: 'user-identity',
+    table: users,
+    why:
+      'The identity table every user foreign key targets. Rows are reached by Clerk id in the ' +
+      'auth middleware, never by a row-ownership predicate, so it is neither user-owned data ' +
+      'nor global reference data.',
+  },
+] as const satisfies readonly TableClassificationEntry[];
+
+/**
+ * The tables `scopeToUser` accepts — derived from the manifest above, never
+ * written twice. Passing a global reference table (`cities`, `countries`,
+ * `regions`) is a compile error by construction, and so is passing a table whose
+ * ownership is only derivable through a parent.
+ */
+export type UserOwnedTable = Extract<
+  (typeof TABLE_CLASSIFICATION)[number],
+  { kind: 'owned-by-column' }
+>['table'];

--- a/src/backend/db/schema.ts
+++ b/src/backend/db/schema.ts
@@ -12,6 +12,15 @@
  * column names and relationships are identical; only the table builder
  * and column type imports change.
  *
+ * ADDING A TABLE? It must also be classified in `ownership.ts` — whose data is
+ * this, and how is that expressed (its own `user_id` column, a named parent,
+ * global reference data, or identity). That is build-enforced: CHECK 3 of
+ * `scripts/scope-completeness-check.sh` fails on any table defined here and
+ * classified nowhere (QUAL-47). If a table is user data, its ownership column
+ * must be named `user_id` — the scope guard's CHECK 1 finds hand-authored
+ * ownership by that name, so an ownership column called anything else would be
+ * invisible to it.
+ *
  * @see jobs/architect/tech/20260307-ER-schema.md (v1.1 — original design, historical).
  *      Schema evolution since v1.1 (users, trip_countries, is_owner, place dates,
  *      user_id FKs) is recorded in the architecture-decisions-log (ADL-16/19/20/23/24/27).

--- a/src/backend/repositories/scope.ts
+++ b/src/backend/repositories/scope.ts
@@ -29,19 +29,20 @@
  * build rather than warning. It matches text, not syntax, so do not quote either
  * flagged pattern in a comment in any backend source file — reword instead
  * (OP-30: fix your own text rather than weakening the scanner).
+ *
+ * That grep only sees ownership columns NAMED `userId`, which made the guard
+ * depend on an unwritten convention. QUAL-47 closed that: CHECK 3 of the same
+ * script requires every table in `schema.ts` to be classified in
+ * `db/ownership.ts`, requires each user-owned table's ownership column to be
+ * named `user_id`, and requires any other table carrying a `users.id` foreign key
+ * to state what that key means instead (`cities.created_by_user_id` is
+ * provenance). A table this file cannot scope is now a build failure rather than
+ * a silent omission.
  */
 
 import { and, eq, type SQL } from 'drizzle-orm';
-import {
-  type activities,
-  type companions,
-  getDb,
-  type items,
-  type mapShadingConfig,
-  type tripCategories,
-  type tripPlaces,
-  trips,
-} from '../db/index.js';
+import { getDb, trips } from '../db/index.js';
+import type { UserOwnedTable } from '../db/ownership.js';
 import { LockError, NotFoundError } from '../errors.js';
 
 /**
@@ -50,15 +51,14 @@ import { LockError, NotFoundError } from '../errors.js';
  * "is this table user data?" is answered once, in the type system, rather than
  * re-litigated at each call site. Passing a global reference table (`cities`,
  * `countries`, `regions`) is a compile error by construction.
+ *
+ * QUAL-47: this union is no longer written here. It is DERIVED from the
+ * `owned-by-column` entries of `db/ownership.ts`, which classifies every table in
+ * the schema and is build-enforced by CHECK 3 of the scope guard. Re-exported
+ * from here because this is where callers already look for it. A table becomes
+ * user-owned by being classified there — there is no second list to keep in step.
  */
-export type UserOwnedTable =
-  | typeof activities
-  | typeof companions
-  | typeof items
-  | typeof mapShadingConfig
-  | typeof tripCategories
-  | typeof tripPlaces
-  | typeof trips;
+export type { UserOwnedTable };
 
 /**
  * The single ownership predicate. Phase-3 sharing changes ONLY this function

--- a/tsconfig.backend.json
+++ b/tsconfig.backend.json
@@ -17,6 +17,6 @@
     "incremental": true,
     "tsBuildInfoFile": ".cache/tsconfig.backend.tsbuildinfo"
   },
-  "include": ["src/backend/**/*", "drizzle.config.ts"],
+  "include": ["src/backend/**/*", "drizzle.config.ts", "scripts/**/*.ts"],
   "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
Tracker: **QUAL-47** — extends **QUAL-43 / ADL-53** (all six stages, merged earlier today).
No GitHub issue exists for QUAL-47, so there is no `Closes #N` line — see "For the COO" below.
BRD: n/a (guard hardening, no requirement touched).

## What this closes

QUAL-43 made ownership a single definition (`repositories/scope.ts`) and CHECK 1 of
`scripts/scope-completeness-check.sh` enforces it build-wide. But **CHECK 1 is regex-shaped**: it
matches the ownership column by NAME, so its protection rests on an unwritten convention — that
every user-owned table calls that column `userId`. A table using `ownerId` would be invisible to
CHECK 1, absent from the type union `scopeToUser` accepts, and therefore pulled through no
chokepoint and flagged by no guard. `cities.created_by_user_id` already exists (correctly *not*
ownership — provenance on global reference data), which proves the naming pattern occurs here.

## CHECK 3

Every table in `schema.ts` must be classified **exactly once** in `src/backend/db/ownership.ts`:

| class | meaning | what the build verifies |
|---|---|---|
| `owned-by-column` | user data, own `user_id` column | really carries a `users.id` FK, **on a column named `user_id`** |
| `owned-via-parent` | user data scoped through a parent | really has an FK to the named parent; chain terminates in an owned table, no cycles |
| `global-reference` | not user data | non-empty reason; **plus a stated `userFkNote` if it carries a `users.id` FK** |
| `user-identity` | the `users` table | non-empty reason |

Today: 21 tables — 7 owned-by-column, 10 owned-via-parent, 3 global-reference, 1 user-identity;
8 carry a `users.id` FK, each either owned-by-column or explained. Exits 0 on `main` as it stands.

The manifest is a **classification, not an allowlist** (OP-30): nothing is exempted, each entry
makes a claim the build tests against the schema, and a wrong entry fails louder than no entry. No
suppression was added anywhere.

## Where this differs from the brief's proposed design

1. **Classification covers every table, not only the 8 with a user FK.** The brief asked whether a
   user-owned table could exist without one. Ten do, right now — the item extension tables and the
   junctions, scoped through a parent. A user-FK trigger sees 8 of 18 user-data tables. The trigger
   is now "a table exists".
2. **One manifest, not two lists.** `UserOwnedTable` is *derived* from the `owned-by-column`
   entries, so "a table is in both lists" is not a state this codebase can express — the failure
   mode is removed rather than detected. What remains, and is fault-tested, is "classified twice".
3. **Structural, not textual.** Drizzle's `getTableConfig` reads the built table object, so line
   breaks, aliases and formatting cannot hide a foreign key. That needs TypeScript — but the `.ts`
   file is **not a second instrument**: no npm script, no CI step, run from the one shell guard,
   verdict folded into the one verdict.
4. **Manifest lives in `db/ownership.ts`, not `scope.ts`** — it is a statement about the schema, so
   it sits beside `schema.ts`. `scope.ts` imports the derived type **type-only** and re-exports it.

## Verification — 11 injected faults, all exit 1; control exit 0

On a tar-copy of the tree (no `git stash`, clean working tree throughout): unclassified new table ·
ownership column named `owner_id` · table classified twice · entry for a deleted table · `trips`
still `owned-by-column` after its user FK was removed · `cities` `userFkNote` emptied · entry for a
table outside `schema.ts` · parent with no FK to it · chain terminating in global reference data ·
`tsx` absent · check implementation deleted. **The last two confirm it fails closed rather than
skipping** — the QUAL-27 failure mode.

`scopeToUser(cities, …)` and `scopeToUser(tripCountries, …)` re-probed after the derivation change:
both TS2345.

## Limits, stated

CHECK 3 proves a decision was *recorded* and is *consistent with the schema*. It cannot prove the
decision was *right* — a table holding user data can still be classified `global-reference` with a
plausible sentence. What it removes is the silent case: a table nobody classified at all.

## No production behaviour change

`ownership.ts` is imported type-only by `scope.ts`, so it contributes nothing at runtime.
827/827 backend tests unchanged, **zero test files modified**. `type:check:all` clean, `/pre-push`
fully green.

## For the COO

QUAL-47 has no tracker entry and no GitHub issue. Two probes that fail differently: grep of
`_project/tracker.json` found nothing, and `gh issue list --search QUAL-47 --state all` returned
only an unrelated 2026-07-30 issue. Highest existing id is QUAL-46, so QUAL-47 is free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
