### PR TITLE
fix(QUAL-50): item create atomicity + BUG-95 extension-write gate

### DIFF
--- a/jobs/COO/inbox/20260810_2315-BACKEND-qual50-complete.txt
+++ b/jobs/COO/inbox/20260810_2315-BACKEND-qual50-complete.txt
@@ -1,0 +1,38 @@
+BACKEND COMPLETION — QUAL-50 (item create atomicity + BUG-95 gate)
+Tracker: QUAL-50 (closes BUG-95) · PR: (opening) · BRD: n/a · Branch: fix/qual50-item-atomicity
+
+WHAT WAS BUILT
+itemRepository.create now wraps its base + extension insert in one db.transaction()
+(no orphan base row on mid-create failure); update gates the extension write on the
+scoped UPDATE having matched (BUG-95 — a non-owner can no longer mutate an extension
+row). Added a per-test file-backed test client, scoped to the one transaction-using
+test file.
+
+ACCEPTANCE CRITERIA
+- Per-test file-backed client, unique temp path + cleanup, scoped (not suite-wide): PASS
+  (createFileBackedTestDb; used only in repositories/__tests__/items.test.ts)
+- create base+extension in ONE transaction, no orphan on failure: PASS
+- BUG-95: update extension-write gated on scoped UPDATE match: PASS
+- Two regression tests RED-before / GREEN-after: PASS (RED output in park doc)
+- test:backend green, no unrelated test file modified: PASS (53 files / 845 tests)
+- No other production behaviour change: PASS
+
+SECURITY (OP-06 — access-matrix defect BUG-95)
+- Extension-write gate composes the existing scopeToUser predicate via the same scoped
+  UPDATE's .returning() — no parallel/hand-rolled ownership check added, assertion not
+  weakened. Non-owner update now returns null and performs no extension write.
+- No routes added/modified; scope:check PASS (getDb still absent from routes).
+
+CI: opening PR next; will confirm ci-wait.sh green against true head SHA before reporting done.
+
+DESIGN NOTE (challenge to the spike, detail in park doc)
+The spike said create "cannot copy executeCarryForward's :memory:-surviving shape" because
+of its trailing fetch. It CAN — move the fetch INSIDE the transaction and return it. That
+keeps create :memory:-safe, so file-backed was needed in ONE test file, not the 7+ feared.
+Full suite stayed green with no route/service/contract test touched. Spike's GO + mechanism
+were all correct; it just under-explored this cheaper shape.
+
+BLOCKERS: none. drizzle-kit patch untouched (ADL-15).
+
+UNBLOCKED: BUG-95 ready to close on merge; the file-backed client is available for any future
+test that must observe DB state across a db.transaction() boundary.

--- a/jobs/backend/context/current.txt
+++ b/jobs/backend/context/current.txt
@@ -960,3 +960,38 @@ the tx result with no post-tx query (accident of shape, confirmed).
 All three secondary-audit §1d claims confirmed, none overturned. Follow-on
 QUAL-48 part 2 + BUG-95 recommended to proceed on a per-test file-backed client
 design (with temp-file cleanup — spike variant leaked dirs), ATDD-first.
+
+────────────────────────────────────────────────────────────────────
+BACKEND CONTEXT — 2026-08-10 (QUAL-50 item atomicity + BUG-95, latest)
+Branch fix/qual50-item-atomicity (off main @36284da). Closes BUG-95.
+The follow-on the QUAL-48 spike unblocked. THREE pieces, all shipped:
+
+1. create ATOMICITY. itemRepository.create now wraps base insert +
+   type-specific extension insert in ONE db.transaction(); a mid-create
+   failure (extension insert throws) rolls back the base row — no orphan.
+   KEY DESIGN CHOICE (challenges the spike's premise): the read-back runs
+   INSIDE the transaction and its result is returned directly, so create
+   issues NO query on the client AFTER the transaction — the same shape
+   executeCarryForward uses. The spike said "create cannot copy that trick"
+   because of its trailing fetch; it CAN, by moving the fetch inside the tx.
+   Consequence: create stays :memory:-safe, so the file-backed client is
+   needed ONLY where a test queries AFTER a create — not every create site.
+   Full backend suite (845) stayed green with only ONE test file converted.
+
+2. BUG-95 update gate. update's extension write is now gated on the scoped
+   UPDATE having matched a row (.returning({id}); matched.length===0 → return
+   null before updateExtension). Extension tables carry no user_id, so this
+   stops a non-owner mutating an extension row. Composes scopeToUser — no
+   parallel ownership check added.
+
+3. Test client. createFileBackedTestDb() in repositories/__tests__/test-db.ts
+   — per-test UNIQUE temp path (mkdtempSync) + cleanup() the caller runs in
+   afterEach (spike variant leaked temp dirs; this doesn't). Scoped to ONE
+   file: repositories/__tests__/items.test.ts (the transaction-using unit
+   tests). Partial unique indexes stay enforced (spike-verified; QUAL-22
+   mock-fidelity preserved). Per-setup cost: :memory: ~1.6ms vs file-backed
+   ~5.6ms; +~4ms/test over 35 tests — suite-wall delta within noise.
+
+ATDD: two regression tests written FIRST, shown RED against pre-fix code
+(orphan: "expected [ {id:1,…} ] length +0 got 1"; BUG-95: "expected 'HACKED'
+to be 'Air France'"), GREEN after. drizzle-kit patch untouched (ADL-15).

--- a/jobs/backend/park-docs/20260810-BACKEND-qual50-park.txt
+++ b/jobs/backend/park-docs/20260810-BACKEND-qual50-park.txt
@@ -1,0 +1,116 @@
+BACKEND PARK DOC — QUAL-50 (item create atomicity + BUG-95 extension-write gate)
+Date: 2026-08-10
+Branch: fix/qual50-item-atomicity (off main @36284da)
+Tracker: QUAL-50 (chore) — closes BUG-95 on merge
+Class (OP-32): gap. BRD: n/a (internal atomicity / test-infra).
+
+================================================================================
+WHAT SHIPPED
+================================================================================
+Three pieces, all in src/backend/repositories/ (+ its __tests__):
+
+1. itemRepository.create — ATOMIC base + extension insert.
+   Was: insert base (autocommit) → insertExtension (autocommit) → fetch.
+   A throw between the two stranded an ORPHAN base `items` row.
+   Now: db.transaction(tx => { insert base; insertExtension(tx,…); read via tx;
+   return result }). One transaction; a mid-create failure rolls the base row
+   back. Return value + created shape byte-identical.
+
+2. itemRepository.update — BUG-95 gate.
+   Was: scoped UPDATE (userId+tripId+itemId) then updateExtension() ALWAYS.
+   Extension tables carry NO user_id, so a non-owner whose scoped UPDATE matched
+   zero rows still mutated the extension row.
+   Now: UPDATE …returning({id}); if matched.length===0 return null BEFORE
+   updateExtension. Composes the existing scopeToUser predicate (no parallel
+   check). baseUpdates always sets updatedAt, so an owner always matches — no
+   false early-return.
+
+3. createFileBackedTestDb() — repositories/__tests__/test-db.ts (additive).
+   Per-test file:<unique tmp> client (mkdtempSync) + cleanup() the caller runs
+   in afterEach. Reuses the cached DDL snapshot; PRAGMA foreign_keys=ON; partial
+   unique indexes stay enforced. createTestDb (:memory:) remains the default.
+
+================================================================================
+THE DESIGN CHALLENGE TO THE SPIKE (read this before extending)
+================================================================================
+The QUAL-48 spike (jobs/backend/tech/20260810-qual48-transaction-spike.md §5)
+concluded create "cannot copy executeCarryForward's trick" of surviving :memory:
+— because create has a trailing fetch after its writes, and any query AFTER a
+db.transaction() on a :memory: client throws (the client nulls #db and the next
+query reopens an EMPTY in-memory db; empirically re-confirmed here).
+
+That premise loses a plank: create CAN copy the trick — move the fetch INSIDE
+the transaction and return its result, so create issues no post-tx query on the
+client. executeCarryForward survives :memory: for exactly this reason
+(places.ts returns the tx result with no query afterward). Doing the same in
+create means:
+  • create itself is :memory:-safe.
+  • The file-backed client is required ONLY in tests that issue a further query
+    AFTER a create on the same client — NOT every create call site.
+This shrank the blast radius from "every item-creating test file" (feared:
+7+ route files) to ONE file (repositories/__tests__/items.test.ts, the repo
+unit tests that query after create). The full 845-test backend suite stayed
+green with no route/service/contract test touched — verified empirically, not
+reasoned: route tests seed via direct inserts and assert on the POST *response
+body*, never create-then-query on the same client.
+
+Not a spike error — the spike's GO verdict and mechanism are all correct; it
+just under-explored one cheaper implementation shape for create. Recorded so a
+future author doesn't over-convert to file-backed on the spike's wording.
+
+LATENT (documented, not new): a FUTURE test that does create-then-query on a
+:memory: client will break — inherent to db.transaction() on :memory:, same
+constraint that already governs executeCarryForward (trips.ts:288 etc.).
+createFileBackedTestDb's header says exactly when to reach for it.
+
+================================================================================
+ATDD — RED BAR (shown against pre-fix production code)
+================================================================================
+repositories/__tests__/items.test.ts, 2 new tests, RED before / GREEN after:
+
+  × leaves no orphan base item when the extension insert fails mid-create
+    AssertionError: expected [ { id: 1, tripId: 1, …(10) } ] to have a length
+    of +0 but got 1              (orphan base row survived the failed create)
+
+  × does not mutate the extension row when a non-owner calls update (BUG-95)
+    AssertionError: expected 'HACKED' to be 'Air France'
+                                          (non-owner mutated the extension)
+
+Orphan test forces failure deterministically: DROP TABLE item_flights so the
+extension insert throws AFTER the base insert; then asserts SELECT items === 0.
+Its trailing SELECT (a query after a transaction) is why it NEEDS file-backed.
+BUG-95 test: USER_A owns a flight; USER_B calls update with an airline change;
+asserts result===null AND owner's airline unchanged.
+
+Post-fix: repo items.test.ts 35/35 green; full backend suite 845/845 green.
+
+================================================================================
+VERIFICATION
+================================================================================
+npm run test:backend        → 53 files / 845 tests PASS
+npm run type:check:all      → clean (frontend + backend)
+npm run scope:check         → PASS (0 residuals; getDb still not in routes)
+Per-setup delta probe        → :memory: 1.61ms/setup vs file-backed 5.56ms/setup
+
+================================================================================
+FILES
+================================================================================
+  src/backend/repositories/items.ts          — create (tx), update (gate),
+                                                insertExtension(db,…) signature
+  src/backend/repositories/items-helper.ts   — DbHandle type; optional dbHandle
+                                                param on fetchItemsWithExtensions
+  src/backend/repositories/__tests__/test-db.ts    — createFileBackedTestDb
+  src/backend/repositories/__tests__/items.test.ts — file-backed setup + 2 tests
+                                                + reworded stale wrong-user comment
+
+OP-28: no full-file rewrites. All four files edited in place (additive).
+drizzle-kit patch untouched (ADL-15).
+
+================================================================================
+FOLLOW-UPS / NON-GOALS
+================================================================================
+• update was intentionally NOT wrapped in a transaction — BUG-95 is fixed by the
+  match-gate; update has no orphan-pair hazard (single extension write, gated).
+• No route/service change. POST/PATCH handlers unchanged; the atomicity + gate
+  live entirely in the repository.
+EOF

--- a/src/backend/repositories/__tests__/items.test.ts
+++ b/src/backend/repositories/__tests__/items.test.ts
@@ -10,12 +10,13 @@
  *   - delete: removes item, returns false for wrong user
  */
 
+import { sql } from 'drizzle-orm';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import * as schema from '../../db/schema.js';
 import { NotFoundError } from '../../errors.js';
 import type { TestDb } from './test-db.js';
 import {
-  createTestDb,
+  createFileBackedTestDb,
   OTHER_USER_ID,
   seedCity,
   seedCountry,
@@ -55,15 +56,30 @@ const { itemRepository } = await import('../items.js');
 // ----------------------------------------------------------------
 // Test setup
 // ----------------------------------------------------------------
+//
+// QUAL-50: this suite uses the FILE-BACKED test client, not `:memory:`.
+// `itemRepository.create` now wraps its base + extension inserts in one
+// `db.transaction()`. On a `:memory:` client the query issued after a
+// transaction reopens an empty database (see createFileBackedTestDb's header),
+// which would break every create-then-query test here. The file-backed client
+// reopens the same file and observes the committed/rolled-back state — the exact
+// behaviour these tests assert on. Each test gets a unique temp path with
+// per-test cleanup.
+
+let cleanupDb: (() => void) | null = null;
 
 beforeEach(async () => {
-  testDb = await createTestDb();
+  const backed = await createFileBackedTestDb();
+  testDb = backed.db;
+  cleanupDb = backed.cleanup;
   await seedTestUser(testDb, TEST_USER_ID);
   await seedTestUser(testDb, OTHER_USER_ID, 'user_other');
 });
 
 afterEach(() => {
   testDb = null;
+  cleanupDb?.();
+  cleanupDb = null;
 });
 
 // ----------------------------------------------------------------
@@ -208,6 +224,28 @@ describe('itemRepository.create', () => {
       .from(schema.items)
       .where(eq(schema.items.id, item.id as number));
     expect(rows[0].userId).toBe(TEST_USER_ID);
+  });
+
+  // QUAL-50 (ATDD): base insert + extension insert must be ATOMIC. If the
+  // extension insert fails mid-create, no orphan base `items` row may survive.
+  // Failure is forced deterministically by dropping the extension table so its
+  // insert throws "no such table" AFTER the base row is inserted. The trailing
+  // read here (SELECT after a transaction) is why this test needs the
+  // file-backed client — a `:memory:` client would throw on it regardless.
+  it('leaves no orphan base item when the extension insert fails mid-create', async () => {
+    const db = testDb!;
+    const trip = await seedTrip(db);
+
+    // Force insertExtension to fail: remove the flight extension table.
+    await db.run(sql`DROP TABLE item_flights`);
+
+    await expect(
+      itemRepository.create(TEST_USER_ID, trip.id, { itemType: 'flight' }, { airline: 'AF' }),
+    ).rejects.toThrow();
+
+    // No base `items` row may have been left behind by the failed create.
+    const rows = await db.select().from(schema.items);
+    expect(rows).toHaveLength(0);
   });
 });
 
@@ -494,14 +532,15 @@ describe('itemRepository.update', () => {
   });
 
   it('does not persist changes when update is called for wrong user/trip combination', async () => {
-    // The update WHERE clause scopes by userId — no rows are changed.
-    // The repository returns whatever fetchItemsWithExtensions finds by itemId,
-    // so status is NOT updated even though the call returns a non-null object.
+    // The update WHERE clause scopes by userId — no rows are changed. Since the
+    // scoped UPDATE matched nothing, update() returns null (QUAL-43 Stage 4
+    // scoped the read-back; QUAL-50 also short-circuits before the extension
+    // write) and the base row is untouched.
     const db = testDb!;
     const trip = await seedTrip(db, { userId: OTHER_USER_ID });
     const item = await itemRepository.create(OTHER_USER_ID, trip.id, { itemType: 'flight' }, {});
 
-    await itemRepository.update(
+    const result = await itemRepository.update(
       TEST_USER_ID,
       trip.id,
       item.id as number,
@@ -510,9 +549,44 @@ describe('itemRepository.update', () => {
       'flight',
     );
 
+    expect(result).toBeNull();
+
     // Verify the other user's item was NOT changed
     const notChanged = await itemRepository.findById(OTHER_USER_ID, item.id as number);
     expect(notChanged!.status).toBe('consider');
+  });
+
+  // QUAL-50 / BUG-95 (ATDD): the extension write must be gated on the scoped
+  // UPDATE having matched. Extension tables (item_flights, …) carry no user_id,
+  // so a non-owner reaching update() must NOT be able to mutate the extension
+  // row. USER_A owns the item; USER_B attempts to change its airline.
+  it('does not mutate the extension row when a non-owner calls update (BUG-95)', async () => {
+    const db = testDb!;
+    const trip = await seedTrip(db, { userId: OTHER_USER_ID }); // owned by USER_A
+    const item = await itemRepository.create(
+      OTHER_USER_ID,
+      trip.id,
+      { itemType: 'flight' },
+      { airline: 'Air France' },
+    );
+
+    // USER_B (TEST_USER_ID) — does not own the item — tries to mutate the
+    // extension. The scoped UPDATE matches zero rows, so the extension write
+    // must not happen and the call must not silently succeed.
+    const result = await itemRepository.update(
+      TEST_USER_ID,
+      trip.id,
+      item.id as number,
+      {},
+      { airline: 'HACKED' },
+      'flight',
+    );
+
+    expect(result).toBeNull();
+
+    // The owner's extension row must be exactly as created.
+    const owner = await itemRepository.findById(OTHER_USER_ID, item.id as number);
+    expect(owner!.airline).toBe('Air France');
   });
 });
 

--- a/src/backend/repositories/__tests__/test-db.ts
+++ b/src/backend/repositories/__tests__/test-db.ts
@@ -29,6 +29,8 @@
  * is shared, never the data.
  */
 
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { createClient } from '@libsql/client';
@@ -95,6 +97,55 @@ export async function createTestDb() {
 }
 
 export type TestDb = Awaited<ReturnType<typeof createTestDb>>;
+
+/**
+ * A file-backed variant of {@link createTestDb} — QUAL-50 / QUAL-48 part 2.
+ *
+ * WHY THIS EXISTS: `@libsql/client`'s `db.transaction()` hands its live
+ * connection to the transaction and nulls the client's internal `#db`, so the
+ * NEXT query on the same client reopens a fresh connection from the client URL.
+ * For a `:memory:` client that fresh connection is a brand-new EMPTY database —
+ * so any query issued after a `db.transaction()` throws "no such table". A
+ * file-backed client reopens the SAME file and sees the committed (or
+ * rolled-back) state, which is exactly what a test asserting on the outcome of a
+ * transaction needs. The QUAL-48 spike verified this and that the partial unique
+ * indexes stay enforced (mock-fidelity, QUAL-22). See
+ * jobs/backend/tech/20260810-qual48-transaction-spike.md.
+ *
+ * SCOPE: reach for this ONLY in test files that need to observe the DB across a
+ * `db.transaction()` boundary (today: `itemRepository.create`'s atomic
+ * base+extension write, and any test that issues a further query after a create).
+ * `createTestDb()` (`:memory:`) stays the default everywhere else — it is faster
+ * and the file-backed client costs per-test file I/O (~+30% on a suite made
+ * entirely of these; the spike measured it).
+ *
+ * CLEANUP IS THE CALLER'S JOB: this returns a `cleanup()` the caller MUST invoke
+ * (afterEach) to close the client and remove the unique temp directory. The
+ * spike variant leaked temp dirs precisely because it skipped this — do not.
+ */
+export async function createFileBackedTestDb(): Promise<{ db: TestDb; cleanup: () => void }> {
+  const dir = mkdtempSync(join(tmpdir(), 'tt-testdb-'));
+  const file = join(dir, 'test.db');
+  const client = createClient({ url: `file:${file}` });
+
+  await client.execute('PRAGMA foreign_keys = ON;');
+
+  const ddlStatements = await getSchemaDdl();
+  await client.batch(ddlStatements, 'write');
+
+  const db = drizzle(client, { schema });
+
+  const cleanup = () => {
+    try {
+      client.close();
+    } catch {
+      /* already closed */
+    }
+    rmSync(dir, { recursive: true, force: true });
+  };
+
+  return { db, cleanup };
+}
 
 export const TEST_USER_ID = 'test-user-id';
 export const OTHER_USER_ID = 'other-user-id';

--- a/src/backend/repositories/items-helper.ts
+++ b/src/backend/repositories/items-helper.ts
@@ -37,6 +37,16 @@ import { type ItemRow, serializeItem } from '../serializers/item.js';
 import { ownedAnd } from './scope.js';
 
 /**
+ * A database handle that is EITHER the singleton connection or an open
+ * transaction (QUAL-50). Both expose the same query builder, so a query can be
+ * run inside a `db.transaction()` by threading the `tx` through. Derived from
+ * `getDb()`'s return type so it tracks the real driver type.
+ */
+type Db = ReturnType<typeof getDb>;
+type Tx = Parameters<Parameters<Db['transaction']>[0]>[0];
+export type DbHandle = Db | Tx;
+
+/**
  * Fetches items owned by `userId` with all extension fields left-joined.
  * Returns flat objects with type-specific fields merged in.
  *
@@ -49,13 +59,18 @@ import { ownedAnd } from './scope.js';
  * @param opts.sortBy - If 'rating', sort by effective rating across type-specific tables.
  * @param opts.sortOrder - 'asc' or 'desc'. Defaults to 'desc' when sortBy is 'rating'.
  * @param opts.minRating - If set, only return items with effectiveRating >= minRating.
+ * @param dbHandle - Optional connection-or-transaction handle (QUAL-50). When a
+ *   caller runs this read INSIDE a `db.transaction()` (so the created rows are
+ *   visible and no query is issued on the client after the transaction — the
+ *   `:memory:` reopen hazard), it passes the `tx`. Defaults to `getDb()`.
  */
 export async function fetchItemsWithExtensions(
   userId: string,
   conditions?: SQL,
   opts?: { sortBy?: 'rating'; sortOrder?: 'asc' | 'desc'; minRating?: number },
+  dbHandle?: DbHandle,
 ): Promise<Record<string, unknown>[]> {
-  const db = getDb();
+  const db = dbHandle ?? getDb();
 
   const effectiveRatingSql = sql<
     number | null

--- a/src/backend/repositories/items.ts
+++ b/src/backend/repositories/items.ts
@@ -20,7 +20,7 @@ import {
 import type { Item } from '../db/schema.js';
 import { NotFoundError } from '../errors.js';
 import { ensureExperienceExtension } from '../services/items.service.js';
-import { fetchItemsWithExtensions } from './items-helper.js';
+import { type DbHandle, fetchItemsWithExtensions } from './items-helper.js';
 import { assertWritable as assertTripWritable, ownedAnd, scopeToUser } from './scope.js';
 
 // ----------------------------------------------------------------
@@ -144,28 +144,37 @@ export const itemRepository = {
     const db = getDb();
     const now = new Date().toISOString();
 
-    const inserted = await db
-      .insert(items)
-      .values({
-        tripId,
-        tripPlaceId: data.tripPlaceId ?? null,
-        itemType: data.itemType,
-        status: data.status ?? 'consider',
-        notes: data.notes ?? null,
-        mapUrl: data.mapUrl ?? null,
-        isCarriedForward: data.isCarriedForward ? 1 : 0,
-        carriedFromItemId: data.carriedFromItemId ?? null,
-        userId,
-        createdAt: now,
-        updatedAt: now,
-      })
-      .returning();
+    // QUAL-50: the base insert and the type-specific extension insert are ONE
+    // transaction — a failure in the extension write must strand no orphan base
+    // `items` row. The read-back runs INSIDE the transaction and its result is
+    // returned directly, so no query is issued on the client AFTER the
+    // transaction commits (the shape executeCarryForward already relies on) —
+    // that keeps `create` safe on the `:memory:` test client too, where a
+    // post-transaction query would reopen an empty database.
+    return db.transaction(async (tx) => {
+      const inserted = await tx
+        .insert(items)
+        .values({
+          tripId,
+          tripPlaceId: data.tripPlaceId ?? null,
+          itemType: data.itemType,
+          status: data.status ?? 'consider',
+          notes: data.notes ?? null,
+          mapUrl: data.mapUrl ?? null,
+          isCarriedForward: data.isCarriedForward ? 1 : 0,
+          carriedFromItemId: data.carriedFromItemId ?? null,
+          userId,
+          createdAt: now,
+          updatedAt: now,
+        })
+        .returning();
 
-    const item = inserted[0];
-    await insertExtension(item.id, data.itemType, extensionBody);
+      const item = inserted[0];
+      await insertExtension(tx, item.id, data.itemType, extensionBody);
 
-    const result = await fetchItemsWithExtensions(userId, eq(items.id, item.id));
-    return result[0];
+      const result = await fetchItemsWithExtensions(userId, eq(items.id, item.id), undefined, tx);
+      return result[0];
+    });
   },
 
   /**
@@ -193,20 +202,28 @@ export const itemRepository = {
     if (data.notes !== undefined) baseUpdates.notes = data.notes;
     if (data.mapUrl !== undefined) baseUpdates.mapUrl = data.mapUrl;
 
-    await db
+    const matched = await db
       .update(items)
       .set(baseUpdates)
-      .where(and(eq(items.id, itemId), eq(items.tripId, tripId), scopeToUser(items, userId)));
+      .where(and(eq(items.id, itemId), eq(items.tripId, tripId), scopeToUser(items, userId)))
+      .returning({ id: items.id });
+
+    // BUG-95 (QUAL-50): gate the extension write on the SAME scoped UPDATE
+    // having matched a row. The extension tables (item_flights, …) carry no
+    // user_id of their own, so a caller who does not own this item — whose
+    // ownership-scoped UPDATE above matched zero rows — must not be able to
+    // mutate the extension row. `baseUpdates` always sets `updatedAt`, so an
+    // owner's UPDATE always matches; a zero-row result means "not owned / not
+    // found". This composes the existing ownership predicate (`scopeToUser`)
+    // rather than adding a second, independent check.
+    if (matched.length === 0) return null;
 
     await updateExtension(itemType, itemId, extensionBody);
 
-    // QUAL-43 Stage 4: the read-back is now owner-scoped like every other item
-    // read (userId is a required parameter of the helper). Through the routes
-    // this is indistinguishable from before — items.ts PATCH runs
-    // assertWritable + findRawByIdOrThrow, so a mismatched user 404s long
-    // before here. It only differs on a direct repository call with a user who
-    // does not own the item: the UPDATE above already matched zero rows, and
-    // the read-back now returns null rather than the owner's untouched row.
+    // QUAL-43 Stage 4: the read-back is owner-scoped like every other item read
+    // (userId is a required parameter of the helper). Through the routes this is
+    // indistinguishable from before — items.ts PATCH runs assertWritable +
+    // findRawByIdOrThrow, so a mismatched user 404s long before here.
     const result = await fetchItemsWithExtensions(userId, eq(items.id, itemId));
     return result[0] ?? null;
   },
@@ -229,14 +246,18 @@ export const itemRepository = {
 // Extension row helpers (internal to this repository)
 // ----------------------------------------------------------------
 
-/** Inserts the type-specific extension row for a new item. */
+/**
+ * Inserts the type-specific extension row for a new item.
+ *
+ * QUAL-50: takes the active db/transaction handle so the extension insert runs
+ * in the SAME transaction as the base insert in `create` (atomicity).
+ */
 async function insertExtension(
+  db: DbHandle,
   itemId: number,
   itemType: string,
   body: Record<string, unknown>,
 ): Promise<void> {
-  const db = getDb();
-
   switch (itemType) {
     case 'flight':
       await db.insert(itemFlights).values({


### PR DESCRIPTION
Tracker: **QUAL-50** (chore) — **closes BUG-95** on merge. BRD: n/a (internal atomicity / test-infra). Class (OP-32): gap.

Follow-on the QUAL-48 spike (#502, GO) unblocked. No GitHub issue exists for these tracker-only items; referencing tracker IDs.

## What changed (all in `src/backend/repositories/`)
1. **`create` atomicity** — base insert + type-specific extension insert now run in ONE `db.transaction()`; a mid-create failure strands no orphan base `items` row. The read-back runs INSIDE the transaction and is returned directly (the `executeCarryForward` shape), so `create` issues no query on the client after the transaction — keeping it `:memory:`-safe.
2. **BUG-95 gate** — `update`'s extension write is gated on the scoped `UPDATE` having matched a row (`.returning({id})`; zero-match → `return null` before `updateExtension`). Extension tables carry no `user_id`, so this stops a non-owner mutating an extension row. Composes the existing `scopeToUser` predicate — no parallel ownership check added, assertion not weakened.
3. **Test client** — `createFileBackedTestDb()` (per-test unique temp path + cleanup) added to `repositories/__tests__/test-db.ts`, scoped to the one transaction-using test file (`repositories/__tests__/items.test.ts`). Partial unique indexes stay enforced (QUAL-22 mock-fidelity).

## ATDD (RED-before / GREEN-after)
Two regression tests written first and shown RED against pre-fix code:
- `leaves no orphan base item when the extension insert fails mid-create` — was: `expected [ {id:1,…} ] length +0 got 1`.
- `does not mutate the extension row when a non-owner calls update (BUG-95)` — was: `expected 'HACKED' to be 'Air France'`.

Post-fix: repo items 35/35 green; full backend suite **845/845** green (no route/service/contract test modified).

## Design note (challenge to the spike, full detail in the park doc)
The spike said `create` "cannot copy `executeCarryForward`'s `:memory:`-surviving shape" because of its trailing fetch. It CAN — move the fetch inside the transaction and return it. That shrank the file-backed blast radius from every item-creating test file to ONE. Spike's GO + mechanism were correct; it just under-explored this cheaper shape.

## Verification
`test:backend` 845 · `test:frontend` 388 · `type:check:all` clean · `scope:check` PASS · `tracker:check` OK · `status:check` in sync. drizzle-kit patch untouched (ADL-15). OP-28: no full-file rewrites.