### PR TITLE
feat(GE-19): schema migration — needs_attention status + geocode_cause column (ADL-55 §3.5)

### DIFF
--- a/jobs/COO/inbox/20260810_2350-DATABASE-ge19-migration-complete.txt
+++ b/jobs/COO/inbox/20260810_2350-DATABASE-ge19-migration-complete.txt
@@ -1,0 +1,56 @@
+TO: COO
+FROM: Database
+RE: GE-19 / BUG-85 schema migration substrate — COMPLETE
+
+HEADER
+  Tracker: BUG-85 · PR #511 · BRD: GE-19 (v3.20) · Branch: feat/ge19-migration
+  Spec: ADL-55 §3.5 (implemented verbatim, substrate only)
+
+WHAT WAS BUILT
+  schema.ts (Edit): cities.geocode_status CHECK + 'needs_attention'; NEW nullable
+  geocode_cause column + chk_cities_geocode_cause (IN ('ambiguous','unreachable') OR NULL).
+  Migration 0018 (12-step rebuild) + trailing backfill. No routes/services/frontend.
+
+ACCEPTANCE CRITERIA
+  (1) schema.ts adds needs_attention + geocode_cause .......... PASS
+  (2) migration applies cleanly via db:migrate (fresh 18-mig DB) PASS
+  (3) ADL-15 bug 4 hand-correction verified vs schema.ts ...... PASS
+  (4) backfill statement runs ................................ PASS (0 rows on fresh DB;
+      predicate tested: only pending>=5 flips, cause stays NULL, terminals untouched)
+  (5) test:backend still green (845) ......................... PASS (845/845)
+  (6) scope:check Check 3 classifies cities correctly ........ PASS (cities still global-reference)
+
+THREE HAND-CORRECTIONS (drizzle-kit; NOT just the one the brief expected)
+  (a) ADL-15 bug 4 on uniq_cities_pending_per_creator — the one you flagged. Diff:
+      GEN : ...(`"name" COLLATE NOCASE`,`country_code`,`COALESCE("region_id"`,` 0)`,`COALESCE("created_by_user_id"`,` '')`) WHERE "cities"."geocode_status" = 'pending';
+      FIX : ...("name" COLLATE NOCASE, `country_code`, COALESCE("region_id", 0), COALESCE("created_by_user_id", '')) WHERE geocode_status = 'pending';
+      (byte-matches 0017:82; functionally verified — COALESCE sentinels, COLLATE NOCASE,
+       partial WHERE all behave: creator-scoped dedup + case-fold collision confirmed.)
+  (b) "0015 original bug" — generated INSERT..SELECT pulled the NEW geocode_cause FROM the
+      old table (hard-failed at db:migrate, "no such column"). Fixed with NULL literal (0015
+      template). This is why ADL-55 keeps it a single migration; correction is exactly §3.5 pt 2.
+  (c) uniq_cities_osm_ref WHERE re-simplified to bare `osm_id IS NOT NULL` — the scenario the
+      2026-08-06 BUG-75 park doc §2 predicted; surfaced as the one red test on first run.
+  All three were pre-documented by the BUG-75 park doc — read it before any cities migration.
+
+MIGRATION VERIFIED: db:generate → hand-correct → db:migrate clean (never db:push, ADL-15).
+  db:generate re-run after edits: "No schema changes" (schema.ts ⇔ 0018 snapshot in sync).
+
+SINGLE-GREEN-STEP PREMISE: HELD. Two probes that fail differently — (A) 845/845 unchanged;
+  (B) code read: serializers/city.ts types status as plain `string` (no union/switch) & omits
+  geocode_cause (backward-compat omission); no Zod enum on geocode_status; processQueue +
+  findRegionlessUpgradeCandidate whitelist both exclude needs_attention (fail-closed); all 3
+  non-test resolveCity callers fire only on 'pending' rows, so the resolved/unresolvable guard
+  fall-through never sees needs_attention. No path mis-handles the new status/column.
+
+CI: PR #511 — all 18 checks GREEN @ fd033f0 (head SHA re-confirmed, QUAL-46). Not merged.
+
+OPEN ISSUES / BLOCKERS: none.
+
+NOTE FOR THE NEXT BRIEFS (not my scope — do NOT expect them here): ADL F1/F3 + the
+  ['pending','unresolvable','needs_attention'] whitelist extension + findOrUpgradeCity re-open
+  reset are the BACKEND brief; the stale findByIdentityKey "unconditional index" comment (F4)
+  is assigned to the implementation PR per ADL §8/§10 (already stale pre-change, not regressed).
+
+UNBLOCKED: QA red-bar (ADL-55 §7) → Backend (nextGeocodeState, cap-as-transition,
+  findUserGeocodeQueue, GET /api/geocode-queue) → Frontend. Substrate is live.

--- a/jobs/database/context/current.txt
+++ b/jobs/database/context/current.txt
@@ -681,3 +681,65 @@ NEXT DATABASE THREAD:
   landing and COO merging the release branch. ADL-48 S2 (gazetteer tables)
   remains the next queued item, still blocked on the BRD gate (GE-17/GE-18)
   and the §8.3 Turso cold-seed timing probe.
+
+================================================================================
+THREAD — GE-19 / BUG-85 geocode status-lifecycle SUBSTRATE (migration 0018) — 2026-08-10
+================================================================================
+BRANCH: feat/ge19-migration (off main bf965a2)   TRACKER: BUG-85   BRD: GE-19 (v3.20)
+SPEC:   ADL-55 §3.5 (OP-27-reviewed, merged) — implemented verbatim, substrate only.
+
+WHAT SHIPPED (schema + one migration; NO routes/services/frontend):
+  src/backend/db/schema.ts  — cities: (a) chk_cities_geocode_status widened to add
+    'needs_attention'; (b) NEW nullable column geocodeCause text('geocode_cause');
+    (c) NEW check chk_cities_geocode_cause (IN ('ambiguous','unreachable') OR IS NULL).
+  src/backend/migrations/0018_bug85_geocode_needs_attention.sql — 12-step table
+    rebuild (the CHECK widening has no SQLite ALTER), + trailing backfill UPDATE.
+  meta/0018_snapshot.json NEW, meta/_journal.json UPDATED.
+
+THREE HAND-CORRECTIONS to drizzle-generated SQL (all predicted by the 20260806
+BUG-75 park doc — read it before touching cities migrations again):
+  (1) "0015 original bug" — the generated INSERT...SELECT pulled the NEW
+      geocode_cause column FROM the OLD cities table (no such column → runtime
+      failure "no such column: geocode_cause"). Fixed by supplying NULL as the
+      SELECT literal (0015's template), keeping geocode_cause in the INSERT list.
+      Existing rows carry NULL cause (ADL-55 §3.5 pt 2). This is why ADL-55 keeps
+      it a SINGLE migration, not an EXPAND/SWITCH split — one additive nullable
+      column needs no expand phase, only the NULL-literal correction.
+  (2) ADL-15 bug 4 (COALESCE-comma-split) on uniq_cities_pending_per_creator —
+      drizzle split COALESCE("region_id",0)/COALESCE("created_by_user_id",'') on
+      their internal commas into bogus quoted identifiers and wrapped
+      "name" COLLATE NOCASE as one literal identifier. Rewritten to 0017:82's form.
+  (3) uniq_cities_osm_ref WHERE hand-simplified from the table-qualified
+      "cities"."osm_id" IS NOT NULL back to the bare osm_id IS NOT NULL — the exact
+      scenario the 20260806 park doc §2 warned about: bug75-identity-migration.test.ts:84
+      matches /osm_id\s+is\s+not\s+null/i, which the "-closed qualified form fails.
+      idx_cities_geocode left table-qualified (as 0017 did; no test depends on its WHERE).
+
+VERIFICATION (fresh scratch DB, all 18 migrations applied clean):
+  - db:migrate clean; db:generate reports "No schema changes" (schema.ts ⇔ snapshot in sync).
+  - sqlite_master: new column + both CHECKs present; uniq_cities_pending_per_creator
+    keeps COALESCE sentinels + COLLATE NOCASE + partial WHERE geocode_status='pending'.
+  - CHECK probes: needs_attention (all causes) accepted; bad status / bad cause rejected.
+  - Uniqueness probes: two creators same place = OK; same creator dup (COLLATE NOCASE) =
+    rejected; needs_attention same place = OK (not in pending index); NULL-creator sentinel OK.
+  - Backfill predicate: only pending>=5 flips to needs_attention, cause stays NULL;
+    resolved/unresolvable/pending<5 untouched. Fresh DB backfill = 0 rows (expected).
+  - test:backend 845/845; type:check:all clean; scope:check PASS (cities still global-reference).
+
+SINGLE-GREEN-STEP PREMISE — HELD (two probes that fail differently):
+  Probe A (behavioural): 845/845 backend tests pass unchanged — no status-enumerating
+    test broke. Probe B (static): serializers/city.ts types geocode_status as plain
+    `string` (no union/switch/exhaustiveness) and does NOT emit geocode_cause (backward-
+    compatible field omission); NO Zod enum validates geocode_status; processQueue's
+    predicate and findRegionlessUpgradeCandidate's ['pending','unresolvable'] whitelist
+    both exclude needs_attention (fail-closed); all 3 non-test callers of resolveCity fire
+    only on 'pending' rows, so the resolved/unresolvable if-guard fall-through
+    (geocoding.service.ts:390-391) never sees needs_attention. No existing path mis-handles
+    the new status/column. The ADL's F1/F3 + whitelist edits are the Backend brief's job;
+    their ABSENCE here is fail-closed, not a regression.
+
+NEXT DATABASE THREAD:
+  None from Database on GE-19 — substrate is done. Next in the GE-19 chain is the
+  QA red-bar brief then Backend (nextGeocodeState, cap-as-transition, whitelist +
+  needs_attention, findOrUpgradeCity re-open reset, findUserGeocodeQueue) then Frontend.
+  ADL-48 S2 (gazetteer tables) remains queued, still blocked on the GE-17/GE-18 BRD gate.

--- a/jobs/database/park-docs/20260810-DATABASE-park.txt
+++ b/jobs/database/park-docs/20260810-DATABASE-park.txt
@@ -1,0 +1,141 @@
+DATABASE PARK DOCUMENT — 2026-08-10
+THREAD: GE-19 / BUG-85 — geocode status-lifecycle SUBSTRATE (migration 0018)
+BRANCH: feat/ge19-migration (off main bf965a2)
+TRACKER: BUG-85   BRD: GE-19 (v3.20, approved)   SPEC: ADL-55 §3.5   DEFECT CLASS: gap
+
+================================================================================
+1. WHAT WAS ASKED, AND WHAT SHIPPED
+================================================================================
+Asked: implement ADL-55 §3.5 verbatim — the schema substrate for GE-19. Add the new
+terminal status 'needs_attention' to cities' geocode_status CHECK, add a new nullable
+geocode_cause column (+ its CHECK), generate + hand-correct the migration, apply it,
+backfill capped-pending rows. Substrate ONLY — no routes, services, or frontend, no
+GE-19 behaviour (that is the QA red-bar → Backend → Frontend chain that follows).
+
+Shipped exactly that, as ONE migration (ADL-55 §3.5 specifies a single green step, not an
+EXPAND/SWITCH split — one additive nullable column needs no expand phase):
+
+  src/backend/db/schema.ts                                   UPDATED (Edit, not Write):
+      cities.geocodeStatus CHECK widened + 'needs_attention'; NEW geocodeCause
+      text('geocode_cause') (nullable, no default); NEW check chk_cities_geocode_cause.
+  src/backend/migrations/0018_bug85_geocode_needs_attention.sql   NEW — 12-step rebuild
+      + trailing backfill UPDATE.
+  src/backend/migrations/meta/0018_snapshot.json             NEW
+  src/backend/migrations/meta/_journal.json                  UPDATED (1 new entry)
+  jobs/database/tech/0018_bug85_geocode_needs_attention.sql  archived copy
+
+================================================================================
+2. THE THING A FUTURE READER MUST NOT GET WRONG — THREE hand-corrections, all
+   PREDICTED by the 20260806 BUG-75 park doc. Read that doc before any cities migration.
+================================================================================
+The CHECK widening has no SQLite ALTER, so drizzle-kit emits the __new_cities table
+rebuild (same shape as 0017). That rebuild reproduces three drizzle-kit-0.31.9 defects
+on cities. All three were hand-corrected and re-verified against schema.ts:
+
+(1) "0015 ORIGINAL BUG" — the generated INSERT...SELECT put the NEW geocode_cause
+    column in BOTH the INSERT column list AND the SELECT, selecting it FROM THE OLD
+    cities table where it does not yet exist. db:migrate failed at runtime with
+    "no such column: geocode_cause". Fix (mirrors 0015:48-50): keep geocode_cause in the
+    INSERT list, supply NULL as its SELECT literal. Existing rows carry NULL cause
+    (ADL-55 §3.5 pt 2; the §4 null-cause label is the deliberate generic — we do NOT
+    assert 'ambiguous' for historical rows).
+
+(2) ADL-15 BUG 4 (COALESCE-comma-split) on uniq_cities_pending_per_creator — drizzle
+    split COALESCE("region_id",0) and COALESCE("created_by_user_id",'') on their internal
+    commas into bogus separate quoted identifiers, and wrapped `"name" COLLATE NOCASE` as
+    one literal identifier. Rewritten to 0017:82's proven form, byte-verified against
+    schema.ts's uniqueIndex('uniq_cities_pending_per_creator').
+
+(3) uniq_cities_osm_ref WHERE hand-simplified from drizzle's table-qualified
+    `WHERE "cities"."osm_id" IS NOT NULL` back to the bare `WHERE osm_id IS NOT NULL`.
+    This is the EXACT scenario the 20260806 park doc §2 predicted: a future migration
+    that regenerates these indexes re-emits the qualified form, and the still-live
+    bug75-identity-migration.test.ts:84 matches /osm_id\s+is\s+not\s+null/i — the `"` that
+    closes the qualified identifier sits between the column name and the whitespace, so
+    `\s+` fails and the green test goes red on a functionally-correct DDL. This surfaced
+    as the one failing test on the first full test:backend run; fixing the WHERE fixed it.
+    idx_cities_geocode's WHERE was left table-qualified (as 0017 did) — no test depends on
+    its WHERE form, and mirroring 0017 exactly is the faithful shape.
+
+Note: (1) and (2) would have HARD-FAILED (migrate error / invalid SQL). (3) applies fine
+functionally but fails a test regex — all three are real corrections, not cosmetic.
+
+================================================================================
+3. WHY A SINGLE MIGRATION, NOT EXPAND/SWITCH (contrast with BUG-75's two migrations)
+================================================================================
+BUG-75 (0016/0017) split EXPAND then SWITCH because it added THREE columns AND rebuilt the
+index set AND added a CHECK — the INSERT...SELECT "0015 bug" was avoided by having EXPAND
+add the columns to the real table first, so SWITCH's SELECT was valid. GE-19 adds ONE
+nullable column and one CHECK value; ADL-55 §3.5 explicitly specifies a single rebuild
+whose INSERT...SELECT "carries existing columns (geocode_cause defaults NULL for existing
+rows)". The NULL-literal correction (§2 pt 1) is precisely that — so a single migration is
+both correct and the approved spec. ADL-47 single-green-step conditions (§3.5): Railway
+single-instance; start script runs migrate before serving; every change backward-compatible
+with OLD code. All hold (see §5).
+
+================================================================================
+4. VERIFICATION PERFORMED (fresh scratch DB, throwaway libsql scripts, deleted after use)
+================================================================================
+- Fresh DB, all 18 migrations applied clean via db:migrate (SQLITE_PATH scratch file).
+- db:generate AFTER the hand-edits reports "No schema changes" — schema.ts and the 0018
+  snapshot are in sync; the SQL hand-edits do NOT desync the snapshot (snapshot derives
+  from schema.ts, not the SQL). Future generate will report no drift.
+- sqlite_master inspection: geocode_cause column present (nullable); chk_cities_geocode_status
+  includes needs_attention; chk_cities_geocode_cause present; uniq_cities_pending_per_creator
+  keeps COALESCE sentinels + COLLATE NOCASE + partial WHERE geocode_status='pending';
+  uniq_cities_osm_ref bare WHERE.
+- CHECK probes: needs_attention with cause ambiguous / unreachable / NULL all accepted;
+  pending+unreachable accepted; status='bogus' REJECTED; cause='whoops' REJECTED.
+- Uniqueness probes (users + country seeded first to satisfy FKs): userA + userB same
+  (name,country,region) pending = both OK (creator-scoped); userA duplicate 'newport' vs
+  'Newport' pending = REJECTED (COLLATE NOCASE); userA needs_attention same place = OK
+  (partial index only covers pending); NULL-creator sentinel: one OK, duplicate REJECTED.
+- Backfill predicate test (rows inserted with varied status/attempts, exact migration
+  UPDATE run): only pending>=5 → needs_attention; cause stays NULL; resolved/unresolvable/
+  pending<5 untouched. Fresh-DB backfill affected 0 rows (expected — table empty at that
+  point in migration history; staging's one known stuck row city 6 is orphaned per tracker).
+- test:backend 845/845 pass. type:check:all clean. scope:check PASS (Check 3: cities still
+  global-reference, unchanged; 21 tables classified).
+
+================================================================================
+5. SINGLE-GREEN-STEP / BACKWARD-COMPAT — HELD (two probes that fail differently)
+================================================================================
+Claim: no existing code path mis-handles the new 'needs_attention' status or geocode_cause.
+  Probe A (behavioural): 845/845 backend tests pass unchanged.
+  Probe B (static, code-read):
+    - serializers/city.ts types geocode_status as plain `string` (no union, no switch, no
+      exhaustive match) and passes it through; it does NOT serialize geocode_cause at all —
+      a backward-compatible field OMISSION, not a mis-handle. The cause-emitting endpoint
+      is a later brief.
+    - NO Zod enum validates geocode_status (grep of validation/*.ts: enums exist only for
+      itemType/itemStatus/tripStatus/osmType/sort — none for geocode status).
+    - processQueue selects WHERE geocode_status='pending' AND attempts<CAP → excludes
+      needs_attention. findRegionlessUpgradeCandidate uses inArray(['pending','unresolvable'])
+      → excludes needs_attention (comment: "fails closed on a future status").
+    - The resolved/unresolvable early-guard in resolveCity (geocoding.service.ts:390-391)
+      would fall through for needs_attention, BUT all three non-test callers of resolveCity
+      fire only on 'pending' rows: processQueue (predicate), cityIdentityService:107 (guarded
+      by ===' pending' + the whitelist above), and routes/cities.ts:245 (fires on a freshly
+      created 'pending' row). So the fall-through is unreachable for needs_attention today.
+The two probes fail differently: a passing suite can hide a latent static path (B catches),
+a static read can miss a runtime path (A catches). ADL F1/F3 + whitelist extension are the
+BACKEND brief's edits; their absence here is fail-closed, not a regression.
+
+================================================================================
+6. WHAT'S NOW UNBLOCKED
+================================================================================
+The GE-19 chain's substrate is live: 'needs_attention' is a legal terminal status and
+geocode_cause is a live nullable column with its CHECK. Unblocks, in order:
+  - QA red-bar brief (ADL-55 §7 acceptance criteria → failing tests).
+  - Backend brief: nextGeocodeState pure fn; cap-as-active-transition; whitelist +
+    'needs_attention'; findOrUpgradeCity re-open reset (status/attempts/cause + re-fire,
+    ADL F1); findUserGeocodeQueue composing scopeToUser(trips,userId); GET /api/geocode-queue.
+  - Frontend brief: retire the NR-06 localStorage queue; poll the endpoint; (status,cause)
+    → label map; wire re-point/delete recovery.
+
+================================================================================
+7. NEXT DATABASE THREAD
+================================================================================
+None from Database on GE-19 — substrate complete, pending COO merge of feat/ge19-migration.
+ADL-48 S2 (gazetteer tables) remains the next queued Database item, still blocked on the
+GE-17/GE-18 BRD gate and the §8.3 Turso cold-seed timing probe — untouched by this thread.

--- a/jobs/database/tech/0018_bug85_geocode_needs_attention.sql
+++ b/jobs/database/tech/0018_bug85_geocode_needs_attention.sql
@@ -1,0 +1,76 @@
+-- GE-19 / BUG-85 (BRD v3.20) — geocode status-lifecycle substrate (ADL-55 §3.5).
+--
+-- HAND-EDITED, NOT trusted as purely drizzle-generated. Two schema changes drive a table rebuild
+-- (SQLite has no ALTER TABLE ADD CONSTRAINT, so widening chk_cities_geocode_status forces the
+-- __new_cities + INSERT…SELECT + drop/rename shape — same as migration 0017):
+--   1. chk_cities_geocode_status widened to admit the new terminal status 'needs_attention'.
+--   2. New nullable column geocode_cause TEXT + chk_cities_geocode_cause
+--      (IN ('ambiguous','unreachable') OR IS NULL). Existing rows carry NULL (excluded from the
+--      INSERT…SELECT column list, defaults NULL).
+--
+-- TWO drizzle-kit bugs were hand-corrected below (verified against schema.ts); everything else is
+-- emitted as generated:
+--   (a) The INSERT…SELECT wrongly pulled the NEW geocode_cause column FROM the old table (the "0015
+--       original bug" — the old table has no such column; it failed at runtime). Supplied as NULL.
+--   (b) ADL-15 bug 4 (the COALESCE-comma-split bug) on the regenerated uniq_cities_pending_per_creator
+--       index — exactly as it did in 0017. Rewritten to 0017:82's proven form.
+--   (c) uniq_cities_osm_ref's WHERE hand-simplified to the bare `osm_id IS NOT NULL` form (0017:76);
+--       drizzle's table-qualified form is valid but the end-state migration test locks the bare form.
+-- A trailing backfill UPDATE promotes any already-capped 'pending' row to 'needs_attention'
+-- (ADL-55 §3.5). db:push is FORBIDDEN (ADL-15) — this was produced by db:generate then hand-corrected.
+PRAGMA foreign_keys=OFF;--> statement-breakpoint
+CREATE TABLE `__new_cities` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`country_code` text NOT NULL,
+	`region_id` integer,
+	`name` text NOT NULL,
+	`latitude` real,
+	`longitude` real,
+	`geocode_status` text DEFAULT 'pending' NOT NULL,
+	`geocode_cause` text,
+	`geocode_attempted_at` text,
+	`geocode_attempts` integer DEFAULT 0 NOT NULL,
+	`created_by_user_id` text,
+	`created_at` text DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')) NOT NULL,
+	`updated_at` text DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')) NOT NULL,
+	`osm_type` text,
+	`osm_id` integer,
+	`display_name` text,
+	FOREIGN KEY (`country_code`) REFERENCES `countries`(`country_code`) ON UPDATE no action ON DELETE no action,
+	FOREIGN KEY (`region_id`) REFERENCES `regions`(`id`) ON UPDATE no action ON DELETE no action,
+	FOREIGN KEY (`created_by_user_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE set null,
+	CONSTRAINT "chk_cities_geocode_status" CHECK("__new_cities"."geocode_status" IN ('pending', 'resolved', 'unresolvable', 'needs_attention')),
+	CONSTRAINT "chk_cities_geocode_cause" CHECK("__new_cities"."geocode_cause" IN ('ambiguous', 'unreachable') OR "__new_cities"."geocode_cause" IS NULL),
+	CONSTRAINT "chk_cities_osm_both_or_neither" CHECK(("__new_cities"."osm_type" IS NULL) = ("__new_cities"."osm_id" IS NULL))
+);
+--> statement-breakpoint
+-- id PRESERVED. geocode_cause is a NEW column, absent from the OLD cities table, so it is NOT
+-- selected from it — supplied as a NULL literal instead (mirrors 0015:48-50's 0/NULL literals for
+-- geocode_attempts/created_by_user_id). drizzle-kit's generated SELECT wrongly pulled "geocode_cause"
+-- FROM the old table (the "0015 original bug", per 0017's header) and failed at runtime with
+-- "no such column: geocode_cause"; HAND-CORRECTED here. Existing rows carry NULL cause (ADL-55 §3.5
+-- point 2; §4 null-cause label). Every other selected column exists on the pre-migration table.
+INSERT INTO `__new_cities`("id", "country_code", "region_id", "name", "latitude", "longitude", "geocode_status", "geocode_cause", "geocode_attempted_at", "geocode_attempts", "created_by_user_id", "created_at", "updated_at", "osm_type", "osm_id", "display_name") SELECT "id", "country_code", "region_id", "name", "latitude", "longitude", "geocode_status", NULL, "geocode_attempted_at", "geocode_attempts", "created_by_user_id", "created_at", "updated_at", "osm_type", "osm_id", "display_name" FROM `cities`;--> statement-breakpoint
+DROP TABLE `cities`;--> statement-breakpoint
+ALTER TABLE `__new_cities` RENAME TO `cities`;--> statement-breakpoint
+PRAGMA foreign_keys=ON;--> statement-breakpoint
+CREATE INDEX `idx_cities_country` ON `cities` (`country_code`);--> statement-breakpoint
+CREATE INDEX `idx_cities_region` ON `cities` (`region_id`);--> statement-breakpoint
+CREATE INDEX `idx_cities_geocode` ON `cities` (`geocode_status`) WHERE "cities"."geocode_status" = 'pending';--> statement-breakpoint
+-- Resolved-by-OSM identity index — WHERE hand-simplified to a bare unqualified column reference,
+-- mirroring 0017:76 (a partial index's own WHERE implies the indexed table). drizzle emits the
+-- table-qualified `"cities"."osm_id"` form, which is valid SQLite and applies fine, but the end-state
+-- migration test (bug75-identity-migration.test.ts:84) locks the bare form, so 0017's hand form is used.
+CREATE UNIQUE INDEX `uniq_cities_osm_ref` ON `cities` (`osm_type`,`osm_id`) WHERE osm_id IS NOT NULL;--> statement-breakpoint
+-- Pending-per-creator identity index — HAND-CORRECTED (ADL-15 bug 4 recurred: drizzle-kit split each
+-- COALESCE(...) on its internal comma into bogus separate quoted identifiers, and wrapped
+-- `"name" COLLATE NOCASE` as one literal identifier). Rewritten to the proven form migration 0017:82
+-- used, verified equivalent against schema.ts's uniqueIndex('uniq_cities_pending_per_creator')
+-- definition. WHERE written as a bare unqualified column reference (the indexed table is implicit),
+-- matching 0017; drizzle's table-qualified form is also valid SQLite but this mirrors the template.
+CREATE UNIQUE INDEX `uniq_cities_pending_per_creator` ON `cities` ("name" COLLATE NOCASE, `country_code`, COALESCE("region_id", 0), COALESCE("created_by_user_id", '')) WHERE geocode_status = 'pending';--> statement-breakpoint
+-- GE-19 / ADL-55 §3.5 backfill: promote any row already at/over the retry cap to the new terminal
+-- state so the badge stops silently counting it as in-progress. Cap literal 5 is point-in-time-correct
+-- for this migration (GEOCODE_ATTEMPT_CAP at authoring). Backfilled rows keep geocode_cause NULL — their
+-- historical cause is UNVERIFIED and is deliberately not asserted as 'ambiguous' (§3.5; §4 null-cause label).
+UPDATE `cities` SET `geocode_status` = 'needs_attention' WHERE `geocode_status` = 'pending' AND `geocode_attempts` >= 5;

--- a/src/backend/db/schema.ts
+++ b/src/backend/db/schema.ts
@@ -112,8 +112,15 @@ export const cities = sqliteTable(
     latitude: real('latitude'), // NULL while geocode_status = 'pending'
     longitude: real('longitude'), // NULL while geocode_status = 'pending'
     // 'pending' = awaiting Nominatim resolution; 'resolved' = coordinates confirmed;
-    // 'unresolvable' = geocoder answered "no match" — terminal, never retried (ADL-46 D10)
+    // 'unresolvable' = geocoder answered "no match" — terminal, never retried (ADL-46 D10);
+    // 'needs_attention' = retry-exhausted or ambiguous — terminal, user action required (GE-19 / ADL-55 D1)
     geocodeStatus: text('geocode_status').notNull().default('pending'),
+    // GE-19 / ADL-55 D1/D4: WHY a row is pending-retrying or needs_attention. NULLABLE by design —
+    // 'resolved' and 'unresolvable' rows carry no cause, and rows backfilled by migration 0018 keep it
+    // NULL (their historical cause is unknown, not asserted as 'ambiguous'). 'ambiguous' = multiple or
+    // unconfirmed region matches; 'unreachable' = recoverable geocoder failure (network/timeout/5xx/429).
+    // (status, cause) together yield the five user-facing labels (ADL-55 §4); the frontend owns the copy.
+    geocodeCause: text('geocode_cause'),
     geocodeAttemptedAt: text('geocode_attempted_at'), // ISO 8601 timestamp of last attempt
     // ADL-46 D10 (§4.4.1): incremented ONLY on recoverable failures (network/timeout/5xx/429).
     // The retry queue gives up at a cap (WHERE geocode_status = 'pending' AND geocode_attempts < CAP).
@@ -150,7 +157,15 @@ export const cities = sqliteTable(
     index('idx_cities_geocode').on(t.geocodeStatus).where(sql`${t.geocodeStatus} = 'pending'`),
     check(
       'chk_cities_geocode_status',
-      sql`${t.geocodeStatus} IN ('pending', 'resolved', 'unresolvable')`,
+      sql`${t.geocodeStatus} IN ('pending', 'resolved', 'unresolvable', 'needs_attention')`,
+    ),
+    // GE-19 / ADL-55 D1: geocode_cause is one of the two known causes or NULL ('resolved', 'unresolvable',
+    // and migration-0018-backfilled rows carry no cause). NULL is admitted explicitly: `IN (...)` alone
+    // evaluates to NULL (not FALSE) for a NULL value — which SQLite already treats as a passing CHECK — but
+    // the `IS NULL` disjunct states the intent at the schema layer rather than relying on that subtlety.
+    check(
+      'chk_cities_geocode_cause',
+      sql`${t.geocodeCause} IN ('ambiguous', 'unreachable') OR ${t.geocodeCause} IS NULL`,
     ),
     // BUG-75 / GE-16 (v3.19, design v3 §B2 SWITCH stage, migration 0017): the unconditional
     // uniq_cities_name_country_region_ci index (ADL-46 D13) is REPLACED by two partial unique

--- a/src/backend/migrations/0018_bug85_geocode_needs_attention.sql
+++ b/src/backend/migrations/0018_bug85_geocode_needs_attention.sql
@@ -1,0 +1,76 @@
+-- GE-19 / BUG-85 (BRD v3.20) — geocode status-lifecycle substrate (ADL-55 §3.5).
+--
+-- HAND-EDITED, NOT trusted as purely drizzle-generated. Two schema changes drive a table rebuild
+-- (SQLite has no ALTER TABLE ADD CONSTRAINT, so widening chk_cities_geocode_status forces the
+-- __new_cities + INSERT…SELECT + drop/rename shape — same as migration 0017):
+--   1. chk_cities_geocode_status widened to admit the new terminal status 'needs_attention'.
+--   2. New nullable column geocode_cause TEXT + chk_cities_geocode_cause
+--      (IN ('ambiguous','unreachable') OR IS NULL). Existing rows carry NULL (excluded from the
+--      INSERT…SELECT column list, defaults NULL).
+--
+-- TWO drizzle-kit bugs were hand-corrected below (verified against schema.ts); everything else is
+-- emitted as generated:
+--   (a) The INSERT…SELECT wrongly pulled the NEW geocode_cause column FROM the old table (the "0015
+--       original bug" — the old table has no such column; it failed at runtime). Supplied as NULL.
+--   (b) ADL-15 bug 4 (the COALESCE-comma-split bug) on the regenerated uniq_cities_pending_per_creator
+--       index — exactly as it did in 0017. Rewritten to 0017:82's proven form.
+--   (c) uniq_cities_osm_ref's WHERE hand-simplified to the bare `osm_id IS NOT NULL` form (0017:76);
+--       drizzle's table-qualified form is valid but the end-state migration test locks the bare form.
+-- A trailing backfill UPDATE promotes any already-capped 'pending' row to 'needs_attention'
+-- (ADL-55 §3.5). db:push is FORBIDDEN (ADL-15) — this was produced by db:generate then hand-corrected.
+PRAGMA foreign_keys=OFF;--> statement-breakpoint
+CREATE TABLE `__new_cities` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`country_code` text NOT NULL,
+	`region_id` integer,
+	`name` text NOT NULL,
+	`latitude` real,
+	`longitude` real,
+	`geocode_status` text DEFAULT 'pending' NOT NULL,
+	`geocode_cause` text,
+	`geocode_attempted_at` text,
+	`geocode_attempts` integer DEFAULT 0 NOT NULL,
+	`created_by_user_id` text,
+	`created_at` text DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')) NOT NULL,
+	`updated_at` text DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')) NOT NULL,
+	`osm_type` text,
+	`osm_id` integer,
+	`display_name` text,
+	FOREIGN KEY (`country_code`) REFERENCES `countries`(`country_code`) ON UPDATE no action ON DELETE no action,
+	FOREIGN KEY (`region_id`) REFERENCES `regions`(`id`) ON UPDATE no action ON DELETE no action,
+	FOREIGN KEY (`created_by_user_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE set null,
+	CONSTRAINT "chk_cities_geocode_status" CHECK("__new_cities"."geocode_status" IN ('pending', 'resolved', 'unresolvable', 'needs_attention')),
+	CONSTRAINT "chk_cities_geocode_cause" CHECK("__new_cities"."geocode_cause" IN ('ambiguous', 'unreachable') OR "__new_cities"."geocode_cause" IS NULL),
+	CONSTRAINT "chk_cities_osm_both_or_neither" CHECK(("__new_cities"."osm_type" IS NULL) = ("__new_cities"."osm_id" IS NULL))
+);
+--> statement-breakpoint
+-- id PRESERVED. geocode_cause is a NEW column, absent from the OLD cities table, so it is NOT
+-- selected from it — supplied as a NULL literal instead (mirrors 0015:48-50's 0/NULL literals for
+-- geocode_attempts/created_by_user_id). drizzle-kit's generated SELECT wrongly pulled "geocode_cause"
+-- FROM the old table (the "0015 original bug", per 0017's header) and failed at runtime with
+-- "no such column: geocode_cause"; HAND-CORRECTED here. Existing rows carry NULL cause (ADL-55 §3.5
+-- point 2; §4 null-cause label). Every other selected column exists on the pre-migration table.
+INSERT INTO `__new_cities`("id", "country_code", "region_id", "name", "latitude", "longitude", "geocode_status", "geocode_cause", "geocode_attempted_at", "geocode_attempts", "created_by_user_id", "created_at", "updated_at", "osm_type", "osm_id", "display_name") SELECT "id", "country_code", "region_id", "name", "latitude", "longitude", "geocode_status", NULL, "geocode_attempted_at", "geocode_attempts", "created_by_user_id", "created_at", "updated_at", "osm_type", "osm_id", "display_name" FROM `cities`;--> statement-breakpoint
+DROP TABLE `cities`;--> statement-breakpoint
+ALTER TABLE `__new_cities` RENAME TO `cities`;--> statement-breakpoint
+PRAGMA foreign_keys=ON;--> statement-breakpoint
+CREATE INDEX `idx_cities_country` ON `cities` (`country_code`);--> statement-breakpoint
+CREATE INDEX `idx_cities_region` ON `cities` (`region_id`);--> statement-breakpoint
+CREATE INDEX `idx_cities_geocode` ON `cities` (`geocode_status`) WHERE "cities"."geocode_status" = 'pending';--> statement-breakpoint
+-- Resolved-by-OSM identity index — WHERE hand-simplified to a bare unqualified column reference,
+-- mirroring 0017:76 (a partial index's own WHERE implies the indexed table). drizzle emits the
+-- table-qualified `"cities"."osm_id"` form, which is valid SQLite and applies fine, but the end-state
+-- migration test (bug75-identity-migration.test.ts:84) locks the bare form, so 0017's hand form is used.
+CREATE UNIQUE INDEX `uniq_cities_osm_ref` ON `cities` (`osm_type`,`osm_id`) WHERE osm_id IS NOT NULL;--> statement-breakpoint
+-- Pending-per-creator identity index — HAND-CORRECTED (ADL-15 bug 4 recurred: drizzle-kit split each
+-- COALESCE(...) on its internal comma into bogus separate quoted identifiers, and wrapped
+-- `"name" COLLATE NOCASE` as one literal identifier). Rewritten to the proven form migration 0017:82
+-- used, verified equivalent against schema.ts's uniqueIndex('uniq_cities_pending_per_creator')
+-- definition. WHERE written as a bare unqualified column reference (the indexed table is implicit),
+-- matching 0017; drizzle's table-qualified form is also valid SQLite but this mirrors the template.
+CREATE UNIQUE INDEX `uniq_cities_pending_per_creator` ON `cities` ("name" COLLATE NOCASE, `country_code`, COALESCE("region_id", 0), COALESCE("created_by_user_id", '')) WHERE geocode_status = 'pending';--> statement-breakpoint
+-- GE-19 / ADL-55 §3.5 backfill: promote any row already at/over the retry cap to the new terminal
+-- state so the badge stops silently counting it as in-progress. Cap literal 5 is point-in-time-correct
+-- for this migration (GEOCODE_ATTEMPT_CAP at authoring). Backfilled rows keep geocode_cause NULL — their
+-- historical cause is UNVERIFIED and is deliberately not asserted as 'ambiguous' (§3.5; §4 null-cause label).
+UPDATE `cities` SET `geocode_status` = 'needs_attention' WHERE `geocode_status` = 'pending' AND `geocode_attempts` >= 5;

--- a/src/backend/migrations/meta/0018_snapshot.json
+++ b/src/backend/migrations/meta/0018_snapshot.json
@@ -1,0 +1,2017 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "e7a1d202-4161-4ea8-b9e5-efd92e76dd53",
+  "prevId": "fffc9f81-5ad8-41d0-bbed-45703a3f5f86",
+  "tables": {
+    "activities": {
+      "name": "activities",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "uniq_activities_user_name": {
+          "name": "uniq_activities_user_name",
+          "columns": [
+            "user_id",
+            "name"
+          ],
+          "isUnique": true
+        },
+        "idx_activities_user": {
+          "name": "idx_activities_user",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "activities_user_id_users_id_fk": {
+          "name": "activities_user_id_users_id_fk",
+          "tableFrom": "activities",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "chk_activities_is_active": {
+          "name": "chk_activities_is_active",
+          "value": "\"activities\".\"is_active\" IN (0, 1)"
+        }
+      }
+    },
+    "cities": {
+      "name": "cities",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "country_code": {
+          "name": "country_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "region_id": {
+          "name": "region_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "geocode_status": {
+          "name": "geocode_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "geocode_cause": {
+          "name": "geocode_cause",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "geocode_attempted_at": {
+          "name": "geocode_attempted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "geocode_attempts": {
+          "name": "geocode_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        },
+        "osm_type": {
+          "name": "osm_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "osm_id": {
+          "name": "osm_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_cities_country": {
+          "name": "idx_cities_country",
+          "columns": [
+            "country_code"
+          ],
+          "isUnique": false
+        },
+        "idx_cities_region": {
+          "name": "idx_cities_region",
+          "columns": [
+            "region_id"
+          ],
+          "isUnique": false
+        },
+        "idx_cities_geocode": {
+          "name": "idx_cities_geocode",
+          "columns": [
+            "geocode_status"
+          ],
+          "isUnique": false,
+          "where": "\"cities\".\"geocode_status\" = 'pending'"
+        },
+        "uniq_cities_osm_ref": {
+          "name": "uniq_cities_osm_ref",
+          "columns": [
+            "osm_type",
+            "osm_id"
+          ],
+          "isUnique": true,
+          "where": "\"cities\".\"osm_id\" IS NOT NULL"
+        },
+        "uniq_cities_pending_per_creator": {
+          "name": "uniq_cities_pending_per_creator",
+          "columns": [
+            "\"name\" COLLATE NOCASE",
+            "country_code",
+            "COALESCE(\"region_id\", 0)",
+            "COALESCE(\"created_by_user_id\", '')"
+          ],
+          "isUnique": true,
+          "where": "\"cities\".\"geocode_status\" = 'pending'"
+        }
+      },
+      "foreignKeys": {
+        "cities_country_code_countries_country_code_fk": {
+          "name": "cities_country_code_countries_country_code_fk",
+          "tableFrom": "cities",
+          "tableTo": "countries",
+          "columnsFrom": [
+            "country_code"
+          ],
+          "columnsTo": [
+            "country_code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "cities_region_id_regions_id_fk": {
+          "name": "cities_region_id_regions_id_fk",
+          "tableFrom": "cities",
+          "tableTo": "regions",
+          "columnsFrom": [
+            "region_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "cities_created_by_user_id_users_id_fk": {
+          "name": "cities_created_by_user_id_users_id_fk",
+          "tableFrom": "cities",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "chk_cities_geocode_status": {
+          "name": "chk_cities_geocode_status",
+          "value": "\"cities\".\"geocode_status\" IN ('pending', 'resolved', 'unresolvable', 'needs_attention')"
+        },
+        "chk_cities_geocode_cause": {
+          "name": "chk_cities_geocode_cause",
+          "value": "\"cities\".\"geocode_cause\" IN ('ambiguous', 'unreachable') OR \"cities\".\"geocode_cause\" IS NULL"
+        },
+        "chk_cities_osm_both_or_neither": {
+          "name": "chk_cities_osm_both_or_neither",
+          "value": "(\"cities\".\"osm_type\" IS NULL) = (\"cities\".\"osm_id\" IS NULL)"
+        }
+      }
+    },
+    "companions": {
+      "name": "companions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "uniq_companions_user_name": {
+          "name": "uniq_companions_user_name",
+          "columns": [
+            "user_id",
+            "name"
+          ],
+          "isUnique": true
+        },
+        "idx_companions_user": {
+          "name": "idx_companions_user",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "companions_user_id_users_id_fk": {
+          "name": "companions_user_id_users_id_fk",
+          "tableFrom": "companions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "chk_companions_is_active": {
+          "name": "chk_companions_is_active",
+          "value": "\"companions\".\"is_active\" IN (0, 1)"
+        }
+      }
+    },
+    "countries": {
+      "name": "countries",
+      "columns": {
+        "country_code": {
+          "name": "country_code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "region_tier_enabled": {
+          "name": "region_tier_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "region_tier_label": {
+          "name": "region_tier_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "chk_countries_region_tier_enabled": {
+          "name": "chk_countries_region_tier_enabled",
+          "value": "\"countries\".\"region_tier_enabled\" IN (0, 1)"
+        }
+      }
+    },
+    "item_car_rentals": {
+      "name": "item_car_rentals",
+      "columns": {
+        "item_id": {
+          "name": "item_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pickup_location": {
+          "name": "pickup_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dropoff_location": {
+          "name": "dropoff_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pickup_datetime": {
+          "name": "pickup_datetime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dropoff_datetime": {
+          "name": "dropoff_datetime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "booking_reference": {
+          "name": "booking_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vehicle_class": {
+          "name": "vehicle_class",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "item_car_rentals_item_id_items_id_fk": {
+          "name": "item_car_rentals_item_id_items_id_fk",
+          "tableFrom": "item_car_rentals",
+          "tableTo": "items",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "item_experiences": {
+      "name": "item_experiences",
+      "columns": {
+        "item_id": {
+          "name": "item_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "post_visit_notes": {
+          "name": "post_visit_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_item_experiences_rating": {
+          "name": "idx_item_experiences_rating",
+          "columns": [
+            "rating"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "item_experiences_item_id_items_id_fk": {
+          "name": "item_experiences_item_id_items_id_fk",
+          "tableFrom": "item_experiences",
+          "tableTo": "items",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "chk_item_experiences_rating": {
+          "name": "chk_item_experiences_rating",
+          "value": "\"item_experiences\".\"rating\" IS NULL OR (\"item_experiences\".\"rating\" BETWEEN 1 AND 5)"
+        }
+      }
+    },
+    "item_flights": {
+      "name": "item_flights",
+      "columns": {
+        "item_id": {
+          "name": "item_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "airline": {
+          "name": "airline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "flight_number": {
+          "name": "flight_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "departure_airport": {
+          "name": "departure_airport",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "arrival_airport": {
+          "name": "arrival_airport",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "departure_datetime": {
+          "name": "departure_datetime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "arrival_datetime": {
+          "name": "arrival_datetime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "booking_reference": {
+          "name": "booking_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "seat": {
+          "name": "seat",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "item_flights_item_id_items_id_fk": {
+          "name": "item_flights_item_id_items_id_fk",
+          "tableFrom": "item_flights",
+          "tableTo": "items",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "item_hotels": {
+      "name": "item_hotels",
+      "columns": {
+        "item_id": {
+          "name": "item_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "property_name": {
+          "name": "property_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "check_in_date": {
+          "name": "check_in_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "check_out_date": {
+          "name": "check_out_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "booking_reference": {
+          "name": "booking_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "confirmation_number": {
+          "name": "confirmation_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "post_visit_notes": {
+          "name": "post_visit_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_item_hotels_rating": {
+          "name": "idx_item_hotels_rating",
+          "columns": [
+            "rating"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "item_hotels_item_id_items_id_fk": {
+          "name": "item_hotels_item_id_items_id_fk",
+          "tableFrom": "item_hotels",
+          "tableTo": "items",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "chk_item_hotels_rating": {
+          "name": "chk_item_hotels_rating",
+          "value": "\"item_hotels\".\"rating\" IS NULL OR (\"item_hotels\".\"rating\" BETWEEN 1 AND 5)"
+        }
+      }
+    },
+    "item_restaurants": {
+      "name": "item_restaurants",
+      "columns": {
+        "item_id": {
+          "name": "item_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "neighbourhood_area": {
+          "name": "neighbourhood_area",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cuisine_type": {
+          "name": "cuisine_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "post_visit_notes": {
+          "name": "post_visit_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_item_restaurants_rating": {
+          "name": "idx_item_restaurants_rating",
+          "columns": [
+            "rating"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "item_restaurants_item_id_items_id_fk": {
+          "name": "item_restaurants_item_id_items_id_fk",
+          "tableFrom": "item_restaurants",
+          "tableTo": "items",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "chk_item_restaurants_rating": {
+          "name": "chk_item_restaurants_rating",
+          "value": "\"item_restaurants\".\"rating\" IS NULL OR (\"item_restaurants\".\"rating\" BETWEEN 1 AND 5)"
+        }
+      }
+    },
+    "items": {
+      "name": "items",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "trip_id": {
+          "name": "trip_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "trip_place_id": {
+          "name": "trip_place_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "item_type": {
+          "name": "item_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'consider'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "map_url": {
+          "name": "map_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_carried_forward": {
+          "name": "is_carried_forward",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "carried_from_item_id": {
+          "name": "carried_from_item_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "idx_items_trip": {
+          "name": "idx_items_trip",
+          "columns": [
+            "trip_id"
+          ],
+          "isUnique": false
+        },
+        "idx_items_trip_place": {
+          "name": "idx_items_trip_place",
+          "columns": [
+            "trip_place_id"
+          ],
+          "isUnique": false
+        },
+        "idx_items_type": {
+          "name": "idx_items_type",
+          "columns": [
+            "item_type"
+          ],
+          "isUnique": false
+        },
+        "idx_items_status": {
+          "name": "idx_items_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "idx_items_carried": {
+          "name": "idx_items_carried",
+          "columns": [
+            "carried_from_item_id"
+          ],
+          "isUnique": false,
+          "where": "\"items\".\"carried_from_item_id\" IS NOT NULL"
+        },
+        "items_user_id_idx": {
+          "name": "items_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "items_trip_id_trips_id_fk": {
+          "name": "items_trip_id_trips_id_fk",
+          "tableFrom": "items",
+          "tableTo": "trips",
+          "columnsFrom": [
+            "trip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "items_trip_place_id_trip_places_id_fk": {
+          "name": "items_trip_place_id_trip_places_id_fk",
+          "tableFrom": "items",
+          "tableTo": "trip_places",
+          "columnsFrom": [
+            "trip_place_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "items_carried_from_item_id_items_id_fk": {
+          "name": "items_carried_from_item_id_items_id_fk",
+          "tableFrom": "items",
+          "tableTo": "items",
+          "columnsFrom": [
+            "carried_from_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "items_user_id_users_id_fk": {
+          "name": "items_user_id_users_id_fk",
+          "tableFrom": "items",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "chk_items_item_type": {
+          "name": "chk_items_item_type",
+          "value": "\"items\".\"item_type\" IN ('restaurant', 'hotel', 'flight', 'car_rental', 'experience', 'note')"
+        },
+        "chk_items_status": {
+          "name": "chk_items_status",
+          "value": "\"items\".\"status\" IN ('consider', 'confirmed', 'completed', 'cancelled', 'next_time')"
+        },
+        "chk_items_is_carried_forward": {
+          "name": "chk_items_is_carried_forward",
+          "value": "\"items\".\"is_carried_forward\" IN (0, 1)"
+        }
+      }
+    },
+    "map_shading_config": {
+      "name": "map_shading_config",
+      "columns": {
+        "state_key": {
+          "name": "state_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "color_hex": {
+          "name": "color_hex",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "idx_map_shading_user": {
+          "name": "idx_map_shading_user",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "map_shading_config_user_id_users_id_fk": {
+          "name": "map_shading_config_user_id_users_id_fk",
+          "tableFrom": "map_shading_config",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "map_shading_config_state_key_user_id_pk": {
+          "columns": [
+            "state_key",
+            "user_id"
+          ],
+          "name": "map_shading_config_state_key_user_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "chk_map_shading_state_key": {
+          "name": "chk_map_shading_state_key",
+          "value": "\"map_shading_config\".\"state_key\" IN ('active', 'planned', 'visited_once', 'visited_once_planning', 'visited_multiple', 'visited_multiple_planning')"
+        }
+      }
+    },
+    "regions": {
+      "name": "regions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "country_code": {
+          "name": "country_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "iso_3166_2": {
+          "name": "iso_3166_2",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "idx_regions_country": {
+          "name": "idx_regions_country",
+          "columns": [
+            "country_code"
+          ],
+          "isUnique": false
+        },
+        "uniq_regions_iso_3166_2": {
+          "name": "uniq_regions_iso_3166_2",
+          "columns": [
+            "iso_3166_2"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "regions_country_code_countries_country_code_fk": {
+          "name": "regions_country_code_countries_country_code_fk",
+          "tableFrom": "regions",
+          "tableTo": "countries",
+          "columnsFrom": [
+            "country_code"
+          ],
+          "columnsTo": [
+            "country_code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "trip_activities_map": {
+      "name": "trip_activities_map",
+      "columns": {
+        "trip_id": {
+          "name": "trip_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "activity_id": {
+          "name": "activity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "trip_activities_map_trip_id_trips_id_fk": {
+          "name": "trip_activities_map_trip_id_trips_id_fk",
+          "tableFrom": "trip_activities_map",
+          "tableTo": "trips",
+          "columnsFrom": [
+            "trip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "trip_activities_map_activity_id_activities_id_fk": {
+          "name": "trip_activities_map_activity_id_activities_id_fk",
+          "tableFrom": "trip_activities_map",
+          "tableTo": "activities",
+          "columnsFrom": [
+            "activity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "trip_activities_map_trip_id_activity_id_pk": {
+          "columns": [
+            "trip_id",
+            "activity_id"
+          ],
+          "name": "trip_activities_map_trip_id_activity_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "trip_categories": {
+      "name": "trip_categories",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "uniq_trip_categories_user_name": {
+          "name": "uniq_trip_categories_user_name",
+          "columns": [
+            "user_id",
+            "name"
+          ],
+          "isUnique": true
+        },
+        "idx_trip_categories_user": {
+          "name": "idx_trip_categories_user",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "trip_categories_user_id_users_id_fk": {
+          "name": "trip_categories_user_id_users_id_fk",
+          "tableFrom": "trip_categories",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "chk_trip_categories_is_active": {
+          "name": "chk_trip_categories_is_active",
+          "value": "\"trip_categories\".\"is_active\" IN (0, 1)"
+        }
+      }
+    },
+    "trip_categories_map": {
+      "name": "trip_categories_map",
+      "columns": {
+        "trip_id": {
+          "name": "trip_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_tcm_category": {
+          "name": "idx_tcm_category",
+          "columns": [
+            "category_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "trip_categories_map_trip_id_trips_id_fk": {
+          "name": "trip_categories_map_trip_id_trips_id_fk",
+          "tableFrom": "trip_categories_map",
+          "tableTo": "trips",
+          "columnsFrom": [
+            "trip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "trip_categories_map_category_id_trip_categories_id_fk": {
+          "name": "trip_categories_map_category_id_trip_categories_id_fk",
+          "tableFrom": "trip_categories_map",
+          "tableTo": "trip_categories",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "trip_categories_map_trip_id_category_id_pk": {
+          "columns": [
+            "trip_id",
+            "category_id"
+          ],
+          "name": "trip_categories_map_trip_id_category_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "trip_companions_map": {
+      "name": "trip_companions_map",
+      "columns": {
+        "trip_id": {
+          "name": "trip_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "companion_id": {
+          "name": "companion_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_tcpm_companion": {
+          "name": "idx_tcpm_companion",
+          "columns": [
+            "companion_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "trip_companions_map_trip_id_trips_id_fk": {
+          "name": "trip_companions_map_trip_id_trips_id_fk",
+          "tableFrom": "trip_companions_map",
+          "tableTo": "trips",
+          "columnsFrom": [
+            "trip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "trip_companions_map_companion_id_companions_id_fk": {
+          "name": "trip_companions_map_companion_id_companions_id_fk",
+          "tableFrom": "trip_companions_map",
+          "tableTo": "companions",
+          "columnsFrom": [
+            "companion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "trip_companions_map_trip_id_companion_id_pk": {
+          "columns": [
+            "trip_id",
+            "companion_id"
+          ],
+          "name": "trip_companions_map_trip_id_companion_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "trip_countries": {
+      "name": "trip_countries",
+      "columns": {
+        "trip_id": {
+          "name": "trip_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "country_code": {
+          "name": "country_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "idx_trip_countries_country": {
+          "name": "idx_trip_countries_country",
+          "columns": [
+            "country_code"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "trip_countries_trip_id_trips_id_fk": {
+          "name": "trip_countries_trip_id_trips_id_fk",
+          "tableFrom": "trip_countries",
+          "tableTo": "trips",
+          "columnsFrom": [
+            "trip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "trip_countries_country_code_countries_country_code_fk": {
+          "name": "trip_countries_country_code_countries_country_code_fk",
+          "tableFrom": "trip_countries",
+          "tableTo": "countries",
+          "columnsFrom": [
+            "country_code"
+          ],
+          "columnsTo": [
+            "country_code"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "trip_countries_trip_id_country_code_pk": {
+          "columns": [
+            "trip_id",
+            "country_code"
+          ],
+          "name": "trip_countries_trip_id_country_code_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "trip_place_activities_map": {
+      "name": "trip_place_activities_map",
+      "columns": {
+        "trip_place_id": {
+          "name": "trip_place_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "activity_id": {
+          "name": "activity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "trip_place_activities_map_trip_place_id_trip_places_id_fk": {
+          "name": "trip_place_activities_map_trip_place_id_trip_places_id_fk",
+          "tableFrom": "trip_place_activities_map",
+          "tableTo": "trip_places",
+          "columnsFrom": [
+            "trip_place_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "trip_place_activities_map_activity_id_activities_id_fk": {
+          "name": "trip_place_activities_map_activity_id_activities_id_fk",
+          "tableFrom": "trip_place_activities_map",
+          "tableTo": "activities",
+          "columnsFrom": [
+            "activity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "trip_place_activities_map_trip_place_id_activity_id_pk": {
+          "columns": [
+            "trip_place_id",
+            "activity_id"
+          ],
+          "name": "trip_place_activities_map_trip_place_id_activity_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "trip_places": {
+      "name": "trip_places",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "trip_id": {
+          "name": "trip_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "city_id": {
+          "name": "city_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "arrived_on": {
+          "name": "arrived_on",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "departed_on": {
+          "name": "departed_on",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "uniq_trip_places_trip_city": {
+          "name": "uniq_trip_places_trip_city",
+          "columns": [
+            "trip_id",
+            "city_id"
+          ],
+          "isUnique": true
+        },
+        "idx_trip_places_trip": {
+          "name": "idx_trip_places_trip",
+          "columns": [
+            "trip_id"
+          ],
+          "isUnique": false
+        },
+        "idx_trip_places_city": {
+          "name": "idx_trip_places_city",
+          "columns": [
+            "city_id"
+          ],
+          "isUnique": false
+        },
+        "trip_places_user_id_idx": {
+          "name": "trip_places_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "trip_places_trip_id_trips_id_fk": {
+          "name": "trip_places_trip_id_trips_id_fk",
+          "tableFrom": "trip_places",
+          "tableTo": "trips",
+          "columnsFrom": [
+            "trip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "trip_places_city_id_cities_id_fk": {
+          "name": "trip_places_city_id_cities_id_fk",
+          "tableFrom": "trip_places",
+          "tableTo": "cities",
+          "columnsFrom": [
+            "city_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "trip_places_user_id_users_id_fk": {
+          "name": "trip_places_user_id_users_id_fk",
+          "tableFrom": "trip_places",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "trips": {
+      "name": "trips",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'planning'"
+        },
+        "photo_album_ref": {
+          "name": "photo_album_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "idx_trips_status": {
+          "name": "idx_trips_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "idx_trips_start_date": {
+          "name": "idx_trips_start_date",
+          "columns": [
+            "start_date"
+          ],
+          "isUnique": false
+        },
+        "idx_trips_end_date": {
+          "name": "idx_trips_end_date",
+          "columns": [
+            "end_date"
+          ],
+          "isUnique": false
+        },
+        "trips_user_id_idx": {
+          "name": "trips_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "trips_user_id_users_id_fk": {
+          "name": "trips_user_id_users_id_fk",
+          "tableFrom": "trips",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "chk_trips_status": {
+          "name": "chk_trips_status",
+          "value": "\"trips\".\"status\" IN ('planning', 'active', 'review_pending', 'locked')"
+        }
+      }
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "clerk_id": {
+          "name": "clerk_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_owner": {
+          "name": "is_owner",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_clerk_id_unique": {
+          "name": "users_clerk_id_unique",
+          "columns": [
+            "clerk_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {
+      "uniq_cities_pending_per_creator": {
+        "columns": {
+          "\"name\" COLLATE NOCASE": {
+            "isExpression": true
+          },
+          "COALESCE(\"region_id\", 0)": {
+            "isExpression": true
+          },
+          "COALESCE(\"created_by_user_id\", '')": {
+            "isExpression": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/backend/migrations/meta/_journal.json
+++ b/src/backend/migrations/meta/_journal.json
@@ -127,6 +127,13 @@
       "when": 1785994683552,
       "tag": "0017_bug75_identity_switch",
       "breakpoints": true
+    },
+    {
+      "idx": 18,
+      "version": "6",
+      "when": 1786429769287,
+      "tag": "0018_bug85_geocode_needs_attention",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
Tracker: **BUG-85** · BRD: **GE-19** (v3.20, approved) · Spec: **ADL-55 §3.5** (OP-27-reviewed, merged) · Class (OP-32): gap

## What this is
The **schema substrate** for the GE-19 geocode status-lifecycle, implemented verbatim from ADL-55 §3.5. Substrate only — **no routes, services, or frontend, no GE-19 behaviour**. The QA red-bar → Backend → Frontend briefs follow and depend on this.

- `cities.geocode_status` CHECK widened to admit the new terminal status **`needs_attention`**
- new **nullable `geocode_cause`** column + CHECK (`IN ('ambiguous','unreachable') OR IS NULL`)
- migration **0018** — 12-step table rebuild (CHECK widening has no SQLite `ALTER`) + trailing backfill

## Three drizzle-kit hand-corrections (all predicted by the 2026-08-06 BUG-75 park doc)
1. **"0015 original bug"** — generated `INSERT…SELECT` pulled the *new* `geocode_cause` column FROM the old table (failed at runtime, `no such column`). Fixed by supplying `NULL` as the SELECT literal (0015 template); existing rows carry NULL cause.
2. **ADL-15 bug 4** (COALESCE-comma-split) on `uniq_cities_pending_per_creator` — rewritten to migration 0017's proven form, byte-verified against `schema.ts`.
3. **`uniq_cities_osm_ref`** WHERE hand-simplified from the table-qualified form back to bare `WHERE osm_id IS NOT NULL` — the exact case the BUG-75 park doc §2 warned about (`bug75-identity-migration.test.ts:84` regex).

Single migration (not EXPAND/SWITCH) is the approved spec — one additive nullable column needs no expand phase.

## Verification
- Fresh scratch DB: all 18 migrations apply clean; `db:generate` after edits reports **no schema drift**.
- `sqlite_master`: new column + both CHECKs present; the pending-per-creator index keeps its COALESCE sentinels + COLLATE NOCASE + partial WHERE.
- Constraint probes: `needs_attention` (all causes) accepted; bad status/cause rejected; creator-scoped uniqueness + COLLATE NOCASE dedup behave correctly.
- Backfill predicate: only `pending` rows at/over the cap flip to `needs_attention`, cause stays NULL; terminal/under-cap rows untouched (fresh DB = 0 rows affected).
- `test:backend` **845/845**, `test:frontend` 388/388, `type:check:all` clean, `scope:check` PASS (cities still global-reference), `tracker:check` OK, `status:check` in sync.

## Single-green-step / backward-compat — HELD (two probes that fail differently)
Claim: no existing code path mis-handles the new status or column.
- **Probe A (behavioural):** 845/845 backend tests pass unchanged.
- **Probe B (static, code-read):** `serializers/city.ts` types `geocode_status` as plain `string` (no union/switch/exhaustiveness) and does not emit `geocode_cause` (a backward-compatible field omission); no Zod enum validates `geocode_status`; `processQueue`'s predicate and `findRegionlessUpgradeCandidate`'s `['pending','unresolvable']` whitelist both exclude `needs_attention` (fail-closed); all three non-test callers of `resolveCity` fire only on `pending` rows, so the resolved/unresolvable early-guard fall-through never sees `needs_attention`.

The ADL's F1/F3 + whitelist edits are the Backend brief's job; their absence here is fail-closed, not a regression. The `findByIdentityKey` "unconditional index" comment refresh (ADL §8/F4) is assigned to the Backend implementation PR per ADL §10 and was already stale before this change.

Do not merge — COO reviews and merges.