### PR TITLE
test(GE-19): ATDD red bar — geocode status-lifecycle acceptance criteria (ADL-55 §7)

### DIFF
--- a/jobs/COO/inbox/20260811_0013-QA-ge19-red-bar-complete.txt
+++ b/jobs/COO/inbox/20260811_0013-QA-ge19-red-bar-complete.txt
@@ -1,0 +1,44 @@
+TO: COO
+FROM: QA
+RE: GE-19 / BUG-85 ATDD red bar — geocode status-lifecycle acceptance criteria (ADL-55 §7)
+
+TRACKER: BUG-85 · BRD: GE-19 (v3.20) · BRANCH: test/ge19-red-bar · PR: <filled after push>
+CLASS (OP-32): gap · ROLE: independent ATDD red bar — I wrote the tests, did NOT implement behaviour.
+
+WHAT WAS TESTED (build ref main 524e32b): acceptance criteria 1–8 and 10, service + API level,
+against a real libSQL instance (createTestDb — real migrations/CHECKs/partial unique indexes,
+QUAL-22). Criterion 4 (security) seeds two distinct real users. 3 new files, 14 tests.
+
+RED-BAR VERDICT (each demonstrated failing un-skipped on main — full output in tech/):
+  §7.1 crit 1  ambiguous → needs_attention/ambiguous, attempts unchanged   RED  ('pending'→needs_attention)
+  §7.2 crit 2  recoverable @cap → needs_attention/unreachable, BOTH sites   RED  (name-search + carried-OSM)
+  §7.4 crit 4  GET /api/geocode-queue userId-scoped (SECURITY, 2 users)     RED  (404 — endpoint absent)
+  §7.5 crit 5  queue excludes resolved + no-longer-referenced cities         RED  (404)
+  §7.7 crit 7  region re-opens region-less needs_attention row in place      RED  (F1 gap: not reset)
+  §7.8 crit 8  re-point drops abandoned stuck city from queue                RED  (404; re-point PATCH=200)
+  §7.10 crit10 needs_attention/unresolvable bucketed apart from in-progress  RED  (404)
+Consolidated un-skipped run: 10 failed | 4 passed.
+
+GREEN GUARDS (already hold on main — kept UN-SKIPPED, not red bars; cleaner mechanism, CI still green):
+  §7.3 crit 3 (no-match/disabled — "unchanged" per ADL), §7.6 crit 6 (status-blind re-add reuse — the
+  premise the transition relies on), §3.3 unresolvable re-open asymmetry. A passing test here is a
+  correct invariant, not a wrong bar; forcing them red would contradict the ADL's "unchanged".
+
+MECHANISM: red-bar blocks committed `describe.skip` + inline marker
+`// GE-19 RED BAR (BUG-85) — unskip when implemented` (7 blocks). Backend un-skips each as it greens it.
+
+FINDINGS (2 items — action for COO):
+  1. RE-POINT PATH WRONG in ADL-55 D2 / brief / BUG-85 tracker ("PATCH /api/places/:id, verified built").
+     No such route. Real path is PATCH /api/trips/:tripId/places/:placeId (places.ts:121, mounted
+     trips.ts:47). Mechanism works (crit 8 PATCH=200); only the doc path string is wrong. Two probes:
+     grep for /api/places mount = none; read trips.ts:47 + places.ts:121. Recommend fix tracker/ADL.
+  2. Red bar PINS the GET /api/geocode-queue contract to ADL-55 §5.1 columns (JSON array; each item has
+     id + geocode_status snake_case). Backend reconciles in the un-skip diff if it picks another envelope.
+
+OWNED ELSEWHERE (noted so nothing falls through): crit 9 (label strings) = Frontend component tests;
+crit 11 (nextGeocodeState table test) = Backend, co-located with the pure function.
+
+CI: full backend suite 849 passed | 10 skipped; type:check:all clean; biome clean. PR CI: <after push>.
+BLOCKERS: none. FILES: src/backend/{services/__tests__/geocoding.ge19-lifecycle,
+services/__tests__/cityIdentity.ge19-reopen-reuse, routes/__tests__/geocode-queue.ge19}.test.ts +
+jobs/qa/tech/20260811-ge19-red-bar.md. Do NOT merge (COO reviews/merges).

--- a/jobs/COO/inbox/20260811_0013-QA-ge19-red-bar-complete.txt
+++ b/jobs/COO/inbox/20260811_0013-QA-ge19-red-bar-complete.txt
@@ -2,7 +2,7 @@ TO: COO
 FROM: QA
 RE: GE-19 / BUG-85 ATDD red bar — geocode status-lifecycle acceptance criteria (ADL-55 §7)
 
-TRACKER: BUG-85 · BRD: GE-19 (v3.20) · BRANCH: test/ge19-red-bar · PR: <filled after push>
+TRACKER: BUG-85 · BRD: GE-19 (v3.20) · BRANCH: test/ge19-red-bar · PR: #512 (CI green, 18/18)
 CLASS (OP-32): gap · ROLE: independent ATDD red bar — I wrote the tests, did NOT implement behaviour.
 
 WHAT WAS TESTED (build ref main 524e32b): acceptance criteria 1–8 and 10, service + API level,
@@ -38,7 +38,7 @@ FINDINGS (2 items — action for COO):
 OWNED ELSEWHERE (noted so nothing falls through): crit 9 (label strings) = Frontend component tests;
 crit 11 (nextGeocodeState table test) = Backend, co-located with the pure function.
 
-CI: full backend suite 849 passed | 10 skipped; type:check:all clean; biome clean. PR CI: <after push>.
+CI: full backend suite 849 passed | 10 skipped; type:check:all clean; biome clean. PR #512 CI: green (18/18).
 BLOCKERS: none. FILES: src/backend/{services/__tests__/geocoding.ge19-lifecycle,
 services/__tests__/cityIdentity.ge19-reopen-reuse, routes/__tests__/geocode-queue.ge19}.test.ts +
 jobs/qa/tech/20260811-ge19-red-bar.md. Do NOT merge (COO reviews/merges).

--- a/jobs/qa/context/current.txt
+++ b/jobs/qa/context/current.txt
@@ -443,3 +443,44 @@ NEXT STEPS (for incoming QA)
   substrate, then Stages 2/3/4 relocate the named §5.1 paths — Part F must
   stay green through every relocation and go RED if any predicate or prior
   ownership assertion is dropped mid-move.
+
+═══════════════════════════════════════════════════════════════════════════
+2026-08-11 — GE-19 / BUG-85 ATDD RED BAR (ADL-55 §7 criteria 1–8, 10)
+═══════════════════════════════════════════════════════════════════════════
+Branch test/ge19-red-bar off main 524e32b (needs_attention + geocode_cause
+substrate already merged, PR #511). Wrote the executable definition of done
+the Backend/Frontend build against — I write the bar, I do NOT implement.
+
+3 files, 14 tests, real libSQL (createTestDb, QUAL-22):
+  - services/__tests__/geocoding.ge19-lifecycle.test.ts   — crit 1,2 (RED), 3 (green guard)
+  - services/__tests__/cityIdentity.ge19-reopen-reuse.test.ts — crit 7 (RED), 6 + §3.3 asym (green guards)
+  - routes/__tests__/geocode-queue.ge19.test.ts          — crit 4,5,8,10 (RED, endpoint 404s)
+
+MECHANISM: red-bar blocks are describe.skip + inline marker
+"// GE-19 RED BAR (BUG-85) — unskip when implemented" (7 blocks). CI green
+(skipped don't run: 849 passed | 10 skipped). Each RED demonstrated by running
+un-skipped copies (sed describe.skip→describe into throwaway *.redproof copies,
+run, delete — no prod code, no git stash): 10 failed | 4 passed. Full RED table
++ evidence: jobs/qa/tech/20260811-ge19-red-bar.md.
+
+CLEANER-MECHANISM CALL (brief invited it): criteria the ADL marks "unchanged"
+(crit 3, 6, §3.3 asymmetry) PASS on main and are LEFT UN-SKIPPED as continuous
+regression guards, not dressed as red bars. A passing test there is a correct
+invariant, not a wrong bar. Crit 6's status-blind reuse is the PREMISE the
+needs_attention transition relies on, so guarding it continuously matters.
+
+FINDINGS → COO:
+  1. Re-point path in ADL-55 D2 / brief / BUG-85 tracker is WRONG: "PATCH
+     /api/places/:id (verified built)" — no such route. Real path is
+     PATCH /api/trips/:tripId/places/:placeId (places.ts:121, mounted
+     trips.ts:47). Mechanism works (crit 8 PATCH=200); only the doc string is
+     wrong. 2 probes: grep /api/places mount=none; read trips.ts:47+places.ts:121.
+  2. Bar PINS GET /api/geocode-queue contract to ADL-55 §5.1 columns (JSON array;
+     each item id + geocode_status snake_case). Backend reconciles in un-skip diff.
+
+NOT MY SCOPE (noted so nothing drops): crit 9 (label strings) = Frontend
+component tests; crit 11 (nextGeocodeState table) = Backend, with the function.
+
+Completion report: jobs/COO/inbox/20260811_0013-QA-ge19-red-bar-complete.txt
+NEXT: Backend un-skips + greens each red block; a weakened assertion shows in
+that diff. Do NOT merge — COO reviews/merges.

--- a/jobs/qa/park-docs/20260811-QA-park.txt
+++ b/jobs/qa/park-docs/20260811-QA-park.txt
@@ -5,8 +5,8 @@ Session: GE-19 / BUG-85 ATDD RED BAR (ADL-55 §7 criteria 1–8, 10)
 STATE AT PARK
 ────────────────────────────────────────────────────────────────────────
 Branch:  test/ge19-red-bar  (off main 524e32b)
-PR:      test(GE-19): ATDD red bar — geocode status-lifecycle acceptance
-         criteria (ADL-55 §7)   [PR # filled after push; CI green required]
+PR:      #512 — test(GE-19): ATDD red bar — geocode status-lifecycle
+         acceptance criteria (ADL-55 §7)   [CI green, 18/18 @ 18182a3]
 Status:  Red bar delivered and demonstrated. Do NOT merge — COO reviews/merges.
 
 ────────────────────────────────────────────────────────────────────────

--- a/jobs/qa/park-docs/20260811-QA-park.txt
+++ b/jobs/qa/park-docs/20260811-QA-park.txt
@@ -1,0 +1,89 @@
+QA PARK DOCUMENT — 2026-08-11
+Session: GE-19 / BUG-85 ATDD RED BAR (ADL-55 §7 criteria 1–8, 10)
+
+────────────────────────────────────────────────────────────────────────
+STATE AT PARK
+────────────────────────────────────────────────────────────────────────
+Branch:  test/ge19-red-bar  (off main 524e32b)
+PR:      test(GE-19): ATDD red bar — geocode status-lifecycle acceptance
+         criteria (ADL-55 §7)   [PR # filled after push; CI green required]
+Status:  Red bar delivered and demonstrated. Do NOT merge — COO reviews/merges.
+
+────────────────────────────────────────────────────────────────────────
+WHAT WAS DELIVERED
+────────────────────────────────────────────────────────────────────────
+The executable definition of done for GE-19 that the Backend + Frontend
+briefs build against. I wrote the acceptance tests; I did NOT implement the
+behaviour (OP-35 ATDD-first — QA is the red bar).
+
+3 new backend test files (real libSQL, QUAL-22 mock-fidelity):
+  1. src/backend/services/__tests__/geocoding.ge19-lifecycle.test.ts
+        §7.1 crit 1  ambiguous → needs_attention/ambiguous, no retries   [RED, skip]
+        §7.2 crit 2  recoverable @cap → needs_attention/unreachable,     [RED, skip]
+                     BOTH F2 sites (name-search ~:458, carried-OSM ~:413)
+        §7.3 crit 3  no-match unchanged; disabled increments nothing     [GREEN guard, unskipped]
+  2. src/backend/services/__tests__/cityIdentity.ge19-reopen-reuse.test.ts
+        §7.6 crit 6  re-add needs_attention city reuses row (no dup)     [GREEN guard, unskipped]
+        §7.7 crit 7  region re-opens region-less needs_attention in place[RED, skip] (F1 gap)
+        §3.3         unresolvable re-open asymmetry preserved            [GREEN guard, unskipped]
+  3. src/backend/routes/__tests__/geocode-queue.ge19.test.ts
+        §7.4 crit 4  GET /api/geocode-queue userId-scoped (SECURITY,     [RED, skip]
+                     2 real users — USER_B's stuck city never shown to A)
+        §7.5 crit 5  queue excludes resolved + no-longer-referenced      [RED, skip]
+        §7.8 crit 8  re-point drops abandoned stuck city from queue      [RED, skip]
+        §7.10 crit10 needs_attention/unresolvable bucketed apart         [RED, skip]
+
+Detail + full RED output table: jobs/qa/tech/20260811-ge19-red-bar.md
+Completion report: jobs/COO/inbox/20260811_0013-QA-ge19-red-bar-complete.txt
+
+────────────────────────────────────────────────────────────────────────
+SKIP-WITH-DEMONSTRATED-RED MECHANISM (how CI stays green while the bar is red)
+────────────────────────────────────────────────────────────────────────
+Red-bar blocks: describe.skip + inline marker
+  "// GE-19 RED BAR (BUG-85) — unskip when implemented"   (7 blocks total)
+Backend un-skips each block as it greens it; a weakened assertion shows in
+that diff. Verified: full backend suite 849 passed | 10 skipped (CI green).
+RED demonstrated by sed'ing describe.skip→describe into throwaway
+*.redproof.test.ts copies (same dir → imports resolve), running, deleting —
+no production code touched, no git stash (shared-ref hazard). Consolidated
+un-skipped run: 10 failed | 4 passed.
+
+CLEANER MECHANISM (brief invited proposals): the ADL marks crit 3/6/§3.3 as
+UNCHANGED invariants — they PASS on main, so I left them UN-SKIPPED as
+continuous regression guards rather than falsely dressing them as red bars.
+CI green either way. Crit 6's status-blindness is the premise the
+needs_attention transition depends on, so guarding it continuously is the
+right call.
+
+────────────────────────────────────────────────────────────────────────
+OPEN FINDINGS FOR THE COO (2)
+────────────────────────────────────────────────────────────────────────
+1. RE-POINT PATH WRONG in ADL-55 D2, the brief, and the BUG-85 tracker note:
+   all cite "PATCH /api/places/:id (verified built)". No such route exists.
+   Real path: PATCH /api/trips/:tripId/places/:placeId (places.ts:121,
+   accepts city_id via UpdatePlaceDatesSchema; mounted trips.ts:47). The
+   MECHANISM is built and works (crit 8's PATCH returns 200 in the red run) —
+   only the documented path STRING is wrong. Two probes: grep for any
+   /api/places mount = none; read trips.ts:47 + places.ts:121. Recommend the
+   COO correct the tracker/ADL pointer so the Backend/Frontend don't chase a
+   phantom route.
+2. The bar PINS the GET /api/geocode-queue response contract to the ADL-55
+   §5.1 columns: JSON array of city objects, each with at least id (number)
+   and geocode_status (snake_case, matching GET /api/cities search). If the
+   Backend chooses a different envelope it reconciles in the un-skip diff.
+
+────────────────────────────────────────────────────────────────────────
+OUT OF SCOPE (owned elsewhere — noted so nothing falls through)
+────────────────────────────────────────────────────────────────────────
+crit 9  (status,cause)→label strings   — Frontend brief component tests
+crit 11 nextGeocodeState table test    — Backend brief, co-located w/ the fn
+
+────────────────────────────────────────────────────────────────────────
+NEXT / IF RESUMED
+────────────────────────────────────────────────────────────────────────
+- After Backend implements: it un-skips each RED block; QA re-verifies the
+  un-skip diff did not weaken assertions and that crit 3/6/§3.3 guards stayed
+  green through the build.
+- Frontend brief owns crit 9; confirm it lands as component tests.
+- Watch the re-point path finding (#1) is actually corrected in the tracker/ADL
+  before the Backend/Frontend briefs cite it.

--- a/jobs/qa/tech/20260811-ge19-red-bar.md
+++ b/jobs/qa/tech/20260811-ge19-red-bar.md
@@ -1,0 +1,82 @@
+# GE-19 / BUG-85 — ATDD RED BAR (ADL-55 §7 criteria 1–8, 10)
+
+**Date:** 2026-08-11 · **Author:** QA · **Branch:** `test/ge19-red-bar` · **Class (OP-32):** gap
+**Scope:** the executable definition of done the Backend + Frontend briefs build against. QA writes
+the bar; QA does NOT implement the behaviour. Criteria 9 (label rendering) and 11 (`nextGeocodeState`
+table test) are OUT of scope — owned elsewhere (see §Ownership).
+
+## Files + skip markers (what the Backend un-skips)
+
+| File | Blocks |
+|------|--------|
+| `src/backend/services/__tests__/geocoding.ge19-lifecycle.test.ts` | `describe.skip` §7.1 (crit 1, 2 tests), `describe.skip` §7.2 (crit 2, 2 tests — both F2 sites); `describe` §7.3 (crit 3, UNSKIPPED green guard) |
+| `src/backend/services/__tests__/cityIdentity.ge19-reopen-reuse.test.ts` | `describe.skip` §7.7 (crit 7, 1 test); `describe` §7.6 (crit 6) + `describe` §3.3 asymmetry — both UNSKIPPED green guards |
+| `src/backend/routes/__tests__/geocode-queue.ge19.test.ts` | `describe.skip` §7.4 (crit 4, 2 tests — SECURITY), §7.5 (crit 5), §7.8 (crit 8), §7.10 (crit 10) |
+
+Every skipped block carries the inline marker `// GE-19 RED BAR (BUG-85) — unskip when implemented`
+(7 total). CI stays green because skipped tests do not execute (verified: full backend suite
+849 passed | 10 skipped). A weakened assertion shows in the Backend's un-skip diff.
+
+## RED evidence (each red-bar criterion demonstrated failing un-skipped on main `524e32b`)
+
+Method: `sed 's/describe.skip(/describe(/g'` into throwaway `*.redproof.test.ts` copies (same
+dirs → relative imports resolve), run, capture, delete. No production code touched; no `git stash`
+(shared-ref hazard). Consolidated result: **10 failed | 4 passed (14)**.
+
+| Crit | Level | RED assertion output | Why red today |
+|------|-------|----------------------|---------------|
+| 1 | service `resolveCity` | `expected 'pending' to be 'needs_attention'`; and `expected true to be false` | ambiguous branch increments + stays `pending`; no `needs_attention` transition, no early-return |
+| 2 (name-search) | service | `expected 'pending' to be 'needs_attention'` | error branch (~:458) increments to cap, stays `pending` |
+| 2 (carried-OSM) | service | `expected 'pending' to be 'needs_attention'` | error branch (~:413) increments to cap, stays `pending` |
+| 7 | identity `findOrUpgradeCity` | `expected 'needs_attention' to be 'pending'` | `findRegionlessUpgradeCandidate` whitelist excludes `needs_attention` (cities.ts:253); no status reset (F1 third edit); re-fire guard only fires for `pending` |
+| 4 | API `GET /api/geocode-queue` | `expected 404 to be 200` (×2) | endpoint does not exist |
+| 5 | API | `expected 404 to be 200` | endpoint does not exist |
+| 8 | API | `expected 404 to be 200` at queue GET (line 288) — **re-point PATCH returned 200** | re-point route works; queue endpoint does not exist |
+| 10 | API | `expected 404 to be 200` | endpoint does not exist |
+
+**Two probes that the endpoint does not exist (negative claim):** (1) grep across `src/backend/routes/`,
+`server.ts`, `server-test-app.ts` for `geocode-queue`/`geocodeQueue`/`geocode_queue`/`findUserGeocodeQueue`
+→ empty; (2) running the suite → 404. Also confirmed by reading `server-test-app.ts` (no registration;
+`geocodeRouter` mounts at `/api/geocode`, which does not match `/api/geocode-queue` at a segment boundary).
+
+## GREEN regression guards (already hold on main — kept UN-SKIPPED, NOT red bars)
+
+Proposed cleaner mechanism (the brief invited it): criteria the ADL specifies as **unchanged**
+invariants pass today and are left un-skipped so they protect the invariant continuously through the
+build, rather than being falsely dressed as red bars. CI stays green either way.
+
+- **Crit 3 (§7.3, "unchanged"):** no-match → `unresolvable`; `GEOCODING_ENABLED=false` increments nothing. D10 behaviour, already correct.
+- **Crit 6 (§7.6):** re-adding a `needs_attention` city (same name/country/region) reuses the row — `findByIdentityKey` (cities.ts:206) is already status-blind, so step 1 finds it before any insert. This is the **premise** the `needs_attention` transition relies on (a `needs_attention` row leaves the pending partial index), so guarding it continuously matters.
+- **§3.3 asymmetry:** a region-less `unresolvable` row is upgradeable (region set, attempts reset) but stays `unresolvable` and is NOT re-fired — guards that the F1 build does not start re-firing no-match rows.
+
+## Findings for the COO / Backend brief
+
+1. **Re-point path discrepancy (MED — will misdirect the Backend/Frontend if uncorrected).** ADL-55 D2,
+   the brief, and the BUG-85 tracker note all cite the re-point route as `PATCH /api/places/:id`
+   ("verified built"). **No such route exists.** `placesRouter` is mounted under trips
+   (`trips.ts:47` → `/:tripId/places`), so the built path is
+   **`PATCH /api/trips/:tripId/places/:placeId`** (`places.ts:121`, accepting `city_id` via
+   `UpdatePlaceDatesSchema`). The mechanism IS built and works (crit 8's PATCH returns 200 in the red
+   run) — only the *path string* in the docs is wrong. Two probes: grep for any `/api/places` mount →
+   none; read `trips.ts:47` + `places.ts:121`. Recommend the COO correct the tracker/ADL pointer.
+2. **Assumed response contract for `GET /api/geocode-queue`.** The red bar pins the ADL-55 §5.1 columns:
+   a JSON **array** of city objects, each with at least `id` (number) and `geocode_status` (snake_case,
+   matching the existing `GET /api/cities` search shape). Crit 10 also reads `geocode_status` to split
+   buckets. If the Backend picks a different envelope it must reconcile these assertions in the un-skip
+   diff — that reconciliation is the contract negotiation, and a silent weakening shows there.
+3. **`nextGeocodeState` (crit 11) is Backend-owned** (written alongside the pure function it tests); the
+   **label mapping (crit 9) is Frontend-owned** (component tests). Neither is in this bar — flagged so
+   nothing falls through.
+
+## Ownership of out-of-scope criteria
+- **Crit 9** (`(status,cause)` → label string) — Frontend brief component tests (ADL-55 §4, §10).
+- **Crit 11** (`nextGeocodeState` exhaustive table test) — Backend brief, co-located with the pure
+  function (ADL-55 §6 / OP-35).
+
+## Verification
+- Full backend suite (real files, skipped): **849 passed | 10 skipped** (`npm run test:backend`).
+- `type:check:all` clean; `biome check` on the 3 files clean.
+- Mock fidelity (QUAL-22): all tests run against a real libSQL instance built from the real migrations
+  (`createTestDb`) — real CHECK constraints (incl. merged `needs_attention`/`geocode_cause`), real
+  partial unique indexes; only Nominatim egress (service tests) / db+auth (API tests) are mocked. The
+  security bar (crit 4) seeds two distinct real users.

--- a/src/backend/routes/__tests__/geocode-queue.ge19.test.ts
+++ b/src/backend/routes/__tests__/geocode-queue.ge19.test.ts
@@ -1,0 +1,339 @@
+/**
+ * GE-19 / BUG-85 — ATDD RED BAR for the geocode status-lifecycle model.
+ * Acceptance criteria 4, 5, 8, 10 from ADL-55 §7 (API level, the derived
+ * userId-scoped queue endpoint GET /api/geocode-queue — ADL-55 §5, OQ-5).
+ *
+ * ALL FOUR ARE RED on current main: the endpoint does not exist (two probes:
+ * (1) grep across routes/ + server-test-app.ts finds no geocode-queue
+ * registration; (2) this suite hits it and gets 404). Each is committed
+ * `describe.skip` with the RED-BAR marker so CI stays green; the Backend brief
+ * un-skips each block as it builds the endpoint.
+ *
+ * SECURITY BAR (OP-06, criterion 4): cross-user isolation of the queue —
+ * composes the QUAL-43 cross-tenant matrix pattern (ADL-53 §5.1). Seeds two
+ * distinct real users (USER_A / USER_B) and proves USER_B's solely-referenced
+ * stuck city never appears for USER_A. This is the exact class a vacuous double
+ * passes silently, so it runs against a real libSQL instance with the partial
+ * unique indexes live (createTestDb), NOT a stubbed repository (QUAL-22).
+ *
+ * ASSUMED RESPONSE CONTRACT (pins the ADL-55 §5.1 columns): a JSON array of
+ * city objects, each carrying at least `id` (number) and `geocode_status`
+ * (snake_case, matching the existing GET /api/cities search shape). If the
+ * Backend chooses a different envelope it must reconcile these assertions in
+ * the un-skip diff — that reconciliation is the contract negotiation, and a
+ * silently-weakened assertion shows there. Endpoint path is `/api/geocode-queue`
+ * per OQ-5.
+ */
+
+import { eq } from 'drizzle-orm';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as schema from '../../db/schema.js';
+import { createTestDb, type TestDb } from '../../repositories/__tests__/test-db.js';
+
+const USER_A_ID = 'user-a-00000000-0000-0000-0000-000000000000';
+const USER_B_ID = 'user-b-00000000-0000-0000-0000-000000000000';
+
+let testDb: TestDb | null = null;
+let mockUserId = USER_A_ID;
+let mockIsOwner = 1;
+let mockAuthEnabled = true;
+
+vi.mock('../../db/index.js', async (importOriginal) => {
+  const real = await importOriginal<typeof import('../../db/index.js')>();
+  return {
+    ...real,
+    getDb: () => {
+      if (!testDb) throw new Error('[TEST] testDb not initialised');
+      return testDb;
+    },
+  };
+});
+
+vi.mock('../../middleware/auth.js', () => ({
+  requireAuth: (
+    req: import('express').Request,
+    res: import('express').Response,
+    next: import('express').NextFunction,
+  ) => {
+    if (!mockAuthEnabled) {
+      res.status(401).json({ error: 'Unauthorized' });
+      return;
+    }
+    (req as import('express').Request & { user?: unknown }).user = {
+      id: mockUserId,
+      clerkId: mockUserId === USER_A_ID ? 'clerk_user_a' : 'clerk_user_b',
+      email: mockUserId === USER_A_ID ? 'usera@example.com' : 'userb@example.com',
+      isOwner: mockIsOwner,
+    };
+    next();
+  },
+}));
+
+vi.mock('../../services/geocoding.service.js', () => ({
+  resolveCity: async () => undefined,
+}));
+
+vi.mock('../../services/shading.service.js', () => ({
+  getAllCountryShading: async () => [],
+  getCountryShading: async () => null,
+  getRegionShading: async () => [],
+  invalidateConfigCache: () => undefined,
+}));
+
+const { default: app } = await import('../../server-test-app.js');
+const supertest = (await import('supertest')).default;
+
+// ----------------------------------------------------------------
+// Seed helpers (mirrors security.access-matrix.test.ts Part F)
+// ----------------------------------------------------------------
+
+async function seedUser(db: TestDb, userId: string, isOwner: number) {
+  const now = Date.now();
+  await db
+    .insert(schema.users)
+    .values({
+      id: userId,
+      clerkId: userId === USER_A_ID ? 'clerk_user_a' : 'clerk_user_b',
+      email: `${userId}@example.com`,
+      isOwner,
+      createdAt: new Date(now),
+      updatedAt: new Date(now),
+    })
+    .onConflictDoNothing();
+}
+
+async function seedCountry(db: TestDb) {
+  await db
+    .insert(schema.countries)
+    .values({ countryCode: 'US', name: 'United States' })
+    .onConflictDoNothing();
+}
+
+async function seedTrip(db: TestDb, userId: string): Promise<number> {
+  const now = new Date().toISOString();
+  const [trip] = await db
+    .insert(schema.trips)
+    .values({
+      name: 'Test Trip',
+      startDate: '2026-01-01',
+      endDate: '2026-01-10',
+      status: 'planning',
+      userId,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .returning({ id: schema.trips.id });
+  return trip.id;
+}
+
+/** Cities are global reference data — no userId column. */
+async function seedCity(
+  db: TestDb,
+  name: string,
+  overrides: Partial<typeof schema.cities.$inferInsert> = {},
+): Promise<number> {
+  const [city] = await db
+    .insert(schema.cities)
+    .values({ name, countryCode: 'US', geocodeStatus: 'needs_attention', ...overrides })
+    .returning({ id: schema.cities.id });
+  return city.id;
+}
+
+async function seedTripPlace(
+  db: TestDb,
+  tripId: number,
+  cityId: number,
+  userId: string,
+): Promise<number> {
+  const now = new Date().toISOString();
+  const [place] = await db
+    .insert(schema.tripPlaces)
+    .values({ tripId, cityId, userId, createdAt: now, updatedAt: now })
+    .returning({ id: schema.tripPlaces.id });
+  return place.id;
+}
+
+/** ids present in a queue response, tolerant of an empty/absent body. */
+function idsOf(body: unknown): number[] {
+  return Array.isArray(body) ? body.map((c: { id: number }) => c.id) : [];
+}
+
+beforeEach(async () => {
+  testDb = await createTestDb();
+  mockAuthEnabled = true;
+  mockIsOwner = 1;
+  mockUserId = USER_A_ID;
+  await seedUser(testDb, USER_A_ID, 1);
+  await seedUser(testDb, USER_B_ID, 0);
+  await seedCountry(testDb);
+});
+
+afterEach(() => {
+  testDb = null;
+  mockAuthEnabled = true;
+  mockIsOwner = 1;
+  mockUserId = USER_A_ID;
+});
+
+// ================================================================
+// Criterion 4 (ADL-55 §7.4 / §5.1) — THE SECURITY BAR. Cross-user isolation:
+// the queue returns only cities referenced by the requester's own trips/places;
+// a needs_attention city referenced SOLELY by USER_B never appears for USER_A.
+// ================================================================
+// GE-19 RED BAR (BUG-85) — unskip when implemented
+describe.skip('GE-19 RED BAR (BUG-85) §7.4 — GET /api/geocode-queue is userId-scoped (SECURITY)', () => {
+  it("USER_A's queue contains their own stuck city and NEVER USER_B's solely-referenced stuck city", async () => {
+    // USER_A's stuck city.
+    const tripA = await seedTrip(testDb!, USER_A_ID);
+    const cityA = await seedCity(testDb!, 'AlphaTown', { geocodeCause: 'ambiguous' });
+    await seedTripPlace(testDb!, tripA, cityA, USER_A_ID);
+
+    // USER_B's stuck city — referenced ONLY by USER_B.
+    const tripB = await seedTrip(testDb!, USER_B_ID);
+    const cityB = await seedCity(testDb!, 'BravoCity', { geocodeCause: 'ambiguous' });
+    await seedTripPlace(testDb!, tripB, cityB, USER_B_ID);
+
+    mockUserId = USER_A_ID;
+    const res = await supertest(app).get('/api/geocode-queue');
+
+    expect(res.status).toBe(200);
+    const ids = idsOf(res.body);
+    expect(ids).toContain(cityA); // own stuck city visible
+    expect(ids).not.toContain(cityB); // another user's stuck city is invisible
+  });
+
+  it("USER_B does not see USER_A's stuck city either (symmetry)", async () => {
+    const tripA = await seedTrip(testDb!, USER_A_ID);
+    const cityA = await seedCity(testDb!, 'AlphaTown', { geocodeCause: 'ambiguous' });
+    await seedTripPlace(testDb!, tripA, cityA, USER_A_ID);
+
+    mockUserId = USER_B_ID;
+    mockIsOwner = 0;
+    const res = await supertest(app).get('/api/geocode-queue');
+
+    expect(res.status).toBe(200);
+    expect(idsOf(res.body)).not.toContain(cityA);
+  });
+});
+
+// ================================================================
+// Criterion 5 (ADL-55 §7.5 / §5.1) — the queue EXCLUDES resolved cities and
+// cities the user no longer references (the last referencing place removed).
+// ================================================================
+// GE-19 RED BAR (BUG-85) — unskip when implemented
+describe.skip('GE-19 RED BAR (BUG-85) §7.5 — queue excludes resolved and no-longer-referenced cities', () => {
+  it('a resolved city and an unreferenced city are absent; a still-referenced stuck city is present', async () => {
+    const tripA = await seedTrip(testDb!, USER_A_ID);
+
+    // Still referenced + stuck → present.
+    const cityStuck = await seedCity(testDb!, 'StuckTown', { geocodeCause: 'ambiguous' });
+    await seedTripPlace(testDb!, tripA, cityStuck, USER_A_ID);
+
+    // Referenced but resolved → excluded (query is WHERE status <> 'resolved').
+    const cityResolved = await seedCity(testDb!, 'ResolvedTown', {
+      geocodeStatus: 'resolved',
+      latitude: 1,
+      longitude: 2,
+    });
+    await seedTripPlace(testDb!, tripA, cityResolved, USER_A_ID);
+
+    // Stuck, but its only referencing place is then removed → excluded.
+    const cityUnref = await seedCity(testDb!, 'AbandonedTown', { geocodeCause: 'ambiguous' });
+    const placeUnref = await seedTripPlace(testDb!, tripA, cityUnref, USER_A_ID);
+    // The user removes the last place referencing it (the DELETE-place recovery
+    // lever); modelled here as the row removal that lever performs.
+    await testDb!.delete(schema.tripPlaces).where(eq(schema.tripPlaces.id, placeUnref));
+
+    mockUserId = USER_A_ID;
+    const res = await supertest(app).get('/api/geocode-queue');
+
+    expect(res.status).toBe(200);
+    const ids = idsOf(res.body);
+    expect(ids).toContain(cityStuck);
+    expect(ids).not.toContain(cityResolved); // resolved cities never in the queue
+    expect(ids).not.toContain(cityUnref); // no longer referenced → left the queue
+  });
+});
+
+// ================================================================
+// Criterion 8 (ADL-55 §7.8) — RE-POINT RECOVERY. Re-pointing the last place off
+// a stuck city onto a corrected city drops the abandoned stuck city from the
+// user's queue. Uses the REAL GE-16 re-point route.
+//
+// NOTE (QA finding): the ADL/brief/tracker cite the re-point path as
+// `PATCH /api/places/:id`, but no such route exists — placesRouter is mounted
+// under trips (trips.ts:47), so the built path is
+// `PATCH /api/trips/:tripId/places/:placeId` (places.ts:121, accepting city_id
+// via UpdatePlaceDatesSchema). This suite uses the real path.
+// ================================================================
+// GE-19 RED BAR (BUG-85) — unskip when implemented
+describe.skip('GE-19 RED BAR (BUG-85) §7.8 — re-point drops the abandoned stuck city from the queue', () => {
+  it('after re-pointing the last place onto a corrected city, the stuck city leaves the queue', async () => {
+    const tripA = await seedTrip(testDb!, USER_A_ID);
+    const cityStuck = await seedCity(testDb!, 'MistypedTown', { geocodeCause: 'ambiguous' });
+    const place = await seedTripPlace(testDb!, tripA, cityStuck, USER_A_ID);
+    const cityGood = await seedCity(testDb!, 'CorrectTown', {
+      geocodeStatus: 'resolved',
+      latitude: 1,
+      longitude: 2,
+    });
+
+    mockUserId = USER_A_ID;
+
+    // Re-point the place onto the corrected city (the real GE-16 recovery lever).
+    const patchRes = await supertest(app)
+      .patch(`/api/trips/${tripA}/places/${place}`)
+      .send({ city_id: cityGood });
+    expect(patchRes.status).toBe(200); // re-point route works on main
+
+    // The abandoned stuck city is now referenced by nothing of USER_A's.
+    const res = await supertest(app).get('/api/geocode-queue');
+    expect(res.status).toBe(200);
+    expect(idsOf(res.body)).not.toContain(cityStuck);
+  });
+});
+
+// ================================================================
+// Criterion 10 (ADL-55 §7.10 / §4) — needs_attention AND unresolvable rows are
+// counted in the NEEDS-ATTENTION bucket, not the in-progress/resolving count.
+// The endpoint returns each city's geocode_status so the client can split
+// status='pending' (in-progress) from status IN ('needs_attention',
+// 'unresolvable') (needs-attention) without conflation.
+// ================================================================
+// GE-19 RED BAR (BUG-85) — unskip when implemented
+describe.skip('GE-19 RED BAR (BUG-85) §7.10 — needs_attention/unresolvable bucketed apart from in-progress', () => {
+  it('returns pending, needs_attention and unresolvable rows distinguishably so the two buckets never conflate', async () => {
+    const tripA = await seedTrip(testDb!, USER_A_ID);
+
+    const cityPending = await seedCity(testDb!, 'PendingTown', { geocodeStatus: 'pending' });
+    await seedTripPlace(testDb!, tripA, cityPending, USER_A_ID);
+
+    const cityNeedsAttn = await seedCity(testDb!, 'AttnTown', {
+      geocodeStatus: 'needs_attention',
+      geocodeCause: 'ambiguous',
+    });
+    await seedTripPlace(testDb!, tripA, cityNeedsAttn, USER_A_ID);
+
+    const cityUnresolvable = await seedCity(testDb!, 'NoMatchTown', {
+      geocodeStatus: 'unresolvable',
+    });
+    await seedTripPlace(testDb!, tripA, cityUnresolvable, USER_A_ID);
+
+    mockUserId = USER_A_ID;
+    const res = await supertest(app).get('/api/geocode-queue');
+
+    expect(res.status).toBe(200);
+    const body = res.body as Array<{ id: number; geocode_status: string }>;
+    const ids = body.map((c) => c.id);
+    expect(ids).toEqual(expect.arrayContaining([cityPending, cityNeedsAttn, cityUnresolvable]));
+
+    const inProgress = body.filter((c) => c.geocode_status === 'pending');
+    const needsAttention = body.filter((c) =>
+      ['needs_attention', 'unresolvable'].includes(c.geocode_status),
+    );
+    expect(inProgress.map((c) => c.id)).toEqual([cityPending]); // exactly the pending row
+    expect(needsAttention.map((c) => c.id).sort()).toEqual(
+      [cityNeedsAttn, cityUnresolvable].sort((a, b) => a - b),
+    );
+  });
+});

--- a/src/backend/services/__tests__/cityIdentity.ge19-reopen-reuse.test.ts
+++ b/src/backend/services/__tests__/cityIdentity.ge19-reopen-reuse.test.ts
@@ -1,0 +1,226 @@
+/**
+ * GE-19 / BUG-85 — ATDD RED BAR for the geocode status-lifecycle model.
+ * Acceptance criteria 6 and 7 from ADL-55 §7 (identity-service level,
+ * findOrUpgradeCity).
+ *
+ * Criterion 7 (§7.7 — the F1 in-place re-open the fresh-eyes review caught) is
+ * RED on current main: findRegionlessUpgradeCandidate's whitelist
+ * (['pending','unresolvable'], cities.ts:253) excludes 'needs_attention', so a
+ * region-less stuck row is never adopted; and even if it were, the upgrade
+ * UPDATE (cityIdentityService.ts:96-100) does not reset status/cause and the
+ * re-fire guard (:106) only fires for a 'pending' row. It is committed
+ * `describe.skip` with the RED-BAR marker; the Backend brief un-skips it.
+ *
+ * Criterion 6 (§7.6 — re-adding a needs_attention city reuses the row, asserting
+ * §8 status-blindness) is GREEN on main: findByIdentityKey (cities.ts:206) is
+ * already status-blind, so a re-add finds the existing row before any insert.
+ * It is therefore LEFT UN-SKIPPED as a regression guard — the status-blindness
+ * it protects is a PREMISE the needs_attention transition relies on (a
+ * needs_attention row leaves the pending partial index, so if step 1 were not
+ * status-blind a re-add could mint a duplicate). It must survive the build.
+ *
+ * MOCK FIDELITY (QUAL-22): real libSQL (:memory:) with the real migrations —
+ * real partial unique indexes, real CHECK constraints. resolveCity /
+ * resolveByOsmId are mocked to no-op spies so (a) the re-fired resolution does
+ * not mutate the row out from under the reset assertions, and (b) criterion 7
+ * can assert the re-fire was TRIGGERED without a network.
+ */
+
+import { and, eq } from 'drizzle-orm';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as schema from '../../db/schema.js';
+import { createTestDb, type TestDb } from '../../repositories/__tests__/test-db.js';
+
+const USER_A = 'user-a-00000000-0000-0000-0000-000000000000';
+
+let testDb: TestDb | null = null;
+
+vi.mock('../../db/index.js', async (importOriginal) => {
+  const real = await importOriginal<typeof import('../../db/index.js')>();
+  return {
+    ...real,
+    getDb: () => {
+      if (!testDb) throw new Error('[TEST] testDb not initialised');
+      return testDb;
+    },
+  };
+});
+
+// Spy on the geocoder so the fire-and-forget re-resolve cannot race the reset
+// assertions, and so the re-fire itself is observable.
+const { resolveCitySpy, resolveByOsmIdSpy } = vi.hoisted(() => ({
+  resolveCitySpy: vi.fn(async () => undefined),
+  resolveByOsmIdSpy: vi.fn(async () => null),
+}));
+vi.mock('../geocoding.service.js', () => ({
+  resolveCity: resolveCitySpy,
+  resolveByOsmId: resolveByOsmIdSpy,
+}));
+
+const { findOrUpgradeCity } = await import('../cityIdentityService.js');
+
+// ----------------------------------------------------------------
+// Seed helpers
+// ----------------------------------------------------------------
+
+async function seedUserA(db: TestDb) {
+  const now = Date.now();
+  await db
+    .insert(schema.users)
+    .values({
+      id: USER_A,
+      clerkId: 'clerk_user_a',
+      email: 'usera@example.com',
+      isOwner: 1,
+      createdAt: new Date(now),
+      updatedAt: new Date(now),
+    })
+    .onConflictDoNothing();
+}
+
+async function seedRegionTierUS(db: TestDb): Promise<number> {
+  await db
+    .insert(schema.countries)
+    .values({ countryCode: 'US', name: 'United States', regionTierEnabled: 1 })
+    .onConflictDoNothing();
+  const [region] = await db
+    .insert(schema.regions)
+    .values({ countryCode: 'US', name: 'Colorado', iso3166_2: 'US-CO' })
+    .returning();
+  return region.id;
+}
+
+async function seedCity(
+  db: TestDb,
+  overrides: Partial<typeof schema.cities.$inferInsert>,
+): Promise<number> {
+  const [city] = await db
+    .insert(schema.cities)
+    .values({ name: 'Denver', countryCode: 'US', geocodeStatus: 'pending', ...overrides })
+    .returning();
+  return city.id;
+}
+
+async function readCity(cityId: number) {
+  const [row] = await testDb!.select().from(schema.cities).where(eq(schema.cities.id, cityId));
+  return row;
+}
+
+async function countByName(name: string) {
+  const rows = await testDb!
+    .select()
+    .from(schema.cities)
+    .where(and(eq(schema.cities.name, name), eq(schema.cities.countryCode, 'US')));
+  return rows.length;
+}
+
+beforeEach(async () => {
+  testDb = await createTestDb();
+  await seedUserA(testDb);
+  resolveCitySpy.mockClear();
+  resolveByOsmIdSpy.mockClear();
+});
+
+afterEach(() => {
+  testDb = null;
+});
+
+// ================================================================
+// Criterion 6 (ADL-55 §7.6 / §8) — DUPLICATE-SAFETY. Re-adding a
+// needs_attention city with the same (name, country, region) REUSES the
+// existing row (no second row). GREEN on main — regression guard, NOT a red
+// bar. Left UN-SKIPPED.
+// ================================================================
+describe('GE-19 REGRESSION GUARD (BUG-85) §7.6 — re-add of a needs_attention city reuses the row (GREEN on main)', () => {
+  it('findOrUpgradeCity returns the existing needs_attention row, minting no duplicate (status-blind step 1)', async () => {
+    const regionId = await seedRegionTierUS(testDb!);
+    const existingId = await seedCity(testDb!, {
+      name: 'Denver',
+      regionId,
+      geocodeStatus: 'needs_attention',
+      geocodeCause: 'ambiguous',
+      createdByUserId: USER_A,
+    });
+
+    // Re-add the SAME identity (name, country, region).
+    const result = await findOrUpgradeCity('Denver', 'US', regionId, USER_A);
+
+    expect(result).not.toBeNull();
+    expect(result?.id).toBe(existingId); // reused, not re-created
+    expect(await countByName('Denver')).toBe(1); // no second row
+    // The reused terminal row is returned untouched (status-blind reuse).
+    expect(result?.geocodeStatus).toBe('needs_attention');
+  });
+});
+
+// ================================================================
+// Criterion 7 (ADL-55 §7.7 / §R F1) — IN-PLACE RE-OPEN. Supplying a region for
+// a REGION-LESS needs_attention city adopts that same row and RESETS it to
+// pending / attempts 0 / cause null (region set), then RE-FIRES resolution.
+// RED on main (whitelist excludes needs_attention; no status/cause reset; the
+// re-fire guard only fires for 'pending'). Assert the reset EXPLICITLY.
+// ================================================================
+// GE-19 RED BAR (BUG-85) — unskip when implemented
+describe.skip('GE-19 RED BAR (BUG-85) §7.7 — region supplied re-opens a region-less needs_attention row in place', () => {
+  it('resets the region-less needs_attention row to pending/attempts 0/cause null, sets the region, and re-fires resolveCity', async () => {
+    const regionId = await seedRegionTierUS(testDb!);
+    // A region-LESS needs_attention row (region_id NULL), some retry budget spent.
+    const stuckId = await seedCity(testDb!, {
+      name: 'Denver',
+      regionId: null,
+      geocodeStatus: 'needs_attention',
+      geocodeCause: 'ambiguous',
+      geocodeAttempts: 3,
+      createdByUserId: USER_A,
+    });
+
+    // Supplying the region should ADOPT this exact row (wildcard upgrade), not
+    // insert a new one.
+    const result = await findOrUpgradeCity('Denver', 'US', regionId, USER_A);
+
+    // Re-read the ORIGINAL row by id so the assertions are deterministic even
+    // when findOrUpgradeCity returns null today (the row is simply not adopted).
+    const row = await readCity(stuckId);
+
+    // TARGET (all RED on main — today the row is untouched: still
+    // needs_attention / cause 'ambiguous' / attempts 3 / region NULL, and
+    // findOrUpgradeCity returns null so nothing is re-fired).
+    expect(row.geocodeStatus).toBe('pending'); // §R F1: status reset (the third edit)
+    expect(row.geocodeCause).toBeNull(); // cause cleared
+    expect(row.geocodeAttempts).toBe(0); // retry budget reset
+    expect(row.regionId).toBe(regionId); // region now set
+    expect(result?.id).toBe(stuckId); // adopted in place — not a new insert
+    expect(await countByName('Denver')).toBe(1); // no duplicate row
+    expect(resolveCitySpy).toHaveBeenCalledWith(stuckId); // resolution re-fired
+  });
+});
+
+// ================================================================
+// Criterion 7 counterpart (ADL-55 §3.3 / §R F1 "asymmetry preserved untouched")
+// — a region-less UNRESOLVABLE row IS upgradeable (region set, attempts reset)
+// but stays 'unresolvable' and is NOT re-fired: a no-match cannot become a
+// match by adding a region. GREEN on main (the whitelist already includes
+// 'unresolvable' and the re-fire guard only fires for 'pending') — a regression
+// guard so the F1 build does not accidentally start re-firing no-match rows.
+// Left UN-SKIPPED.
+// ================================================================
+describe('GE-19 REGRESSION GUARD (BUG-85) §3.3 — unresolvable re-open asymmetry preserved (GREEN on main)', () => {
+  it('an adopted unresolvable region-less row is upgraded but NOT status-reset and NOT re-fired', async () => {
+    const regionId = await seedRegionTierUS(testDb!);
+    const noMatchId = await seedCity(testDb!, {
+      name: 'Denver',
+      regionId: null,
+      geocodeStatus: 'unresolvable',
+      geocodeAttempts: 2,
+      createdByUserId: USER_A,
+    });
+
+    const result = await findOrUpgradeCity('Denver', 'US', regionId, USER_A);
+
+    const row = await readCity(noMatchId);
+    expect(result?.id).toBe(noMatchId);
+    expect(row.regionId).toBe(regionId);
+    expect(row.geocodeStatus).toBe('unresolvable');
+    expect(resolveCitySpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/backend/services/__tests__/geocoding.ge19-lifecycle.test.ts
+++ b/src/backend/services/__tests__/geocoding.ge19-lifecycle.test.ts
@@ -1,0 +1,266 @@
+/**
+ * GE-19 / BUG-85 — ATDD RED BAR for the geocode status-lifecycle model.
+ * Acceptance criteria 1, 2, 3 from ADL-55 §7 (service level, resolveCity).
+ *
+ * These are the executable definition of done the Backend brief builds against.
+ * Criteria 1 and 2 assert the NEW terminal-state transitions and are RED on
+ * current main (the transitions are unbuilt — a stuck row stays 'pending').
+ * They are committed with `describe.skip` + a per-block RED-BAR marker so CI
+ * stays green (skipped tests do not execute); the Backend brief un-skips each
+ * block as it greens it, and a weakened assertion shows in that diff.
+ *
+ * Criterion 3 is an UNCHANGED-behaviour regression guard (ADL-55 §7.3 / §3.2:
+ * no-match → 'unresolvable' is D10 behaviour, disabled increments nothing) — it
+ * is GREEN on main and is therefore left UN-SKIPPED as a live guard, not a red
+ * bar. It must survive the build. See the QA completion report for the split.
+ *
+ * MOCK FIDELITY (QUAL-22): runs against a real libSQL (:memory:) instance built
+ * from the real migrations (createTestDb — real CHECK constraints incl. the
+ * merged `needs_attention`/`geocode_cause` substrate, real partial unique
+ * indexes). Only the Nominatim egress chokepoint (nominatim-client) is mocked,
+ * so the verdict each branch of resolveCity sees is controllable without a
+ * network — the identical pattern to geocoding.service.test.ts. Both
+ * nominatimSearch (name-search path) and nominatimLookup (carried-OSM path)
+ * are faked because criterion 2 covers BOTH recoverable-error sites (ADL-55 §R
+ * F2: geocoding.service.ts ~:413 carried-OSM and ~:458 name-search).
+ */
+
+import { eq } from 'drizzle-orm';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as schema from '../../db/schema.js';
+import { createTestDb, type TestDb } from '../../repositories/__tests__/test-db.js';
+import type { NominatimSearchResult } from '../nominatim-client.js';
+
+let testDb: TestDb | null = null;
+
+vi.mock('../../db/index.js', async (importOriginal) => {
+  const real = await importOriginal<typeof import('../../db/index.js')>();
+  return {
+    ...real,
+    getDb: () => {
+      if (!testDb) throw new Error('[TEST] testDb not initialised');
+      return testDb;
+    },
+  };
+});
+
+// Controllable chokepoint — each test sets what the next name-search AND the
+// next id-lookup return. resolveCity uses nominatimSearch on the non-carried
+// path and nominatimLookup on the carried-osm-ref path.
+let nextSearchResult: NominatimSearchResult = { status: 'ok', candidates: [] };
+let nextLookupResult: NominatimSearchResult = { status: 'ok', candidates: [] };
+vi.mock('../nominatim-client.js', () => ({
+  nominatimSearch: vi.fn(async () => nextSearchResult),
+  nominatimLookup: vi.fn(async () => nextLookupResult),
+}));
+
+const { resolveCity } = await import('../geocoding.service.js');
+
+// ----------------------------------------------------------------
+// Seed helpers (self-contained — mirrors geocoding.service.test.ts)
+// ----------------------------------------------------------------
+
+/** Region-less US city (non-region-tier), driven via the name-search path. */
+async function seedPlainCity(
+  db: TestDb,
+  overrides: Partial<typeof schema.cities.$inferInsert> = {},
+): Promise<number> {
+  await db
+    .insert(schema.countries)
+    .values({ countryCode: 'US', name: 'United States', regionTierEnabled: 0 })
+    .onConflictDoNothing();
+  const [city] = await db
+    .insert(schema.cities)
+    .values({ name: 'Testville', countryCode: 'US', geocodeStatus: 'pending', ...overrides })
+    .returning();
+  return city.id;
+}
+
+/** Region-tier US city carrying US-CO, needed to drive the region-aware
+ * ambiguity branch (region-unconfirmed). */
+async function seedRegionCity(
+  db: TestDb,
+  overrides: Partial<typeof schema.cities.$inferInsert> = {},
+): Promise<number> {
+  await db
+    .insert(schema.countries)
+    .values({ countryCode: 'US', name: 'United States', regionTierEnabled: 1 })
+    .onConflictDoNothing();
+  const [region] = await db
+    .insert(schema.regions)
+    .values({ countryCode: 'US', name: 'Colorado', iso3166_2: 'US-CO' })
+    .returning();
+  const [city] = await db
+    .insert(schema.cities)
+    .values({
+      name: 'Denver',
+      countryCode: 'US',
+      regionId: region.id,
+      geocodeStatus: 'pending',
+      ...overrides,
+    })
+    .returning();
+  return city.id;
+}
+
+function candidate(
+  overrides: { name?: string; regionIso?: string | null; lat?: number; lon?: number } = {},
+) {
+  return {
+    displayName: overrides.name ?? 'Testville',
+    name: overrides.name ?? 'Testville',
+    latitude: overrides.lat ?? 1,
+    longitude: overrides.lon ?? 1,
+    countryCode: 'US',
+    regionIso: overrides.regionIso ?? null,
+    class: 'place',
+    type: 'city',
+  };
+}
+
+async function readCity(cityId: number) {
+  const [row] = await testDb!.select().from(schema.cities).where(eq(schema.cities.id, cityId));
+  return row;
+}
+
+beforeEach(async () => {
+  testDb = await createTestDb();
+  vi.stubEnv('GEOCODING_ENABLED', 'true');
+  nextSearchResult = { status: 'ok', candidates: [] };
+  nextLookupResult = { status: 'ok', candidates: [] };
+});
+
+afterEach(() => {
+  testDb = null;
+  vi.unstubAllEnvs();
+});
+
+// ================================================================
+// Criterion 1 (ADL-55 §7.1 / D1a / OQ-3) — an AMBIGUOUS verdict is terminal on
+// the FIRST verdict: the row lands needs_attention/ambiguous, coordinates stay
+// NULL, and NO further retry budget is consumed (attempts unchanged).
+// ================================================================
+// GE-19 RED BAR (BUG-85) — unskip when implemented
+describe.skip('GE-19 RED BAR (BUG-85) §7.1 — ambiguous verdict → needs_attention/ambiguous, no retries', () => {
+  it('an ambiguous verdict marks the row needs_attention with cause=ambiguous and does NOT increment attempts', async () => {
+    const cityId = await seedRegionCity(testDb!, { geocodeAttempts: 0 }); // regionIso = US-CO
+    // Two candidates that disagree with the row's selected region (US-CO) and
+    // with each other → classifyCandidates returns ambiguous/region-unconfirmed.
+    nextSearchResult = {
+      status: 'ok',
+      candidates: [
+        candidate({ name: 'Denver', regionIso: 'US-TX' }),
+        candidate({ name: 'Denver', regionIso: 'US-NY' }),
+      ],
+    };
+
+    const ok = await resolveCity(cityId);
+    expect(ok).toBe(false);
+
+    const row = await readCity(cityId);
+    // TARGET (RED on main — today this branch increments attempts and stays 'pending').
+    expect(row.geocodeStatus).toBe('needs_attention');
+    expect(row.geocodeCause).toBe('ambiguous');
+    expect(row.geocodeAttempts).toBe(0); // OQ-3: deterministic answer — no retry spent
+    expect(row.latitude).toBeNull();
+    expect(row.longitude).toBeNull();
+  });
+
+  it('a needs_attention row is terminal — resolveCity does not re-resolve it against its will (§R F3)', async () => {
+    // Seed a row already in the target terminal state (the substrate admits it).
+    const cityId = await seedRegionCity(testDb!, {
+      geocodeStatus: 'needs_attention',
+      geocodeCause: 'ambiguous',
+    });
+    // Even a resolvable answer waiting in the chokepoint must not touch it,
+    // because resolveCity early-returns on a needs_attention row (ADL-55 §R F3).
+    nextSearchResult = {
+      status: 'ok',
+      candidates: [candidate({ name: 'Denver', regionIso: 'US-CO' })],
+    };
+
+    const ok = await resolveCity(cityId);
+    expect(ok).toBe(false); // not re-resolved against its will
+
+    const row = await readCity(cityId);
+    expect(row.geocodeStatus).toBe('needs_attention');
+    expect(row.latitude).toBeNull();
+  });
+});
+
+// ================================================================
+// Criterion 2 (ADL-55 §7.2 / §R F2) — a row hitting GEOCODE_ATTEMPT_CAP
+// RECOVERABLE errors transitions to needs_attention/unreachable rather than
+// sitting 'pending'-at-cap forever. BOTH recoverable-error sites are covered:
+// the name-search path (~geocoding.service.ts:458) and the carried-OSM path
+// (~:413). Cap is 5; seed attempts=4 so the next failing attempt is the cap.
+// ================================================================
+// GE-19 RED BAR (BUG-85) — unskip when implemented
+describe.skip('GE-19 RED BAR (BUG-85) §7.2 — recoverable error at cap → needs_attention/unreachable (both sites)', () => {
+  it('name-search site: an error at the attempt cap transitions to needs_attention/unreachable, never pending-at-cap', async () => {
+    const cityId = await seedPlainCity(testDb!, { geocodeAttempts: 4 });
+    nextSearchResult = { status: 'error' }; // recoverable (network/timeout/5xx/429)
+
+    const ok = await resolveCity(cityId);
+    expect(ok).toBe(false);
+
+    const row = await readCity(cityId);
+    // TARGET (RED on main — today it increments to 5 and stays 'pending' forever).
+    expect(row.geocodeStatus).toBe('needs_attention');
+    expect(row.geocodeCause).toBe('unreachable');
+    expect(row.geocodeAttempts).toBe(5); // the failing attempt still counts
+  });
+
+  it('carried-OSM site: a lookup error at the attempt cap transitions to needs_attention/unreachable', async () => {
+    // A row carrying an OSM ref is canonicalized via nominatimLookup, not search.
+    const cityId = await seedPlainCity(testDb!, {
+      geocodeAttempts: 4,
+      osmType: 'node',
+      osmId: 12345,
+    });
+    nextLookupResult = { status: 'error' }; // recoverable on the /lookup path
+
+    const ok = await resolveCity(cityId);
+    expect(ok).toBe(false);
+
+    const row = await readCity(cityId);
+    // TARGET (RED on main — today the carried-ref error branch increments and
+    // stays 'pending' at cap, ADL-55 §R F2 site ~:413).
+    expect(row.geocodeStatus).toBe('needs_attention');
+    expect(row.geocodeCause).toBe('unreachable');
+    expect(row.geocodeAttempts).toBe(5);
+  });
+});
+
+// ================================================================
+// Criterion 3 (ADL-55 §7.3 / §3.2) — UNCHANGED behaviour (D10). This is a
+// REGRESSION GUARD, GREEN on main, deliberately LEFT UN-SKIPPED so it protects
+// the invariant continuously through the GE-19 build. It is NOT a red bar.
+//   - no-match ('the geocoder answered, zero usable') → 'unresolvable', terminal.
+//   - a disabled/global condition increments nothing.
+// ================================================================
+describe('GE-19 REGRESSION GUARD (BUG-85) §7.3 — no-match unchanged; disabled increments nothing (GREEN on main)', () => {
+  it("no-match marks the row 'unresolvable' and does not consume a recoverable attempt", async () => {
+    const cityId = await seedPlainCity(testDb!, { geocodeAttempts: 0 });
+    nextSearchResult = { status: 'ok', candidates: [] }; // geocoder answered, nothing usable
+
+    const ok = await resolveCity(cityId);
+    expect(ok).toBe(false);
+
+    const row = await readCity(cityId);
+    expect(row.geocodeStatus).toBe('unresolvable');
+    expect(row.geocodeAttempts).toBe(0);
+  });
+
+  it('GEOCODING_ENABLED=false (global) does NOT increment geocode_attempts', async () => {
+    const cityId = await seedPlainCity(testDb!, { geocodeAttempts: 2 });
+    vi.stubEnv('GEOCODING_ENABLED', 'false');
+
+    const ok = await resolveCity(cityId);
+    expect(ok).toBe(false);
+
+    const row = await readCity(cityId);
+    expect(row.geocodeStatus).toBe('pending');
+    expect(row.geocodeAttempts).toBe(2); // unchanged — offline is not a per-city failure
+  });
+});


### PR DESCRIPTION
**Tracker:** BUG-85 · **BRD:** GE-19 (v3.20) · **Spec:** ADL-55 §7 (criteria 1–8, 10)
**Class (OP-32):** gap · **Role:** independent ATDD red bar — QA writes the bar, does NOT implement the behaviour.

Not `Closes` — GE-19/BUG-85 close when the feature is built. This PR is the executable definition of done the Backend + Frontend briefs build against.

## What this is
Acceptance tests for ADL-55 §7 criteria 1–8 and 10, service + API level, against a real libSQL instance (`createTestDb` — real migrations/CHECKs/partial unique indexes, QUAL-22). Criterion 4 (the security bar) seeds two distinct real users.

Red-bar blocks are `describe.skip` + inline marker `// GE-19 RED BAR (BUG-85) — unskip when implemented` (7 blocks) so **CI stays green** (skipped tests don't run). The Backend brief un-skips each block as it greens it; a weakened assertion shows in that diff.

## RED bar (each demonstrated failing un-skipped on `main` 524e32b — 10 failed | 4 passed)
| Crit | Level | RED |
|---|---|---|
| 1 §7.1 | `resolveCity` | ambiguous → needs_attention/ambiguous, attempts unchanged (`'pending'`→needs_attention) |
| 2 §7.2 | `resolveCity` | recoverable @cap → needs_attention/unreachable — **both** F2 sites (name-search + carried-OSM) |
| 4 §7.4 | `GET /api/geocode-queue` | userId-scoped, USER_B's stuck city never shown to USER_A (SECURITY) |
| 5 §7.5 | API | queue excludes resolved + no-longer-referenced cities |
| 7 §7.7 | `findOrUpgradeCity` | region re-opens a region-less needs_attention row in place (the F1 gap) |
| 8 §7.8 | API | re-point drops the abandoned stuck city from the queue |
| 10 §7.10 | API | needs_attention/unresolvable bucketed apart from in-progress |

## GREEN guards (already hold on `main` — kept UN-SKIPPED, not red bars)
Criteria the ADL marks **unchanged** invariants: crit 3 (§7.3 no-match/disabled), crit 6 (§7.6 status-blind re-add reuse — the premise the transition relies on), §3.3 unresolvable re-open asymmetry. A passing test here is a correct invariant, not a wrong bar.

## Findings for the COO (2)
1. **Re-point path wrong in ADL-55 D2 / brief / BUG-85 tracker** — all cite `PATCH /api/places/:id` "verified built". No such route exists (two probes: grep for any `/api/places` mount = none; read `trips.ts:47` + `places.ts:121`). The real, built path is `PATCH /api/trips/:tripId/places/:placeId`. The mechanism works (crit 8's PATCH returns 200 in the red run); only the documented path string is wrong. Recommend correcting the tracker/ADL pointer.
2. The bar **pins** the `GET /api/geocode-queue` contract to the ADL-55 §5.1 columns (JSON array; each item `id` + `geocode_status` snake_case). The endpoint does not exist today (two probes: grep finds no registration in `routes/`/`server-test-app.ts`; the suite returns 404). Backend reconciles the envelope in the un-skip diff.

## Out of scope (owned elsewhere)
crit 9 (label strings) = Frontend component tests; crit 11 (`nextGeocodeState` table test) = Backend, co-located with the pure function.

## Verification
Full backend suite 849 passed | 10 skipped · frontend 388 passed · type:check:all clean · biome clean · status/tracker/scope checks pass.

Detail: `jobs/qa/tech/20260811-ge19-red-bar.md`. **Do not merge — COO reviews/merges.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)