### PR TITLE
feat(GE-19): backend — status lifecycle, cause, userId-scoped queue endpoint (ADL-55)

### DIFF
--- a/jobs/COO/inbox/20260811_0100-BACKEND-ge19-backend-complete.txt
+++ b/jobs/COO/inbox/20260811_0100-BACKEND-ge19-backend-complete.txt
@@ -1,0 +1,45 @@
+BACKEND COMPLETION — GE-19 / BUG-85 backend (geocode status lifecycle)
+Tracker: BUG-85 · BRD: GE-19 (v3.20) · Design: ADL-55 §3/§4/§5/§8/§R
+Branch: feat/ge19-backend · PR: <to be opened this thread>
+
+WHAT: Greened the merged QA red bar (#512). nextGeocodeState pure state machine +
+resolveCity rewired; ambiguous→needs_attention on first verdict (D1a); both
+recoverable-error sites transition at cap (F2); needs_attention early-return (F3);
+findOrUpgradeCity re-opens a needs_attention adoptee + whitelist (F1); stale
+findByIdentityKey comment refreshed (F4); GET /api/geocode-queue (userId-scoped).
+
+ACCEPTANCE CRITERIA (ADL-55 §7):
+  1 ambiguous→needs_attention/ambiguous, no retry .......... PASS
+  2 recoverable at cap→needs_attention/unreachable (both) .. PASS
+  3 no-match/disabled regression guards .................... PASS (stayed green)
+  4 GET /api/geocode-queue userId-scoped (SECURITY) ........ PASS
+  5 excludes resolved / no-longer-referenced ............... PASS
+  6 re-add reuses row (dup-safety) ......................... PASS (stayed green)
+  7 in-place re-open resets + re-fires ..................... PASS
+  8 re-point drops abandoned city .......................... PASS
+  9 (label rendering) ...................................... FRONTEND scope (not built)
+  10 needs_attention/unresolvable bucketed apart ........... PASS
+  11 nextGeocodeState table test ........................... PASS (new, mine)
+All 7 RED BAR describe.skip blocks un-skipped; git diff confirms NO QA assertion changed.
+
+SECURITY (OP-06, GET /api/geocode-queue):
+  1 Auth: global requireAuth (app.use('/api/', requireAuth)); no owner gate owed.
+  2 Scope: query composes scopeToUser(trips, userId) — structural isolation, no
+    hand-rolled predicate. scope:check PASS (Check 1 = 0 residuals, Check 2 = 0
+    getDb in routes).
+  3 FK notNull: N/A — no schema change, no new table/user column (0018 already landed).
+
+CONTRACT: ADL matches QA envelope (JSON array; id + snake_case status/cause) — no
+reconciliation needed. Re-point path already fixed on main (#513).
+
+DECLARED (OP-28): updated 2 SUPERSEDED ADL-46 R4 ambiguity assertions in
+geocoding.service.test.ts (backend-owned, NOT a QA/ATDD file) to the D1a lifecycle —
+declared here per OP-28. No full-file rewrites.
+
+DOCS same-PR: api-reference 1.8→1.9 (needs_attention + geocode_cause enum, full
+/api/geocode-queue section). Stale three-state enum corrected.
+
+CI: <scripts/ci-wait.sh pr N — to confirm green before this report is final>.
+UNBLOCKED: the FRONTEND GE-19 brief (poll /api/geocode-queue, retire NR-06
+localStorage, panel UI + label map, criterion 9).
+BLOCKERS: none.

--- a/jobs/COO/inbox/20260811_0100-BACKEND-ge19-backend-complete.txt
+++ b/jobs/COO/inbox/20260811_0100-BACKEND-ge19-backend-complete.txt
@@ -1,6 +1,6 @@
 BACKEND COMPLETION — GE-19 / BUG-85 backend (geocode status lifecycle)
 Tracker: BUG-85 · BRD: GE-19 (v3.20) · Design: ADL-55 §3/§4/§5/§8/§R
-Branch: feat/ge19-backend · PR: <to be opened this thread>
+Branch: feat/ge19-backend · PR: #514
 
 WHAT: Greened the merged QA red bar (#512). nextGeocodeState pure state machine +
 resolveCity rewired; ambiguous→needs_attention on first verdict (D1a); both
@@ -39,7 +39,7 @@ declared here per OP-28. No full-file rewrites.
 DOCS same-PR: api-reference 1.8→1.9 (needs_attention + geocode_cause enum, full
 /api/geocode-queue section). Stale three-state enum corrected.
 
-CI: <scripts/ci-wait.sh pr N — to confirm green before this report is final>.
+CI: GREEN — all 18 checks pass on PR #514 @ 332e92a (ci-wait.sh; true head re-confirmed, QUAL-46).
 UNBLOCKED: the FRONTEND GE-19 brief (poll /api/geocode-queue, retire NR-06
 localStorage, panel UI + label map, criterion 9).
 BLOCKERS: none.

--- a/jobs/backend/context/current.txt
+++ b/jobs/backend/context/current.txt
@@ -1,3 +1,58 @@
+BACKEND CONTEXT — 2026-08-11 (GE-19 / BUG-85 backend — geocode status lifecycle, latest)
+PROJECT: Travel Tracker
+CURRENT STATUS: implemented the GE-19 backend (ADL-55 §3/§4/§5/§8/§R) on branch
+  feat/ge19-backend — greened the merged QA red bar (#512) without weakening any
+  assertion. All 7 `describe.skip` RED BAR blocks un-skipped and GREEN; the
+  nextGeocodeState table test (criterion 11) written and green.
+  1. nextGeocodeState(row, verdict) — the PURE state machine (ADL-55 D5),
+     co-located export in geocoding.service.ts; resolveCity rewired to
+     "produce verdict → nextGeocodeState → apply". applyGeocodeState writes the
+     three policy fields for every non-ok verdict; the ok path stays in
+     commitResolvedOrMerge (which now also clears geocode_cause).
+  2. D1a/OQ-3: an ambiguous verdict → needs_attention/cause='ambiguous' on the
+     FIRST verdict, NO retry consumed (refines ADL-46 D10/R4 — the ambiguous
+     branch used to incrementAttempts + stay pending). incrementAttempts REMOVED
+     (all three call sites now route through nextGeocodeState).
+  3. F2: BOTH recoverable-error sites (carried-OSM ~:407 and name-search ~:447)
+     now transition to needs_attention/unreachable AT the cap (attempts+1>=5),
+     never pending-at-cap. The cap is an active transition; processQueue's
+     WHERE attempts<CAP predicate stays as belt-and-braces.
+  4. F3: resolveCity early-returns on a needs_attention row (not re-resolved unbidden).
+  5. F1 (the third edit): findOrUpgradeCity resets a needs_attention adoptee to
+     geocode_status='pending', geocode_cause=null (so the re-fire guard fires),
+     and findRegionlessUpgradeCandidate's whitelist gained 'needs_attention'.
+     The 'unresolvable' asymmetry is preserved untouched (not reset, not re-fired).
+  6. F4: refreshed the stale findByIdentityKey "unconditional index" comment
+     (cities.ts) — 0017 replaced it with two partials; the sibling claims in
+     cityIdentityService.ts were swept too (same-PR doc-lifecycle).
+  7. D3: citiesRepository.findUserGeocodeQueue(userId) — selectDistinct composing
+     scopeToUser(trips, userId) (mirrors findCarryForwardItems), returns each
+     unresolved city with geocode_status + geocode_cause. New route
+     src/backend/routes/geocode-queue.ts (GET /api/geocode-queue, requireAuth via
+     the global mount, nosemgrep requireAuth-global convention), mounted in BOTH
+     server.ts and server-test-app.ts.
+  SECURITY (OP-06): the endpoint's only gate is the global requireAuth; the queue
+  query composes the QUAL-43 chokepoint (scopeToUser) so cross-user isolation is
+  STRUCTURAL — no hand-rolled ownership. No new table, no new user FK. scope:check
+  PASS (Check 2: 0 getDb in routes — the route delegates to the repo).
+  ADL-vs-QA reconciliation: the endpoint envelope is a JSON array of city objects
+  (id + snake_case geocode_status/geocode_cause), per the QA test's asserted
+  contract — matches ADL-55 §5.1. No divergence found (the re-point path was
+  already corrected on main by #513).
+  TWO PRE-EXISTING TESTS UPDATED (declared, OP-28): geocoding.service.test.ts's two
+  ADL-46 R4 ambiguity assertions ('stays pending'/attempts+1) were SUPERSEDED by
+  D1a and updated to needs_attention/ambiguous/attempts-unchanged. NOT a QA
+  red-bar file, not the frozen ATDD suite — the merged ADL-55 explicitly refines
+  ADL-46 D10. Verified via git diff that the three GE-19 QA files' assertions are
+  unchanged (only describe.skip → describe).
+  DOCS same-PR: api-reference 1.8 → 1.9 (needs_attention + geocode_cause enum;
+  full GET /api/geocode-queue section with the (status,cause)→label map + recovery
+  levers). NOT in my scope (frontend brief): NR-06 localStorage retirement, the
+  panel UI, label rendering (criterion 9). Full backend 871 tests green (57
+  files), type:check:all clean, scope:check PASS, all pre-push green.
+  Full detail: jobs/backend/park-docs/20260811-BACKEND-ge19-park.txt
+
+=== PRIOR STATUS: QUAL-49 entity-serializers thread ===
 BACKEND CONTEXT — 2026-08-10 (QUAL-49 entity-serializers thread, latest)
 PROJECT: Travel Tracker
 CURRENT STATUS: extracted per-entity serializers into NEW

--- a/jobs/backend/park-docs/20260811-BACKEND-ge19-park.txt
+++ b/jobs/backend/park-docs/20260811-BACKEND-ge19-park.txt
@@ -1,0 +1,157 @@
+BACKEND PARK DOCUMENT — GE-19 / BUG-85 backend (geocode status lifecycle)
+Date: 2026-08-11
+Branch: feat/ge19-backend  (off main @ 704e6bf)
+Tracker: BUG-85   BRD: GE-19 (v3.20)   Design: ADL-55 §3/§4/§5/§8/§R
+Class (OP-32): gap
+
+================================================================
+WHAT WAS BUILT
+================================================================
+The GE-19 backend — the largest step of the GE-19 rollout. The schema substrate
+(migration 0018, #511) and the QA red bar (#512) plus the re-point path fix (#513)
+were already merged; this brief makes the red bar GREEN by implementing ADL-55's
+state machine, cause persistence, the re-open path folds, and the userId-scoped
+queue endpoint.
+
+--- 1. nextGeocodeState — the pure state machine (ADL-55 D5) ---
+geocoding.service.ts gains an exported pure function
+  nextGeocodeState(row: GeocodeStateInput, verdict: GeocodeLifecycleVerdict)
+    -> { status, attempts, cause }
+covering every §3.2 cell. verdict ∈ {ok, no_match, ambiguous, unreachable,
+disabled}. No DB, no network — the whole lifecycle is a table test (criterion 11,
+new file services/__tests__/nextGeocodeState.test.ts, 13 cases incl. the cap
+boundary attempts=3→pending vs attempts=4→needs_attention).
+
+resolveCity is rewired to "produce verdict → nextGeocodeState → apply":
+  - a new applyGeocodeState(cityId, next) writes {geocodeStatus, geocodeAttempts,
+    geocodeCause, geocodeAttemptedAt, updatedAt} in one UPDATE for every non-ok
+    verdict.
+  - the 'ok' path stays in commitResolvedOrMerge (coordinates + OSM ref + merge
+    fallback), which now ALSO sets geocodeCause: null (a resolved row carries no
+    cause).
+  - the initial SELECT now also reads geocodeAttempts + geocodeCause (needed by
+    the state machine).
+  - the private incrementAttempts() helper is REMOVED — its three call sites
+    (carried-OSM error, name-search error, ambiguous) now all route through
+    nextGeocodeState. `sql` dropped from the drizzle import (was only used there).
+
+--- 2. D1a / OQ-3 — ambiguous is terminal on the first verdict ---
+An ambiguous verdict → needs_attention/cause='ambiguous', attempts UNCHANGED (no
+retry spent). Pre-GE-19 (ADL-46 D10/R4) this incrementAttempts'd and stayed
+pending. Deterministic answer ⇒ retrying was waste; re-askability is preserved by
+the re-open path (F1) resetting attempts when a region is later supplied.
+
+--- 3. F2 — both recoverable-error sites route the cap transition ---
+Both the carried-OSM lookup error (~:407) and the name-search error (~:447) now
+apply nextGeocodeState(row, 'unreachable'): stay pending + attempts+1 below the
+cap; needs_attention/cause='unreachable' AT the cap (attempts+1 >= 5). A row never
+sits pending-at-cap. processQueue's WHERE attempts<CAP predicate is kept as
+defense-in-depth.
+
+--- 4. F3 — needs_attention early-return ---
+resolveCity early-returns false on a needs_attention row (alongside resolved/
+unresolvable) so a re-processed row is not re-resolved unbidden.
+
+--- 5. F1 — the re-open path (the "third edit") ---
+cityIdentityService.findOrUpgradeCity: when the adopted region-less row is
+needs_attention, the upgrade UPDATE additionally sets geocode_status='pending',
+geocode_cause=null, so the existing re-fire guard (status === 'pending') fires and
+resolution re-runs against the now-region-constrained lookup. Without this the row
+would stay needs_attention, the guard would be false, and it would be stranded —
+the BUG-85 stuck class reintroduced on the recovery path.
+citiesRepository.findRegionlessUpgradeCandidate whitelist:
+  ['pending','unresolvable'] -> ['pending','unresolvable','needs_attention'].
+The 'unresolvable' asymmetry is PRESERVED untouched (ADL-55 §2.5 / §3.3): a
+no-match cannot become a match by adding a region, so an adopted unresolvable row
+is NOT status-reset and NOT re-fired — only its region + attempt budget move.
+
+--- 6. F4 — stale-comment refresh (same-PR doc-lifecycle) ---
+findByIdentityKey's doc comment (cities.ts) claimed "the unique index is
+unconditional"; migration 0017 replaced that with two partials. Reworded to state
+the correct reason the lookup is status/creator-blind (reuse-not-duplicate, since
+a terminal row leaves the pending partial index and no longer blocks a duplicate
+insert — the exact §7.6 duplicate-safety). Swept the sibling identical claims in
+cityIdentityService.ts's step-1/step-2 header comment.
+
+--- 7. D3 — the userId-scoped queue endpoint ---
+citiesRepository.findUserGeocodeQueue(userId): selectDistinct over cities INNER
+JOIN trip_places INNER JOIN trips LEFT JOIN regions, WHERE
+  and(scopeToUser(trips, userId), ne(cities.geocodeStatus, 'resolved'))
+ordered by name. Returns id, name, country_code, region_id, region_name,
+region_iso, geocode_status, geocode_cause (snake_case). Mirrors
+findCarryForwardItems' user-owned-join shape.
+New route src/backend/routes/geocode-queue.ts: geocodeQueueRouter, GET '/' →
+findUserGeocodeQueue(req.user!.id). Mounted at /api/geocode-queue in BOTH
+server.ts and server-test-app.ts. nosemgrep requireAuth-global annotation
+(existing convention, OP-30-sanctioned — not a new suppression).
+
+================================================================
+SECURITY CHECKLIST (OP-06) — new route GET /api/geocode-queue
+================================================================
+1. Auth: requireAuth — applied globally via app.use('/api/', requireAuth) in
+   server.ts / server-test-app.ts (the same gate every /api route mounts under).
+   The QA criterion-4 test proves 401 when auth disabled. No owner gate is owed —
+   it reads a user's OWN references, not an owner-only surface.
+2. Scoping: the queue query composes scopeToUser(trips, userId) — the QUAL-43
+   chokepoint. Cross-user isolation is STRUCTURAL: a city referenced solely by
+   another user's trips has no qualifying trip_places row and cannot appear. No
+   hand-rolled eq(...userId...) anywhere (scope:check Check 1 = 0 residuals;
+   Check 2 = 0 getDb in routes — the route delegates to the repo).
+3. New user-data column FK notNull: N/A — no schema change, no new table, no new
+   user-referencing column (cities is global reference data; 0018 already landed
+   the two additive columns). Criterion 4's cross-tenant test runs against real
+   libSQL with two seeded users (QUAL-22 mock-fidelity).
+
+================================================================
+RED BAR — un-skipped, GREEN, no assertion weakened
+================================================================
+7 `describe.skip` blocks flipped to `describe` (only that token changed):
+  geocoding.ge19-lifecycle.test.ts       §7.1 (crit 1), §7.2 (crit 2)
+  cityIdentity.ge19-reopen-reuse.test.ts §7.7 (crit 7)
+  geocode-queue.ge19.test.ts             §7.4 (crit 4), §7.5 (crit 5),
+                                         §7.8 (crit 8), §7.10 (crit 10)
+The GREEN-on-main regression guards in those files (§7.3, §7.6, §3.3) were already
+un-skipped and stayed passing. Verified via git diff that no assertion line in any
+of the three QA files changed — only the describe.skip→describe token.
+
+================================================================
+DELIBERATE / DECLARED CHANGES (OP-28)
+================================================================
+- Two pre-existing tests in geocoding.service.test.ts (the ADL-46 F1/F2 ruling
+  thread's own service test — NOT a QA GE-19 file, NOT the frozen ATDD suite)
+  asserted the ADL-46 R4 ambiguous behaviour (stays 'pending', attempts+1). ADL-55
+  D1a/OQ-3 explicitly supersedes that. Updated both to needs_attention/ambiguous/
+  attempts-unchanged with a comment naming the supersession. This is the correct
+  resolution of a settled-design conflict, not a weakened assertion — the QA red
+  bar (criterion 1) asserts the SAME new behaviour and passed un-modified.
+- No full-file source rewrites. All edits targeted.
+
+================================================================
+ADL-vs-QA CONTRACT RECONCILIATION
+================================================================
+None needed. The endpoint envelope the QA test asserts (JSON array of city
+objects; id + snake_case geocode_status/geocode_cause) matches ADL-55 §5.1. The
+re-point path the criterion-8 test uses (PATCH /api/trips/:tripId/places/:placeId)
+was already corrected on main by #513, consistent with ADL-55 D2's 2026-08-11
+correction.
+
+================================================================
+VERIFICATION
+================================================================
+- test:backend: 57 files / 871 tests green (includes the newly-live red-bar tests
+  + the new nextGeocodeState table test; authoritative count from the full run).
+- type:check:all: clean.  npm run check (biome): clean.
+- scope:check: PASS (all 3 checks enforced).  status:check / tracker:check: clean.
+- test:frontend: 388 green (untouched, sanity).
+- CI: see completion report / PR.
+
+================================================================
+NOT DONE — downstream (out of backend scope)
+================================================================
+- FRONTEND brief: retire the NR-06 localStorage retry queue (OQ-4), poll
+  /api/geocode-queue, render the panel grouped by in-progress vs needs-attention,
+  the (status,cause)→copy map (criterion 9), wire recovery actions. Not built here.
+- No BRD bump (GE-19 already v3.20). The GE-19 inline "status-lifecycle model is an
+  Architect ADL decision" is answered by ADL-55 — COO to stamp on merge if desired.
+
+Bugs Discovered: none.

--- a/jobs/backend/tech/20260307-api-reference.md
+++ b/jobs/backend/tech/20260307-api-reference.md
@@ -1,7 +1,12 @@
 # Travel Tracker — Backend API Reference
 
-**Version:** 1.8
-**Date:** 2026-08-08 (updated: GE-20/BUG-87, ADL-54 — `country_codes` documented on both
+**Version:** 1.9
+**Date:** 2026-08-11 (updated: GE-19/BUG-85, ADL-55 — new `geocode_status: "needs_attention"`
+terminal state + its `geocode_cause` discriminator documented; new `GET /api/geocode-queue`
+endpoint documented — the derived, userId-scoped per-user set of unresolved cities that drives the
+geocode-status indicator, replacing the NR-06 localStorage retry queue as source of truth, with the
+`(status, cause)` → label map and the re-point / supply-region recovery levers)
+**Previously:** 1.8, 2026-08-08 (updated: GE-20/BUG-87, ADL-54 — `country_codes` documented on both
 `GET /api/cities` and `GET /api/geocode`: the trip-country-scoped picker hard filter, its
 empty-string-means-unconstrained contract, the malformed-code/10-code-cap guards, and both
 endpoints' `country_code`-wins precedence when the singular and plural params are both
@@ -1044,7 +1049,15 @@ Search cities by name. Returns local database results only (Nominatim is not que
 ]
 ```
 
-`geocode_status` values: `"pending"` | `"resolved"` | `"unresolvable"`
+`geocode_status` values: `"pending"` | `"resolved"` | `"unresolvable"` | `"needs_attention"`
+
+`geocode_status: "needs_attention"` (GE-19 / ADL-55, BUG-85) — a **terminal** state for a city
+the geocoder could not auto-resolve: retry-exhausted (recoverable failures hit the attempt cap) or
+ambiguous (multiple/unconfirmed region matches). It requires user action and is bucketed apart from
+the in-progress/resolving count (`"pending"`). Its companion discriminator `geocode_cause`
+(`"ambiguous"` | `"unreachable"` | `null`) is NOT returned on this search shape or `GET
+/api/cities/:id` — it is surfaced by `GET /api/geocode-queue` (below), the derived per-user set of a
+user's own unresolved cities that drives the geocode-status indicator.
 
 `region_name` / `region_iso` (BUG-72, GitHub #351, 2026-08-01) — the joined `regions` row's
 `name` and `iso_3166_2`, added so the frontend can disambiguate same-named cities (e.g. two
@@ -1203,6 +1216,80 @@ this fix — added here as part of the same brief that touched its response shap
 
 **Errors:**
 - `404` — city not found, or `id` is not numeric
+
+---
+
+### GET /api/geocode-queue
+
+The requesting user's **derived, userId-scoped geocode queue** (GE-19 / ADL-55 D3, BUG-85): the set
+of that user's OWN cities that are not yet `resolved`. The frontend polls this to render the
+geocode-status indicator, splitting it into two buckets **client-side** on `geocode_status`:
+
+- **in-progress / resolving** — `geocode_status = "pending"`
+- **needs-attention** — `geocode_status IN ("needs_attention", "unresolvable")`
+
+This endpoint **replaces the NR-06 localStorage retry queue as the source of truth** for the
+indicator (ADL-55 OQ-4). It is a query, never a stored list: a city drops out automatically once it
+`resolved`s or the user no longer references it (all referencing places deleted or re-pointed).
+
+Mounted at `/api/geocode-queue`, `requireAuth` only (applied globally). Ownership is **structural** —
+the query reaches cities only through the user's own `trip_places → trips` and scopes on the trips
+join, so a city referenced solely by another user's trips never appears (no owner gate needed; cities
+are global reference data with no per-row owner).
+
+**Query Parameters:** none.
+
+**Response: `200 OK`** — a JSON array of the user's unresolved cities (may be empty), ordered by
+`name`. `geocode_cause` is `null` for a `pending`/`unresolvable` row and for backfilled
+`needs_attention` rows whose historical cause is unknown.
+```json
+[
+  {
+    "id": 6,
+    "name": "Denver",
+    "country_code": "US",
+    "region_id": 14,
+    "region_name": "Colorado",
+    "region_iso": "US-CO",
+    "geocode_status": "needs_attention",
+    "geocode_cause": "ambiguous"
+  },
+  {
+    "id": 9,
+    "name": "Springfield",
+    "country_code": "US",
+    "region_id": null,
+    "region_name": null,
+    "region_iso": null,
+    "geocode_status": "pending",
+    "geocode_cause": null
+  }
+]
+```
+
+`geocode_cause` values: `"ambiguous"` (multiple or unconfirmed region matches) | `"unreachable"`
+(recoverable geocoder failure — network/timeout/5xx/429) | `null`. The `(geocode_status,
+geocode_cause)` pair maps to the user-facing label **frontend-side** (ADL-55 §4 — the backend emits
+stable codes so copy changes need no backend deploy):
+
+| `geocode_status` | `geocode_cause` | label |
+|------------------|-----------------|-------|
+| `pending` | `null` | Resolving… |
+| `pending` | `unreachable` | Couldn't reach the geocoder — retrying |
+| `needs_attention` | `ambiguous` | Needs region — multiple matches |
+| `needs_attention` | `unreachable` | Gave up — couldn't reach the geocoder |
+| `needs_attention` | `null` | Couldn't be resolved — needs attention *(backfilled rows)* |
+| `unresolvable` | (any) | Not found |
+
+**Recovery levers** (both already built; the queue reflects the result of either):
+- **Re-point** a place off the stuck city onto a corrected one: `PATCH
+  /api/trips/:tripId/places/:placeId` with `{ "city_id": <correctedCityId> }` — the abandoned stuck
+  city then has no referencing place of the user's and leaves the queue.
+- **Supply a region** for a region-less `needs_attention` city (via the create/find path,
+  `POST /api/cities` / the picker) — the wildcard upgrade adopts the same row in place, resets it to
+  `pending`, and re-fires resolution.
+
+**Errors:** none beyond auth (`401` if unauthenticated).
 
 ---
 

--- a/src/backend/repositories/cities.ts
+++ b/src/backend/repositories/cities.ts
@@ -25,7 +25,7 @@
  * lives in `../services/cityIdentityService.ts`, not here.
  */
 
-import { and, asc, desc, eq, inArray, isNull, like, notInArray, or, sql } from 'drizzle-orm';
+import { and, asc, desc, eq, inArray, isNull, like, ne, notInArray, or, sql } from 'drizzle-orm';
 import {
   cities,
   countries,
@@ -196,12 +196,19 @@ export const citiesRepository = {
 
   /**
    * ADL-46 D13 step 1 — exact match on the composite identity key
-   * (name COLLATE NOCASE, country_code, COALESCE(region_id,0)), mirroring
-   * uniq_cities_name_country_region_ci exactly.
+   * (name COLLATE NOCASE, country_code, COALESCE(region_id,0)).
    *
-   * Creator- and status-blind ON PURPOSE: the unique index is unconditional, so
-   * a filtered lookup would miss another user's row and the follow-on insert
-   * would collide on it (ADL-46 F1/F2 ruling §3.1/§3.3 amendment 2).
+   * Creator- AND status-blind ON PURPOSE. GE-19 / ADL-55 §R F4 (comment
+   * refresh): the earlier justification — "the unique index is unconditional, so
+   * a filtered lookup would collide on insert" — is STALE. Migration 0017 dropped
+   * the unconditional uniq_cities_name_country_region_ci and replaced it with two
+   * PARTIALS; the (name,country,region) key is now enforced only by
+   * uniq_cities_pending_per_creator (WHERE geocode_status='pending'). A terminal
+   * row (needs_attention/unresolvable) has therefore LEFT that index and would NOT
+   * block a duplicate insert. So the blindness is still correct, for a different
+   * reason: it makes a re-add REUSE the existing row (found here before any insert
+   * is attempted) instead of minting a second row for the same key — the exact
+   * duplicate-safety GE-19 §7.6 pins (ADL-46 F1/F2 ruling §3.1/§3.3 amendment 2).
    */
   async findByIdentityKey(
     name: string,
@@ -227,14 +234,18 @@ export const citiesRepository = {
    * ADL-46 D13 step 2 — the region-less row this request may legitimately
    * adopt (the wildcard upgrade), or null.
    *
-   * ADL-46 F1/F2 ruling §3.3 (R1): scoped to rows the caller may legitimately
-   * MUTATE — `geocode_status IN ('pending','unresolvable')` (a whitelist, not
+   * ADL-46 F1/F2 ruling §3.3 (R1) + GE-19 / ADL-55 §R F1: scoped to rows the
+   * caller may legitimately MUTATE — `geocode_status IN
+   * ('pending','unresolvable','needs_attention')` (a whitelist, not
    * `<> 'resolved'`: it fails closed on a future status) AND
-   * `(created_by_user_id = caller OR created_by_user_id IS NULL)`. A `resolved`
-   * row is visible to the caller (GE-16) but must NOT be upgradeable —
-   * read-through is global because the index is global; write-through is scoped
-   * because nothing forces it to be. This is creator-scoping on global data
-   * (see the header), not row ownership.
+   * `(created_by_user_id = caller OR created_by_user_id IS NULL)`. GE-19 adds
+   * `needs_attention` so a region-less STUCK row is adoptable — supplying a region
+   * is the D2 in-place re-open, and the caller (findOrUpgradeCity) resets a
+   * needs_attention adoptee back to 'pending'/cause null and re-fires resolution.
+   * A `resolved` row is visible to the caller (GE-16) but must NOT be upgradeable —
+   * read-through is creator-blind (step 1 reuses any creator's row); write-through
+   * is scoped because nothing forces it to be. This is creator-scoping on global
+   * data (see the header), not row ownership.
    */
   async findRegionlessUpgradeCandidate(
     name: string,
@@ -250,7 +261,7 @@ export const citiesRepository = {
           eq(cities.countryCode, countryCode),
           sql`${cities.name} = ${name} COLLATE NOCASE`,
           isNull(cities.regionId),
-          inArray(cities.geocodeStatus, ['pending', 'unresolvable']),
+          inArray(cities.geocodeStatus, ['pending', 'unresolvable', 'needs_attention']),
           or(eq(cities.createdByUserId, callerUserId), isNull(cities.createdByUserId)),
         ),
       )
@@ -439,5 +450,49 @@ export const citiesRepository = {
     return minRating
       ? rows.filter((r) => r.effectiveRating != null && r.effectiveRating >= Number(minRating))
       : rows;
+  },
+
+  /**
+   * GE-19 / ADL-55 D3 §5.1 — the DERIVED, userId-scoped geocode queue: the
+   * requesting user's OWN cities that are not yet resolved (pending /
+   * needs_attention / unresolvable), so the frontend can render the geocode-status
+   * indicator split into in-progress vs needs-attention buckets (ADL-55 §4). The
+   * queue is a QUERY, never a stored per-user list — it retires the NR-06
+   * localStorage retry queue as the indicator's source of truth (OQ-4).
+   *
+   * SECURITY (OP-06, criterion 4): ownership is STRUCTURAL. The query reaches
+   * cities only through the user's own trip_places -> trips, and the trips join
+   * composes the QUAL-43 scoping chokepoint (scopeToUser) — the identical shape to
+   * findCarryForwardItems / findCityItems above. A city referenced SOLELY by
+   * another user's trips has no qualifying trip_places row and cannot appear; there
+   * is no hand-authored ownership predicate that could be forgotten. `cities`
+   * itself is global reference data (no user_id column, absent from
+   * UserOwnedTable) — its ownership axis is the trips join, not the cities row.
+   *
+   * DISTINCT because one city may be referenced by several of the user's places or
+   * trips. `<> 'resolved'` returns the whole indicator set in one query; the client
+   * splits in-progress (status='pending') from needs-attention (status IN
+   * ('needs_attention','unresolvable')) on the returned status. region_name is
+   * LEFT-joined for the frontend label; ordered by name for a stable render.
+   */
+  async findUserGeocodeQueue(userId: string) {
+    const db = getDb();
+    return db
+      .selectDistinct({
+        id: cities.id,
+        name: cities.name,
+        country_code: cities.countryCode,
+        region_id: cities.regionId,
+        region_name: regions.name,
+        region_iso: regions.iso3166_2,
+        geocode_status: cities.geocodeStatus,
+        geocode_cause: cities.geocodeCause,
+      })
+      .from(cities)
+      .innerJoin(tripPlaces, eq(tripPlaces.cityId, cities.id))
+      .innerJoin(trips, eq(trips.id, tripPlaces.tripId))
+      .leftJoin(regions, eq(regions.id, cities.regionId))
+      .where(and(scopeToUser(trips, userId), ne(cities.geocodeStatus, 'resolved')))
+      .orderBy(cities.name);
   },
 };

--- a/src/backend/routes/__tests__/geocode-queue.ge19.test.ts
+++ b/src/backend/routes/__tests__/geocode-queue.ge19.test.ts
@@ -181,7 +181,7 @@ afterEach(() => {
 // a needs_attention city referenced SOLELY by USER_B never appears for USER_A.
 // ================================================================
 // GE-19 RED BAR (BUG-85) — unskip when implemented
-describe.skip('GE-19 RED BAR (BUG-85) §7.4 — GET /api/geocode-queue is userId-scoped (SECURITY)', () => {
+describe('GE-19 RED BAR (BUG-85) §7.4 — GET /api/geocode-queue is userId-scoped (SECURITY)', () => {
   it("USER_A's queue contains their own stuck city and NEVER USER_B's solely-referenced stuck city", async () => {
     // USER_A's stuck city.
     const tripA = await seedTrip(testDb!, USER_A_ID);
@@ -221,7 +221,7 @@ describe.skip('GE-19 RED BAR (BUG-85) §7.4 — GET /api/geocode-queue is userId
 // cities the user no longer references (the last referencing place removed).
 // ================================================================
 // GE-19 RED BAR (BUG-85) — unskip when implemented
-describe.skip('GE-19 RED BAR (BUG-85) §7.5 — queue excludes resolved and no-longer-referenced cities', () => {
+describe('GE-19 RED BAR (BUG-85) §7.5 — queue excludes resolved and no-longer-referenced cities', () => {
   it('a resolved city and an unreferenced city are absent; a still-referenced stuck city is present', async () => {
     const tripA = await seedTrip(testDb!, USER_A_ID);
 
@@ -267,7 +267,7 @@ describe.skip('GE-19 RED BAR (BUG-85) §7.5 — queue excludes resolved and no-l
 // via UpdatePlaceDatesSchema). This suite uses the real path.
 // ================================================================
 // GE-19 RED BAR (BUG-85) — unskip when implemented
-describe.skip('GE-19 RED BAR (BUG-85) §7.8 — re-point drops the abandoned stuck city from the queue', () => {
+describe('GE-19 RED BAR (BUG-85) §7.8 — re-point drops the abandoned stuck city from the queue', () => {
   it('after re-pointing the last place onto a corrected city, the stuck city leaves the queue', async () => {
     const tripA = await seedTrip(testDb!, USER_A_ID);
     const cityStuck = await seedCity(testDb!, 'MistypedTown', { geocodeCause: 'ambiguous' });
@@ -301,7 +301,7 @@ describe.skip('GE-19 RED BAR (BUG-85) §7.8 — re-point drops the abandoned stu
 // 'unresolvable') (needs-attention) without conflation.
 // ================================================================
 // GE-19 RED BAR (BUG-85) — unskip when implemented
-describe.skip('GE-19 RED BAR (BUG-85) §7.10 — needs_attention/unresolvable bucketed apart from in-progress', () => {
+describe('GE-19 RED BAR (BUG-85) §7.10 — needs_attention/unresolvable bucketed apart from in-progress', () => {
   it('returns pending, needs_attention and unresolvable rows distinguishably so the two buckets never conflate', async () => {
     const tripA = await seedTrip(testDb!, USER_A_ID);
 

--- a/src/backend/routes/geocode-queue.ts
+++ b/src/backend/routes/geocode-queue.ts
@@ -1,0 +1,45 @@
+/**
+ * Travel Tracker — Geocode Queue Router (GE-19 / ADL-55 D3 §5, BUG-85)
+ *
+ * GET /api/geocode-queue — the derived, userId-scoped set of the requesting
+ * user's OWN cities that are not yet resolved (pending / needs_attention /
+ * unresolvable). The frontend polls this to render the geocode-status indicator
+ * grouped into in-progress vs needs-attention buckets (ADL-55 §4), replacing the
+ * NR-06 localStorage retry queue as the source of truth (OQ-4). The response is a
+ * JSON array of city objects, each carrying id, name, country_code, region_id,
+ * region_name, region_iso, geocode_status and geocode_cause (snake_case, matching
+ * the GET /api/cities search shape); the client derives the two buckets and the
+ * (status, cause) → label copy itself (ADL-55 §4 — labels live frontend-side).
+ *
+ * SECURITY (OP-06, ADL-55 §5.1 / criterion 4): the queue is DERIVED from the
+ * user's own trips, never a stored per-user list. Ownership is STRUCTURAL — the
+ * repository query (citiesRepository.findUserGeocodeQueue) reaches cities only
+ * through the user's own trip_places -> trips and composes the QUAL-43 scoping
+ * chokepoint (scopeToUser), exactly like findCarryForwardItems. A city referenced
+ * solely by another user's trips cannot appear, and there is no hand-authored
+ * ownership predicate to forget. `cities` is global reference data (no user_id
+ * column); its ownership axis is the trips join.
+ *
+ * requireAuth (applied globally via app.use('/api/', requireAuth) in server.ts /
+ * server-test-app.ts) is the gate; req.user.id is the ownership axis passed to the
+ * repository. No userId scoping is hand-rolled here — the chokepoint owns it.
+ */
+
+import { Router } from 'express';
+import { asyncHandler } from '../middleware/error-handler.js';
+import { citiesRepository } from '../repositories/cities.js';
+
+export const geocodeQueueRouter = Router();
+
+// ----------------------------------------------------------------
+// GET /api/geocode-queue
+// ----------------------------------------------------------------
+// nosemgrep: travel-tracker.express-route-no-auth -- reason: requireAuth applied globally via app.use('/api/', requireAuth) in server.ts
+geocodeQueueRouter.get(
+  '/',
+  asyncHandler(async (req, res) => {
+    const userId = req.user!.id;
+    const queue = await citiesRepository.findUserGeocodeQueue(userId);
+    res.json(queue);
+  }),
+);

--- a/src/backend/server-test-app.ts
+++ b/src/backend/server-test-app.ts
@@ -31,6 +31,7 @@ import { categoriesRouter } from './routes/categories.js';
 import { citiesRouter } from './routes/cities.js';
 import { companionsRouter } from './routes/companions.js';
 import { geocodeRouter } from './routes/geocode.js';
+import { geocodeQueueRouter } from './routes/geocode-queue.js';
 import { mapRouter } from './routes/map.js';
 import { meRouter } from './routes/me.js';
 import { tripsRouter } from './routes/trips.js';
@@ -123,6 +124,7 @@ app.use('/api/companions', companionsRouter); // ADL-28 (AD-08): requireAuth onl
 app.use('/api/categories', categoriesRouter); // ADL-46 (AD-09, D3): requireAuth only, userId-scoped
 app.use('/api/activities', activitiesRouter); // ADL-46 (AD-09, D3): requireAuth only, userId-scoped
 app.use('/api/geocode', geocodeRouter); // ADL-46 (D7): geocoding proxy — requireAuth, egress chokepoint
+app.use('/api/geocode-queue', geocodeQueueRouter); // GE-19 (ADL-55 D3): userId-scoped derived geocode queue — requireAuth
 app.use('/api/me', meRouter); // BUG-26: identity endpoint for frontend owner gating
 
 // Health check — same handler shape as server.ts (QUAL-26: liveness + build identity).

--- a/src/backend/server.ts
+++ b/src/backend/server.ts
@@ -44,6 +44,7 @@ import { categoriesRouter } from './routes/categories.js';
 import { citiesRouter } from './routes/cities.js';
 import { companionsRouter } from './routes/companions.js';
 import { geocodeRouter } from './routes/geocode.js';
+import { geocodeQueueRouter } from './routes/geocode-queue.js';
 import { mapRouter } from './routes/map.js';
 import { meRouter } from './routes/me.js';
 import { tripsRouter } from './routes/trips.js';
@@ -216,6 +217,7 @@ app.use('/api/companions', companionsRouter); // ADL-28 (AD-08): requireAuth onl
 app.use('/api/categories', categoriesRouter); // ADL-46 (AD-09, D3): requireAuth only, userId-scoped
 app.use('/api/activities', activitiesRouter); // ADL-46 (AD-09, D3): requireAuth only, userId-scoped
 app.use('/api/geocode', geocodeRouter); // ADL-46 (D7): geocoding proxy — requireAuth, egress chokepoint
+app.use('/api/geocode-queue', geocodeQueueRouter); // GE-19 (ADL-55 D3): userId-scoped derived geocode queue — requireAuth
 app.use('/api/me', meRouter); // BUG-26: identity endpoint for frontend owner gating
 
 // Health check — liveness AND build identity (QUAL-26).

--- a/src/backend/services/__tests__/cityIdentity.ge19-reopen-reuse.test.ts
+++ b/src/backend/services/__tests__/cityIdentity.ge19-reopen-reuse.test.ts
@@ -161,7 +161,7 @@ describe('GE-19 REGRESSION GUARD (BUG-85) §7.6 — re-add of a needs_attention 
 // re-fire guard only fires for 'pending'). Assert the reset EXPLICITLY.
 // ================================================================
 // GE-19 RED BAR (BUG-85) — unskip when implemented
-describe.skip('GE-19 RED BAR (BUG-85) §7.7 — region supplied re-opens a region-less needs_attention row in place', () => {
+describe('GE-19 RED BAR (BUG-85) §7.7 — region supplied re-opens a region-less needs_attention row in place', () => {
   it('resets the region-less needs_attention row to pending/attempts 0/cause null, sets the region, and re-fires resolveCity', async () => {
     const regionId = await seedRegionTierUS(testDb!);
     // A region-LESS needs_attention row (region_id NULL), some retry budget spent.

--- a/src/backend/services/__tests__/geocoding.ge19-lifecycle.test.ts
+++ b/src/backend/services/__tests__/geocoding.ge19-lifecycle.test.ts
@@ -141,7 +141,7 @@ afterEach(() => {
 // NULL, and NO further retry budget is consumed (attempts unchanged).
 // ================================================================
 // GE-19 RED BAR (BUG-85) — unskip when implemented
-describe.skip('GE-19 RED BAR (BUG-85) §7.1 — ambiguous verdict → needs_attention/ambiguous, no retries', () => {
+describe('GE-19 RED BAR (BUG-85) §7.1 — ambiguous verdict → needs_attention/ambiguous, no retries', () => {
   it('an ambiguous verdict marks the row needs_attention with cause=ambiguous and does NOT increment attempts', async () => {
     const cityId = await seedRegionCity(testDb!, { geocodeAttempts: 0 }); // regionIso = US-CO
     // Two candidates that disagree with the row's selected region (US-CO) and
@@ -196,7 +196,7 @@ describe.skip('GE-19 RED BAR (BUG-85) §7.1 — ambiguous verdict → needs_atte
 // (~:413). Cap is 5; seed attempts=4 so the next failing attempt is the cap.
 // ================================================================
 // GE-19 RED BAR (BUG-85) — unskip when implemented
-describe.skip('GE-19 RED BAR (BUG-85) §7.2 — recoverable error at cap → needs_attention/unreachable (both sites)', () => {
+describe('GE-19 RED BAR (BUG-85) §7.2 — recoverable error at cap → needs_attention/unreachable (both sites)', () => {
   it('name-search site: an error at the attempt cap transitions to needs_attention/unreachable, never pending-at-cap', async () => {
     const cityId = await seedPlainCity(testDb!, { geocodeAttempts: 4 });
     nextSearchResult = { status: 'error' }; // recoverable (network/timeout/5xx/429)

--- a/src/backend/services/__tests__/geocoding.service.test.ts
+++ b/src/backend/services/__tests__/geocoding.service.test.ts
@@ -345,7 +345,16 @@ describe('ADL-46 F1/F2 ruling — classifyCandidates (single shared classifier)'
 // Nominatim chokepoint faked.
 // ================================================================
 describe('ADL-46 F1/F2 ruling — resolveCity ambiguity (R2/R3/R4)', () => {
-  it('a multi-region fake leaves the row pending, coordinates NULL, attempts incremented, status NOT unresolvable', async () => {
+  // GE-19 / ADL-55 D1a / OQ-3 (COO-resolved) REFINES ADL-46 R4: an ambiguous
+  // verdict is DETERMINISTIC (the identical name+region query re-derives the
+  // identical verdict), so it is TERMINAL on the first verdict —
+  // needs_attention/ambiguous — rather than consuming the retry budget and
+  // sitting 'pending'. Still NOT 'unresolvable' (the geocoder did not say "no
+  // match"); still coordinates-NULL; re-askability preserved by the re-open path
+  // (findOrUpgradeCity resets attempts when a region is supplied). These two
+  // cases assert the refined lifecycle; the pre-GE-19 pending/+1 assertions are
+  // superseded.
+  it('a multi-region fake marks the row needs_attention/ambiguous on the first verdict, coordinates NULL, NO retry consumed', async () => {
     const cityId = await seedCountryAndCityWithRegion(testDb!); // regionIso = US-CO
     // Two candidates that do NOT match the city's selected region (US-CO) and
     // disagree with each other → ambiguous/region-unconfirmed.
@@ -361,10 +370,11 @@ describe('ADL-46 F1/F2 ruling — resolveCity ambiguity (R2/R3/R4)', () => {
     expect(ok).toBe(false);
 
     const [row] = await testDb!.select().from(schema.cities).where(eq(schema.cities.id, cityId));
-    expect(row.geocodeStatus).toBe('pending'); // NOT unresolvable — the geocoder did not say "no match"
+    expect(row.geocodeStatus).toBe('needs_attention'); // D1a: terminal on first verdict, NOT pending
+    expect(row.geocodeCause).toBe('ambiguous');
     expect(row.latitude).toBeNull();
     expect(row.longitude).toBeNull();
-    expect(row.geocodeAttempts).toBe(1); // R4: the ambiguity budget was consumed
+    expect(row.geocodeAttempts).toBe(0); // D1a: no retry spent on a deterministic answer
   });
 
   it('a row at attempts = CAP is not re-selected by processQueue, even with a multi-region fake available', async () => {
@@ -386,7 +396,9 @@ describe('ADL-46 F1/F2 ruling — resolveCity ambiguity (R2/R3/R4)', () => {
 
   // Bonus coverage beyond the mandatory five (R3, not separately enumerated in
   // ruling §4 but directly exercises the rule stated in §2.2 step 3 / §2.4).
-  it('bonus — R3: a region was requested but no candidate matches it → stays pending, never resolves outside the selected region', async () => {
+  // GE-19 / ADL-55 D1a: region-unconfirmed is ambiguous → needs_attention on the
+  // first verdict (was 'pending'/attempts=1 under ADL-46 R4).
+  it('bonus — R3: a region was requested but no candidate matches it → needs_attention/ambiguous, never resolves outside the selected region', async () => {
     const cityId = await seedCountryAndCityWithRegion(testDb!); // regionIso = US-CO
     nextResult = {
       status: 'ok',
@@ -397,9 +409,10 @@ describe('ADL-46 F1/F2 ruling — resolveCity ambiguity (R2/R3/R4)', () => {
     expect(ok).toBe(false);
 
     const [row] = await testDb!.select().from(schema.cities).where(eq(schema.cities.id, cityId));
-    expect(row.geocodeStatus).toBe('pending');
+    expect(row.geocodeStatus).toBe('needs_attention');
+    expect(row.geocodeCause).toBe('ambiguous');
     expect(row.latitude).toBeNull();
-    expect(row.geocodeAttempts).toBe(1);
+    expect(row.geocodeAttempts).toBe(0);
   });
 });
 

--- a/src/backend/services/__tests__/nextGeocodeState.test.ts
+++ b/src/backend/services/__tests__/nextGeocodeState.test.ts
@@ -1,0 +1,134 @@
+/**
+ * GE-19 / BUG-85 — nextGeocodeState PURE-FUNCTION TABLE TEST (ADL-55 §7
+ * criterion 11, §3.2). The Backend-owned unit-level red bar for the geocode
+ * state machine: every (current-row × verdict) cell of the §3.2 table yields the
+ * specified {status, attempts, cause}. No DB, no network — nextGeocodeState is a
+ * pure function (ADL-55 D5), which is the whole point of extracting the policy
+ * out of resolveCity's IO.
+ *
+ * The cap is GEOCODE_ATTEMPT_CAP = 5 (geocoding.service.ts). The boundary is
+ * pinned via attempts=3 (3+1=4 < 5 → stays pending) vs attempts=4 (4+1=5 >= 5 →
+ * needs_attention), so the semantics are asserted without importing the private
+ * constant — if the cap moves, this test's boundary cases surface it as the
+ * behaviour change it is.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  type GeocodeLifecycleVerdict,
+  type GeocodeStateInput,
+  type NextGeocodeState,
+  nextGeocodeState,
+} from '../geocoding.service.js';
+
+interface Case {
+  name: string;
+  row: GeocodeStateInput;
+  verdict: GeocodeLifecycleVerdict;
+  expected: NextGeocodeState;
+}
+
+/** Terse constructor for a current-row state. */
+const row = (
+  geocodeStatus: GeocodeStateInput['geocodeStatus'],
+  geocodeAttempts: number,
+  geocodeCause: GeocodeStateInput['geocodeCause'] = null,
+): GeocodeStateInput => ({ geocodeStatus, geocodeAttempts, geocodeCause });
+
+const cases: Case[] = [
+  // ── 'ok' → resolved. Attempts are irrelevant once resolved (preserved as-is);
+  //    any prior cause is cleared.
+  {
+    name: 'ok → resolved, attempts preserved, cause cleared',
+    row: row('pending', 2, 'unreachable'),
+    verdict: 'ok',
+    expected: { status: 'resolved', attempts: 2, cause: null },
+  },
+
+  // ── 'no_match' → unresolvable (terminal, ADL-46 D10). NOT a recoverable
+  //    failure, so no attempt is consumed; cause null.
+  {
+    name: 'no_match → unresolvable, no attempt consumed, cause null',
+    row: row('pending', 0),
+    verdict: 'no_match',
+    expected: { status: 'unresolvable', attempts: 0, cause: null },
+  },
+  {
+    name: 'no_match preserves an existing attempt count (does not increment)',
+    row: row('pending', 3, 'unreachable'),
+    verdict: 'no_match',
+    expected: { status: 'unresolvable', attempts: 3, cause: null },
+  },
+
+  // ── 'ambiguous' → needs_attention/ambiguous on the FIRST verdict (D1a / OQ-3).
+  //    Deterministic answer, so NO retry is ever spent, whatever the budget.
+  {
+    name: 'ambiguous → needs_attention/ambiguous, attempts unchanged (fresh)',
+    row: row('pending', 0),
+    verdict: 'ambiguous',
+    expected: { status: 'needs_attention', attempts: 0, cause: 'ambiguous' },
+  },
+  {
+    name: 'ambiguous never consumes budget even mid-retry',
+    row: row('pending', 3, 'unreachable'),
+    verdict: 'ambiguous',
+    expected: { status: 'needs_attention', attempts: 3, cause: 'ambiguous' },
+  },
+
+  // ── 'unreachable' below the cap → pending, +1, unreachable. The failing
+  //    attempt counts; the row keeps retrying.
+  {
+    name: 'unreachable below cap → pending, +1, unreachable (0→1)',
+    row: row('pending', 0),
+    verdict: 'unreachable',
+    expected: { status: 'pending', attempts: 1, cause: 'unreachable' },
+  },
+  {
+    name: 'unreachable one below cap → still pending (3→4 < 5)',
+    row: row('pending', 3),
+    verdict: 'unreachable',
+    expected: { status: 'pending', attempts: 4, cause: 'unreachable' },
+  },
+
+  // ── 'unreachable' AT/beyond the cap → needs_attention/unreachable. The cap is
+  //    an ACTIVE transition, so a row never sits pending-at-cap (§R F2).
+  {
+    name: 'unreachable reaching cap → needs_attention/unreachable (4→5 >= 5)',
+    row: row('pending', 4),
+    verdict: 'unreachable',
+    expected: { status: 'needs_attention', attempts: 5, cause: 'unreachable' },
+  },
+  {
+    name: 'unreachable beyond cap → needs_attention/unreachable (5→6)',
+    row: row('pending', 5),
+    verdict: 'unreachable',
+    expected: { status: 'needs_attention', attempts: 6, cause: 'unreachable' },
+  },
+
+  // ── 'disabled' → nothing changes at all (no increment), whatever the current
+  //    state. A global offline window must not burn a city's budget (D10).
+  {
+    name: 'disabled → unchanged mid-retry pending row (no increment)',
+    row: row('pending', 2, 'unreachable'),
+    verdict: 'disabled',
+    expected: { status: 'pending', attempts: 2, cause: 'unreachable' },
+  },
+  {
+    name: 'disabled → unchanged fresh pending row',
+    row: row('pending', 0),
+    verdict: 'disabled',
+    expected: { status: 'pending', attempts: 0, cause: null },
+  },
+  {
+    name: 'disabled → leaves a needs_attention row exactly as-is',
+    row: row('needs_attention', 5, 'ambiguous'),
+    verdict: 'disabled',
+    expected: { status: 'needs_attention', attempts: 5, cause: 'ambiguous' },
+  },
+];
+
+describe('GE-19 (BUG-85) §7 criterion 11 — nextGeocodeState table (ADL-55 §3.2)', () => {
+  it.each(cases)('$name', ({ row: input, verdict, expected }) => {
+    expect(nextGeocodeState(input, verdict)).toEqual(expected);
+  });
+});

--- a/src/backend/services/cityIdentityService.ts
+++ b/src/backend/services/cityIdentityService.ts
@@ -25,36 +25,43 @@ import { resolveByOsmId, resolveCity } from './geocoding.service.js';
 /**
  * ADL-46 D13 (§4.2.1) — the three-step find-or-create, steps 1 & 2. Returns an
  * existing (or wildcard-upgraded) city row for (name, countryCode, regionId), or
- * null if a genuine insert is needed. NOT creator-scoped: the unique index is
- * global, so pass 1 must be able to return another user's pending row (OP-27 P2 /
- * §8 row 6) rather than colliding with the index on insert.
+ * null if a genuine insert is needed. NOT creator-scoped: pass 1 must be able to
+ * return another user's (or a terminal) row for this identity key so the request
+ * REUSES it rather than minting a duplicate (OP-27 P2 / §8 row 6).
  *
- *   Step 1 — exact match on (name COLLATE NOCASE, country_code, COALESCE(region_id,0)),
- *            mirroring uniq_cities_name_country_region_ci exactly. Creator- and
- *            status-blind: the unique index is unconditional, so a filtered
- *            step 1 would miss another user's row and the follow-on insert
- *            would collide on it (ADL-46 F1/F2 ruling §3.1/§3.3 amendment 2).
+ *   Step 1 — exact match on (name COLLATE NOCASE, country_code, COALESCE(region_id,0)).
+ *            Creator- AND status-blind ON PURPOSE. Since migration 0017 there is no
+ *            unconditional (name,country,region) unique index — uniqueness on that
+ *            key is enforced only by the PARTIAL uniq_cities_pending_per_creator
+ *            (WHERE geocode_status='pending'), so a TERMINAL row
+ *            (needs_attention/unresolvable) has left that index and no longer blocks
+ *            a duplicate insert. A status-filtered step 1 would miss such a row and
+ *            the caller would mint a SECOND row for the same key (GE-19 §7.6). So
+ *            reuse-not-duplicate — not "collide with a global index" — is why the
+ *            lookup is blind (the global unconditional index was dropped by 0017).
  *   Step 2 — WILDCARD UPGRADE: if the request carries a region and step 1 missed,
  *            adopt a region-less row of the same name+country by SETTING its
  *            region_id. A region-less row is an under-specified record, not a
  *            different city — specialising it prevents the duplicate that naively
  *            adding `AND COALESCE(region_id,0)=…` would create (the BUG-33 class).
- *            ADL-46 F1/F2 ruling §3.3 (R1): scoped to rows the caller may
- *            legitimately mutate — `geocode_status IN ('pending','unresolvable')`
- *            (whitelist, not `<> 'resolved'`: fails closed on a future status)
- *            AND `(created_by_user_id = caller OR created_by_user_id IS NULL)`.
+ *            ADL-46 F1/F2 ruling §3.3 (R1) + GE-19 / ADL-55 §R F1: scoped to rows
+ *            the caller may legitimately mutate — `geocode_status IN
+ *            ('pending','unresolvable','needs_attention')` (whitelist, not
+ *            `<> 'resolved'`: fails closed on a future status) AND
+ *            `(created_by_user_id = caller OR created_by_user_id IS NULL)`.
  *            A `resolved` row is visible to the caller (GE-16) but must NOT be
- *            upgradeable — read-through is global because the index is global;
- *            write-through is scoped because nothing forces it to be. Declining
- *            falls through to the ordinary insert on a distinct identity key
- *            (legal under D13, at most one extra row per name+country). On a
- *            successful upgrade the retry budget resets and, if the adopted row
- *            is still 'pending', resolution is re-fired — the region is the
- *            question, and a region-constrained lookup can collapse an
- *            ambiguity the unconstrained one could not (ruling §2.5/§3.3
- *            amendment 3). Not fired for an adopted 'unresolvable' row: the
- *            geocoder returned zero candidates, and a region constraint cannot
- *            turn zero into some (ruling §2.5 asymmetry).
+ *            upgradeable — read-through is creator-blind (step 1 reuses any
+ *            creator's row); write-through is scoped because nothing forces it to
+ *            be. Declining falls through to the ordinary insert on a distinct
+ *            identity key (legal under D13, at most one extra row per name+country).
+ *            On a successful upgrade the retry budget resets; a needs_attention
+ *            adoptee is additionally RE-OPENED to 'pending'/cause null (GE-19 /
+ *            ADL-55 §R F1, the third edit) so that — like an already-'pending'
+ *            adoptee — resolution re-fires: the region is the question, and a
+ *            region-constrained lookup can collapse an ambiguity the unconstrained
+ *            one could not (ruling §2.5/§3.3 amendment 3). NOT reset or re-fired for
+ *            an adopted 'unresolvable' row: the geocoder returned zero candidates,
+ *            and a region constraint cannot turn zero into some (ruling §2.5 asymmetry).
  *
  *   Step 2b (reverse, NO region requested) — collapse to (name, country_code)
  *            regardless of region. This is the "today's behaviour" case the old
@@ -93,16 +100,29 @@ export async function findOrUpgradeCity(
     );
     if (regionless) {
       const now = new Date().toISOString();
+      // GE-19 / ADL-55 §R F1 (the THIRD edit) + §3.3: a needs_attention row
+      // adopted by supplying a region is RE-OPENED — reset to a fresh 'pending'
+      // with cause cleared — so the re-fire guard below reopens it. Without this
+      // status/cause reset the row would stay needs_attention, the guard would be
+      // false, and it would be stranded with no path back to 'pending' (the exact
+      // BUG-85 stuck class, reintroduced on the recovery path). The 'unresolvable'
+      // asymmetry is PRESERVED untouched (ruling §2.5 / ADL-55 §3.3): a no-match
+      // cannot become a match by adding a region, so an adopted 'unresolvable' row
+      // is neither status-reset nor re-fired — only its region and attempt budget
+      // move. A 'pending' adoptee already has the right status; only its budget resets.
+      const reopen = regionless.geocodeStatus === 'needs_attention';
       const upgraded = await citiesRepository.updateCity(regionless.id, {
         regionId,
         geocodeAttempts: 0,
+        ...(reopen ? { geocodeStatus: 'pending', geocodeCause: null } : {}),
         updatedAt: now,
       });
       const upgradedRow = upgraded[0];
-      // Re-ask: the region is the question, and a region-constrained lookup
-      // can collapse an ambiguity the unconstrained one could not. Never fired
-      // for an adopted 'unresolvable' row (ruling §2.5 asymmetry — zero
-      // candidates cannot become some just because a region was added).
+      // Re-ask: the region is the question, and a region-constrained lookup can
+      // collapse an ambiguity the unconstrained one could not. Fires whenever the
+      // adopted row is now 'pending' (it already was, or was just reopened from
+      // needs_attention). Never fired for an adopted 'unresolvable' row (ruling
+      // §2.5 asymmetry — zero candidates cannot become some just by adding a region).
       if (upgradedRow.geocodeStatus === 'pending') {
         resolveCity(upgradedRow.id).catch(() => {
           /* handled internally — defensive catch */

--- a/src/backend/services/geocoding.service.ts
+++ b/src/backend/services/geocoding.service.ts
@@ -51,7 +51,7 @@
  *     transaction wrapper.)
  */
 
-import { and, asc, eq, lt, sql } from 'drizzle-orm';
+import { and, asc, eq, lt } from 'drizzle-orm';
 import { cities, getDb, regions, tripPlaces } from '../db/index.js';
 import { isUniqueViolation } from './db-errors.js';
 import {
@@ -303,6 +303,9 @@ async function commitResolvedOrMerge(
         osmId: candidate.osmId ?? null,
         displayName: candidate.displayName ?? null,
         geocodeStatus: 'resolved',
+        // GE-19 / ADL-55 §3.2: a resolved row carries no cause — clear any prior
+        // 'unreachable' a recoverable attempt may have written before this one won.
+        geocodeCause: null,
         geocodeAttemptedAt: resolvedAt,
         updatedAt: resolvedAt,
       })
@@ -355,9 +358,126 @@ async function mergeIntoWinner(loserId: number, osmType: string, osmId: number):
   return true;
 }
 
+// ================================================================
+// GE-19 / ADL-55 — the geocode STATUS LIFECYCLE (D1a / D5)
+// ================================================================
+
+/** The four persisted geocode statuses (schema `chk_cities_geocode_status`). */
+export type GeocodeStatus = 'pending' | 'resolved' | 'unresolvable' | 'needs_attention';
+/** The persisted cause discriminator (schema `chk_cities_geocode_cause`). */
+export type GeocodeCause = 'ambiguous' | 'unreachable' | null;
+
+/**
+ * GE-19 / ADL-55 D1a — the classified outcome of ONE resolution attempt, reduced
+ * to what the state machine needs. Produced inside `resolveCity` from whichever
+ * geocoder path ran (name-search or carried-OSM `/lookup`) and fed to
+ * {@link nextGeocodeState}. Distinct from {@link CandidateVerdict}, which decides
+ * "which candidate, if any" one step earlier.
+ *
+ *   - 'ok'          — a single confident candidate; coordinates are committed
+ *                     separately by `commitResolvedOrMerge` (which also clears cause).
+ *   - 'no_match'    — the geocoder answered with zero usable candidates, OR a
+ *                     carried OSM ref no longer resolves to a settlement (M-B).
+ *                     Terminal 'unresolvable' (ADL-46 D10, unchanged).
+ *   - 'ambiguous'   — eligible candidates disagree on region / the selected region
+ *                     could not be confirmed. Deterministic, so terminal on the
+ *                     FIRST verdict (D1a / OQ-3) — no retry is spent.
+ *   - 'unreachable' — a recoverable failure (network/timeout/5xx/429). Counts the
+ *                     attempt and retries below the cap; AT the cap it becomes
+ *                     needs_attention rather than sitting pending-at-cap (§R F2).
+ *   - 'disabled'    — GEOCODING_ENABLED=false / a global condition. Changes nothing
+ *                     (no increment) — one offline window must not burn a city's
+ *                     budget (ADL-46 D10).
+ */
+export type GeocodeLifecycleVerdict = 'ok' | 'no_match' | 'ambiguous' | 'unreachable' | 'disabled';
+
+/** The current-row fields the state machine reads — nothing else is needed. */
+export interface GeocodeStateInput {
+  geocodeStatus: GeocodeStatus;
+  geocodeAttempts: number;
+  geocodeCause: GeocodeCause;
+}
+
+/** The persisted policy fields a resolution attempt writes back. */
+export interface NextGeocodeState {
+  status: GeocodeStatus;
+  attempts: number;
+  cause: GeocodeCause;
+}
+
+/**
+ * GE-19 / ADL-55 D5 — THE geocode state machine (§3.2), extracted as a PURE
+ * function so the entire lifecycle is an exhaustive table test with no DB and no
+ * network (OP-35 criterion 11). Given the current row and one attempt's verdict,
+ * it returns the `{status, attempts, cause}` to persist. All IO stays in
+ * `resolveCity`: the 'ok' verdict is applied by `commitResolvedOrMerge`
+ * (coordinates + OSM ref + the merge fallback); every other verdict is applied by
+ * {@link applyGeocodeState} — a single UPDATE of exactly these three fields.
+ *
+ * Two deliberate changes vs. the pre-GE-19 behaviour (both in ADL-55 §3.2):
+ *   - 'ambiguous' is TERMINAL on the first verdict (needs_attention/ambiguous),
+ *     spending no further retry — the identical query returns the identical
+ *     verdict, so retrying is waste. Re-askability is preserved by the re-open
+ *     path (findOrUpgradeCity resets attempts when a region is supplied).
+ *   - the cap is an ACTIVE transition (increment-then-check) rather than a passive
+ *     `WHERE attempts < cap` drop, so a row never sits pending-at-cap forever.
+ *
+ * @param row     - The current geocode_status / _attempts / _cause of the row.
+ * @param verdict - The classified outcome of this resolution attempt.
+ */
+export function nextGeocodeState(
+  row: GeocodeStateInput,
+  verdict: GeocodeLifecycleVerdict,
+): NextGeocodeState {
+  switch (verdict) {
+    case 'ok':
+      // Coordinates confirmed — attempts no longer matter once resolved; cause clears.
+      return { status: 'resolved', attempts: row.geocodeAttempts, cause: null };
+    case 'no_match':
+      // Terminal: the geocoder answered "no usable match" (ADL-46 D10). Never retried.
+      return { status: 'unresolvable', attempts: row.geocodeAttempts, cause: null };
+    case 'ambiguous':
+      // D1a / OQ-3: deterministic → terminal on the first verdict, no retry spent.
+      return { status: 'needs_attention', attempts: row.geocodeAttempts, cause: 'ambiguous' };
+    case 'unreachable': {
+      // Recoverable: the failing attempt still counts. AT the cap the row becomes
+      // needs_attention/unreachable; below it, it stays pending and retries.
+      const attempts = row.geocodeAttempts + 1;
+      return attempts >= GEOCODE_ATTEMPT_CAP
+        ? { status: 'needs_attention', attempts, cause: 'unreachable' }
+        : { status: 'pending', attempts, cause: 'unreachable' };
+    }
+    case 'disabled':
+      // Global condition — change nothing at all (no increment). ADL-46 D10.
+      return { status: row.geocodeStatus, attempts: row.geocodeAttempts, cause: row.geocodeCause };
+  }
+}
+
+/**
+ * GE-19 / ADL-55 D5 — persists a non-'ok' {@link nextGeocodeState} result: the
+ * three policy fields plus the attempt timestamp, in one UPDATE. The 'ok' path
+ * does NOT flow through here — `commitResolvedOrMerge` writes coordinates + the
+ * OSM ref + the merge fallback and clears the cause itself.
+ */
+async function applyGeocodeState(cityId: number, next: NextGeocodeState): Promise<void> {
+  const db = getDb();
+  const now = new Date().toISOString();
+  await db
+    .update(cities)
+    .set({
+      geocodeStatus: next.status,
+      geocodeAttempts: next.attempts,
+      geocodeCause: next.cause,
+      geocodeAttemptedAt: now,
+      updatedAt: now,
+    })
+    .where(eq(cities.id, cityId));
+}
+
 /**
  * Attempts to resolve coordinates for a single EXISTING city row via Nominatim
- * (the geocode queue / on-create trigger path). Applies D10's classification.
+ * (the geocode queue / on-create trigger path). Produces a lifecycle verdict and
+ * applies it through {@link nextGeocodeState} (ADL-46 D10 + GE-19 / ADL-55 §3.2).
  *
  * @param cityId - The cities.id to resolve.
  * @returns true if coordinates were resolved and saved, false otherwise.
@@ -370,6 +490,8 @@ export async function resolveCity(cityId: number): Promise<boolean> {
       id: cities.id,
       name: cities.name,
       geocodeStatus: cities.geocodeStatus,
+      geocodeAttempts: cities.geocodeAttempts,
+      geocodeCause: cities.geocodeCause,
       countryCode: cities.countryCode,
       regionIso: regions.iso3166_2,
       osmType: cities.osmType,
@@ -386,12 +508,27 @@ export async function resolveCity(cityId: number): Promise<boolean> {
     return false;
   }
 
-  // Never re-query a resolved city (ADL-10). Unresolvable rows are terminal.
+  // Terminal / do-not-touch states, all returning without a write:
+  //   resolved       — never re-queried (ADL-10).
+  //   unresolvable   — terminal (ADL-46 D10).
+  //   needs_attention— terminal, awaiting a user action (GE-19 / ADL-55 §R F3): a
+  //                    re-processed row must NOT be re-resolved unbidden. The
+  //                    re-open path (findOrUpgradeCity) is what returns it to
+  //                    'pending' when the user supplies a region.
   if (city.geocodeStatus === 'resolved') return true;
   if (city.geocodeStatus === 'unresolvable') return false;
+  if (city.geocodeStatus === 'needs_attention') return false;
 
   // GEOCODING_ENABLED=false is a GLOBAL condition — do NOT increment attempts.
   if (!geocodingEnabled()) return false;
+
+  // The pure state machine reads exactly these three fields; capture them once
+  // BEFORE the attempt so the cap decision uses the pre-attempt count.
+  const stateRow: GeocodeStateInput = {
+    geocodeStatus: city.geocodeStatus as GeocodeStatus,
+    geocodeAttempts: city.geocodeAttempts,
+    geocodeCause: city.geocodeCause as GeocodeCause,
+  };
 
   const attemptedAt = new Date().toISOString();
   await db
@@ -411,8 +548,9 @@ export async function resolveCity(cityId: number): Promise<boolean> {
       return false;
     }
     if (result.status === 'error') {
-      // Recoverable — increment, stay pending, retry later (up to cap).
-      await incrementAttempts(cityId);
+      // Recoverable — GE-19 / ADL-55 §R F2 (carried-OSM site): stay pending and
+      // retry below the cap, transition to needs_attention/unreachable AT it.
+      await applyGeocodeState(cityId, nextGeocodeState(stateRow, 'unreachable'));
       return false;
     }
 
@@ -421,14 +559,9 @@ export async function resolveCity(cityId: number): Promise<boolean> {
       // M-B (delta review): the carried object no longer resolves to a
       // settlement — deleted, or reclassified to a non-settlement type
       // (HTTP 200, zero/filtered rows). Distinct from disabled/error above.
-      // TERMINAL: a deleted/reclassified OSM object will not come back as a
-      // settlement — degrade safely (never a wrong-town pin), never retried
-      // again, rather than looping pending forever.
-      const now = new Date().toISOString();
-      await db
-        .update(cities)
-        .set({ geocodeStatus: 'unresolvable', geocodeAttemptedAt: now, updatedAt: now })
-        .where(eq(cities.id, cityId));
+      // TERMINAL 'unresolvable': a deleted/reclassified OSM object will not come
+      // back as a settlement — degrade safely, never retried again.
+      await applyGeocodeState(cityId, nextGeocodeState(stateRow, 'no_match'));
       console.info(
         `[GEO] City ${cityId} (${city.name}) unresolvable — carried osm ref no longer resolves to a settlement`,
       );
@@ -439,11 +572,10 @@ export async function resolveCity(cityId: number): Promise<boolean> {
   }
 
   // Non-carried — the existing name-search path. M-A (delta review, v2 §7
-  // rule 2c): now ALSO stamps the winning candidate's osm ref on every
-  // resolve, not only carried-pick resolves (via commitResolvedOrMerge
-  // below) — otherwise a freshly-resolved row is invisible to the
-  // resolved-by-OSM merge mechanism and two users resolving the same
-  // non-ambiguous city land as duplicate NULL-osm_id rows.
+  // rule 2c): commitResolvedOrMerge stamps the winning candidate's osm ref on
+  // every resolve, not only carried-pick resolves — otherwise a freshly-resolved
+  // row is invisible to the resolved-by-OSM merge mechanism and two users
+  // resolving the same non-ambiguous city land as duplicate NULL-osm_id rows.
   const result = await nominatimSearch({
     q: city.name,
     countrycodes: city.countryCode.toLowerCase(),
@@ -456,14 +588,14 @@ export async function resolveCity(cityId: number): Promise<boolean> {
   }
 
   if (result.status === 'error') {
-    // Recoverable — increment the counter, stay pending, retry later (up to cap).
-    await incrementAttempts(cityId);
+    // Recoverable — GE-19 / ADL-55 §R F2 (name-search site): stay pending and
+    // retry below the cap, transition to needs_attention/unreachable AT it.
+    await applyGeocodeState(cityId, nextGeocodeState(stateRow, 'unreachable'));
     return false;
   }
 
   // result.status === 'ok' — the geocoder answered. ADL-46 F1/F2 ruling §2.4:
-  // this is F1 — the single shared classifier replaces the old `pickBest`,
-  // which decided "is this ambiguous?" differently than resolveCityName did.
+  // the single shared classifier decides "which candidate, if any".
   const verdict = classifyCandidates(
     result.candidates,
     new Set([city.countryCode.toUpperCase()]),
@@ -471,45 +603,29 @@ export async function resolveCity(cityId: number): Promise<boolean> {
   );
 
   if (verdict.status === 'unresolved') {
-    // TERMINAL: the geocoder answered with no usable match. Never retried (D10).
-    const now = new Date().toISOString();
-    await db
-      .update(cities)
-      .set({ geocodeStatus: 'unresolvable', geocodeAttemptedAt: now, updatedAt: now })
-      .where(eq(cities.id, cityId));
+    // TERMINAL 'unresolvable': the geocoder answered with no usable match (D10).
+    await applyGeocodeState(cityId, nextGeocodeState(stateRow, 'no_match'));
     console.info(`[GEO] City ${cityId} (${city.name}) unresolvable — no match`);
     return false;
   }
 
   if (verdict.status === 'ambiguous') {
-    // ADL-46 F1/F2 ruling §2.4/§2.5 (R2/R3/R4): the geocoder DID answer, but
-    // could not confirm a single region — this is not a "no match" (D10's
-    // 'unresolvable' does not apply) and it must not guess (D14). Consume the
-    // existing geocode_attempts budget (a bounded question, re-askable if the
-    // row's region_id later changes — R1 §3.3) and leave the row 'pending'.
-    await incrementAttempts(cityId);
+    // GE-19 D1a / OQ-3 (refines ADL-46 D10/F1): the geocoder DID answer but could
+    // not confirm a single region — not a "no match" (D10 'unresolvable' does not
+    // apply) and it must not guess (D14). The answer is DETERMINISTIC, so this is
+    // terminal on the FIRST verdict: needs_attention/ambiguous, spending no
+    // further retry (pre-GE-19 this consumed the budget and stayed 'pending').
+    // Re-askability is preserved — the re-open path resets attempts when a region
+    // is later supplied.
+    await applyGeocodeState(cityId, nextGeocodeState(stateRow, 'ambiguous'));
     console.info(
-      `[GEO] City ${cityId} (${city.name}) ambiguous (${verdict.reason}): regions=${verdict.regionIsos.join(',')}`,
+      `[GEO] City ${cityId} (${city.name}) needs attention — ambiguous (${verdict.reason}): regions=${verdict.regionIsos.join(',')}`,
     );
     return false;
   }
 
   // verdict.status === 'ok'
   return commitResolvedOrMerge(cityId, verdict.best);
-}
-
-/** ADL-46 D10: increment the recoverable-failure counter for a pending row. */
-async function incrementAttempts(cityId: number): Promise<void> {
-  const db = getDb();
-  const now = new Date().toISOString();
-  await db
-    .update(cities)
-    .set({
-      geocodeAttempts: sql`${cities.geocodeAttempts} + 1`,
-      geocodeAttemptedAt: now,
-      updatedAt: now,
-    })
-    .where(eq(cities.id, cityId));
 }
 
 /**


### PR DESCRIPTION
**Tracker:** BUG-85 · **BRD:** GE-19 (v3.20) · **Design:** ADL-55 §3/§4/§5/§8/§R
**Class (OP-32):** gap · **ATDD-first (OP-35):** greens the merged QA red bar (#512) — no `Closes` (GE-19/BUG-85 close when the whole feature, incl. frontend, ships).

Makes the QA red bar GREEN by implementing the ADL-55 backend. All 7 `describe.skip` RED BAR blocks un-skipped and green; **no QA assertion weakened** (git diff shows only `describe.skip`→`describe`).

## What this implements (ADL-55)
- **D5 / criterion 11** — `nextGeocodeState(row, verdict)` pure state machine (§3.2) co-located in `geocoding.service.ts`; `resolveCity` rewired to *produce verdict → nextGeocodeState → apply*. New `nextGeocodeState.test.ts` table test.
- **D1a / OQ-3** — an ambiguous verdict → `needs_attention`/`cause='ambiguous'` on the **first** verdict, no retry consumed (refines ADL-46 D10/R4).
- **§R F2** — recoverable error at the cap → `needs_attention`/`cause='unreachable'` at **both** sites (carried-OSM + name-search); never pending-at-cap.
- **§R F3** — `resolveCity` early-returns on a `needs_attention` row.
- **§R F1** — `findOrUpgradeCity` resets a `needs_attention` adoptee to `pending`/`cause=null` + re-fires; `findRegionlessUpgradeCandidate` whitelist gains `needs_attention`; the `unresolvable` asymmetry is preserved.
- **§R F4** — refreshed the stale `findByIdentityKey` "unconditional index" comment (0017 replaced it with two partials); swept the sibling claim in `cityIdentityService`.
- **D3** — `citiesRepository.findUserGeocodeQueue(userId)` + new `GET /api/geocode-queue` route, mounted in both apps.

## Security (OP-06 — the new route is the surface)
1. **Auth:** `requireAuth` on the route — via the global `app.use('/api/', requireAuth)` mount (server.ts + server-test-app.ts). No owner gate owed (a user reads their own references). Criterion 4 proves 401 when auth is disabled.
2. **Scope:** the queue query composes `scopeToUser(trips, userId)` (repositories/scope.ts) — the QUAL-43 chokepoint — so cross-user isolation is **structural**, not a hand-rolled predicate. `scope:check` PASS (Check 1 = 0 residuals; Check 2 = 0 `getDb` in routes — the route delegates to the repo). Criterion 4 runs against real libSQL with two seeded users (QUAL-22).
3. **FK notNull:** N/A — no schema change, no new table, no new user-referencing column (migration 0018/#511 already landed the two additive columns).

## Contract reconciliation (ADL vs QA)
None needed — the endpoint envelope QA asserts (JSON array; `id` + snake_case `geocode_status`/`geocode_cause`) matches ADL-55 §5.1. QA's re-point finding was already fixed on main by #513 (`PATCH /api/trips/:tripId/places/:placeId`).

## Declared (OP-28)
Updated **2** pre-existing `geocoding.service.test.ts` assertions (the ADL-46 R4 ambiguous behaviour — "stays pending"/`attempts+1`) that ADL-55 D1a explicitly supersedes, to the new `needs_attention`/`ambiguous`/attempts-unchanged lifecycle. This is a settled-design supersession, **not** a QA/ATDD file and **not** a weakened bar (criterion 1 asserts the same new behaviour and passes un-modified). No full-file source rewrites.

## Docs same-PR
API reference 1.8 → 1.9: corrected the stale three-state `geocode_status` enum (`+needs_attention`), documented `geocode_cause`, and added the full `GET /api/geocode-queue` section with the `(status, cause)`→label map and recovery levers.

## Out of scope (FRONTEND brief)
NR-06 localStorage retirement (OQ-4), the panel UI, and label rendering (criterion 9).

## Verification
Backend 871 green · frontend 388 green · `type:check:all` clean · biome clean · `scope:check`/`status:check`/`tracker:check` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)