### PR TITLE
chore(UAT): process 2026-08-11 round — 8 pass, 3 reopen, 3 new

### DIFF
--- a/_project/STATUS.md
+++ b/_project/STATUS.md
@@ -17,7 +17,7 @@ _Tracker last updated: 2026-07-28 (B9 merged — QUAL-03 + QUAL-11 done, PR #292
 | PHASE-5 | Integrations — Notification Engine | ⬜ Pending |
 | PHASE-6 | v3 Planning-First Delivery | ⬜ Pending |
 
-## Open work (82)
+## Open work (85)
 
 ### P1 — Critical (1)
 
@@ -25,7 +25,7 @@ _Tracker last updated: 2026-07-28 (B9 merged — QUAL-03 + QUAL-11 done, PR #292
 |---|---|---|---|
 | QUAL-18 | E2E serves the frontend from vite preview, not Express — so no CSP header is ever under test | qa | ⬜ Pending |
 
-### P2 — Important (41)
+### P2 — Important (42)
 
 | ID | Title | Owner | Status |
 |---|---|---|---|
@@ -62,6 +62,7 @@ _Tracker last updated: 2026-07-28 (B9 merged — QUAL-03 + QUAL-11 done, PR #292
 | BUG-90 | "Scotland" and other UK home nations not selectable in the add-trip country picker | architect | ⬜ Pending |
 | BUG-91 | Trip-create form saves and closes prematurely when selecting from the picker (can't set dates in the same flow) | frontend | done_pending_uat |
 | QUAL-43 | Structural userId-scoping chokepoint + citiesRepository (design-reflection R1) | architect | done_pending_uat |
+| BUG-97 | Add-place ambiguity is pre-empted by a single cached city match (the cached-vs-live seam) | architect | ⬜ Pending |
 | QUAL-45 | Admin name-list BACKEND consolidation — repo+router factory keeping validateOwnership explicit (QUAL-29 part b) | architect | ⬜ Pending |
 | QUAL-26 | You cannot tell which build staging is serving — put the commit SHA in /health, the UI and the shakedown | backend | done_pending_uat |
 | ENV-02 | Staging 502s — Railway proxy 'connection dial timeout' to a single-replica service; app-side causes ruled out | coo | ⬜ Pending |
@@ -71,7 +72,7 @@ _Tracker last updated: 2026-07-28 (B9 merged — QUAL-03 + QUAL-11 done, PR #292
 | QUAL-39 | PO-journey Playwright pack — encode the PO's UAT checklist flows as E2E specs | qa | ⬜ Pending |
 | QUAL-40 | react-hook-form + shared zod schemas in ItemForm — real client validation + retires several folded cleanups (Architect ADL first) | frontend | ⬜ Pending |
 
-### P3 — Minor (40)
+### P3 — Minor (42)
 
 | ID | Title | Owner | Status |
 |---|---|---|---|
@@ -105,6 +106,8 @@ _Tracker last updated: 2026-07-28 (B9 merged — QUAL-03 + QUAL-11 done, PR #292
 | BUG-93 | Newly-added place's map marker doesn't appear until a refresh (render lag on add) | frontend | done_pending_uat |
 | BUG-94 | GE-20 bypass: the manual '+Add new' country dropdown in the picker isn't restricted to the trip's countries | frontend | ⬜ Pending |
 | QUAL-44 | Stale file:line cross-references in comments — remaining low-value ones + adopt cite-symbols-not-lines | unassigned | ⬜ Pending |
+| BUG-98 | City resolved in a region-tier country with state left blank is saved region-null, not backfilled (Melbourne -> 'Australia, no state set') | architect | ⬜ Pending |
+| UX-15 | Blue-date tooltip copy 'set explicitly for this place' is unclear to users | frontend | ⬜ Pending |
 | QUAL-48 | Spike — does a file-backed libSQL test client honour db.transaction() (unblocks items base+extension atomicity)? | backend | ⬜ Pending |
 | QUAL-49 | One serializer per entity, every handler routed through it (the persisted-but-dropped-from-response class) | backend | done_pending_uat |
 | QUAL-28 | The devcontainer allowlist matches IPs, not hostnames — any Cloudflare-proxied origin is reachable by pinning it to an allowlisted CF edge | architect | ⬜ Pending |
@@ -122,7 +125,7 @@ _Tracker last updated: 2026-07-28 (B9 merged — QUAL-03 + QUAL-11 done, PR #292
 |---|---|---|---|---|
 | feature | `█████████████░░░░░░░` 37/57 | 37 | 20 | 4 |
 | requirement | `███████████████████░` 32/33 | 32 | 1 | 6 |
-| bug | `███████████████░░░░░` 65/89 | 65 | 24 | 3 |
+| bug | `██████████████░░░░░░` 65/91 | 65 | 26 | 3 |
 | task | `██████████████████░░` 11/12 | 11 | 1 | 0 |
 | chore | `████████████░░░░░░░░` 37/64 | 37 | 27 | 1 |
 
@@ -158,4 +161,4 @@ _Tracker last updated: 2026-07-28 (B9 merged — QUAL-03 + QUAL-11 done, PR #292
 
 ---
 
-_190 done · 9 deferred · 5 closed · 82 open — 286 tracked items_
+_190 done · 9 deferred · 5 closed · 85 open — 289 tracked items_

--- a/_project/tracker.json
+++ b/_project/tracker.json
@@ -2816,7 +2816,7 @@
       "priority": "P3",
       "brdRefs": [],
       "phase": 6,
-      "notes": "Found 2026-08-08 owner UAT (finding 6.3, PO 'yes'). On the picker/disambiguation screen the city name entered on the previous screen is editable, but editing it does NOT re-run the geocode lookup, so a changed value silently mismatches the candidates. Grey out / make read-only with a hint to go back to change it. Small frontend fix; part of the geocoder-picker bundle."
+      "notes": "Found 2026-08-08 owner UAT (finding 6.3, PO 'yes'). On the picker/disambiguation screen the city name entered on the previous screen is editable, but editing it does NOT re-run the geocode lookup, so a changed value silently mismatches the candidates. Grey out / make read-only with a hint to go back to change it. Small frontend fix; part of the geocoder-picker bundle. || RE-CONFIRMED in PO UAT 2026-08-11 (Finding 2): the City Name input (AddPlaceFlow.tsx:676-683) stays editable while the picker is shown; editing it does NOT re-fire the lookup (no useEffect watches newCityName), and on pick it sends the edited name with the OLD candidate's osm_id — a name/identity mismatch. Fix: make the input read-only/greyed once a lookup has run, with a 'go Back to change' hint."
     },
 
     {
@@ -2924,6 +2924,39 @@
       "brdRefs": ["GE-19"],
       "phase": 6,
       "notes": "Found by the PO during BUG-85/GE-19 UAT 2026-08-11. The collapsed needs-attention BADGE (not the panel, which reads fine) renders `{needsAttentionCount} need attention` at GeocodeQueueIndicator.tsx:124 and in the aria-label at :114 — grammatically wrong at every count ('1 need' should be '1 needs'; only 2+ takes 'need'). PO-specified fix, which also sidesteps verb agreement by adding the noun: '1 place needs attention' / 'N places need attention'. FIX: pluralize both the visible badge (:124) and the aria-label (:114) as `${n} place${n===1?'':'s'} need${n===1?'s':''} attention`; consider mirroring the 'place(s)' noun on the resolving chip for consistency. Add a component test asserting the string at n=1 and n=2. Cosmetic, does NOT block GE-19 (done); tracked separately. || FIXED 2026-08-11, PR #520 (main @ dfc4fdb). Badge + aria-label now pluralize: '1 place needs attention' / 'N places need attention' (PO wording); the resolving chip was mirrored to '1 place resolving' for parallelism (agent consistency call, flagged for PO — easy to revert). Two shared helpers so the visible copy and the aria-label can't drift; component test asserts n=1 and n=2 for both. 403 frontend tests."
+    },
+    {
+      "id": "BUG-97",
+      "type": "bug",
+      "title": "Add-place ambiguity is pre-empted by a single cached city match (the cached-vs-live seam)",
+      "status": "pending",
+      "owner": "architect",
+      "priority": "P2",
+      "brdRefs": ["GE-16", "GE-19"],
+      "phase": 6,
+      "notes": "Found 2026-08-11 by PO UAT (Newport auto-resolved to Oregon with no ambiguity prompt) + a read-only COO investigation that confirmed the mechanism. THE SEAM: the backend create path gates the entire LIVE ambiguity classifier behind a cached find-or-create. findOrUpgradeCity step-2b (cityIdentityService.ts:142-145) reuses a SINGLE cached name+country match (findByNameAndCountry capped at 2, repositories/cities.ts:278-285) BEFORE classifyCandidates ever runs; the search-dropdown click path reuses a cached row with zero geocoding. So Springfield (2+ cached rows) falls through to the live classifier -> multi-region ambiguous -> needs_attention (GE-19), but Newport (1 cached 'Newport, Oregon') is reused blind. The PO's cached-vs-live instinct was right about the EFFECT (cache pre-empts) though the classifier itself runs on live Nominatim, not cache. SECOND DEFECT (same seam): a FE/BE ambiguity-DEFINITION divergence — the frontend picker fires on osm_id (place-level) distinctness (decideCityDisambiguation.ts:60) while the backend fires needs_attention on region_iso (region-level) distinctness (geocoding.service.ts:188-190), so a place-ambiguous-but-region-unambiguous city (two same-state Newports) is shown a picker by the FE yet silently resolved by the BE name path. THIRD (folds in BUG-73's partial): the DB-search 'No matches in <country>' message reflects the cached search, not a live lookup, so it is misleading (PO: 'Add new' then returns live results). ARCHITECT-LEVEL: this is the design seam between 'reuse the catalogue' (BUG-72 convergence) and 'don't auto-pick an ambiguous city' (GE-16/BUG-71/GE-19). Wants an ADL that decides how a live-ambiguous name is routed to disambiguation even when one cached row exists, and reconciles the FE/BE ambiguity definitions + the message copy. UNVERIFIED (investigation blind spot): could not inspect staging DB rows / replay the live Nominatim call, so cannot prove WHICH reuse path fired for the PO's Newport nor why the FE '+Add new' picker didn't fire; the cached-reuse short-circuit is a verified code path that fully accounts for the symptom."
+    },
+    {
+      "id": "BUG-98",
+      "type": "bug",
+      "title": "City resolved in a region-tier country with state left blank is saved region-null, not backfilled (Melbourne -> 'Australia, no state set')",
+      "status": "pending",
+      "owner": "architect",
+      "priority": "P3",
+      "brdRefs": ["GE-16"],
+      "phase": 6,
+      "notes": "Found 2026-08-11 by PO UAT (added Melbourne without a state -> saved 'Australia (no state set)', no picker, no needs_attention) + COO investigation. DISTINCT from BUG-97 — here the live classifier DID run and returned 'ok' (within AU, Melbourne is one region, AU-VIC), so it resolved. But D12 rule-3 'never overwrite the user's country/region' means the geocoder NEVER backfills region_id: the resolved insert uses regionId = region_id ?? null (cities.ts:191) and commitResolvedOrMerge sets coords/OSM ref but not region (geocoding.service.ts:297-312). Result: a city resolved to Victoria's coordinates but region_id null, rendered 'Australia (no state set)'. The geocoder unambiguously knew the region and deliberately didn't apply it. POLICY RULING (Architect): either backfill region_id from the resolved candidate's region_iso when the user left it null in a region-tier country, OR route 'region-tier + null region + resolved' to needs_attention. No local bug — a D12 policy decision. Likely folds into BUG-97's ADL."
+    },
+    {
+      "id": "UX-15",
+      "type": "ux",
+      "title": "Blue-date tooltip copy 'set explicitly for this place' is unclear to users",
+      "status": "pending",
+      "owner": "frontend",
+      "priority": "P3",
+      "brdRefs": ["DP-06"],
+      "phase": 6,
+      "notes": "Split from UX-14's UAT pass 2026-08-11. The blue-date tooltip now EXISTS (UX-14 passed) but the PO: 'I don't know what 'set explicitly for this place' is meant to tell a user.' Reword the tooltip to convey what the blue accent means in plain terms (that this place carries its own dates rather than inheriting the trip/hotel fallback, per BRD-DP06 / ADL-24). Copy-only frontend change."
     },
     {
       "id": "BUG-95",

--- a/jobs/PO/uat-log.md
+++ b/jobs/PO/uat-log.md
@@ -6,92 +6,41 @@ leaves this file. History lives in [`uat-archive.md`](./uat-archive.md).
 **Recording a verdict:** write on the `Result:` line, or just tell me `N PASS` / `N FAIL: <what you saw>` / `N N/A`.
 On a PASS I flip the tracker item to done and remove it from here.
 
-**Before you start (10 seconds):** hard-refresh staging (**Cmd/Ctrl+Shift+R** — the browser caches the old
-bundle), then open **`/health`** and confirm the `commit` matches the latest `main`. If it doesn't, staging
-is stale — tell me and everything below is void until it redeploys. *(This bit us once already.)*
+**Before you start (10 seconds):** hard-refresh staging (**Cmd/Ctrl+Shift+R**), then open **`/health`** and
+confirm the `commit` matches the latest `main`. If it doesn't, staging is stale — tell me.
 
 ---
 
-## A · Add-a-place / city picker — test as one pass
+## Awaiting your testing
 
-All of these live in the **Add Place** flow (open a trip → **Add Place** → type a city), so run them
-together. They came back **PARTIAL** on 2026-08-08. Your three complaints last round: **coordinates shown**
-in the picker, **two indistinguishable rows**, and the **city name editable** on the picker screen when it
-shouldn't be — check those explicitly; any survivor is a FAIL regardless of tracker status.
-
-1. **BUG-71 — ambiguous city offers a disambiguation choice.**
-   - Steps: Add Place → type **"Springfield"** (US).
-   - Expected: you're offered a choice of candidates (each with its state/region) to pick from — **not** a silent auto-fill of one state. (It used to arrive pre-filled with "Virginia" and no hint another Springfield exists.)
+1. **QUAL-43 + QUAL-49 — backend refactor smoke *(smoke test, not a feature)*.**
+   You already exercised most of this during the 2026-08-11 round (trips, add place, add item, map) with no
+   refactor-attributable regression. To close it: confirm the **admin panel** opens and a fresh **add-item**
+   looks normal — or just say "covered" and I'll close it.
    - Result:
 
-2. **BUG-72 — picker rows tell you *which* city.**
-   - Steps: with the autocomplete open for "Springfield" (or "Newport"), read the rows.
-   - Expected: each row shows **city + state/region + country** (e.g. "Springfield, Illinois, US") — enough to pick the right one, not just "Springfield US".
+2. **BUG-74 — an *upstream* geocoder failure is signalled ("couldn't reach the geocoder", not a false "found nothing").**
+   Hard to force on purpose — you didn't hit it in the round. Opportunistic: if a lookup ever hangs/errors,
+   note what you saw. Or tell me and **I'll force one** so you can test it deliberately.
    - Result:
 
-3. **BUG-81 — picker rows are clean and skimmable.**
-   - Steps: trigger the disambiguation picker on an ambiguous city (Springfield → ~20 US rows).
-   - Expected: rows read as **"City, State, Country"** — no county, no postcode, no raw-address cruft (was "Springfield, Fairfax County, Virginia, 22150, United States"), and **no raw coordinates**.
-   - Result:
+---
 
-4. **BUG-73 — a lookup that finds nothing is signalled, not silent.**
-   - Steps: Add Place → type a made-up city that can't exist (e.g. **"Xyzzyville"**).
-   - Expected: a **visible signal** that the lookup found nothing / failed — not silently-blank country/state fields with no explanation.
-   - Result:
+## In the dev pipeline — will return here once fixed (no action from you now)
 
-5. **BUG-74 — an *upstream* geocoder failure is signalled too.**
-   - Steps: hard to force on purpose (needs the geocoder itself to error, not just find no match). **Opportunistic:** if any city lookup hangs or errors while you test, note what you saw. *(Tell me if you want to test it deliberately — I can force one.)*
-   - Expected: a "couldn't reach the geocoder" signal — **not** a false "found nothing".
-   - Result:
+These came out of the 2026-08-11 round as fails/partials or new findings. They're tracked and go back to
+dev; they'll reappear above for re-testing when fixed.
 
-6. **BUG-87 — picker narrows to the trip's countries.**
-   - Steps: open a trip with a country set (a **UK** trip) → Add Place → search **"Newport"**.
-   - Expected: candidates narrow/rank to the trip's declared countries (you get UK Newports, not only USA Newports). A trip with **no** country set should prompt rather than filter to nothing.
-   - Result:
-
-## B · Trips list & status
-
-7. **BUG-58 — changing a trip's status keeps it selected.**
-   - Steps: select a trip in the left panel → change its status — **lock** it, or move it **backward** (e.g. Confirmed → Planning).
-   - Expected: the trip **stays selected and visible** in the left panel — it must not blank out and force you to re-find it.
-   - Result:
-
-8. **BUG-86 — "Back to trip" returns to the trip.**
-   - Steps: open a trip in **review** status → click **Back to trip**.
-   - Expected: lands on the active trip view, **not** a blank/deselected panel.
-   - Result:
-
-9. **BUG-91 — trip-create form doesn't submit early.**
-   - Steps: **Add a trip** → in the **country-search** field, press **Enter**.
-   - Expected: the form does **not** save/close; you can still set dates in the same flow.
-   - Result:
-
-10. **BUG-93 — new place's map marker appears without a refresh.**
-    - Steps: add a place to a trip.
-    - Expected: its **pin shows on the map immediately**, with no manual refresh.
-    - Result:
-
-11. **UX-14 — blue date tooltip *(not a bug — confirm the copy)*.**
-    - Steps: hover a **blue** date field (the first place's dates render blue).
-    - Expected: a tooltip explains the "explicit dates" accent and **reads sensibly**. (The blue is deliberate; first-place-only-blue at creation is expected per BRD-DP06.)
-    - Result:
-
-## C · Quick checks
-
-12. **QUAL-26 — you can tell which build staging is serving.**
-    - Steps: open **`/health`** on staging.
-    - Expected: a `commit` SHA is present and **matches the latest `main`**. *(Same as the pre-flight check above — record once.)*
-    - Result:
-
-13. **QUAL-43 + QUAL-49 — backend refactor smoke *(smoke test, not a feature)*.**
-    - Steps: do a normal loop — trip list → open a trip → view its places & items → add a place → add an item → check the map renders → open the admin panel.
-    - Expected: **everything behaves exactly as before.** The backend data layer and response serialization were rewritten with zero intended behaviour change — anything that feels different is a FAIL, tell me even if it seems trivial.
-    - Result:
+- **BUG-97** *(the big one)* — add-place ambiguity is pre-empted by a single cached city match (why "Newport" silently went to Oregon). Also folds in **BUG-73**'s misleading "no matches" message and the frontend/backend disagreement on what counts as ambiguous. **Architect design first.**
+- **BUG-98** — a city resolved in a region-tier country with the state left blank saves as "no state set" instead of using the region the geocoder already knew (Melbourne → "Australia, no state set"). Architect policy call; likely folds into BUG-97.
+- **BUG-86** — "Back to trip" works but breaks the way *back* to the review screen / reversing a status. (Reopened — the fix went one way only.)
+- **BUG-91** — the trip-create form still auto-saves when you **click** a country (the earlier fix only stopped the Enter key).
+- **UX-13** — city name stays editable on the picker screen but editing it does nothing; grey it out. (Re-confirmed this round.)
+- **UX-15** — the blue-date tooltip wording ("set explicitly for this place") is unclear — reword.
 
 ---
 
 ## Adding a new finding
 
-Add a numbered line under the right section (or a new section), or just tell me and I'll log it. For a
-behaviour bug, steps-to-reproduce beat a screenshot; for a visual bug, a screenshot + one line is ideal.
-Screenshots → `jobs/PO/screenshots/[date]-[short-description].png`.
+Add a numbered line under "Awaiting your testing", or just tell me. Steps-to-reproduce beat a screenshot
+for behaviour bugs; screenshot + one line for visual. Screenshots → `jobs/PO/screenshots/`.


### PR DESCRIPTION
Processes the PO's full UAT round.

**Passed → done (8):** BUG-58, BUG-71, BUG-72, BUG-81, BUG-87, BUG-93, QUAL-26, UX-14.

**Reopened → pending (fix incomplete):** BUG-73 (the 'no matches' message reflects the cached DB search, not a live lookup — misleading), BUG-86 (the fix broke the path *back* to the review screen / status reversal), BUG-91 (click-selecting a country still auto-saves; the fix only stopped Enter).

**New findings** (from a read-only investigation of the Newport/Melbourne behaviour):
- **BUG-97** (P2, architect) — the cached-vs-live seam: a single cached city match pre-empts the live ambiguity classifier, so Newport silently resolves to Oregon; plus a frontend/backend divergence on what 'ambiguous' means; folds in BUG-73's message. Needs an ADL.
- **BUG-98** (P3, architect) — resolved-but-region-null in a region-tier country (Melbourne 'no state set'); D12 policy gap.
- **UX-15** (P3, frontend) — blue-date tooltip copy unclear (split from UX-14). **UX-13** re-confirmed.

BUG-71 passed on Springfield but the same class still fails for Newport via the distinct cached-reuse mechanism now owned by BUG-97 — flagged, not silently reopened.

`tracker:check` (296) + `status:check` green.