### PR TITLE
chore: BUG-86/BUG-91 round-2 → done_pending_uat; UAT queue + D-33 capture

### DIFF
--- a/_project/tracker.json
+++ b/_project/tracker.json
@@ -2751,12 +2751,12 @@
       "id": "BUG-86",
       "type": "bug",
       "title": "\"Back to trip\" button in review status deselects the trip instead of returning to the active view",
-      "status": "pending",
+      "status": "done_pending_uat",
       "owner": "frontend",
       "priority": "P3",
       "brdRefs": [],
       "phase": 6,
-      "notes": "Found 2026-08-08 owner UAT (finding 1.5, PO 'yes'). In review/review_pending status the 'Back to trip' control deselects the trip entirely (blank panel) rather than returning to the active-status trip view the PO expects. Small frontend fix. Same 'status transition drops the selection' family as BUG-58 (locking a trip also deselects it) — consider fixing together. || FIXED PR #458 (done_pending_uat): same root as BUG-58 (ReviewPanel onClose navigation); 'Back to trip' now returns to the trip view via the shared visibility hook, not a deselecting navigate. Awaiting PO re-UAT. || UAT PARTIAL/REGRESSION 2026-08-11 (PO): 'Back to trip' from review works, but breaks the path BACK to review — no way to return to the review page or reverse to active; re-locking works but unlocking goes to trip view, not review. The fix (shared visibility hook, no navigation) removed the return path. Reopened."
+      "notes": "Found 2026-08-08 owner UAT (finding 1.5, PO 'yes'). In review/review_pending status the 'Back to trip' control deselects the trip entirely (blank panel) rather than returning to the active-status trip view the PO expects. Small frontend fix. Same 'status transition drops the selection' family as BUG-58 (locking a trip also deselects it) — consider fixing together. || FIXED PR #458 (done_pending_uat): same root as BUG-58 (ReviewPanel onClose navigation); 'Back to trip' now returns to the trip view via the shared visibility hook, not a deselecting navigate. Awaiting PO re-UAT. || UAT PARTIAL/REGRESSION 2026-08-11 (PO): 'Back to trip' from review works, but breaks the path BACK to review — no way to return to the review page or reverse to active; re-locking works but unlocking goes to trip view, not review. The fix (shared visibility hook, no navigation) removed the return path. Reopened. || FIXED (round 2) PR #527, closes #526, 2026-08-12 -> done_pending_uat. Root (found by reading #458's diff): useReviewPanelVisibility dismissal was keyed on the (tripId,status) VALUE pair, so a locked->review_pending unlock returned to a value dismissed earlier and stayed suppressed. Fix resets dismissal on any real (tripId,status) change + adds an explicit 'Back to Review' control (TripDetail/MobileTripDetailView); regression test proven real by reverting #458's hook (7 tests fail against it). CI green. Awaiting PO re-UAT."
     },
 
     {
@@ -2823,12 +2823,12 @@
       "id": "BUG-91",
       "type": "bug",
       "title": "Trip-create form saves and closes prematurely when selecting from the picker (can't set dates in the same flow)",
-      "status": "pending",
+      "status": "done_pending_uat",
       "owner": "frontend",
       "priority": "P2",
       "brdRefs": [],
       "phase": 6,
-      "notes": "Found 2026-08-08 non-owner UAT (finding N1). Adding a trip and selecting from the picker (country) saves and closes the whole create form, forcing the user to re-open the trip to edit dates — breaks the single add-trip flow. Observed as non-owner; owner-scope UNVERIFIED (re-check whether it also affects the owner path — the PO listed it only under non-owner). Rising importance: BUG-87 makes the trip's declared country set authoritative for place-picker filtering, so the trip-create country step (this form) is now doubly load-bearing. frontend. || FIXED PR #458 (done_pending_uat): reproduced against TripForm — clicking a country was already safe; pressing ENTER in the country search fell through to native form submission, saving/closing the create modal. Fixed with a scoped onKeyDown preventDefault. Confirmed NOT owner-scoped. Awaiting PO re-UAT. || UAT FAIL 2026-08-11 (PO): clicking a country selection auto-saves+closes the trip-create form before dates can be set. The fix stopped Enter->submit only; the click-select path still submits early. Reopened."
+      "notes": "Found 2026-08-08 non-owner UAT (finding N1). Adding a trip and selecting from the picker (country) saves and closes the whole create form, forcing the user to re-open the trip to edit dates — breaks the single add-trip flow. Observed as non-owner; owner-scope UNVERIFIED (re-check whether it also affects the owner path — the PO listed it only under non-owner). Rising importance: BUG-87 makes the trip's declared country set authoritative for place-picker filtering, so the trip-create country step (this form) is now doubly load-bearing. frontend. || FIXED PR #458 (done_pending_uat): reproduced against TripForm — clicking a country was already safe; pressing ENTER in the country search fell through to native form submission, saving/closing the create modal. Fixed with a scoped onKeyDown preventDefault. Confirmed NOT owner-scoped. Awaiting PO re-UAT. || UAT FAIL 2026-08-11 (PO): clicking a country selection auto-saves+closes the trip-create form before dates can be set. The fix stopped Enter->submit only; the click-select path still submits early. Reopened. || FIXED (round 2) PR #530, closes #529, 2026-08-12 -> done_pending_uat. Root: structural fix — the Create/Save button is now type=button calling handleSave directly, so no submit button exists in the form and no field can implicitly submit (click OR Enter, any browser). Agent could not reproduce a native click-submit via 3 differently-failing probes (jsdom+user-event with fields filled, live Chromium E2E, E2E with overlapping dropdown); WebKit/Safari left UNVERIFIED (no sudo to install Playwright libs) but the fix is mechanism-agnostic so it holds regardless. Trade-off flagged: Enter-in-Name no longer submits (never a PO/BRD requirement). CI green. Awaiting PO re-UAT."
     },
 
     {

--- a/jobs/COO/open-dialogues.md
+++ b/jobs/COO/open-dialogues.md
@@ -28,22 +28,16 @@ Checked at every `/coo-startup` pickup and by the Restart Preview step in `/coo-
 
 ## Open
 
-### D-32: Add-place cached-vs-live seam — fix sequencing (BUG-97/98 + BUG-86/91)
-**Raised:** 2026-08-11 · **Status:** plan proposed by the COO, PO deferred the sequencing call to a fresh session.
+### D-33: Multi-user geocoding scaling — does the shared cache suffice, or do we need coalescing / a hosted source?
+**Raised:** 2026-08-11 · **Status:** parked (PO agreed) — capture now, pull into an Architect ADL only when multi-user is actually on the roadmap. Sibling of D-30 (build-vs-buy).
 
-PO UAT (2026-08-11) surfaced a cluster of add-place findings that share one root — the **cached-vs-live
-seam**: BUG-97 (a single cached city match pre-empts the live ambiguity classifier, so "Newport" silently
-resolved to Oregon; also a FE/BE ambiguity-definition divergence), BUG-98 (region-null in a region-tier
-country, "Melbourne → no state set"), and BUG-73's misleading "no matches" message (reflects the cached
-search). Plus two discrete functional bugs: **BUG-91** (clicking a country still auto-saves the trip-create
-form) and **BUG-86** (the "Back to trip" fix broke the path back to the review screen / status reversal).
+Thinking ahead to multi-user, the PO asked whether the public-Nominatim 1 req/s budget forces request batching and/or a local/hosted geocoding source. Verified facts (recorded so they aren't re-derived):
+- **The shared catalogue already accretes cross-user.** A city is visible to every user the moment it is `resolved` (`repositories/cities.ts` search containment: `geocodeStatus='resolved' OR createdByUserId=caller OR createdByUserId IS NULL`), per the deliberate GE-16 / ADL-46 D5 design. Every resolved city any user adds is cached-first for everyone — "the growing shared cache reduces Nominatim reliance over time" is the *current* design, not aspirational. Residual live load at steady state = cache misses only.
+- **The 1 req/s is a shared, app-wide budget** (public nominatim.openstreetmap.org; single serialized chokepoint at 1100ms, `services/nominatim-client.ts`). Not a free tier with an in-place upgrade — heavy use needs self-hosting or a paid Nominatim-compatible provider. Because ALL egress funnels through one chokepoint, swapping endpoints later is a base-URL/auth change, not a rewrite.
+- **The earlier "no" to a local list (GE-17) was withdrawn on four grounds that ALL failed — none was multi-user** (offline=false, testability=false, ambiguity-detection=weakened, Scotland-coverage=false). So multi-user rate-budget is a genuinely NEW, un-probed argument, not one weighed and dismissed. Per OP-33 it is a multi-plank case owed the same probing the four dead planks got — and the verified cross-user accretion is its strongest counter-plank.
+- **Batching reality:** the queue already fires at ~1/sec; `/lookup` (by osm_id) already batches ids; `/search` (by name) cannot batch distinct names. The real multi-user win is COALESCING duplicate pending lookups (many users adding the same new city → one shared resolution).
 
-**COO recommendation (unconfirmed):** start the **Architect ADL for the seam** first — it carries
-product-shaped questions only the PO can answer (chiefly: *when a name is live-ambiguous but you already
-hold one cached row, should it still prompt?*) — and fix **BUG-91 + BUG-86 in parallel** (different code,
-no conflict). Hold **UX-13** (grey the picker name) and **UX-15** (tooltip copy) to ride the seam work,
-since both touch the picker. **Everything is already tracked** (BUG-97/98/86/91, UX-13/15); only the
-go-ahead and the sequencing are open. Pick up: confirm sequencing, then dispatch (ADL → OP-27 review → build).
+**Why parked, not spiked now:** sizing it needs user-count / add-rate / cache-miss-rate premises that don't exist yet; OP-33 says don't promote a design on premises we can't establish. Trigger to pull it: multi-user moves from "thinking ahead" to on the roadmap.
 
 ### D-30: A build-vs-buy rule
 **Raised:** 2026-08-09 · **Status:** PO wants to discuss; not yet framed. Placeholder so it isn't lost.

--- a/jobs/PO/uat-log.md
+++ b/jobs/PO/uat-log.md
@@ -24,6 +24,22 @@ confirm the `commit` matches the latest `main`. If it doesn't, staging is stale 
    note what you saw. Or tell me and **I'll force one** so you can test it deliberately.
    - Result:
 
+3. **BUG-86 — review ⇄ trip navigation round-trip (round-2 fix, PR #527).**
+   Steps: open a trip and **lock** it (it goes to review) → click **"Back to trip"** (should show the active
+   trip view, *not* a blank panel) → from there use **"Back to Review"** (should return to the review screen)
+   → **unlock** the trip (should land back on **review**, not the plain trip view); re-locking still works.
+   Expected: you can move **both** directions (trip ⇄ review), unlocking returns you to review, and no step
+   shows a blank panel.
+   - Result:
+
+4. **BUG-91 — trip-create form no longer saves early when you click a country (round-2 fix, PR #530).**
+   Steps: start creating a new trip → in the country picker, **click** a country to select it. The form should
+   **stay open** so you can set dates in the same flow → set dates → **Save**. (Also: pressing **Enter** in the
+   country search no longer submits either.)
+   Expected: clicking a country does **not** save/close the form; you complete dates in one flow; the form
+   saves only when you click Save.
+   - Result:
+
 ---
 
 ## In the dev pipeline — will return here once fixed (no action from you now)
@@ -33,8 +49,6 @@ dev; they'll reappear above for re-testing when fixed.
 
 - **BUG-97** *(the big one)* — add-place ambiguity is pre-empted by a single cached city match (why "Newport" silently went to Oregon). Also folds in **BUG-73**'s misleading "no matches" message and the frontend/backend disagreement on what counts as ambiguous. **Architect design first.**
 - **BUG-98** — a city resolved in a region-tier country with the state left blank saves as "no state set" instead of using the region the geocoder already knew (Melbourne → "Australia, no state set"). Architect policy call; likely folds into BUG-97.
-- **BUG-86** — "Back to trip" works but breaks the way *back* to the review screen / reversing a status. (Reopened — the fix went one way only.)
-- **BUG-91** — the trip-create form still auto-saves when you **click** a country (the earlier fix only stopped the Enter key).
 - **UX-13** — city name stays editable on the picker screen but editing it does nothing; grey it out. (Re-confirmed this round.)
 - **UX-15** — the blue-date tooltip wording ("set explicitly for this place") is unclear — reword.
 


### PR DESCRIPTION
Post-merge bookkeeping for the two round-2 frontend fixes merged this session (#527 BUG-86, #530 BUG-91).

- **tracker.json** — BUG-86 and BUG-91 flipped `pending` → `done_pending_uat`, each with the round-2 root/fix and PR/issue cross-refs.
- **uat-log.md** — both moved from the dev-pipeline list to *Awaiting your testing* with steps + expected results.
- **open-dialogues.md** — D-32 (add-place seam sequencing) resolved and removed; **D-33** (multi-user geocoding scaling) captured and parked next to D-30.

No code change. 🤖 Generated with [Claude Code](https://claude.com/claude-code)